### PR TITLE
replace perltidyrc with on that specifies -pbp with two exceptions

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -1,16 +1,3 @@
---block-brace-tightness=0
---brace-tightness=1
---continuation-indentation=2
---indent-columns=4
---line-up-parentheses
---maximum-line-length=120
---noblanks-before-blocks
---opening-brace-always-on-right
---opening-token-right
---paren-tightness=2
---square-bracket-tightness=2
---stack-closing-tokens
---stack-opening-tokens
---vertical-tightness-closing=2
---vertical-tightness=2
---want-break-after="."
+--perl-best-practices
+--brace-vertical-tightness=0 # always break after {
+--maximum-line-length=120    # max line length is 120


### PR DESCRIPTION
previously, the perltidyrc was written with the original recommendations of the
upstream bugzilla project. The style used there is... inconsistent at best. For
a while now, I've been using perltidy -pbp and telling others to do the same for
new code. However there are two exceptions to -pbp that are widely useful:

1. line length can be up to 120.
2. brace vertical tigntness is turned off.
   This means that there is always a newline after the { in a multi-line brace
   construct.