### PR TITLE
Bug 1429888 - See All link in Requests dropdown should show results grouped by flags as before

### DIFF
--- a/extensions/Review/template/en/default/hook/global/header-badge.html.tmpl
+++ b/extensions/Review/template/en/default/hook/global/header-badge.html.tmpl
@@ -32,7 +32,7 @@
         <div class="empty">You’re all caught up!</div>
       [%- END -%]
       <footer>
-        <div><a href="request.cgi?action=queue&amp;requestee=[% user.login FILTER uri %]&amp;group=requestee"
+        <div><a href="request.cgi?action=queue&amp;requestee=[% user.login FILTER uri %]&amp;group=type"
                 role="menuitem" tabindex="-1">See All</a></div>
       </footer>
     </section>

--- a/extensions/Review/web/js/badge.js
+++ b/extensions/Review/web/js/badge.js
@@ -47,7 +47,7 @@ Bugzilla.Review.Badge = class Badge {
 
         this.initialized = true;
 
-        const url = this.$panel.querySelector('footer a').href + '&ctype=json';
+        const url = this.$panel.querySelector('footer a').href.replace(/type$/, 'requestee') + '&ctype=json';
         const response = await fetch(url, { credentials: 'same-origin' });
         const _requests = response.ok ? await response.json() : [];
 


### PR DESCRIPTION
Fix [Bug 1429888 - See All link in Requests dropdown should show results grouped by flags as before](https://bugzilla.mozilla.org/show_bug.cgi?id=1429888)

## Description

* The link should show results grouped by flag/type as before.
* The background fetch request should still be grouped by requestee so the response will be ordered by date, saving some time to reorder the results with JavaScript. 