### PR TITLE
Bug 1321596 - Add verbiage about using recovery codes

### DIFF
--- a/template/en/default/mfa/totp/verify.html.tmpl
+++ b/template/en/default/mfa/totp/verify.html.tmpl
@@ -15,7 +15,8 @@
 
 <p>
   <b>[% reason FILTER html %]</b> requires verification.<br>
-  Please enter your verification code from your TOTP application:
+  Please enter your verification code from your TOTP application. If your device has been lost or stolen, you
+  may use one of your pregenerated recovery codes.
 </p>
 <div class="verify-totp">
   <form method="POST" action="[% postback.action FILTER none %]">


### PR DESCRIPTION
An acquaintance of mine (@josephlhall) recently had something happen to his phone, and wasn't able to recover the seeds from his TOTP application.  He was frustrated at not being able to get into his account without his 2FA device, because we didn't have a fallback 2FA option.

It turns out that we do (and did) have a fallback option; he had just forgotten about it, because the signin page makes no mention of it.  Once I reminded him about them, he was able to use those codes to get into his account.

It would be great if our 2FA login page mentioned these recovery codes.