### PR TITLE
Bug 1372539 - Fix incorrect caching on bzapi/configuration

### DIFF
--- a/extensions/BzAPI/lib/Resources/Bugzilla.pm
+++ b/extensions/BzAPI/lib/Resources/Bugzilla.pm
@@ -59,7 +59,7 @@ sub get_configuration {
     my $user   = Bugzilla->user;
     my $params = Bugzilla->input_params;
 
-    my $can_cache = not exists $params->{product} and not exists $params->{flags};
+    my $can_cache = !exists $params->{product} && !exists $params->{flags};
     my $cache_key = 'bzapi_get_configuration';
 
     if ($can_cache) {


### PR DESCRIPTION
I made a rookie mistake and confused the precedence of and/not vs. &&/!. Using && and ! results in the desired behavior.