### PR TITLE
Bug 1257608 - Attaching a file can't be done in a new tab/window

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -1193,7 +1193,7 @@
 
 [% IF user.id %]
   <div id="top-actions">
-    <button type="button" id="attachments-add-btn" class="minor">Attach File</button>
+    <a href="attachment.cgi?bugid=[% bug.bug_id FILTER uri %]&amp;action=enter"><button type="button" id="attachments-add-btn" class="minor">Attach File</button></a>
     [% IF user.settings.comment_box_position.value == 'after_comments' %]
       <button type="button" id="add-comment-btn" class="minor">Add Comment &darr;</button>
     [% ELSE %]

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -766,12 +766,6 @@ $(function() {
             tracking_flag_change(event.target);
         });
 
-    // add attachments
-    $('#attachments-add-btn')
-        .click(function(event) {
-            event.preventDefault();
-            window.location.href = 'attachment.cgi?bugid=' + BUGZILLA.bug_id + '&action=enter';
-        });
 
     // take button
     $('.take-btn')


### PR DESCRIPTION
[Bug 125608](https://bugzilla.mozilla.org/show_bug.cgi?id=1257608)