### PR TITLE
Bug 1277409 - new user interface doesn't have an obvious way to confirm a bug

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -1255,7 +1255,9 @@
     <div id="new-comment-actions">
       <button type="submit" class="save-btn major" id="bottom-save-btn">Save Changes</button>
       <div id="resolve-as">
-        [%
+        [% IF bug.bug_status == "UNCONFIRMED";%] 
+            <button type="button" class="minor confirm-btn">Confirm [% terms.bug  %]</button> 
+        [% END;
           IF bug.resolution == "";
             seen_header = 0;
             FOREACH resolution IN ["FIXED", "INVALID", "DUPLICATE"];

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -866,6 +866,18 @@ $(function() {
             $('#resolve-as').hide();
             $('#bottom-status').show();
         });
+    $('.confirm-btn')
+        .click(function(event) {
+            event.preventDefault();
+            $('#field-status-view').hide();
+            $('#field-status-edit').show();
+            $('#field-status-edit .name').show();
+            $('#bug_status').val('NEW').change();
+            $('#resolution').val($(event.target).text()).change();
+            $('#top-save-btn').show();
+            $('#resolve-as').hide();
+            $('#bottom-status').show();
+        });
     $('.status-btn')
         .click(function(event) {
             event.preventDefault();


### PR DESCRIPTION
[Bug 1277409 - new user interface doesn't have an obvious way to confirm a bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1277409)





[Bug 1277409](https://bugzilla.mozilla.org/show_bug.cgi?id=1277409)
