### PR TITLE
Bug 1323244 - Make the link to Mozilla Community Participation Guidelines not participate in keyboard navigation

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/new_comment.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/new_comment.html.tmpl
@@ -49,7 +49,7 @@
   </div>
 
   <div id="bugzilla-etiquette">
-    <a href="page.cgi?id=etiquette.html" target="_blank">
+    <a href="page.cgi?id=etiquette.html" target="_blank" tabindex="-1">
       Comments Subject to Etiquette and Contributor Guidelines</a>
   </div>
 

--- a/template/en/default/bug/comment.html.tmpl
+++ b/template/en/default/bug/comment.html.tmpl
@@ -13,7 +13,7 @@
   #%]
 
 <div id="bugzilla-etiquette">
-  <a href="page.cgi?id=etiquette.html" target="_blank">
+  <a href="page.cgi?id=etiquette.html" target="_blank" tabindex="-1">
     Comments Subject to Etiquette and Contributor Guidelines</a>
 </div>
 


### PR DESCRIPTION
r? @dklawren 