### PR TITLE
Bug 905763 - Fix named anchors in various pages so that the Sandstone theme header can be set to a fixed position

### DIFF
--- a/js/comments.js
+++ b/js/comments.js
@@ -178,23 +178,3 @@ function getText(element) {
     }
     return text;
 }
-
-/**
- * If the URL contains a comment ID like #c10, scroll down the page to show the
- * entire comment below the fixed global header.
- */
-function scroll_comment_into_view() {
-    if (location.hash.match(/^#c\d+$/)) {
-        var $header = document.querySelector('#header');
-        var $comment = document.querySelector(location.hash);
-
-        if ($comment) {
-            window.setTimeout(function() {
-                window.scrollTo(0, $comment.offsetTop - $header.offsetHeight - 20);
-            }, 100);
-        }
-    }
-}
-
-window.addEventListener('load', scroll_comment_into_view, { once: true });
-window.addEventListener('hashchange', scroll_comment_into_view);

--- a/js/global.js
+++ b/js/global.js
@@ -190,3 +190,24 @@ $().ready(function() {
         $('.bz_autocomplete').attr('autocomplete', 'off');
     });
 });
+
+/**
+ * If the URL contains a hash like #c10, scroll down the page to show the
+ * element below the fixed global header. This workaround is required for
+ * comments on show_bug.cgi, components on describecomponents.cgi, etc.
+ */
+const scroll_element_into_view = () => {
+    if (location.hash) {
+        const $header = document.querySelector('#header');
+        const $comment = document.querySelector(location.hash);
+
+        if ($comment) {
+            window.setTimeout(() => {
+                window.scrollTo(0, $comment.offsetTop - $header.offsetHeight - 20);
+            }, 100);
+        }
+    }
+}
+
+window.addEventListener('load', scroll_element_into_view, { once: true });
+window.addEventListener('hashchange', scroll_element_into_view);

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -39,6 +39,7 @@
         font-family: sans-serif;
         color: #000;
         background: #fff url("global/body-back.gif") repeat-x;
+        scroll-behavior: smooth;
     }
     body, td, th, input {
         font-family: Verdana, sans-serif;


### PR DESCRIPTION
Fix [Bug 905763 - Fix named anchors in various pages so that the Sandstone theme header can be set to a fixed position](https://bugzilla.mozilla.org/show_bug.cgi?id=905763)

## Description

* Apply the fixed header + comment focus workaround (added in #289) to any page
* Enable [smooth scroll](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior) for a better experience
* Use ECMAScript 6+, notably [arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) 🎉 