### PR TITLE
Lowercase the email address before generating the MD5 for Gravatar

### DIFF
--- a/extensions/Review/web/js/badge.js
+++ b/extensions/Review/web/js/badge.js
@@ -84,7 +84,7 @@ Bugzilla.Review.Badge = class Badge {
             $li.setAttribute('role', 'none');
             $li.innerHTML = `<a href="${link}" role="menuitem" tabindex="-1" `
                 + `class="${(req.restricted ? 'secure' : '')}" data-type="${req.type}">`
-                + `<img src="https://secure.gravatar.com/avatar/${md5(email)}?d=mm&amp;size=64" alt="">`
+                + `<img src="https://secure.gravatar.com/avatar/${md5(email.toLowerCase())}?d=mm&amp;size=64" alt="">`
                 + `<label><strong>${pretty_name.htmlEncode()}</strong> asked for your `
                 + (req.type === 'needinfo' ? 'info' : req.type) + (req.attach_id ? ' on ' : '')
                 + (req.attach_id && req.ispatch ? (req.dup_count > 1 ? `${req.dup_count} patches` : 'a patch') : '')


### PR DESCRIPTION
This is step 2 of https://en.gravatar.com/site/implement/hash/

My email address has uppercase so Gravatars for me are currently broken in this UI. The Perl BMO code already calls [`lc`](https://github.com/mozilla-bteam/bmo/blob/e655f5133b4dd5c5d6f253069767db75c64eb349/extensions/Gravatar/Extension.pm#L34).