### PR TITLE
Bug 1404092 - Bugzilla->localconfig should directly use environmental variables and ignore the localconfig file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ defaults:
 
   bmo_env: &bmo_env
     PORT: 8000
+    LOCALCONFIG_ENV: 1
     BMO_db_user: bugs
     BMO_db_host: 127.0.0.1
     BMO_db_pass: bugs
@@ -95,7 +96,6 @@ jobs:
       - run:
           name: run sanity tests
           command: |
-            rm /app/localconfig
             /app/scripts/entrypoint.pl prove -qf $(circleci tests glob 't/*.t' | circleci tests split) | tee artifacts/$CIRCLE_JOB.txt
       - store_artifacts:
           path: /app/artifacts
@@ -108,14 +108,14 @@ jobs:
       - checkout
       - *default_qa_setup
       - run: |
-          rm -f /app/localconfig
           /app/scripts/entrypoint.pl load_test_data
       - run:
           command: |
-            rm -f /app/localconfig
             /app/scripts/entrypoint.pl test_webservices | tee artifacts/$CIRCLE_JOB.txt
       - store_artifacts:
           path: /app/artifacts
+      - store_artifacts:
+          path: /app/logs
 
   test_selenium:
     parallelism: 1
@@ -125,14 +125,14 @@ jobs:
       - checkout
       - *default_qa_setup
       - run: |
-          rm -f /app/localconfig
           /app/scripts/entrypoint.pl load_test_data --legacy
       - run:
           command: |
-            rm -f /app/localconfig
             /app/scripts/entrypoint.pl test_selenium | tee artifacts/$CIRCLE_JOB.txt
       - store_artifacts:
           path: /app/artifacts
+      - store_artifacts:
+          path: /app/logs
 
   test_bmo:
     parallelism: 1
@@ -153,18 +153,16 @@ jobs:
       - checkout
       - run: |
           mv /opt/bmo/local /app/local
-          perl checksetup.pl --no-database --default-localconfig
+          perl checksetup.pl --no-database
           perl -MSys::Hostname -i -pE 's/<<HOSTNAME>>/hostname()/ges' $BZ_QA_ANSWERS_FILE
-          rm -f /app/localconfig
           /app/scripts/entrypoint.pl load_test_data
           mkdir artifacts
       - run: |
           BZ_BASE_URL="http://$(hostname):$PORT"
           export BZ_BASE_URL
-          rm -f /app/localconfig
           /app/scripts/entrypoint.pl test_bmo -q -f t/bmo/*.t
-
-
+      - store_artifacts:
+          path: /app/logs
 
 workflows:
   version: 2

--- a/Bugzilla/Install/Filesystem.pm
+++ b/Bugzilla/Install/Filesystem.pm
@@ -21,7 +21,8 @@ use warnings;
 
 use Bugzilla::Constants;
 use Bugzilla::Error;
-use Bugzilla::Install::Localconfig;
+use Bugzilla::Install::Localconfig qw(ENV_KEYS);
+
 use Bugzilla::Install::Util qw(install_string);
 use Bugzilla::Util;
 use Bugzilla::Hook;
@@ -100,6 +101,14 @@ use constant INDEX_HTML => <<'EOT';
 </body>
 </html>
 EOT
+
+sub HTTPD_ENV_CONF {
+
+    return join( "\n",
+      "PerlPassEnv LOCALCONFIG_ENV",
+      map { "PerlPassEnv " . $_ } ENV_KEYS
+    ) . "\n";
+}
 
 ###############
 # Permissions #
@@ -407,6 +416,9 @@ sub FILESYSTEM {
         "robots.txt"              => { perms     => CGI_READ,
                                        overwrite => 1,
                                        contents  => \&robots_txt},
+        "httpd/env.conf"          => { perms     => CGI_READ,
+                                       overwrite => 1,
+                                       contents  => \&HTTPD_ENV_CONF },
     );
 
     # Because checksetup controls the creation of index.html separately

--- a/Bugzilla/ModPerl/StartupFix.pm
+++ b/Bugzilla/ModPerl/StartupFix.pm
@@ -1,0 +1,43 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+package Bugzilla::ModPerl::StartupFix;
+use 5.10.1;
+use strict;
+use warnings;
+
+use Filter::Util::Call;
+use Apache2::ServerUtil ();
+
+my $FIRST_STARTUP = <<'CODE';
+warn "Bugzilla::ModPerl::StartupFix: Skipping first startup using source filter\n";
+1;
+CODE
+
+sub import {
+    my ($type) = @_;
+    my ($ref)  = {};
+    filter_add( bless $ref );
+}
+
+sub filter {
+    my ($self) = @_;
+    my ($status);
+    if ($status = filter_read() > 0) {
+        if (Apache2::ServerUtil::restart_count() < 2) {
+            if (!$self->{did_it}) {
+                $self->{did_it} = 1;
+                $_ = $FIRST_STARTUP;
+            }
+            else {
+                $_ = "";
+            }
+        }
+    }
+    return $status;
+}
+
+1;

--- a/checksetup.pl
+++ b/checksetup.pl
@@ -149,8 +149,10 @@ Bugzilla->installation_answers($answers_file);
 # Check and update --LOCAL-- configuration
 ###########################################################################
 
-print "Reading " .  bz_locations()->{'localconfig'} . "...\n" unless $silent;
-update_localconfig({ output => !$silent, use_defaults => $switch{'default-localconfig'} });
+unless ($ENV{LOCALCONFIG_ENV}) {
+    print "Reading " .  bz_locations()->{'localconfig'} . "...\n" unless $silent;
+    update_localconfig({ output => !$silent, use_defaults => $switch{'default-localconfig'} });
+}
 my $lc_hash = Bugzilla->localconfig;
 
 ###########################################################################

--- a/httpd/httpd.conf
+++ b/httpd/httpd.conf
@@ -85,6 +85,8 @@ AddType application/x-gzip .gz .tgz
 AddType application/x-x509-ca-cert .crt
 AddType application/x-pkcs7-crl    .crl
 
+Include /app/httpd/env.conf
+
 PerlSwitches -wT
 PerlRequire /app/mod_perl.pl
 DirectoryIndex index.cgi

--- a/mod_perl.pl
+++ b/mod_perl.pl
@@ -76,6 +76,12 @@ my $server = Apache2::ServerUtil->server;
 my $conf = Bugzilla::ModPerl->apache_config($cgi_path);
 $server->add_config([ grep { length $_ } split("\n", $conf)]);
 
+# Pre-load localconfig. It might already be loaded, but we need to make sure.
+Bugzilla->localconfig;
+if ($ENV{LOCALCONFIG_ENV}) {
+    delete @ENV{ (Bugzilla::Install::Localconfig::ENV_KEYS) };
+}
+
 # Pre-load all extensions
 Bugzilla::Extension->load_all();
 

--- a/mod_perl.pl
+++ b/mod_perl.pl
@@ -22,6 +22,8 @@ BEGIN {
     lib->import($dir, File::Spec->catdir($dir, "lib"), File::Spec->catdir($dir, qw(local lib perl5)));
 }
 
+use Bugzilla::ModPerl::StartupFix;
+
 use Bugzilla::Constants ();
 
 # If you have an Apache2::Status handler in your Apache configuration,


### PR DESCRIPTION
This includes a patch from #256 which should land first.