### PR TITLE
Bug 1424363 - securemail help page recommends getting a certificate from StartCom

### DIFF
--- a/extensions/SecureMail/template/en/default/pages/securemail/help.html.tmpl
+++ b/extensions/SecureMail/template/en/default/pages/securemail/help.html.tmpl
@@ -36,10 +36,10 @@ be required to decrypt it to view the reset instructions.
 
 <b>S/MIME Keys must be in PEM format - i.e. Base64-encoded text, with the first line containing BEGIN CERTIFICATE.</b></p>
 
-<p>
-S/MIME certificates can be obtained from a number of providers. You can get a free one from <a href="https://www.startssl.com/?app=12">StartCom</a>. 
-Once you have it, <a href="https://www.startssl.com/?app=25#52">export it from your browser as a .p12 file and import it into your mail client</a>. 
-You'll need to provide a password when you export - pick a strong one, and then back up the .p12 file somewhere safe.</p>
+<p>S/MIME certificates can be obtained from a number of providers. 
+Once you have it, export it from your browser as a .p12 file and import it into your mail client. 
+You'll need to provide a password when you export - pick a strong one, 
+and then back up the .p12 file somewhere safe.</p>
 
 <p>Import on Thunderbird as follows:</p>
 


### PR DESCRIPTION
StartCom is untrusted, should not be mentioned as a certificate provider on Secure Bug Mail help page. This patch removes the reference.