### PR TITLE
Bug 1389372 - Add REST API endpoint to validate whether a BMO user ID can see a given BMO bug

### DIFF
--- a/extensions/PhabBugz/template/en/default/hook/global/user-error-errors.html.tmpl
+++ b/extensions/PhabBugz/template/en/default/hook/global/user-error-errors.html.tmpl
@@ -18,8 +18,22 @@
   [% title = "Invalid Phabricator Sync Groups" %]
   You must provide a comma delimited list of security groups
   to sync with Phabricator.
+
 [% ELSIF error == "invalid_phabricator_revision_id" %]
   [% title = "Invalid Phabricator Revision ID" %]
   You must provide a valid Phabricator revision ID.
+
+[% ELSIF error == "phabricator_not_enabled" %]
+  [% title = "Phabricator Support Not Enabled" %]
+  The Phabricator to Bugzilla library, PhabBugz,
+  is not enabled in Bugzilla.
+
+[% ELSIF error == "phabricator_invalid_request_params" %]
+  [% title = "Incomplete Information Provided by Phabricator" %]
+  The parameters 'user_id' and '[% terms.bug %]_id' must be provided.
+
+[% ELSIF error == "phabricator_unauthorized_user" %]
+  [% title = "Unauthorized User" %]
+  You do not have permission to use this endpoint.
 
 [% END %]


### PR DESCRIPTION
Phabricator will need this endpoint to validate whether a given BMO account ID has permission to view a given BMO bug ID.

To test, comment out the `ThrowUserError('unauthorized_user') unless $user->login eq PHAB_BMO_USER_EMAIL;` line and use cURL to check visibility of public and private bugs:

```
curl -H 'Content-Type: application/json' -H 'Accept: application/json' -H 'X-Bugzilla-API-Key: {api_key}' http://bmo-web.vm/rest/phabbugz/check_bug/{bugid}/{userid}
```