### PR TITLE
use mozillabteam/bmo-slim:20170818.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2
 
 defaults:
   bmo_slim_image: &bmo_slim_image
-    image: mozillabteam/bmo-slim:20170807.1
+    image: mozillabteam/bmo-slim:20170818.1
     user: app
 
   mysql_image: &mysql_image


### PR DESCRIPTION
need to use a newer version of bmo-slim, which includes git. Without git, the "native" circleci is used which has a lot of bugs.