### PR TITLE
Bug 1355100 - Add rel=nofollow to all external links in bug comments

### DIFF
--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -200,7 +200,7 @@ sub quoteUrls {
     my $safe_protocols = SAFE_URL_REGEXP();
     $text =~ s~\b($safe_protocols)
               ~($tmp = html_quote($1)) &&
-               ($things[$count++] = "<a href=\"$tmp\">$tmp</a>") &&
+               ($things[$count++] = "<a rel="nofollow" href=\"$tmp\">$tmp</a>") &&
                ("\x{FDD2}" . ($count-1) . "\x{FDD3}")
               ~egox;
 

--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -200,7 +200,7 @@ sub quoteUrls {
     my $safe_protocols = SAFE_URL_REGEXP();
     $text =~ s~\b($safe_protocols)
               ~($tmp = html_quote($1)) &&
-               ($things[$count++] = "<a rel="nofollow" href=\"$tmp\">$tmp</a>") &&
+               ($things[$count++] = "<a rel=\"nofollow\" href=\"$tmp\">$tmp</a>") &&
                ("\x{FDD2}" . ($count-1) . "\x{FDD3}")
               ~egox;
 


### PR DESCRIPTION
Bug Desc: [Bug 1355100](https://bugzilla.mozilla.org/show_bug.cgi?id=1355100)
Refer https://support.google.com/webmasters/answer/96569\?hl\=en
