### PR TITLE
Bug 1373295 - Encoded slashes in url allow misleading text on unstyled 404 pages due to AllowEncodedSlashes

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -11,11 +11,6 @@
 AddType image/x-icon .ico
 AddType application/font-woff .woff
 
-ErrorDocument 401 /errors/401.html
-ErrorDocument 403 /errors/403.html
-ErrorDocument 404 /errors/404.html
-ErrorDocument 500 /errors/500.html
-
 Redirect permanent /queryhelp.cgi https://bugzilla.mozilla.org/query.cgi?format=advanced&help=1
 Redirect permanent /bug_status.html https://bugzilla.mozilla.org/page.cgi?id=fields.html
 Redirect permanent /bugwritinghelp.html https://bugzilla.mozilla.org/page.cgi?id=bug-writing.html

--- a/Bugzilla/ModPerl.pm
+++ b/Bugzilla/ModPerl.pm
@@ -72,6 +72,10 @@ __DATA__
 # the built-in rand(), even though we never use it in Bugzilla itself,
 # so we need to srand() both of them.)
 PerlChildInitHandler "sub { Bugzilla::RNG::srand(); srand(); }"
+ErrorDocument 401 /errors/401.html
+ErrorDocument 403 /errors/403.html
+ErrorDocument 404 /errors/404.html
+ErrorDocument 500 /errors/500.html
 
 <Directory "[% cgi_path %]">
     AddHandler perl-script .cgi

--- a/Bugzilla/ModPerl.pm
+++ b/Bugzilla/ModPerl.pm
@@ -74,7 +74,7 @@ __DATA__
 PerlChildInitHandler "sub { Bugzilla::RNG::srand(); srand(); }"
 
 # It is important to specify ErrorDocuments outside of all directories.
-# These used to be in .htaccess, but then things like AllowEncodedSlashes no
+# These used to be in .htaccess, but then things like "AllowEncodedSlashes no"
 # mean that urls containing %2f are unstyled.
 ErrorDocument 401 /errors/401.html
 ErrorDocument 403 /errors/403.html

--- a/Bugzilla/ModPerl.pm
+++ b/Bugzilla/ModPerl.pm
@@ -72,6 +72,10 @@ __DATA__
 # the built-in rand(), even though we never use it in Bugzilla itself,
 # so we need to srand() both of them.)
 PerlChildInitHandler "sub { Bugzilla::RNG::srand(); srand(); }"
+
+# It is important to specify ErrorDocuments outside of all directories.
+# These used to be in .htaccess, but then things like AllowEncodedSlashes no
+# mean that urls containing %2f are unstyled.
 ErrorDocument 401 /errors/401.html
 ErrorDocument 403 /errors/403.html
 ErrorDocument 404 /errors/404.html


### PR DESCRIPTION
So the fix here is to give an ErrorDocument outside of any <Directory>,
as the "global" level ErrorDocument is what AllowEncodedSlashes wants to use.