### PR TITLE
Bug 1380531 - Write initial CircleCI configuration for BMO

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,25 @@
+# References:
+# 1. https://circleci.com/blog/how-to-build-a-docker-image-on-circleci-2-0/
+# 2. https://circleci.com/docs/2.0/building-docker-images/
+#
+
+version: 2
+jobs:
+  build:
+    working_directory: /app
+    docker:
+      - image: docker:17.06.1-ce
+        environment:
+          BMO_IMAGE_NAME: mozillabteam/bmo
+    steps:
+      - setup_remote_docker
+      - run:
+          name: install git and ssh
+          command: apk update && apk add git openssh-client
+      - checkout
+      - run: |
+          docker build -t $BMO_IMAGE_NAME:$CIRCLE_BRANCH .
+          if [[ -n "$DOCKER_USER" && -n "$DOCKER_PASS" ]]; then
+            docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
+            docker push $BMO_IMAGE_NAME:$CIRCLE_BRANCH
+          fi

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ indent_style = space
 indent_size = 4
 
 # 2 space indentation style for .tmpl files
-[.tmpl]
+[.{tmpl,yml}]
 indent_style = space
 indent_size = 2
 

--- a/Bugzilla/Install/Localconfig.pm
+++ b/Bugzilla/Install/Localconfig.pm
@@ -44,11 +44,16 @@ sub _sensible_group {
 }
 
 sub _migrate_param {
-  my ($name, $fallback_value) = @_;
+    my ( $name, $fallback_value ) = @_;
 
-  return sub {
-      return Bugzilla->params->{$name} // $fallback_value;
-  };
+    return sub {
+        if ( Bugzilla->can('params') ) {
+            return Bugzilla->params->{$name} // $fallback_value;
+        }
+        else {
+            return $fallback_value;
+        }
+    };
 }
 
 use constant LOCALCONFIG_VARS => (

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-FROM centos:6.7
+FROM mozillabteam/bmo-base:slim
 MAINTAINER Dylan William Hardison <dylan@mozilla.com>
 
-RUN yum update -y && \
-    yum install -y perl perl-core mod_perl httpd wget tar openssl mysql-libs gd git && \
-    wget -q https://s3.amazonaws.com/moz-devservices-bmocartons/bmo/vendor.tar.gz && \
-    tar -C /opt -zxvf /vendor.tar.gz bmo/local/ bmo/LIBS.txt bmo/cpanfile bmo/cpanfile.snapshot && \
+RUN wget -q https://s3.amazonaws.com/moz-devservices-bmocartons/bmo/vendor.tar.gz && \
+    tar -C /opt -zxf /vendor.tar.gz bmo/local/ bmo/LIBS.txt bmo/cpanfile bmo/cpanfile.snapshot && \
     rm /vendor.tar.gz && \
     mkdir /opt/bmo/httpd && \
     ln -s /usr/lib64/httpd/modules /opt/bmo/httpd/modules && \
@@ -12,21 +10,7 @@ RUN yum update -y && \
     cp {/etc/httpd/conf,/opt/bmo/httpd}/magic && \
     awk '{print $1}' > LIBS.txt \
         | perl -nE 'chomp; unless (-f $_) { $missing++; say $_ } END { exit 1 if $missing }' && \
-    useradd -u 10001 -U app -m && \
-    curl -L https://cpanmin.us > /usr/local/bin/cpanm && \
-    chmod 755 /usr/local/bin/cpanm && \
-    mkdir /opt/bmo/build && \
-    rpm -qa > /tmp/rpms.list && \
-    yum install -y gcc mod_perl-devel && \
-    cpanm -l /opt/bmo/build --notest Apache2::SizeLimit && \
-    yum erase -y $(rpm -qa | diff -u - /tmp/rpms.list | sed -n '/^-[^-]/ s/^-//p') && \
-    rm -rf /opt/bmo/build/lib/perl5/{CPAN,Parse,JSON,ExtUtils} && \
-    mkdir /usr/local/share/perl5 && \
-    mv /opt/bmo/build/lib/perl5/x86_64-linux-thread-multi/ /usr/local/lib64/perl5/ && \
-    mv /opt/bmo/build/lib/perl5/Linux /usr/local/share/perl5/ && \
-    rm -vfr /opt/bmo/build && \
-    rm /tmp/rpms.list /usr/local/bin/cpanm && \
-    yum clean all -y
+    useradd -u 10001 -U app -m
 
 COPY . /app
 WORKDIR /app

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@ BMO: bugzilla.mozilla.org
 
 BMO is Mozilla's highly customized version of Bugzilla.
 
+.. image:: https://circleci.com/gh/mozilla-bteam/bmo/tree/master.svg?style=svg
+    :target: https://circleci.com/gh/mozilla-bteam/bmo/tree/master
+
 .. contents::
 ..
     1  Using Vagrant (For Development)

--- a/docker_files/init.pl
+++ b/docker_files/init.pl
@@ -31,7 +31,8 @@ foreach my $key (keys %ENV) {
 }
 
 write_localconfig(\%localconfig);
-system("perl", "checksetup.pl", "--no-templates", "--no-permissions", '--no-assets');
+sleep(10);
+system('perl', 'checksetup.pl', '--no-templates', '--no-permissions');
 
 my $cmd = shift @ARGV or die "usage: init.pl CMD";
 my $method = "run_$cmd";

--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -2544,8 +2544,11 @@ sub install_filesystem {
     my $contribute = eval {
         $json->decode(scalar read_file(bz_locations()->{cgi_path} . "/contribute.json"));
     };
-    my $commit = `git rev-parse HEAD`;
-    chomp $commit;
+    my $commit = $ENV{CIRCLE_SHA1};
+    unless ($commit) {
+        $commit = `git rev-parse HEAD`;
+        chomp $commit;
+    }
 
     if (!$contribute) {
         die "Missing or invalid contribute.json file";
@@ -2555,7 +2558,7 @@ sub install_filesystem {
         source  => $contribute->{repository}{url},
         version => BUGZILLA_VERSION,
         commit  => $commit // "unknown",
-        build   => $ENV{BUGZILLA_CI_BUILD} // "unknown",
+        build   => $ENV{CIRCLE_BUILD_NUM} // "unknown",
     };
 
     $create_files->{'version.json'} = {

--- a/t/901-secure-mail-loop.t
+++ b/t/901-secure-mail-loop.t
@@ -16,7 +16,7 @@ my $pubring = new Crypt::OpenPGP::KeyRing(Data => PUBLIC_KEY());
 my $pgp = new Crypt::OpenPGP(PubRing => $pubring);
 {
     local $SIG{ALRM} = sub { fail("stuck in a loop"); exit; };
-    alarm(60);
+    alarm(120);
     my $encrypted = $pgp->encrypt(
         Data       => "hello, world",
         Recipients => "@",


### PR DESCRIPTION
This is the first (working) iteration of a configuration that allows
CircleCI to build 'bmo' docker images that are runnable.

Some other changes were required for this:

1. The base image used in Dockerfile was changed from centos:6.7 to
   mozillabteam/bmo-base:slim.
   This is a new version of (github) mozilla-bteam/docker-bmo-base
   which is much smaller, and includes all the system RPMs and other
   bits that our bmo Dockerfile expects.
2. init.pl mistakenly had '--no-assets' which is not currently a checksetup.pl
   option.
3. 901-secure-mail-loop.t (which checks for an infinite loop) had
   to have its timeout increased because CircleCI sometimes is quite slow.
4. version.txt // __version__ now includes build information from CircleCI
   environmental variables
5. editorconfig knows about yml files now.
6. An error where we write out the default localconfig
   configuration when 'Bugzilla.pm' is not loaded was fixed.
   (in Bugzilla/Install/Localconfig.pm)
