### PR TITLE
Bug 1396957 - Synchronize CC list on security bugs over to revisions as subscribers

### DIFF
--- a/Bugzilla/Config/Common.pm
+++ b/Bugzilla/Config/Common.pm
@@ -30,6 +30,7 @@ use base qw(Exporter);
     check_bug_status check_smtp_auth check_theschwartz_available
     check_maxattachmentsize check_email
     check_comment_taggers_group
+    get_all_group_names
 );
 
 # Checking functions for the various values
@@ -343,6 +344,13 @@ sub check_comment_taggers_group {
         return "Comment tagging requires installation of the JSONRPC feature";
     }
     return check_group($group_name);
+}
+
+sub get_all_group_names {
+    return [
+        '',
+        map { $_->name } Bugzilla::Group->get_all,
+    ];
 }
 
 # OK, here are the parameter definitions themselves.

--- a/Bugzilla/Config/GroupSecurity.pm
+++ b/Bugzilla/Config/GroupSecurity.pm
@@ -29,7 +29,7 @@ sub get_param_list {
         {
             name    => 'chartgroup',
             type    => 's',
-            choices => \&_get_all_group_names,
+            choices => \&get_all_group_names,
             default => 'editbugs',
             checker => \&check_group
         },
@@ -37,7 +37,7 @@ sub get_param_list {
         {
             name    => 'insidergroup',
             type    => 's',
-            choices => \&_get_all_group_names,
+            choices => \&get_all_group_names,
             default => '',
             checker => \&check_group
         },
@@ -45,7 +45,7 @@ sub get_param_list {
         {
             name    => 'timetrackinggroup',
             type    => 's',
-            choices => \&_get_all_group_names,
+            choices => \&get_all_group_names,
             default => 'editbugs',
             checker => \&check_group
         },
@@ -53,7 +53,7 @@ sub get_param_list {
         {
             name    => 'querysharegroup',
             type    => 's',
-            choices => \&_get_all_group_names,
+            choices => \&get_all_group_names,
             default => 'editbugs',
             checker => \&check_group
         },
@@ -61,7 +61,7 @@ sub get_param_list {
         {
             name    => 'comment_taggers_group',
             type    => 's',
-            choices => \&_get_all_group_names,
+            choices => \&get_all_group_names,
             default => 'editbugs',
             checker => \&check_comment_taggers_group
         },
@@ -69,7 +69,7 @@ sub get_param_list {
         {
             name    => 'debug_group',
             type    => 's',
-            choices => \&_get_all_group_names,
+            choices => \&get_all_group_names,
             default => 'admin',
             checker => \&check_group
         },
@@ -89,10 +89,6 @@ sub get_param_list {
     return @param_list;
 }
 
-sub _get_all_group_names {
-    my @group_names = map { $_->name } Bugzilla::Group->get_all;
-    unshift( @group_names, '' );
-    return \@group_names;
-}
+
 
 1;

--- a/extensions/AntiSpam/lib/Config.pm
+++ b/extensions/AntiSpam/lib/Config.pm
@@ -23,7 +23,7 @@ sub get_param_list {
         {
             name => 'antispam_spammer_exclude_group',
             type => 's',
-            choices => \&_get_all_group_names,
+            choices => \&get_all_group_names,
             default => 'canconfirm',
             checker => \&check_group
         },
@@ -77,12 +77,6 @@ sub get_param_list {
     );
 
     return @param_list;
-}
-
-sub _get_all_group_names {
-    my @group_names = map {$_->name} Bugzilla::Group->get_all;
-    unshift(@group_names, '');
-    return \@group_names;
 }
 
 1;

--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -31,7 +31,7 @@ use base qw(Bugzilla::Extension);
 
 use Bugzilla::Bug;
 use Bugzilla::BugMail;
-use Bugzilla::Config::Common qw(check_group);
+use Bugzilla::Config::Common qw(check_group get_all_group_names);
 use Bugzilla::Constants;
 use Bugzilla::Error;
 use Bugzilla::Field;
@@ -2579,7 +2579,7 @@ sub config_modify_panels {
     push @{ $args->{panels}->{groupsecurity}->{params} }, {
         name    => 'delete_comments_group',
         type    => 's',
-        choices => \&Bugzilla::Config::GroupSecurity::_get_all_group_names,
+        choices => \&get_all_group_names,
         default => 'admin',
         checker => \&check_group
     };

--- a/extensions/EditComments/Extension.pm
+++ b/extensions/EditComments/Extension.pm
@@ -249,7 +249,7 @@ sub config_modify_panels {
     push @{ $args->{panels}->{groupsecurity}->{params} }, {
         name    => 'edit_comments_group',
         type    => 's',
-        choices => \&Bugzilla::Config::GroupSecurity::_get_all_group_names,
+        choices => \&get_all_group_names,
         default => 'admin',
         checker => \&check_group
     };

--- a/extensions/PhabBugz/lib/Util.pm
+++ b/extensions/PhabBugz/lib/Util.pm
@@ -202,7 +202,7 @@ sub edit_revision_policy {
 
     if (@$subscribers) {
         push(@{ $data->{transactions} }, {
-            type  => 'subscribers.add',
+            type  => 'subscribers.set',
             value => $subscribers
         });
     }

--- a/extensions/PhabBugz/lib/Util.pm
+++ b/extensions/PhabBugz/lib/Util.pm
@@ -38,6 +38,7 @@ our @EXPORT = qw(
     make_revision_public
     request
     set_project_members
+    set_revision_subscribers
 );
 
 sub get_revisions_by_ids {
@@ -206,6 +207,22 @@ sub edit_revision_policy {
             value => $subscribers
         });
     }
+
+    return request('differential.revision.edit', $data);
+}
+
+sub set_revision_subscribers {
+    my ($revision_phid, $subscribers) = @_;
+
+    my $data = {
+        transactions => [
+            {
+                type  => 'subscribers.set',
+                value => $subscribers
+            }
+        ],
+        objectIdentifier => $revision_phid
+    };
 
     return request('differential.revision.edit', $data);
 }

--- a/extensions/Push/lib/Connector/Phabricator.pm
+++ b/extensions/Push/lib/Connector/Phabricator.pm
@@ -21,8 +21,8 @@ use Bugzilla::User;
 use Bugzilla::Extension::PhabBugz::Constants;
 use Bugzilla::Extension::PhabBugz::Util qw(
   add_comment_to_revision create_private_revision_policy
-  edit_revision_policy get_attachment_revisions get_bug_role_phids 
-  get_revisions_by_ids intersect is_attachment_phab_revision 
+  edit_revision_policy get_attachment_revisions get_bug_role_phids
+  get_revisions_by_ids intersect is_attachment_phab_revision
   make_revision_public make_revision_private);
 use Bugzilla::Extension::Push::Constants;
 use Bugzilla::Extension::Push::Util qw(is_public);
@@ -79,6 +79,12 @@ sub send {
 
         my @revisions = get_attachment_revisions($bug);
         foreach my $revision (@revisions) {
+            Bugzilla->audit(sprintf(
+              'Making revision %s for bug %s private due to unkown Bugzilla groups: %s',
+              $revision->{id},
+              $bug->id,
+              join(', ', @set_groups)
+            ));
             add_comment_to_revision( $revision->{phid}, $phab_error_message );
             make_revision_private( $revision->{phid} );
         }
@@ -115,9 +121,19 @@ sub send {
         my $revision_phid = $revision->{phid};
 
         if ($is_public) {
+            Bugzilla->audit(sprintf(
+              'Making revision %s public for bug %s',
+              $revision->{id},
+              $bug->id
+            ));
             make_revision_public($revision_phid);
         }
         else {
+            Bugzilla->audit(sprintf(
+              'Giving revision %s a custom policy for bug %s',
+              $revision->{id},
+              $bug->id
+            ));
             edit_revision_policy( $revision_phid, $policy_phid, $subscribers );
         }
     }

--- a/extensions/RestrictComments/lib/Config.pm
+++ b/extensions/RestrictComments/lib/Config.pm
@@ -23,26 +23,20 @@ sub get_param_list {
         {
             name => 'restrict_comments_group',
             type => 's',
-            choices => \&_get_all_group_names,
+            choices => \&get_all_group_names,
             default => '',
             checker => \&check_group
         },
         {
             name => 'restrict_comments_enable_group',
             type => 's',
-            choices => \&_get_all_group_names,
+            choices => \&get_all_group_names,
             default => '',
             checker => \&check_group
         },
     );
 
     return @param_list;
-}
-
-sub _get_all_group_names {
-    my @group_names = map {$_->name} Bugzilla::Group->get_all;
-    unshift(@group_names, '');
-    return \@group_names;
 }
 
 1;


### PR DESCRIPTION
- This change will update the subscriber list of the revision when assignee, qa_contact, or cc list members   change since any of those will allow access to the bug.
- I switched to using subscribers.set instead of add in the Conduit API call which will overwrite whatever the current subscriber list is. This works well except in the case where someone adds themself as a subscriber in Phabricator instead of as a CC on the bug.
- TODO: we need to check the group changes in the push connector data to see if the groups actually changed and if not, then just do the subscribers change only. Right now it will create a new custom policy even if groups have not changed. This pollutes the change history of the revision needlessly.