### PR TITLE
Bug 1424787 - Due Date on bug modal is 1 day ahead

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
@@ -161,7 +161,7 @@ END;
 
           [% CASE constants.FIELD_TYPE_DATE %]
             [%# date %]
-            [% value FILTER time("%Y-%m-%d") %]
+            <time>[% value FILTER html %]</time>
 
           [% CASE constants.FIELD_TYPE_BUG_ID %]
             [%# bug id %]


### PR DESCRIPTION
Fix [Bug 1424787 - Due Date on bug modal is 1 day ahead](https://bugzilla.mozilla.org/show_bug.cgi?id=1424787)

## Description

* Use the default `html` filter in the same way as the hidden `<input>` field for the due date.
* Enclose the value in the `<time>` element.
* I have added the custom field locally but can't find on bug pages, so not tested this yet actually.