### PR TITLE
Bug 1429194 - Clicking requests icon gives "Loading... " but never actually completes

### DIFF
--- a/extensions/Review/web/js/badge.js
+++ b/extensions/Review/web/js/badge.js
@@ -76,8 +76,8 @@ Bugzilla.Review.Badge = class Badge {
         // Show up to 20 newest requests
         requests.slice(0, 20).forEach(req => {
             const $li = document.createElement('li');
-            const [, name, email] = req.requester.match(/^(.*)\s<(.*)>$/);
-            const pretty_name = name.replace(/([\[\(<‹].*?[›>\)\]]|\:[\w\-]+|\s+\-\s+.*)/g, '').trim();
+            const [, name, email] = req.requester.match(/^(?:(.*)\s<)?(.+?)>?$/);
+            const pretty_name = name ? name.replace(/([\[\(<‹].*?[›>\)\]]|\:[\w\-]+|\s+\-\s+.*)/g, '').trim() : email;
             const link = req.attach_id && req.dup_count === 1
                 ? `attachment.cgi?id=${req.attach_id}&amp;action=edit` : `show_bug.cgi?id=${req.bug_id}`;
 


### PR DESCRIPTION
Fix [Bug 1429194 - Clicking requests icon gives "Loading... " but never actually completes](https://bugzilla.mozilla.org/show_bug.cgi?id=1429194)

## Description

The regex will fail when any requester has their user name like "<:john>" or they don't have any real name set. This fixes both cases. Later I'll create a helper function to extract real name, nick name and email.