### PR TITLE
Bug 1331302 - Restrict the max-width of the textarea of "add comment"

### DIFF
--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -696,6 +696,7 @@ h3.change-name {
     width: 100%;
     box-sizing: border-box !important;
     margin: 0 0 1em;
+    max-width: 1024px;
 }
 
 #comment-preview {


### PR DESCRIPTION
Please see https://bugzilla.mozilla.org/show_bug.cgi?id=1331302.