### PR TITLE
Bug 1344979 - When adding a patch to an unassigned bug, pre-check the reassignment checkbox

### DIFF
--- a/template/en/default/attachment/create.html.tmpl
+++ b/template/en/default/attachment/create.html.tmpl
@@ -84,7 +84,7 @@ TUI_hide_default('attachment_text_field');
         <td>
           <em>If you want to assign this [% terms.bug %] to yourself,
               check the box below.</em><br>
-          <input type="checkbox" id="takebug" name="takebug" value="1">
+          <input type="checkbox" id="takebug" name="takebug" value="1" checked>
           <label for="takebug">take [% terms.bug %]</label>
           [% bug_statuses = [] %]
           [% FOREACH bug_status = bug.status.can_change_to %]

--- a/template/en/default/attachment/create.html.tmpl
+++ b/template/en/default/attachment/create.html.tmpl
@@ -84,7 +84,7 @@ TUI_hide_default('attachment_text_field');
         <td>
           <em>If you want to assign this [% terms.bug %] to yourself,
               check the box below.</em><br>
-          <input type="checkbox" id="takebug" name="takebug" value="1" checked>
+          <input type="checkbox" id="takebug" name="takebug" value="1" [% IF bug.assigned_to.login == "nobody@mozilla.org" || bug.assigned_to.login.search('.bugs$') %] checked [% END %]>
           <label for="takebug">take [% terms.bug %]</label>
           [% bug_statuses = [] %]
           [% FOREACH bug_status = bug.status.can_change_to %]


### PR DESCRIPTION
[Bug 1344979 - When adding a patch to an unassigned bug, pre-check the reassignment checkbox](https://bugzilla.mozilla.org/show_bug.cgi?id=1344979)







