### PR TITLE
Redefine html_quote() in terms of HTML::Escape::escape_html()

### DIFF
--- a/t/007util.t
+++ b/t/007util.t
@@ -35,7 +35,7 @@ my $tz = Bugzilla->local_timezone->short_name_for_datetime(DateTime->new(year =>
 # XXX: test taint functions
 
 #html_quote():
-is(html_quote("<lala&@>"),"&lt;lala&amp;&#64;&gt;",'html_quote');
+is(html_quote("<lala&>"),"&lt;lala&amp;&gt;",'html_quote');
 
 #url_quote():
 is(url_quote("<lala&>gaa\"'[]{\\"),"%3Clala%26%3Egaa%22%27%5B%5D%7B%5C",'url_quote');


### PR DESCRIPTION
This is a lot faster. On show_bug, this is the difference between 11 ms and 584µs

This means we "lose" the Bi-Di stripping from [bug 319331](https://bugzilla.mozilla.org/show_bug.cgi?id=319331)