### PR TITLE
Bug 1405754 - Autocomplete failing at random for some nicks (including, and especially bz)

### DIFF
--- a/js/field.js
+++ b/js/field.js
@@ -720,6 +720,7 @@ $(function() {
         paramName: 'match',
         deferRequestBy: 250,
         minChars: 2,
+        noCache: true,
         tabDisabled: true,
         autoSelectFirst: true,
         triggerSelectOnValidInput: false,


### PR DESCRIPTION
Avoid caching search results.