### PR TITLE
Bug 1429290 - Bugs now display too wide to fit in my window; reading bugs is much harder

### DIFF
--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -63,7 +63,7 @@
 /* wrapper (end) */
 
 /* fixed global header (begin) */
-    @media screen and (min-width: 1024px) {
+    @media screen and (min-width: 800px) {
         #wrapper {
             overflow: hidden;
             width: 100%;
@@ -571,6 +571,27 @@
         content: '\E5CD';
     }
 /* header (end) */
+
+/* narrower global header (begin) */
+    @media screen and (max-width: 1024px) {
+        #header .inner {
+            width: 800px;
+        }
+
+        #header-nav .links a {
+            padding: 0;
+            width: 32px;
+            justify-content: center;
+            text-align: center;
+        }
+
+        #header-nav .links a .label {
+            overflow: hidden;
+            width: 0;
+            height: 0;
+        }
+    }
+/* narrower global header (end) */
 
 /* link lists (begin) */
     ul.links {


### PR DESCRIPTION
Fix [Bug 1429290 - Bugs now display too wide to fit in my window; reading bugs is much harder](https://bugzilla.mozilla.org/show_bug.cgi?id=1429290)

## Description

* Give some narrower style to the fixed header: hide menu labels
* The modal bug detail pages won't get a horizontal scrollbar on window size > 920px