### PR TITLE
Bug 1344769 - Cancel editing button loads BugZilla homepage instead of current bug

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -710,7 +710,7 @@ $(function() {
     $('#cancel-btn')
         .click(function(event) {
             event.preventDefault();
-            window.location.replace($('#this-bug').val());
+            window.location.replace($('#this-bug').attr('href'));
         });
 
     // Open help page


### PR DESCRIPTION
Bug [1344769](https://bugzilla.mozilla.org/show_bug.cgi?id=1344769)