### PR TITLE
Bug 1429076 - Can we have a lock icon for requests in security-sensitive bugs in Requests Quick Look Dropdown?

### DIFF
--- a/extensions/Review/web/js/badge.js
+++ b/extensions/Review/web/js/badge.js
@@ -82,14 +82,16 @@ Bugzilla.Review.Badge = class Badge {
                 ? `attachment.cgi?id=${req.attach_id}&amp;action=edit` : `show_bug.cgi?id=${req.bug_id}`;
 
             $li.setAttribute('role', 'none');
-            $li.innerHTML = `<a href="${link}" role="menuitem" tabindex="-1" data-type="${req.type}">
-                <img src="https://secure.gravatar.com/avatar/${md5(email)}?d=mm&amp;size=64" alt="">
-                <label><strong>${pretty_name.htmlEncode()}</strong> asked for your
-                ${(req.type === 'needinfo' ? 'info' : req.type)} ${(req.attach_id ? 'on' : '')}
-                ${(req.attach_id && req.ispatch ? (req.dup_count > 1 ? `${req.dup_count} patches` : 'a patch') : '')}
-                ${(req.attach_id && !req.ispatch ? (req.dup_count > 1 ? `${req.dup_count} files` : 'a file') : '')}
-                in <strong>Bug ${req.bug_id} &ndash; ${req.bug_summary.htmlEncode()}</strong>.</label>
-                <time datetime="${req.created}">${timeAgo(new Date(req.created))}</time></a>`;
+            $li.innerHTML = `<a href="${link}" role="menuitem" tabindex="-1" `
+                + `class="${(req.restricted ? 'secure' : '')}" data-type="${req.type}">`
+                + `<img src="https://secure.gravatar.com/avatar/${md5(email)}?d=mm&amp;size=64" alt="">`
+                + `<label><strong>${pretty_name.htmlEncode()}</strong> asked for your `
+                + (req.type === 'needinfo' ? 'info' : req.type) + (req.attach_id ? ' on ' : '')
+                + (req.attach_id && req.ispatch ? (req.dup_count > 1 ? `${req.dup_count} patches` : 'a patch') : '')
+                + (req.attach_id && !req.ispatch ? (req.dup_count > 1 ? `${req.dup_count} files` : 'a file') : '')
+                + ' in ' + (req.restricted ? '<span class="icon" aria-label="secure"></span>&nbsp;' : '')
+                + `<strong>Bug ${req.bug_id} &ndash; ${req.bug_summary.htmlEncode()}</strong>.</label>`
+                + `<time datetime="${req.created}">${timeAgo(new Date(req.created))}</time></a>`;
             $fragment.appendChild($li);
         });
 

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -353,6 +353,10 @@
         pointer-events: none;
     }
 
+    #header .dropdown-panel .notifications a {
+        overflow: hidden;
+    }
+
     #header .dropdown-panel .notifications img {
         float: left;
         border-radius: 50%;
@@ -377,6 +381,16 @@
     #header .dropdown-panel .notifications time {
         font-size: 12px;
         color: #999;
+    }
+
+    #header .dropdown-panel .notifications .secure .icon {
+        display: inline;
+        font-size: 16px;
+        vertical-align: text-bottom;
+    }
+
+    #header .dropdown-panel .notifications .secure .icon::before {
+        content: '\E88D';
     }
 
     #header .dropdown-panel .loading,

--- a/template/en/default/request/queue.json.tmpl
+++ b/template/en/default/request/queue.json.tmpl
@@ -8,7 +8,7 @@
 [% RAWPERL %]
 my @display_columns = (
     "requester", "requestee",      "type",    "status",  "bug_id", "bug_summary",
-    "attach_id", "attach_summary", "ispatch", "created", "category"
+    "attach_id", "attach_summary", "ispatch", "created", "category", "restricted"
 );
 my $requests    = $stash->get('requests');
 my $time_filter = $context->filter('time', [ '%Y-%m-%dT%H:%M:%SZ', 'UTC' ]);
@@ -28,7 +28,7 @@ foreach my $request (@$requests) {
         elsif ( $column =~ /_id$/ ) {
             $val = $request->{$column} ? 0 + $request->{$column} : undef;
         }
-        elsif ( $column =~ /^is/ ) {
+        elsif ( $column =~ /^is/ or $column eq 'restricted' ) {
             $val = $request->{$column} ? \1 : \0;
         }
         else {


### PR DESCRIPTION
Fix [Bug 1429076 - Can we have a lock icon for requests in security-sensitive bugs in Requests Quick Look Dropdown?](https://bugzilla.mozilla.org/show_bug.cgi?id=1429076)

## Description

Sure we can!

## Screenshot

![screenshot-2018-1-9 1 - remove mozmozmoz api](https://user-images.githubusercontent.com/2929505/34732305-e3b490b6-f532-11e7-815c-954d01937227.png)
