### PR TITLE
Bug 905763 follow-up - Make sure focused comment will always be displayed under global header

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -204,7 +204,7 @@ const scroll_element_into_view = () => {
         if ($comment) {
             window.setTimeout(() => {
                 window.scrollTo(0, $comment.offsetTop - $header.offsetHeight - 20);
-            }, 100);
+            }, 250);
         }
     }
 }


### PR DESCRIPTION
Follow up [Bug 905763 - Fix named anchors in various pages so that the Sandstone theme header can be set to a fixed position](https://bugzilla.mozilla.org/show_bug.cgi?id=905763) / #301

## Description

@dklawren has mentioned on IRC that a focused comment sometimes goes under the new global header when the page is loaded. This extends the `setTimeout` timer in JS a little bit to try fixing the issue.