### PR TITLE
Bug 1364634 - Point people to the editbugs request component instead of the mailing list

### DIFF
--- a/extensions/BMO/template/en/default/pages/get_permissions.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/get_permissions.html.tmpl
@@ -18,8 +18,10 @@
 </p>
 
 <p>
-  If you want <kbd>editbugs</kbd>, email <a href="mailto:bmo-perms@mozilla.org">
-  bmo-perms@mozilla.org</a> either:
+  If you want <kbd>editbugs</kbd>, open a
+  <a href="enter_bug.cgi?assigned_to=nobody%40mozilla.org&bug_file_loc=http%3A%2F%2F&bug_ignored=0&bug_severity=normal&bug_status=NEW&cf_fx_iteration=---&cf_fx_points=---&component=Editbugs%20Requests&contenttypemethod=autodetect&contenttypeselection=text%2Fplain&defined_groups=1&flag_type-4=X&flag_type-607=X&flag_type-791=X&flag_type-800=X&flag_type-803=X&flag_type-916=X&form_name=enter_bug&maketemplate=Remember%20values%20as%20bookmarkable%20template&op_sys=Unspecified&priority=--&product=bugzilla.mozilla.org&rep_platform=Unspecified&target_milestone=---&version=Production">
+    new bug requesting permissions
+  </a> with either:
   <ul>
     <li>
       The URLs of two [% terms.bugs %] to which you have attached patches

--- a/extensions/BMO/template/en/default/pages/get_permissions.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/get_permissions.html.tmpl
@@ -17,9 +17,11 @@
   the <a href="page.cgi?id=triage_request.html">triage request form</a>.
 </p>
 
+[% editbugs = "enter_bug.cgi?assigned_to=nobody%40mozilla.org&bug_file_loc=http%3A%2F%2F&bug_ignored=0&bug_severity=normal&bug_status=NEW&cf_fx_iteration=---&cf_fx_points=---&component=Editbugs%20Requests&contenttypemethod=autodetect&contenttypeselection=text%2Fplain&defined_groups=1&flag_type-4=X&flag_type-607=X&flag_type-791=X&flag_type-800=X&flag_type-803=X&flag_type-916=X&form_name=enter_bug&maketemplate=Remember%20values%20as%20bookmarkable%20template&op_sys=Unspecified&priority=--&product=bugzilla.mozilla.org&rep_platform=Unspecified&target_milestone=---&version=Production" %]
+
 <p>
   If you want <kbd>editbugs</kbd>, open a
-  <a href="enter_bug.cgi?assigned_to=nobody%40mozilla.org&amp;bug_file_loc=http%3A%2F%2F&amp;bug_ignored=0&amp;bug_severity=normal&amp;bug_status=NEW&amp;cf_fx_iteration=---&amp;cf_fx_points=---&amp;component=Editbugs%20Requests&amp;contenttypemethod=autodetect&amp;contenttypeselection=text%2Fplain&amp;defined_groups=1&amp;flag_type-4=X&amp;flag_type-607=X&amp;flag_type-791=X&amp;flag_type-800=X&amp;flag_type-803=X&amp;flag_type-916=X&amp;form_name=enter_bug&amp;maketemplate=Remember%20values%20as%20bookmarkable%20template&amp;op_sys=Unspecified&amp;priority=--&amp;product=bugzilla.mozilla.org&amp;rep_platform=Unspecified&amp;target_milestone=---&amp;version=Production">
+  <a href=[% editbugs FILTER html %]>
     new bug requesting permissions
   </a> with either:
   <ul>

--- a/extensions/BMO/template/en/default/pages/get_permissions.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/get_permissions.html.tmpl
@@ -21,7 +21,7 @@
 
 <p>
   If you want <kbd>editbugs</kbd>, open a
-  <a href=[% editbugs FILTER html %]>
+  <a href="[% editbugs FILTER html %]">
     new bug requesting permissions
   </a> with either:
   <ul>

--- a/extensions/BMO/template/en/default/pages/get_permissions.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/get_permissions.html.tmpl
@@ -19,7 +19,7 @@
 
 <p>
   If you want <kbd>editbugs</kbd>, open a
-  <a href="enter_bug.cgi?assigned_to=nobody%40mozilla.org&bug_file_loc=http%3A%2F%2F&bug_ignored=0&bug_severity=normal&bug_status=NEW&cf_fx_iteration=---&cf_fx_points=---&component=Editbugs%20Requests&contenttypemethod=autodetect&contenttypeselection=text%2Fplain&defined_groups=1&flag_type-4=X&flag_type-607=X&flag_type-791=X&flag_type-800=X&flag_type-803=X&flag_type-916=X&form_name=enter_bug&maketemplate=Remember%20values%20as%20bookmarkable%20template&op_sys=Unspecified&priority=--&product=bugzilla.mozilla.org&rep_platform=Unspecified&target_milestone=---&version=Production">
+  <a href="enter_bug.cgi?assigned_to=nobody%40mozilla.org&amp;bug_file_loc=http%3A%2F%2F&amp;bug_ignored=0&amp;bug_severity=normal&amp;bug_status=NEW&amp;cf_fx_iteration=---&amp;cf_fx_points=---&amp;component=Editbugs%20Requests&amp;contenttypemethod=autodetect&amp;contenttypeselection=text%2Fplain&amp;defined_groups=1&amp;flag_type-4=X&amp;flag_type-607=X&amp;flag_type-791=X&amp;flag_type-800=X&amp;flag_type-803=X&amp;flag_type-916=X&amp;form_name=enter_bug&amp;maketemplate=Remember%20values%20as%20bookmarkable%20template&amp;op_sys=Unspecified&amp;priority=--&amp;product=bugzilla.mozilla.org&amp;rep_platform=Unspecified&amp;target_milestone=---&amp;version=Production">
     new bug requesting permissions
   </a> with either:
   <ul>


### PR DESCRIPTION
As specified in [Bug: 1364634](https://bugzilla.mozilla.org/show_bug.cgi?id=1364634), the link to `editbugs` in `get_permissions.html.tmpl` has been updated successfully.
