### PR TITLE
add a developer mode to make frontend changes a bit easier

### DIFF
--- a/Bugzilla/Constants.pm
+++ b/Bugzilla/Constants.pm
@@ -222,7 +222,7 @@ use constant LOCAL_FILE  => 'bugzilla-update.xml'; # Relative to datadir.
 # When true CSS and JavaScript assets will be concatanted and minified at
 # run-time, to reduce the number of requests required to render a page.
 # Setting this to a false value can help debugging.
-use constant CONCATENATE_ASSETS => 1;
+use constant CONCATENATE_ASSETS => !$ENV{BUGZILLA_DEVELOPER_MODE};
 
 # These are unique values that are unlikely to match a string or a number,
 # to be used in criteria for match() functions and other things. They start

--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -1148,10 +1148,14 @@ sub create {
     };
 
     # under mod_perl, use a provider (template loader) that preloads all templates into memory
+    my $can_preload = $ENV{MOD_PERL} && !$ENV{BUGZILLA_DEVELOPER_MODE};
     my $provider_class
-        = $ENV{MOD_PERL}
-        ? 'Bugzilla::Template::PreloadProvider'
-        : 'Template::Provider';
+      = $can_preload
+      ? 'Bugzilla::Template::PreloadProvider'
+      : 'Template::Provider';
+
+    # we don't want to cache templates at all in dev mode
+    delete $config->{COMPILE_DIR} if $ENV{BUGZILLA_DEVELOPER_MODE};
 
     # Use a per-process provider to cache compiled templates in memory across
     # requests.

--- a/vagrant_support/apache.j2
+++ b/vagrant_support/apache.j2
@@ -1,4 +1,7 @@
 PerlSwitches -wT
+PerlSetEnv BUGZILLA_DEVELOPER_MODE 1
+PerlSetEnv BUGZILLA_UNSAFE_AUTH_DELEGATION 1
+
 PerlConfigRequire /vagrant/mod_perl.pl
 
 <IfModule mpm_prefork_module>


### PR DESCRIPTION
1. assets are not concatenated
2. templates are not cached in memory or on disk

As a result, templates or js/css can be updated with rsync:

for instance:
```
rsync -vaz --chmod=a+rX template/ web:template/
```