### PR TITLE
Bug 1399519 - Rewrite bugzil.la links to urlbase

### DIFF
--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -199,6 +199,13 @@ sub quoteUrls {
                ("\x{FDD2}" . ($count-1) . "\x{FDD3}")
               ~egox;
 
+    my $urlbase = Bugzilla->params->{'urlbase'};
+    $text =~ s~\bhttps?\Q://bugzil.la/\E([0-9]+)(\#c([0-9]+))?\b
+              ~($things[$count++] = $bug_link_func->($1, "${urlbase}show_bug.cgi?id=$1$2",
+                                               { comment_num => $3, user => $user })) &&
+               ("\x{FDD2}" . ($count-1) . "\x{FDD3}")
+              ~egox;
+
     # non-mailto protocols
     my $safe_protocols = SAFE_URL_REGEXP();
     $text =~ s~\b($safe_protocols)
@@ -900,7 +907,7 @@ sub create {
             html_light => \&Bugzilla::Util::html_light_quote,
 
             email => \&Bugzilla::Util::email_filter,
-            
+
             mtime => \&mtime_filter,
 
             # iCalendar contentline filter


### PR DESCRIPTION
```
10:57 <whimboo> ato: fyi its better on bugzilla to write "bug 1234" because it gets auto-linkified and the summary shown when hovering
10:57 <bugbot> Bug https://bugzilla.mozilla.org/show_bug.cgi?id=1234 CSS Parsing and Computation, normal, peterl-retired, VERIFIED FIXED, we need default style for the html 4 style tags
10:58 <whimboo> with links like https://bugzil.la/1396866 you are forced to click on those to see what's behind
10:58 <ato> whimboo: Not in email. Besides, the URI is canonical.
10:58 <whimboo> who cares about email. intelligent clients should also show a URL
10:59 <ato> Um.
11:01 <dylan> I think he means mouse-over on bugzilla itself, but we can fix that.
```