### PR TITLE
no bug - avoid running compile tests in CI

### DIFF
--- a/t/001compile.t
+++ b/t/001compile.t
@@ -17,6 +17,11 @@ use warnings;
 use lib qw(. lib local/lib/perl5 t);
 use Config;
 use Support::Files;
+BEGIN {
+    plan skip_all => 'T::P::C::Progressive required for this test' if $ENV{CI};
+    exit;
+}
+
 use Test::More tests => scalar(@Support::Files::testitems)
                         + scalar(@Support::Files::test_files);
 

--- a/t/001compile.t
+++ b/t/001compile.t
@@ -17,15 +17,14 @@ use warnings;
 use lib qw(. lib local/lib/perl5 t);
 use Config;
 use Support::Files;
+use Test::More;
 BEGIN {
-    plan skip_all => 'T::P::C::Progressive required for this test' if $ENV{CI};
-    exit;
-}
+    if ($ENV{CI}) {
+        plan skip_all => 'Not running compile tests in CI.';
+        exit;
+    }
+    plan tests => @Support::Files::testitems + @Support::Files::test_files;
 
-use Test::More tests => scalar(@Support::Files::testitems)
-                        + scalar(@Support::Files::test_files);
-
-BEGIN { 
     use_ok('Bugzilla::Constants');
     use_ok('Bugzilla::Install::Requirements');
     use_ok('Bugzilla');


### PR DESCRIPTION
This should make tests finish much quicker.
The code is already going to be compiled by other tests, and so most of the time this test is not useful.