### PR TITLE
Bug 1352913 - Extensions must register for template_before_process()

### DIFF
--- a/Bugzilla/Hook.pm
+++ b/Bugzilla/Hook.pm
@@ -11,34 +11,48 @@ use 5.10.1;
 use strict;
 use warnings;
 
+use Scalar::Util qw(blessed);
+
 sub process {
-    my ($name, $args) = @_;
+    my ($name, $args, $extensions) = @_;
 
-    _entering($name);
+    $extensions //= Bugzilla->extensions;
 
-    foreach my $extension (@{ Bugzilla->extensions }) {
-        if ($extension->can($name)) {
-            $extension->$name($args);
+    my $hook_stack = Bugzilla->request_cache->{hook_stack} ||= [];
+    push @$hook_stack, $name;
+
+    foreach my $extension (@$extensions) {
+        if (my $hook = $extension->can($name)) {
+            $hook->($extension, $args);
         }
     }
 
-    _leaving($name);
+    pop @$hook_stack;
+}
+
+sub collect_wants {
+    my ($name) = @_;
+    my %result;
+
+    foreach my $extension (@{ Bugzilla->extensions }) {
+        my $hook = $extension->can($name);
+        if ($hook) {
+            my $wants = $hook->($extension);
+            foreach my $want (keys %$wants) {
+                if ($wants->{$want}) {
+                    $result{ $want }{ blessed $extension } = 1;
+                }
+            }
+        }
+    }
+
+    return \%result;
 }
 
 sub in {
     my $hook_name = shift;
     my $currently_in = Bugzilla->request_cache->{hook_stack}->[-1] || '';
     return $hook_name eq $currently_in ? 1 : 0;
-}
-
-sub _entering {
-    my ($hook_name) = @_;
-    my $hook_stack = Bugzilla->request_cache->{hook_stack} ||= [];
-    push(@$hook_stack, $hook_name);
-}
-
-sub _leaving {
-    pop @{ Bugzilla->request_cache->{hook_stack} };
 }
 
 1;

--- a/Bugzilla/Template/Context.pm
+++ b/Bugzilla/Template/Context.pm
@@ -69,13 +69,24 @@ sub stash {
     # template object for Throw*Error).
     #
     # Checking Bugzilla::Hook::in prevents infinite recursion on this hook.
-    if ($self->{bz_in_process} and $name =~ /\./
-        and !grep($_ eq $name, @$pre_process)
-        and !Bugzilla::Hook::in('template_before_process'))
+
+    if (    $self->{bz_in_process}
+        and $name =~ /\./
+        and !grep( $_ eq $name, @$pre_process )
+        and !Bugzilla::Hook::in('template_before_process') )
     {
-        Bugzilla::Hook::process("template_before_process",
-                                { vars => $stash, context => $self,
-                                  file => $name });
+        state $WANT = Bugzilla::Hook::collect_wants('template_before_process_wants');
+        if ( $WANT->{$name} ) {
+            my @extensions = grep { $WANT->{$name}{ blessed $_ } } @{ Bugzilla->extensions };
+            Bugzilla::Hook::process(
+                "template_before_process" => {
+                    vars    => $stash,
+                    context => $self,
+                    file    => $name
+                },
+                \@extensions
+            ) if @extensions;
+        }
     }
 
     # This prevents other calls to stash() that might somehow happen

--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -89,6 +89,50 @@ BEGIN {
     *Bugzilla::Attachment::fetch_github_pr_diff     = \&_attachment_fetch_github_pr_diff;
 }
 
+sub template_before_process_wants {
+    return {
+        'bug/create/create-user-engagement.html.tmpl'        => 1,
+        'bug/create/create-employee-incident.html.tmpl'      => 1,
+        'bug/create/create-fxos-mcts-waiver.html.tmpl'       => 1,
+        'bug/create/create-crm.html.tmpl'                    => 1,
+        'bug/create/create-presentation.html.tmpl'           => 1,
+        'bug/create/create-fxos-feature.html.tmpl'           => 1,
+        'bug/create/create-ipc.html.tmpl'                    => 1,
+        'bug/create/create-ipp.html.tmpl'                    => 1,
+        'bug/create/create-mobile-compat.html.tmpl'          => 1,
+        'bug/create/create-mozpr.html.tmpl'                  => 1,
+        'bug/create/create-third-party-apps.html.tmpl'       => 1,
+        'bug/create/create-itrequest.html.tmpl'              => 1,
+        'bug/create/create-fxos-betaprogram.html.tmpl'       => 1,
+        'bug/create/create-trademark.html.tmpl'              => 1,
+        'bug/create/create-dev-engagement-event.html.tmpl'   => 1,
+        'bug/create/create-name-clearance.html.tmpl'         => 1,
+        'list/list.microsummary.tmpl'                        => 1,
+        'bug/create/create-legal.html.tmpl'                  => 1,
+        'bug/create/create-creative.html.tmpl'               => 1,
+        'bug/create/create-swag.html.tmpl'                   => 1,
+        'bug/create/create-doc.html.tmpl'                    => 1,
+        'bug/create/create-web-bounty.html.tmpl'             => 1,
+        'bug/create/create-poweredby.html.tmpl'              => 1,
+        'bug/create/create-fsa-budget.html.tmpl'             => 1,
+        'bug/create/create-automative.html.tmpl'             => 1,
+        'bug/create/create-data-compliance.html.tmpl'        => 1,
+        'bug/create/create-finance.html.tmpl'                => 1,
+        'bug/create/create-nda.html.tmpl'                    => 1,
+        'bug/create/create-fxos-preload-app.html.tmpl'       => 1,
+        'bug/create/create-shield-studies.html.tmpl'         => 1,
+        'bug/create/create-mozlist.html.tmpl'                => 1,
+        'bug/create/create-recoverykey.html.tmpl'            => 1,
+        'bug/create/create-comm-newsletter.html.tmpl'        => 1,
+        'bug/create/create-recruiting.html.tmpl'             => 1,
+        'bug/create/create-intern.html.tmpl'                 => 1,
+        'bug/create/create-screen-share-whitelist.html.tmpl' => 1,
+        'bug/create/create-costume.html.tmpl'                => 1,
+        'bug/create/create-mdn.html.tmpl'                    => 1,
+        'bug/create/create-fxos-partner.html.tmpl'           => 1
+    };
+}
+
 sub template_before_process {
     my ($self, $args) = @_;
     my $file = $args->{'file'};

--- a/extensions/BugModal/Extension.pm
+++ b/extensions/BugModal/Extension.pm
@@ -150,6 +150,17 @@ sub template_after_create {
     );
 }
 
+sub template_before_process_wants {
+    return {
+        'bug/process/header.html.tmpl' => 1,
+        'bug/create/created.html.tmpl' => 1,
+        'attachment/created.html.tmpl' => 1,
+        'attachment/updated.html.tmpl' => 1,
+        'bug_modal/edit.html.tmpl'     => 1,
+        'bug/show-modal.html.tmpl'     => 1,
+    };
+}
+
 sub template_before_process {
     my ($self, $args) = @_;
     my $file = $args->{file};

--- a/extensions/BzAPI/Extension.pm
+++ b/extensions/BzAPI/Extension.pm
@@ -46,6 +46,10 @@ sub install_filesystem {
 # Template Hooks #
 ##################
 
+sub template_before_process_wants {
+    return { 'config.json.tmpl' => 1 };
+}
+
 sub template_before_process {
     my ($self, $args) = @_;
     my $vars = $args->{'vars'};

--- a/extensions/ComponentWatching/Extension.pm
+++ b/extensions/ComponentWatching/Extension.pm
@@ -131,6 +131,12 @@ sub template_before_create {
     $constants->{REL_COMPONENT_WATCHER} = REL_COMPONENT_WATCHER;
 }
 
+sub template_before_process_wants {
+    return {
+        'admin/components/create.html.tmpl' => 1,
+    }
+}
+
 sub template_before_process {
     my ($self, $args) = @_;
     return unless $args->{file} eq 'admin/components/create.html.tmpl';

--- a/extensions/FlagDefaultRequestee/Extension.pm
+++ b/extensions/FlagDefaultRequestee/Extension.pm
@@ -41,6 +41,12 @@ sub install_update_db {
 # Templates #
 #############
 
+sub template_before_process_wants {
+    return {
+        map { $_ => 1 } FLAGTYPE_TEMPLATES,
+    }
+}
+
 sub template_before_process {
     my ($self, $args) = @_;
     return unless Bugzilla->user->id;

--- a/extensions/FlagTypeComment/Extension.pm
+++ b/extensions/FlagTypeComment/Extension.pm
@@ -70,6 +70,10 @@ sub db_schema_abstract_schema {
 # Templates #
 #############
 
+sub template_before_process_wants {
+    return { map { $_ => 1 } FLAGTYPE_COMMENT_TEMPLATES };
+}
+
 sub template_before_process {
     my ($self, $args) = @_;
     my ($vars, $file) = @$args{qw(vars file)};

--- a/extensions/InlineHistory/Extension.pm
+++ b/extensions/InlineHistory/Extension.pm
@@ -36,6 +36,12 @@ sub template_before_create {
     };
 }
 
+sub template_before_process_wants {
+    return {
+        'bug/edit.html.tmpl' => 1,
+    }
+}
+
 sub template_before_process {
     my ($self, $args) = @_;
     my $file = $args->{'file'};

--- a/extensions/MozReview/Extension.pm
+++ b/extensions/MozReview/Extension.pm
@@ -42,6 +42,16 @@ BEGIN {
     }
 }
 
+sub template_before_process_wants {
+    return {
+        'bug/edit.html.tmpl'          => 1,
+        'bug_modal/header.html.tmpl'  => 1,
+        'bug_modal/edit.html.tmpl'    => 1,
+        'attachment/create.html.tmpl' => 1,
+        'bug/show-header.html.tmpl'   => 1
+    };
+}
+
 sub template_before_process {
     my ($self, $args) = @_;
     my $file = $args->{'file'};

--- a/extensions/OrangeFactor/Extension.pm
+++ b/extensions/OrangeFactor/Extension.pm
@@ -19,6 +19,15 @@ use Bugzilla::Attachment;
 
 our $VERSION = '1.0';
 
+sub template_before_process_wants {
+    return {
+        'bug/show-header.html.tmpl' => 1,
+        'bug/edit.html.tmpl' => 1,
+        'bug_modal/header.html.tmpl' => 1,
+        'bug_modal/edit.html.tmpl' => 1,
+    };
+}
+
 sub template_before_process {
     my ($self, $args) = @_;
     my $file = $args->{'file'};

--- a/extensions/SecureMail/Extension.pm
+++ b/extensions/SecureMail/Extension.pm
@@ -216,6 +216,13 @@ sub user_preferences {
     $$handled = 1;
 }
 
+sub template_before_process_wants {
+    return {
+        'email/bugmail.html.tmpl' => 1,
+        'email/bugmail.txt.tmpl'  => 1,
+    };
+}
+
 sub template_before_process {
     my ($self, $args) = @_;
     my $file = $args->{'file'};

--- a/extensions/ShadowBugs/Extension.pm
+++ b/extensions/ShadowBugs/Extension.pm
@@ -45,6 +45,14 @@ sub _cf_shadow_bug_obj {
     return $self->{cf_shadow_bug_obj} ||= Bugzilla::Bug->new($self->cf_shadow_bug);
 }
 
+sub template_before_process_wants {
+    return {
+        'bug/edit.html.tmpl' => 1,
+        'bug/show.html.tmpl' => 1,
+        'bug/show-header.html.tmpl' => 1,
+    };
+}
+
 sub template_before_process {
     my ($self, $args) = @_;
     my $file = $args->{'file'};

--- a/extensions/SiteMapIndex/Extension.pm
+++ b/extensions/SiteMapIndex/Extension.pm
@@ -45,6 +45,12 @@ use POSIX;
 # Pages #
 #########
 
+sub template_before_process_wants {
+    return {
+        'global/header.html.tmpl' => 1,
+    }
+}
+
 sub template_before_process {
     my ($self, $args) = @_;
     my ($vars, $file) = @$args{qw(vars file)};

--- a/extensions/TrackingFlags/Extension.pm
+++ b/extensions/TrackingFlags/Extension.pm
@@ -69,6 +69,17 @@ sub page_before_template {
     }
 }
 
+sub template_before_process_wants {
+    return {
+        'bug/edit.html.tmpl'           => 1,
+        'email/bugmail.txt.tmpl'       => 1,
+        'email/bugmail.html.tmpl'      => 1,
+        'bug/show.xml.tmpl'            => 1,
+        'list/edit-multiple.html.tmpl' => 1,
+        'bug/create/create.html.tmpl'  => 1,
+    };
+}
+
 sub template_before_process {
     my ($self, $args) = @_;
     my $file = $args->{'file'};

--- a/extensions/Voting/Extension.pm
+++ b/extensions/Voting/Extension.pm
@@ -221,6 +221,11 @@ sub template_before_create {
     $constants->{DEFAULT_VOTES_PER_BUG} = DEFAULT_VOTES_PER_BUG;
 }
 
+sub template_before_process_wants {
+    return {
+        'admin/users/confirm-delete.html.tmpl' => 1
+    }
+}
 
 sub template_before_process {
     my ($self, $args) = @_;


### PR DESCRIPTION
We can skip a lot of method calls if extensions must declare what
templates they act on.