### PR TITLE
Bug 1352908 - Optimize certain filters in the template compiler

### DIFF
--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -12,7 +12,9 @@ use 5.10.1;
 use strict;
 use warnings;
 
+use Bugzilla::Template::Directive;
 use Bugzilla::Template::PreloadProvider;
+
 use Bugzilla::Bug;
 use Bugzilla::Constants;
 use Bugzilla::Hook;
@@ -845,6 +847,7 @@ sub create {
         },
 
         PLUGIN_BASE => 'Bugzilla::Template::Plugin',
+        FACTORY     => 'Bugzilla::Template::Directive',
 
         # We don't want this feature.
         CONSTANT_NAMESPACE => '__const',

--- a/Bugzilla/Template/Directive.pm
+++ b/Bugzilla/Template/Directive.pm
@@ -1,0 +1,70 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+# This exists to implement the template-before_process hook.
+package Bugzilla::Template::Directive;
+
+use 5.10.1;
+use strict;
+use warnings;
+
+use base qw(Template::Directive);
+
+sub filter {
+    package Template::Directive;
+    our ($PRETTY, $OUTPUT);
+
+    my ($self, $lnameargs, $block) = @_;
+    my ($name, $args, $alias) = @$lnameargs;
+    $name = shift @$name;
+    $args = &args($self, $args);
+    $args = $args ? "$args, $alias" : ", undef, $alias"
+        if $alias;
+
+    if ($name eq "'none'") {
+        return "# NO FILTER\n\n$block";
+    }
+    elsif ($name eq "'null'") {
+        return <<EOF;
+# null filter
+$OUTPUT do {
+    my \$output = '';
+$block
+    '';
+};
+EOF
+    }
+    elsif ($name eq "'html'") {
+        return <<EOF;
+# HTML filter
+$OUTPUT do {
+    my \$output = '';
+$block
+    Bugzilla::Util::html_quote(\$output);
+};
+EOF
+    } else {
+        $name .= ", $args" if $args;
+        $block = pad($block, 1) if $PRETTY;
+
+        return <<EOF;
+
+# FILTER
+$OUTPUT do {
+    my \$output = '';
+    my \$_tt_filter = \$context->filter($name)
+              || \$context->throw(\$context->error);
+
+$block
+    
+    &\$_tt_filter(\$output);
+};
+EOF
+    }
+}
+
+1;

--- a/Bugzilla/Template/Directive.pm
+++ b/Bugzilla/Template/Directive.pm
@@ -21,52 +21,19 @@ our ($PRETTY, $OUTPUT);
 *OUTPUT = \$Template::Directive::OUTPUT;
 *PRETTY = \$Template::Directive::PRETTY;
 *args   = \&Template::Directive::args;
+*pad    = \&Template::Directive::pad;
 
-sub filter_ignore {
+sub filter {
     my ($self, $lnameargs, $block) = @_;
     my ($name, $args, $alias) = @$lnameargs;
     $name = shift @$name;
-    $args = &args($self, $args);
+    $args = args($self, $args);
     $args = $args ? "$args, $alias" : ", undef, $alias"
         if $alias;
+    $name .= ", $args" if $args;
+    $block = pad($block, 1) if $PRETTY;
 
-    if ($name eq "'none'") {
-        return "# NO FILTER\n\n$block";
-    }
-    elsif ($name eq "'null'") {
-        return <<EOF;
-# null filter
-$OUTPUT do {
-    my \$output = '';
-$block
-    '';
-};
-EOF
-    }
-    elsif ($name eq "'uri'") {
-        return <<EOF;
-# HTML filter
-$OUTPUT do {
-    my \$output = '';
-$block
-    $URI_FILTER(\$output);
-};
-EOF
-    }
-    elsif ($name eq "'html'") {
-        return <<EOF;
-# HTML filter
-$OUTPUT do {
-    my \$output = '';
-$block
-    $HTML_FILTER(\$output);
-};
-EOF
-    } else {
-        $name .= ", $args" if $args;
-        $block = pad($block, 1) if $PRETTY;
-
-        return <<EOF;
+    return <<"EOF";
 
 # FILTER
 $OUTPUT do {
@@ -79,7 +46,6 @@ $block
     &\$_tt_filter(\$output);
 };
 EOF
-    }
 }
 
 1;

--- a/Bugzilla/Template/Directive.pm
+++ b/Bugzilla/Template/Directive.pm
@@ -22,7 +22,7 @@ our ($PRETTY, $OUTPUT);
 *PRETTY = \$Template::Directive::PRETTY;
 *args   = \&Template::Directive::args;
 
-sub filter {
+sub filter_ignore {
     my ($self, $lnameargs, $block) = @_;
     my ($name, $args, $alias) = @$lnameargs;
     $name = shift @$name;


### PR DESCRIPTION
[% ... FILTER none %] is optimized away. There is no cost for using it.
[% ... FILTER html %] is optimized to a direct call to
Bugzilla::Util::html_quote(), saving a method call to $stash->filter.
[% ... FILTER uri %] also saves a call to $stash->filter.
[% ... FILTER null %] avoids a filter call and always results in ''

without patch:
```
spent 2.53s (1.64+890ms) within Bugzilla::Template::Context::filter which was called 381645 times, avg 7µs/call
```

with patch:
```
spent 470ms (186+285) within Bugzilla::Template::Context::filter which was called 37008 times, avg 13µs/call
```