### PR TITLE
Bug 1405011 - Prevent code in mod_perl.pl from executing twice

### DIFF
--- a/Bugzilla/ModPerl/StartupFix.pm
+++ b/Bugzilla/ModPerl/StartupFix.pm
@@ -1,0 +1,43 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+package Bugzilla::ModPerl::StartupFix;
+use 5.10.1;
+use strict;
+use warnings;
+
+use Filter::Util::Call;
+use Apache2::ServerUtil ();
+
+my $FIRST_STARTUP = <<'CODE';
+warn "Bugzilla::ModPerl::StartupFix: Skipping first startup using source filter\n";
+1;
+CODE
+
+sub import {
+    my ($type) = @_;
+    my ($ref)  = {};
+    filter_add( bless $ref );
+}
+
+sub filter {
+    my ($self) = @_;
+    my ($status);
+    if ($status = filter_read() > 0) {
+        if (Apache2::ServerUtil::restart_count() < 2) {
+            if (!$self->{did_it}) {
+                $self->{did_it} = 1;
+                $_ = $FIRST_STARTUP;
+            }
+            else {
+                $_ = "";
+            }
+        }
+    }
+    return $status;
+}
+
+1;

--- a/mod_perl.pl
+++ b/mod_perl.pl
@@ -22,6 +22,8 @@ BEGIN {
     lib->import($dir, File::Spec->catdir($dir, "lib"), File::Spec->catdir($dir, qw(local lib perl5)));
 }
 
+use Bugzilla::ModPerl::StartupFix;
+
 use Bugzilla::Constants ();
 
 # If you have an Apache2::Status handler in your Apache configuration,


### PR DESCRIPTION
The code in mod_perl.pl is executed twice. mod_perl does this to "make sure graceful restarts work".

It isn't clear that this is useful, since we don't use graceful restarts (which are not recommended with apache / mod_perl anyway) and it costs performance.
But more importantly it makes sanitizing %ENV more complicated than it needs to be.

This patch uses a source filter which clears out the rest of the mod_perl.pl during the first apache restart (when restart_count < 2). It includes a warning message so that this won't be a weird to debug problem in the future. Although I doubt it will, since I'm getting the hell off of apache as soon as we're out of scl3.)
