### PR TITLE
Bug 1368739 - Make OrangeFactor extension work with SSO

### DIFF
--- a/extensions/OrangeFactor/web/js/orange_factor.js
+++ b/extensions/OrangeFactor/web/js/orange_factor.js
@@ -74,6 +74,9 @@ $(function() {
         var bugId = document.forms['changeform'].id.value;
         var request = {
             dataType: "json",
+            xhrFields: {
+                withCredentials: true
+            },
             url: "https://brasstacks.mozilla.com/orangefactor/api/count?" +
                  "bugid=" + encodeURIComponent(bugId) + "&tree=trunk"
         };
@@ -82,8 +85,7 @@ $(function() {
                 getOrangeCount(data);
             })
             .fail(function() {
-                $('#graph-count').hide();
-                $('#orange-graph').hide()
+                $('#orange-count').text('Please sign into OrangeFactor first');
             });
     }
 


### PR DESCRIPTION
OrangeFactor is now behind SSO, so cross-origin requests to the API must use `withCredentials` to ensure the session cookie is sent if it exists. OrangeFactor's API permits this via appropriately set `Access-Control-Allow-{Origin,Credentials}` headers.

Users will also now be reminded about the need to sign in via OrangeFactor first.

Unfortunately there's no way to catch the SSO HTTP 302 separately from other failure modes, since:
(a) the `XMLHttpRequest` spec doesn't allow for telling if a request redirected
(b) the workaround (sniffing content-type of the response and seeing if it's `text/html` rather than `application/json`) isn't possible since BMO's CSP blocks the request to auth0.com.

...however this extension is going to be replaced once OrangeFactor is decommissioned, so meh.

The redundant hiding of `#orange-graph` has also been removed.