### PR TITLE
Bug 1429688 - focus Search Bugs box by default

### DIFF
--- a/template/en/default/index.html.tmpl
+++ b/template/en/default/index.html.tmpl
@@ -55,7 +55,7 @@
 
         <form id="quicksearchForm" name="quicksearchForm" action="buglist.cgi">
           <div>
-            <input id="quicksearch_main" type="text" name="quicksearch"
+            <input id="quicksearch_main" type="text" name="quicksearch" autofocus
               placeholder="Enter [% terms.abug %] number or some search terms"
               title="Quick Search">
             <input id="find" type="submit" value="Quick Search">


### PR DESCRIPTION
Fix [Bug 1429688 - focus Search Bugs box by default](https://bugzilla.mozilla.org/show_bug.cgi?id=1429688)

## Description

Automatically focus the Quick Search box on the home page when the page is loaded by simply adding the `autofocus` attribute.