### PR TITLE
Simplify using Devel::NYTProf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ main_filters: &main_filters
 
 defaults:
   bmo_slim_image: &bmo_slim_image
-    image: mozillabteam/bmo-slim:20170927.1
+    image: mozillabteam/bmo-slim:20171222.1
     user: app
 
   mysql_image: &mysql_image

--- a/Bugzilla/Extension.pm
+++ b/Bugzilla/Extension.pm
@@ -46,7 +46,7 @@ sub INC_HOOK {
                 return 1;
             }
             else {
-                $_ = qq{# line 0 "$real_file"\n};
+                $_ = qq{# line 1 "$real_file"\n};
                 $first = 0;
                 return 1;
             }

--- a/Bugzilla/Template/PreloadProvider.pm
+++ b/Bugzilla/Template/PreloadProvider.pm
@@ -43,7 +43,7 @@ sub _init {
                 }
                 trick_taint($name);
                 my $data = {
-                    name => $key,
+                    name => $name,
                     text => do {
                         open my $fh, '<:utf8', $name or die "cannot open $name";
                         local $/ = undef;

--- a/Bugzilla/Template/PreloadProvider.pm
+++ b/Bugzilla/Template/PreloadProvider.pm
@@ -43,7 +43,8 @@ sub _init {
                 }
                 trick_taint($name);
                 my $data = {
-                    name => $name,
+                    path => $name,
+                    name => $key,
                     text => do {
                         open my $fh, '<:utf8', $name or die "cannot open $name";
                         local $/ = undef;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mozillabteam/bmo-slim:20170927.1
+FROM mozillabteam/bmo-slim:20171222.1
 
 ARG CI
 ARG CIRCLE_SHA1

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -66,6 +66,7 @@ my %requires = (
     'URI'                      => '1.55',
     'version'                  => '0.87',
     'Taint::Util'              => 0,
+    'Devel::NYTProf'           => 0,
 );
 my %build_requires = (
     'ExtUtils::MakeMaker' => '7.22',

--- a/mod_perl.pl
+++ b/mod_perl.pl
@@ -152,7 +152,7 @@ sub handler : method {
         state $count = {};
         my $script = File::Basename::basename($ENV{SCRIPT_FILENAME});
         $script =~ s/\.cgi$//;
-        my $file = bz_locations()->{datadir} . "/nytprof.$script." . ++$count{$$};
+        my $file = bz_locations()->{datadir} . "/nytprof.$script." . ++$count->{$$};
         DB::enable_profile($file);
     }
     Bugzilla::init_page();

--- a/mod_perl.pl
+++ b/mod_perl.pl
@@ -23,6 +23,14 @@ BEGIN {
 }
 
 use Bugzilla::ModPerl::StartupFix;
+use English qw(-no_match_vars $EUID);
+use constant USE_NYTPROF => !! $ENV{USE_NYTPROF};
+BEGIN {
+    if (USE_NYTPROF) {
+        $ENV{NYTPROF} = "savesrc=0:start=no:addpid=0";
+    }
+}
+use if USE_NYTPROF, 'Devel::NYTProf::Apache';
 
 use Bugzilla::Constants ();
 
@@ -122,7 +130,7 @@ package Bugzilla::ModPerl::ResponseHandler;
 use strict;
 use base qw(ModPerl::Registry);
 use Bugzilla;
-use Bugzilla::Constants qw(USAGE_MODE_REST);
+use Bugzilla::Constants qw(USAGE_MODE_REST bz_locations);
 use Time::HiRes;
 
 sub handler : method {
@@ -140,9 +148,20 @@ sub handler : method {
     local *lib::import = sub {};
     use warnings;
 
+    if (Bugzilla::ModPerl::USE_NYTPROF) {
+        state $count = {};
+        my $script = File::Basename::basename($ENV{SCRIPT_FILENAME});
+        $script =~ s/\.cgi$//;
+        my $file = bz_locations()->{datadir} . "/nytprof.$script." . ++$count{$$};
+        DB::enable_profile($file);
+    }
     Bugzilla::init_page();
     my $start = Time::HiRes::time();
     my $result = $class->SUPER::handler(@_);
+    if (Bugzilla::ModPerl::USE_NYTPROF) {
+        DB::disable_profile();
+        DB::finish_profile();
+    }
     warn "[request_time] ", Bugzilla->cgi->request_uri, " took ", Time::HiRes::time() - $start, " seconds to execute";
 
     # When returning data from the REST api we must only return 200 or 304,

--- a/mod_perl.pl
+++ b/mod_perl.pl
@@ -23,11 +23,11 @@ BEGIN {
 }
 
 use Bugzilla::ModPerl::StartupFix;
-use English qw(-no_match_vars $EUID);
+
 use constant USE_NYTPROF => !! $ENV{USE_NYTPROF};
 BEGIN {
     if (USE_NYTPROF) {
-        $ENV{NYTPROF} = "savesrc=0:start=no:addpid=0";
+        $ENV{NYTPROF} = "savesrc=0:start=no:addpid=1";
     }
 }
 use if USE_NYTPROF, 'Devel::NYTProf::Apache';

--- a/vagrant_support/bashrc
+++ b/vagrant_support/bashrc
@@ -8,4 +8,7 @@ fi
 # User specific aliases and functions
 PS1='\[\e[0;31m\]\u\[\e[m\] \[\e[1;34m\]\w\[\e[m\] $ '
 
+export PERL5LIB=/vagrant/local/lib/perl5
+export PATH=/vagrant/local/bin:$PATH
+
 cd /vagrant


### PR DESCRIPTION
This patch adds an environmental variable USE_NYTPROF, that when set causes the apache config to load Devel::NYTProf::Apache. Profiles are stored in the data directory and get relatively unique names (per request).

Additionally, we now pass the full filename to PreloadProvider, and we begin source code lines
at line 1, both of which prevent warnings in Devel::NYTProf.