### PR TITLE
Bug 1370973 - Add support for CONNECT proxy (add LWP::Protocol::connect)

### DIFF
--- a/Bugzilla/Install/Requirements.pm
+++ b/Bugzilla/Install/Requirements.pm
@@ -99,7 +99,6 @@ use constant FEATURE_FILES => (
     mfa           => ['Bugzilla/MFA/*.pm'],
     markdown      => ['Bugzilla/Markdown.pm'],
     memcached     => ['Bugzilla/Memcache.pm'],
-    auth_delegation => ['auth.cgi'],
     s3            => ['Bugzilla/S3.pm', 'Bugzilla/S3/Bucket.pm', 'Bugzilla/Attachment/S3.pm']
 );
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -49,11 +49,14 @@ my %requires = (
     'Email::Send'              => '1.911',
     'File::Slurp'              => '9999.13',
     'JSON::XS'                 => '2.01',
+    'LWP::Protocol::connect'   => 0,
+    'LWP::UserAgent'           => '5.835',
     'List::MoreUtils'          => $^V > v5.10.1 ? '0.418' : '0.22',
     'Math::Random::ISAAC'      => '1.0.1',
     'Module::Metadata'         => '1.000033',
     'Module::Runtime'          => 0,
     'Moo'                      => 2,
+    'Mozilla::CA'              => 0,
     'Parse::CPAN::Meta'        => '1.44',
     'Template'                 => '2.24',
     'Text::CSV_XS'             => 0,
@@ -122,10 +125,6 @@ my %optional_features = (
         prereqs     => {
             runtime => { requires => { 'Cache::Memcached::Fast' => '0.17' } }
         }
-    },
-    auth_delegation => {
-        description => 'Auth Delegation',
-        prereqs => { runtime => { requires => { 'LWP::UserAgent' => 0 } } }
     },
     updates => {
         description => 'Automatic Update Notifications',

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -130,7 +130,7 @@ my %optional_features = (
         description => 'Automatic Update Notifications',
         prereqs     => {
             runtime =>
-                { requires => { 'LWP::UserAgent' => 0, 'XML::Twig' => 0 } }
+                { requires => { 'XML::Twig' => 0 } }
         }
     },
     auth_radius => {

--- a/extensions/Bitly/Config.pm
+++ b/extensions/Bitly/Config.pm
@@ -13,23 +13,8 @@ use warnings;
 
 use constant NAME => 'Bitly';
 
-sub REQUIRED_MODULES {
-    return [
-        {
-            package => 'LWP',
-            module  => 'LWP',
-            version => '5.835',
-        },
-    ];
-}
-
-use constant OPTIONAL_MODULES => [
-    {
-        package => 'Mozilla-CA',
-        module  => 'Mozilla::CA',
-        version => 0
-    },
-];
+use constant REQUIRED_MODULES => [];
+use constant OPTIONAL_MODULES => [];
 
 use constant API_VERSION_MAP  => { '1_0' => '1_0' };
 


### PR DESCRIPTION
This patch:

1. adds LWP::Protocol::connect
2. moves LWP::UserAgent (also known as 'LWP') and Mozilla::CA from Bitly (which required the specific version) to the main, always-required part of Makefile.PL. 
3. Removes LWP::UserAgent from the 'updates' feature
4. As auth_delegation now doesn't require anything that isn't always present, there is no reason to define it as a 'feature' in Makefile.PL so that is also removed.

I've also pushed this to the 'carton' branch, and started a new build of the vendored dependencies. I'll update this bug with a link to build results shortly. (probably it will take an hour to finish building).