### PR TITLE
Bug 1275568 - bottom of page duplicate button focuses top of page duplicate field

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -861,10 +861,11 @@ $(function() {
             $('#field-status-edit').show();
             $('#field-status-edit .name').show();
             $('#bug_status').val('RESOLVED').change();
-            $('#resolution').val($(event.target).text()).change();
+            $('#bottom-resolution').val($(event.target).text()).change();
             $('#top-save-btn').show();
             $('#resolve-as').hide();
             $('#bottom-status').show();
+	    $('#bottom-dup_id').focus();
         });
     $('.status-btn')
         .click(function(event) {


### PR DESCRIPTION
[Bug 1275568](https://bugzilla.mozilla.org/show_bug.cgi?id=1275568)