### PR TITLE
Bug 1430495 - Make loading of Requests dropdown faster

### DIFF
--- a/extensions/Review/web/js/badge.js
+++ b/extensions/Review/web/js/badge.js
@@ -26,12 +26,14 @@ Bugzilla.Review.Badge = class Badge {
      * @returns {Badge} New Badge instance.
      */
     constructor() {
+        this.initialized = false;
         this.$button = document.querySelector('#header-requests-menu-button');
         this.$panel = document.querySelector('#header-requests .dropdown-panel');
         this.$loading = document.querySelector('#header-requests .dropdown-panel .loading');
 
         if (this.$loading) {
-            this.$button.addEventListener('click', () => this.init(), { once: true });
+            this.$button.addEventListener('mouseover', () => this.init(), { once: true });
+            this.$button.addEventListener('focus', () => this.init(), { once: true });
         }
     }
 
@@ -39,6 +41,12 @@ Bugzilla.Review.Badge = class Badge {
      * Initialize the Reviews dropdown menu.
      */
     async init() {
+        if (this.initialized) {
+            return;
+        }
+
+        this.initialized = true;
+
         const url = this.$panel.querySelector('footer a').href + '&ctype=json';
         const response = await fetch(url, { credentials: 'same-origin' });
         const _requests = response.ok ? await response.json() : [];


### PR DESCRIPTION
Fix [Bug 1430495 - Make loading of Requests dropdown faster](https://bugzilla.mozilla.org/show_bug.cgi?id=1430495)

## Description

* Use the same technique as Firefox's tab warming to load the Requests dropdown content faster.