### PR TITLE
Fix bug #1370378 - Add Phabricator Extension enabled flag to instantly toggle off all Phabricator syncing. r?dkl

### DIFF
--- a/extensions/PhabBugz/Extension.pm
+++ b/extensions/PhabBugz/Extension.pm
@@ -22,9 +22,11 @@ sub config_add_panels {
 
 sub auth_delegation_confirm {
     my ($self, $args) = @_;
+    my $phab_enabled      = Bugzilla->params->{phabricator_enabled};
     my $phab_callback_url = Bugzilla->params->{phabricator_auth_callback_url};
     my $phab_app_id       = Bugzilla->params->{phabricator_app_id};
 
+    return unless $phab_enabled;
     return unless $phab_callback_url;
     return unless $phab_app_id;
 

--- a/extensions/PhabBugz/bin/update_project_members.pl
+++ b/extensions/PhabBugz/bin/update_project_members.pl
@@ -27,6 +27,10 @@ Bugzilla->usage_mode(USAGE_MODE_CMDLINE);
 
 my ($phab_uri, $phab_api_key, $phab_sync_groups, $ua);
 
+if (!Bugzilla->params->{phabricator_enabled}) {
+    exit;
+}
+
 # Sanity checks
 unless ($phab_uri = Bugzilla->params->{phabricator_base_uri}) {
     ThrowUserError('invalid_phabricator_uri');

--- a/extensions/PhabBugz/lib/Config.pm
+++ b/extensions/PhabBugz/lib/Config.pm
@@ -20,6 +20,11 @@ sub get_param_list {
 
     my @params = (
         {
+            name    => 'phabricator_enabled',
+            type    => 'b',
+            default => 0
+        },
+        {
             name    => 'phabricator_base_uri',
             type    => 't',
             default => '',

--- a/extensions/PhabBugz/template/en/default/admin/params/phabbugz.html.tmpl
+++ b/extensions/PhabBugz/template/en/default/admin/params/phabbugz.html.tmpl
@@ -13,6 +13,7 @@
 
 [%
    param_descs = {
+     phabricator_enabled     => 'Enable Phabricator Integration',
      phabricator_base_uri    => 'Phabricator Base URI',
      phabricator_api_key     => 'Phabricator User API Key',
      phabricator_sync_groups => 'Comma delimited list of Bugzilla groups to sync to Phabricator projects',


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1370378