### PR TITLE
Bug 1435735 - Add script to add email job to jobqueue

### DIFF
--- a/scripts/sendmail.pl
+++ b/scripts/sendmail.pl
@@ -1,0 +1,39 @@
+#!/usr/bin/perl
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+# This file has detailed POD docs, do "perldoc checksetup.pl" to see them.
+
+######################################################################
+# Initialization
+######################################################################
+
+use 5.10.1;
+use strict;
+use warnings;
+
+use File::Basename;
+use File::Spec;
+BEGIN {
+    require lib;
+    my $dir = File::Spec->rel2abs(dirname(__FILE__));
+    my $base = File::Spec->catdir($dir, "..");
+    lib->import($base, File::Spec->catdir($base, "lib"), File::Spec->catdir($base, qw(local lib perl5)));
+    chdir $base;
+}
+
+use Bugzilla;
+BEGIN { Bugzilla->extensions }
+use Bugzilla::Mailer;
+
+my $msg = do {
+    local $/ = undef;
+    binmode STDIN, ':bytes';
+    <STDIN>;
+};
+
+MessageToMTA($msg);


### PR DESCRIPTION
To review this, @Micheletto can you verify this by testing it against the dev stack?

1. Copy the one file from this patch to the admin container
2. set mail_delivery_method in data/params to Test
3. run:

```bash
echo -e "To: robot@example.com\r\nFrom: bugzilla@example.com\r\nSubject:\r\nBatman\r\n\r\nanananananananana" | perl scripts/sendmail.pl
```

If the jobqueue daemom isn't running in the stack yet, run it once manually:

```bash
perl jobqueue.pl -d -f onepass
```

After that, you should see something like this in data/mail.testfile:

```
From - Wed, 07 Feb 2018 04:45:02 -0800
To: robot@example.com
From: bugzilla@example.com
Subject: Batman
X-Bugzilla-URL: http://bmo-web.vm/
Auto-Submitted: auto-generated
MIME-Version: 1.0
Date: Wed, 07 Feb 2018 04:45:02 -0800
X-Generated-By: /bmo-web.vm(24743)
Content-Type: text/plain; charset="UTF-8"
Content-Transfer-Encoding: quoted-printable

anananananananana
```