### PR TITLE
Bug 1360675 - Bugzilla->clear_request_cache: add option to preserve some keys in the request cache

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -710,7 +710,11 @@ sub audit {
 use constant request_cache => Bugzilla::Install::Util::_cache();
 
 sub clear_request_cache {
-    %{ request_cache() } = ();
+    my ($class, %option) = @_;
+    my $request_cache = request_cache();
+    my @except        = $option{except} ? @{ $option{except} } : ();
+
+    %{ $request_cache } = map { $_ => $request_cache->{$_} } @except;
 }
 
 # This is a per-process cache.  Under mod_cgi it's identical to the


### PR DESCRIPTION
Instead of setting the request cache to an empty list, we set it to a list
k/v pairs built as a map over the 'except' option (which defaults to nothing)