### PR TITLE
no bug - Update editorconfig to use 2 space indentation for CSS and JavaScript

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,13 +1,13 @@
 # top-most EditorConfig file
 root = true
 
-# 4 space indentation for .pl,.PL,.css,.js and .pm files
-[*.{pl,PL,css,js,pm}]
+# 4 space indentation for Perl files
+[*.{pl,PL,pm,cgi}]
 indent_style = space
 indent_size = 4
 
-# 2 space indentation style for .tmpl files
-[.{tmpl,yml}]
+# 2 space indentation for HTML, CSS, JavaScript and YAML files
+[.{html,tmpl,css,js,yml}]
 indent_style = space
 indent_size = 2
 


### PR DESCRIPTION
I think 2 space indentation is common for CSS and JavaScript files these days. 4 spaces are too much for me.

* [Google Style Guides](https://google.github.io/styleguide/)
* [Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript)
* [Mozilla Coding Style Guide](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Coding_Style)
* [Why is two-space tab indent becoming the standard?](https://www.reddit.com/r/javascript/comments/5rjrcy/why_is_twospace_tab_indent_becoming_the_standard/)