### PR TITLE
Bug 1426414: Send preload headers for webfonts

### DIFF
--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -521,7 +521,7 @@ sub header {
         "skins/standard/fonts/FiraSans-SemiBold.woff2?v=4.203",
         "skins/standard/fonts/MaterialIcons-Regular.woff2",
     );
-    $headers{'-link'} = join(", ", map { sprintf('</static/v%s/%s>; rel="preload"; as="font";', BUGZILLA->VERSION, $_) } @fonts);
+    $headers{'-link'} = join(", ", map { sprintf('</static/v%s/%s>; rel="preload"; as="font"', Bugzilla->VERSION, $_) } @fonts);
 
     return $self->SUPER::header(%headers) || "";
 }

--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -513,6 +513,16 @@ sub header {
     );
     $self->{_header_done} = 1;
 
+    my @fonts = (
+        "skins/standard/fonts/FiraMono-Regular.woff2?v=3.202",
+        "skins/standard/fonts/FiraSans-Bold.woff2?v=4.203",
+        "skins/standard/fonts/FiraSans-Italic.woff2?v=4.203",
+        "skins/standard/fonts/FiraSans-Regular.woff2?v=4.203",
+        "skins/standard/fonts/FiraSans-SemiBold.woff2?v=4.203",
+        "skins/standard/fonts/MaterialIcons-Regular.woff2",
+    );
+    $headers{'-link'} = join(", ", map { sprintf('</static/v%s/%s>; rel="preload"; as="font";', BUGZILLA->VERSION, $_) } @fonts);
+
     return $self->SUPER::header(%headers) || "";
 }
 


### PR DESCRIPTION
patch for https://bugzilla.mozilla.org/show_bug.cgi?id=1426414  
  
I decided to only preload woff2, as those should be font used by most mondern browsers I guess.
sending all fonts in all formats doesnt sound like a good idea to me.

I wasnt able to test this locally as I didnt have a working bmo setup on my dev box.
could this be deployed somewhere so we can test it?