### PR TITLE
Bug 1428166 - Move <meta charset> to start of <head>

### DIFF
--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -94,6 +94,10 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    [% IF Param('utf8') %]
+      <meta charset="UTF-8">
+    [% END %]
+
     [%- js_BUGZILLA = {
             param => {
                 maxusermatches => Param('maxusermatches'),
@@ -128,10 +132,6 @@
     <meta name="bugzilla-global" content="dummy"
         id="bugzilla-global" data-bugzilla="[% json_encode(js_BUGZILLA) FILTER html %]">
     <title>[% title %]</title>
-
-    [% IF Param('utf8') %]
-      <meta charset="UTF-8">
-    [% END %]
 
     [% IF no_index %]
       <meta name="robots" content="noindex">


### PR DESCRIPTION
The `<meta>` element declaring the encoding must be inside the `<head>` element and **within the first 1024 bytes** of the HTML as some browsers only look at those bytes before choosing an encoding.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-charset