### PR TITLE
Bug 1283323 - Rename Triage Report link on Reports page

### DIFF
--- a/extensions/BMO/template/en/default/hook/reports/menu-end.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/reports/menu-end.html.tmpl
@@ -16,7 +16,7 @@
   </li>
   <li>
     <strong>
-      <a href="[% urlbase FILTER none %]page.cgi?id=triage_reports.html">Triage Report</a>
+      <a href="[% urlbase FILTER none %]page.cgi?id=triage_reports.html">Unconfirmed Report</a>
     </strong> - Report on UNCONFIRMED [% terms.bugs %] to assist triage.
   </li>
   <li>

--- a/extensions/BMO/template/en/default/pages/triage_reports.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/triage_reports.html.tmpl
@@ -39,7 +39,7 @@ var selected_components = [
 [% END %]
 
 [% INCLUDE global/header.html.tmpl
-  title = "Triage Reports"
+  title = "Unconfirmed Reports"
   generate_api_token = 1
   yui = [ 'calendar' ]
   javascript = js_data


### PR DESCRIPTION
Description: See [Bug 1283323](https://bugzilla.mozilla.org/show_bug.cgi?id=1283323)