### PR TITLE
Bug 1378873 - user autocomplete no longer works for some strings

### DIFF
--- a/Bugzilla/User.pm
+++ b/Bugzilla/User.pm
@@ -215,7 +215,7 @@ sub es_document {
         },
     };
     my $name = $self->name;
-    my @nicks = defined($name) ? ( $name =~ /:(\w+)\b/mg ) : ();
+    my @nicks = extract_nicks($name);
 
     if (@nicks) {
         $doc->{suggest_nick} = {

--- a/Bugzilla/Util.pm
+++ b/Bugzilla/Util.pm
@@ -26,7 +26,7 @@ use base qw(Exporter);
                              validate_email_syntax clean_text
                              get_text template_var disable_utf8
                              enable_utf8 detect_encoding email_filter
-                             round);
+                             round extract_nicks);
 
 use Bugzilla::Constants;
 use Bugzilla::RNG qw(irand);
@@ -881,6 +881,28 @@ sub round {
             : ceil($_ - ROUND_HALF);
     } @_;
     return (wantarray) ? @res : $res[0];
+}
+
+sub extract_nicks {
+    my ($name) = @_;
+    return () unless defined $name;
+    my @nicks = (
+        $name =~ /
+            # This negative lookbehind lets us
+            # match colons that are not followed by numbers.
+            (?<!\d)
+            :
+            # try tp capture a "word", plus some symbols
+            # this covers most everything people use for ircnicks
+            # in bmo.
+            ([\p{IsAlnum}|._-]+)
+            # require a word terminator, which
+            # can be the end of the string or some punctuation.
+            \b
+        /mgx
+    );
+
+    return grep { defined $_ } @nicks;
 }
 
 1;

--- a/t/extract-nicks.t
+++ b/t/extract-nicks.t
@@ -1,0 +1,67 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+use utf8;
+use strict;
+use warnings;
+use 5.10.1;
+use lib qw( . lib local/lib/perl5 );
+use Bugzilla::Util qw(extract_nicks);
+use Test::More;
+binmode STDOUT, ':encoding(utf-8)';
+
+my @expect = (
+    ['dhanesh95'],
+    ['kentuckyfriedtakahe', 'k17e'],
+    ['emceeaich'],
+    ['seban'],
+    ['emceeaich'],
+    ['glob'],
+    ['briansmith', 'bsmith'],
+    ['bz'],
+    ['dkl-test'],
+    ['dylan'],
+    ['7'],
+    ['bwinton'],
+    ['canuckistani'],
+    ['GaryChen', 'PYChen', 'gchen', '陳柏宇'],
+    ['gfx'],
+    ['ted.mielczarek'],
+    [],
+    ['tb-l10n'],
+    ['Gavin'],
+    ['прозвище'],
+
+);
+
+while (<DATA>) {
+    my @nicks = extract_nicks($_);
+    is_deeply(\@nicks, shift @expect);
+}
+
+done_testing;
+
+__DATA__
+Dhanesh Sabane [:dhanesh95] (UTC+5:30)
+Anthony Jones (:kentuckyfriedtakahe, :k17e)
+Emma Humphries' Possibly Evil Twin (don't assign me bugs or needinfo, send those to :emceeaich, I'm just here for testing bmo)
+Sebastin Santy [:seban]
+Emma Humphries ☕️ (she/her) [:emceeaich] (UTC-8) +needinfo me
+Byron Jones ‹:glob›
+Brian Smith (:briansmith, :bsmith, use NEEDINFO?)
+Boris Zbarsky [:bz]
+Dave Lawrence (not real account) [:dkl-test]
+Dylan Hardison [:dylan] (he/him)
+[:7]
+Blake Winton (:bwinton) (:☕️)
+Jeff Griffiths (:canuckistani) (:⚡︎)
+GaryChen [:GaryChen][:PYChen][:gchen][:陳柏宇]
+Mozilla Graphics [:gfx] [:#gfx]
+Ted Mielczarek [:ted.mielczarek]
+Michiel van Leeuwen (email: mvl+moz@)
+Thunderbird Localization Community [:tb-l10n]
+:Gavin Sharp [email: censored@censored.com]
+Ошибка монстра (:прозвище)


### PR DESCRIPTION
Changed up the regex to match a much wider arrange of characters -- all letters, numbers,
and the symbols |._-

Also ignores 5:30 (or other timezones in people's realnames)