### PR TITLE
Comment typo fix: INCOMPELTE > INCOMPLETE

### DIFF
--- a/extensions/BugModal/Extension.pm
+++ b/extensions/BugModal/Extension.pm
@@ -243,7 +243,7 @@ sub template_before_process {
                 && $resolution ne 'DUPLICATE';
         }
 
-        # reporters can set it to anything, except INCOMPELTE
+        # reporters can set it to anything, except INCOMPLETE
         if ($perms->{isreporter}
             && !($perms->{canconfirm} || $perms->{canedit}))
         {


### PR DESCRIPTION
Noticed this while looking for something else and now I can't stop seeing it.