### PR TITLE
Bug 1427230 - Avoid loading CGI::Carp, which makes templates slow.

### DIFF
--- a/Bugzilla/Sentry.pm
+++ b/Bugzilla/Sentry.pm
@@ -358,9 +358,8 @@ sub _sentry_die_handler {
 }
 
 sub install_sentry_handler {
-    require CGI::Carp;
-    CGI::Carp::set_die_handler(\&_sentry_die_handler);
-    $main::SIG{__WARN__} = sub {
+    $SIG{__DIE__}  = \&sentry_die_handler;
+    $SIG{__WARN__} = sub {
         return if _in_eval();
         sentry_handle_error('warning', shift);
     };

--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -529,6 +529,9 @@ sub process {
     my $current_langs = Bugzilla->request_cache->{template_current_lang} ||= [];
     unshift(@$current_langs, $self->context->{bz_language});
     local $is_processing = 1;
+    local $SIG{__DIE__};
+    delete $SIG{__DIE__};
+    warn "WARNING: CGI::Carp makes templates slow" if $INC{"CGI/Carp.pm"};
     my $retval = $self->SUPER::process(@_);
     shift @$current_langs;
     return $retval;


### PR DESCRIPTION
It's hard to get a single accurate number for this change, but this change
is good:
Most noticeable here:
spent 46.4ms Bugzilla::Template::Plugin::Hook::process
spent 72.2ms  Bugzilla::Template::Plugin::Hook::process

Before:
<img width="1091" alt="screen shot 2017-12-23 at 10 39 27" src="https://user-images.githubusercontent.com/47717/34320788-35cd215e-e7cf-11e7-9678-3fc706170ded.png">

After:
<img width="1156" alt="screen shot 2017-12-23 at 10 40 04" src="https://user-images.githubusercontent.com/47717/34320786-30076eb4-e7cf-11e7-94e0-0f81098a025e.png">