### PR TITLE
Bug 1372363 - Fix BMO defaults (bug modal pref, needinfo exclusions)

### DIFF
--- a/extensions/BugModal/Extension.pm
+++ b/extensions/BugModal/Extension.pm
@@ -325,7 +325,7 @@ sub install_before_final_checks {
     add_setting({
         name     => 'ui_experiments',
         options  => ['on', 'off'],
-        default  => 'off',
+        default  => 'on',
         category => 'User Interface'
     });
     add_setting({

--- a/extensions/Needinfo/Extension.pm
+++ b/extensions/Needinfo/Extension.pm
@@ -39,6 +39,8 @@ sub install_update_db {
     print "Creating needinfo flag ... " . 
           "enable the Needinfo feature by editing the flag's properties.\n";
 
+    # inclusions 0:0 maps to __ANY__ : __ANY__ in the UI,
+    # meaning needinfo is enabled for all products and components by default
     my $flagtype = Bugzilla::FlagType->create({
         name        => 'needinfo',
         description => "Set this flag when the bug is in need of additional information",

--- a/extensions/Needinfo/Extension.pm
+++ b/extensions/Needinfo/Extension.pm
@@ -39,8 +39,6 @@ sub install_update_db {
     print "Creating needinfo flag ... " . 
           "enable the Needinfo feature by editing the flag's properties.\n";
 
-    # Initially populate the list of exclusions as __Any__:__Any__ to
-    # allow admin to decide which products to enable the flag for.
     my $flagtype = Bugzilla::FlagType->create({
         name        => 'needinfo',
         description => "Set this flag when the bug is in need of additional information",
@@ -53,8 +51,8 @@ sub install_update_db {
         is_multiplicable => 0,
         request_group    => '',
         grant_group      => '',
-        inclusions       => [],
-        exclusions       => ['0:0'],
+        inclusions       => ['0:0'],
+        exclusions       => [],
     });
 }
 


### PR DESCRIPTION
By default, include needinfo everywhere.
Also set the default for bug modal to on.