### PR TITLE
Bug 1431294 - requests.cgi - allocate less memory

### DIFF
--- a/request.cgi
+++ b/request.cgi
@@ -277,25 +277,24 @@ sub queue {
 
     my $results = $dbh->selectall_arrayref($query);
     my @requests = ();
-    foreach my $result (@$results) {
-        my @data = @$result;
+    foreach my $data (@$results) {
         my $request = {
-          'id'              => $data[0] ,
-          'type'            => $data[1] ,
-          'status'          => $data[2] ,
-          'bug_id'          => $data[3] ,
-          'bug_summary'     => $data[4] ,
-          'category'        => "$data[5]: $data[6]" ,
-          'attach_id'       => $data[7] ,
-          'attach_summary'  => $data[8] ,
-          'requester'       => ($data[9] ? "$data[9] <$data[10]>" : $data[10]) ,
-          'requestee'       => ($data[11] ? "$data[11] <$data[12]>" : $data[12]) ,
-          'restricted'      => $data[13] ? 1 : 0,
-          'created'         => $data[14],
-          'ispatch'         => $data[15],
-          'bug_status'      => $data[16],
-          'priority'        => $data[17],
-          'bug_severity'    => $data[18],
+          'id'              => $data->[0] ,
+          'type'            => $data->[1] ,
+          'status'          => $data->[2] ,
+          'bug_id'          => $data->[3] ,
+          'bug_summary'     => $data->[4] ,
+          'category'        => "$data->[5]: $data->[6]" ,
+          'attach_id'       => $data->[7] ,
+          'attach_summary'  => $data->[8] ,
+          'requester'       => ($data->[9] ? "$data->[9] <$data->[10]>" : $data->[10]) ,
+          'requestee'       => ($data->[11] ? "$data->[11] <$data->[12]>" : $data->[12]) ,
+          'restricted'      => $data->[13] ? 1 : 0,
+          'created'         => $data->[14],
+          'ispatch'         => $data->[15],
+          'bug_status'      => $data->[16],
+          'priority'        => $data->[17],
+          'bug_severity'    => $data->[18],
         };
         push(@requests, $request);
     }


### PR DESCRIPTION
`@data = @$result` makes a copy of an array. Instead of doing that, we just use the array ref (and rename `$result` to `$data`)