### PR TITLE
Bug 1385947 - Make revisions fully public

### DIFF
--- a/extensions/PhabBugz/lib/Util.pm
+++ b/extensions/PhabBugz/lib/Util.pm
@@ -133,8 +133,8 @@ sub make_revision_public {
     return request('differential.revision.edit', {
         transactions => [
             {
-                type  => "view",
-                value => "users"
+                type  => 'view',
+                value => 'public'
             }
         ],
         objectIdentifier => $revision_phid


### PR DESCRIPTION
The `public` value, along with env var config, allows for truly public revisions.