### PR TITLE
Bug 1429344 - Review requests in requests dropdown should link to MozReview or GitHub instead of Bugzilla details page

### DIFF
--- a/request.cgi
+++ b/request.cgi
@@ -102,6 +102,7 @@ sub queue {
                 requesters.realname, requesters.login_name,
                 requestees.realname, requestees.login_name, COUNT(privs.group_id),
     " . $dbh->sql_date_format('flags.modification_date', '%Y.%m.%d %H:%i') . ",
+                attachments.mimetype,
                 attachments.ispatch,
                 bugs.bug_status,
                 bugs.priority,
@@ -248,7 +249,7 @@ sub queue {
                 requesters.login_name, requestees.realname,
                 requestees.login_name, flags.modification_date, attachments.ispatch
                 cclist_accessible, bugs.reporter, bugs.reporter_accessible,
-                bugs.assigned_to, attachments.ispatch');
+                bugs.assigned_to, attachments.mimetype');
 
     # Group the records, in other words order them by the group column
     # so the loop in the display template can break them up into separate
@@ -291,10 +292,11 @@ sub queue {
           'requestee'       => ($data->[11] ? "$data->[11] <$data->[12]>" : $data->[12]) ,
           'restricted'      => $data->[13] ? 1 : 0,
           'created'         => $data->[14],
-          'ispatch'         => $data->[15],
-          'bug_status'      => $data->[16],
-          'priority'        => $data->[17],
-          'bug_severity'    => $data->[18],
+          'attach_mimetype' => $data->[15],
+          'attach_ispatch'  => $data->[16],
+          'bug_status'      => $data->[17],
+          'priority'        => $data->[18],
+          'bug_severity'    => $data->[19],
         };
         push(@requests, $request);
     }

--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -107,6 +107,7 @@
     [%- js_BUGZILLA = {
             param => {
                 maxusermatches => Param('maxusermatches'),
+                splinter_base => Param('splinter_base'),
             },
             constant => {
                 COMMENT_COLS => constants.COMMENT_COLS,

--- a/template/en/default/request/queue.json.tmpl
+++ b/template/en/default/request/queue.json.tmpl
@@ -6,10 +6,9 @@
   # defined by the Mozilla Public License, v. 2.0. #%]
 
 [% RAWPERL %]
-my @display_columns = (
-    "requester", "requestee",      "type",    "status",  "bug_id", "bug_summary",
-    "attach_id", "attach_summary", "ispatch", "created", "category", "restricted"
-);
+my @display_columns = ('requester', 'requestee', 'type', 'created', 'category',
+                       'restricted', 'bug_id', 'bug_summary', 'attach_id',
+                       'attach_summary', 'attach_mimetype', 'attach_ispatch');
 my $requests    = $stash->get('requests');
 my $time_filter = $context->filter('time', [ '%Y-%m-%dT%H:%M:%SZ', 'UTC' ]);
 my $mail_filter = $context->filter('email');
@@ -28,7 +27,7 @@ foreach my $request (@$requests) {
         elsif ( $column =~ /_id$/ ) {
             $val = $request->{$column} ? 0 + $request->{$column} : undef;
         }
-        elsif ( $column =~ /^is/ or $column eq 'restricted' ) {
+        elsif ( $column =~ /^(restricted|attach_ispatch)$/ ) {
             $val = $request->{$column} ? \1 : \0;
         }
         else {


### PR DESCRIPTION
Fix [Bug 1429344 - Review requests in requests dropdown should link to MozReview or GitHub instead of Bugzilla details page](https://bugzilla.mozilla.org/show_bug.cgi?id=1429344)

## Description

* Retrieve `attachments.mimetype` from DB as `attach_mimetype`
* Retrieve `attachments.ispatch` from DB as `attach_ispatch` instead of `ispatch` for consistency (this field is not used in other templates so the change should be safe)
* Treat MozReview and Phabricator requests as patches
* Support GitHub pull requests and Google Docs as well
* Link directly to those external sites
* For regular patches, link to the Splinter Review page if available