### PR TITLE
Bug 1428270 - Unwrappable content in summary can cause top buttons to bleed out of main content box

### DIFF
--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -683,6 +683,18 @@ sub create {
                 return $var;
             },
 
+            # Insert `<wbr>` HTML tags to camel and snake case words in the
+            # given string so a long bug summary, for example, will be wrapped
+            # in a preferred manner rather than overflowing or expanding the
+            # parent element. Examples:
+            # * `test<wbr>_switch<wbr>_window<wbr>_content<wbr>.py`
+            # * `Test<wbr>Switch<wbr>To<wbr>Window<wbr>Content`
+            wbr => sub {
+                my ($var) = @_;
+                $var =~ s/([a-z])([A-Z\._])/$1<wbr>$2/g;
+                return $var;
+            },
+
             xml => \&Bugzilla::Util::xml_quote ,
 
             # This filter is similar to url_quote but used a \ instead of a %

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -202,7 +202,7 @@
         no_label = 1
         hide_on_edit = 1
     %]
-      <h1 id="field-value-short_desc">[% bug.short_desc FILTER quoteUrls(bug) %]</h1>
+      <h1 id="field-value-short_desc">[% bug.short_desc FILTER quoteUrls(bug) FILTER wbr %]</h1>
     [% END %]
 
     [%# alias %]

--- a/template/en/default/bug/edit.html.tmpl
+++ b/template/en/default/bug/edit.html.tmpl
@@ -253,7 +253,7 @@
           (<span id="alias_nonedit_display">[% bug.alias FILTER html %]</span>) 
         [% END %]
       [% END %]
-      <span role="heading" aria-level="1" id="short_desc_nonedit_display">[% bug.short_desc FILTER quoteUrls(bug) %]</span>
+      <span role="heading" aria-level="1" id="short_desc_nonedit_display">[% bug.short_desc FILTER quoteUrls(bug) FILTER wbr %]</span>
       [% IF bug.check_can_change_field('short_desc', 0, 1) || 
             bug.check_can_change_field('alias', 0, 1)  %]
         <small class="editme">(<a href="#" id="editme_action">edit</a>)</small>

--- a/template/en/default/list/table.html.tmpl
+++ b/template/en/default/list/table.html.tmpl
@@ -230,7 +230,7 @@
                                         col_abbrev.ellipsis) FILTER html %]
       [% ELSIF column == 'short_desc' || column == "short_short_desc" %]
         <a href="show_bug.cgi?id=[% bug.bug_id FILTER html %]">
-          [%- bug.$column.truncate(col_abbrev.maxlength, col_abbrev.ellipsis) FILTER html -%]
+          [%- bug.$column.truncate(col_abbrev.maxlength, col_abbrev.ellipsis) FILTER html FILTER wbr -%]
         </a>
       [% ELSIF bug_fields.$column.type == constants.FIELD_TYPE_BUG_ID %]
         <a href="show_bug.cgi?id=[% bug.$column FILTER html %]">


### PR DESCRIPTION
Fix [Bug 1428270 - Unwrappable content in summary can cause top buttons to bleed out of main content box](https://bugzilla.mozilla.org/show_bug.cgi?id=1428270)

## Description

* Add a simple template filter for inserting [`<wbr>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr) elements to camel and/or snake case words, like what I'm doing on [fxsitecompat.com](https://github.com/fxsitecompat/www.fxsitecompat.com/blob/master/layouts/docs/single.html#L32)
* Use the filter for the bug summary on the bug details and search results
* It can also be used for other pages but those are good starting points!

## Screenshots

![screen shot 2018-01-14 at 23 27 52](https://user-images.githubusercontent.com/2929505/34927250-ce05b6a6-f982-11e7-9a63-0cb76e819e0d.png)
![screen shot 2018-01-14 at 23 27 15](https://user-images.githubusercontent.com/2929505/34927249-cddef994-f982-11e7-97eb-cdbd46385955.png)