### PR TITLE
Bug 1211377 - needinfo from someone not in sec group shows warning message even when bug is being removed from sec group

### DIFF
--- a/extensions/Needinfo/Extension.pm
+++ b/extensions/Needinfo/Extension.pm
@@ -172,6 +172,10 @@ sub bug_start_of_update {
                 if ($requestee ne 'anyone') {
                     _check_requestee($requestee);
                     $needinfo_flag->{requestee} = $requestee;
+                    my $requestee_obj = Bugzilla::User->check($requestee);
+                    if ($requestee_obj && !$requestee_obj->can_see_bug($bug->id)) {
+                        $bug->add_cc($requestee_obj);
+                    }
                 }
                 push(@new_flags, $needinfo_flag);
             }

--- a/extensions/Needinfo/Extension.pm
+++ b/extensions/Needinfo/Extension.pm
@@ -173,7 +173,7 @@ sub bug_start_of_update {
                     _check_requestee($requestee);
                     $needinfo_flag->{requestee} = $requestee;
                     my $requestee_obj = Bugzilla::User->check($requestee);
-                    if ($requestee_obj && !$requestee_obj->can_see_bug($bug->id)) {
+                    if (!$requestee_obj->can_see_bug($bug->id)) {
                         $bug->add_cc($requestee_obj);
                     }
                 }


### PR DESCRIPTION
This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1211377 for me, in local testing in vagrant. It's only 4 lines of perl but it's probably terrible. Please tell me how to make it sufficient so we can ship this and I can stop wanting to throw my computer out of the window when updating security bugs.