### PR TITLE
Bug 1426673 - The logout link cannot be found as what Sessions page says

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -192,6 +192,18 @@ $().ready(function() {
 });
 
 /**
+ * Check if Gravatar images on the page are successfully loaded, and if blocked
+ * (by any content blocker), replace them with the default/fallback image.
+ */
+const detect_blocked_gravatars = () => {
+    document.querySelectorAll('img[src^="https://secure.gravatar.com/avatar/"]').forEach($img => {
+        if (!$img.complete || !$img.naturalHeight) {
+            $img.src = 'extensions/Gravatar/web/default.jpg';
+        }
+    });
+}
+
+/**
  * If the URL contains a hash like #c10, scroll down the page to show the
  * element below the fixed global header. This workaround is required for
  * comments on show_bug.cgi, components on describecomponents.cgi, etc.
@@ -209,5 +221,6 @@ const scroll_element_into_view = () => {
     }
 }
 
+window.addEventListener('load', detect_blocked_gravatars, { once: true });
 window.addEventListener('load', scroll_element_into_view, { once: true });
 window.addEventListener('hashchange', scroll_element_into_view);

--- a/template/en/default/account/prefs/sessions.html.tmpl
+++ b/template/en/default/account/prefs/sessions.html.tmpl
@@ -18,7 +18,7 @@
   from that location again you will have to log back in.</p>
 
 <p>Note that you may not logout your current session from this page.
-  You can use the "Logout" link from the top right menu for that.</p>
+  You can use the "Log out" link from the top right Account menu for that.</p>
 
 <h3>Active Sessions</h3>
 


### PR DESCRIPTION
Fix [Bug 1426673 - The logout link cannot be found as what Sessions page says](https://bugzilla.mozilla.org/show_bug.cgi?id=1426673)

## Description

* Show the fallback image on the Account menu if loading of Gravatar is blocked
* Tested with the Ghostery extension and Firefox's built-in Tracking Protection (strict mode)