### PR TITLE
Bug 1437646 - Part 1 - Add confdir to Bugzilla::Constants

### DIFF
--- a/Bugzilla/Constants.pm
+++ b/Bugzilla/Constants.pm
@@ -659,18 +659,21 @@ sub _bz_locations {
     $libpath =~ /(.*)/;
     $libpath = $1;
 
-    my ($localconfig, $datadir);
+    my ($localconfig, $datadir, $confdir);
     if ($project && $project =~ /^(\w+)$/) {
         $project = $1;
         $localconfig = "localconfig.$project";
         $datadir = "data/$project";
+        $confdir = "conf/$project";
     } else {
         $project = undef;
         $localconfig = "localconfig";
         $datadir = "data";
+        $confdir = "conf";
     }
 
     $datadir = "$libpath/$datadir";
+    $confdir = "$libpath/$confdir";
     # We have to return absolute paths for mod_perl.
     # That means that if you modify these paths, they must be absolute paths.
     return {
@@ -698,6 +701,7 @@ sub _bz_locations {
         'assetsdir'      => "$datadir/assets",
         # error_reports store error/warnings destined for sentry
         'error_reports'  => "$libpath/error_reports",
+        'confdir'        => $confdir,
     };
 }
 

--- a/Bugzilla/Install/Filesystem.pm
+++ b/Bugzilla/Install/Filesystem.pm
@@ -173,6 +173,7 @@ sub DIR_ALSO_WS_SERVE { _suexec() ? 0001 : 0 };
 # when exploiting some security flaw somewhere (not necessarily in Bugzilla!)
 sub FILESYSTEM {
     my $datadir        = bz_locations()->{'datadir'};
+    my $confdir        = bz_locations()->{'confdir'};
     my $attachdir      = bz_locations()->{'attachdir'};
     my $extensionsdir  = bz_locations()->{'extensionsdir'};
     my $webdotdir      = bz_locations()->{'webdotdir'};
@@ -320,6 +321,8 @@ sub FILESYSTEM {
                                      dirs => DIR_WS_SERVE },
          "$extensionsdir/*/web" => { files => WS_SERVE,
                                      dirs => DIR_WS_SERVE },
+         $confdir               => { files => WS_SERVE,
+                                     dirs => DIR_WS_SERVE, },
 
          # Purpose: allow webserver to read .bzr so we execute bzr commands
          # in backticks and look at the result over the web. Used to show
@@ -364,6 +367,7 @@ sub FILESYSTEM {
         # Directories that contain content served directly by the web server.
         "$skinsdir/custom"      => DIR_WS_SERVE,
         "$skinsdir/contrib"     => DIR_WS_SERVE,
+        $confdir                => DIR_CGI_READ,
     );
 
     my $yui_all_css = sub {
@@ -457,6 +461,8 @@ sub FILESYSTEM {
         '.circleci/.htaccess'        => { perms    => WS_SERVE,
                                           contents => HT_DEFAULT_DENY },
         'httpd/.htaccess'            => { perms    => WS_SERVE,
+                                          contents => HT_DEFAULT_DENY },
+        "$confdir/.htaccess"         => { perms    => WS_SERVE,
                                           contents => HT_DEFAULT_DENY },
         "$datadir/.htaccess"         => { perms    => WS_SERVE,
                                           contents => HT_DEFAULT_DENY },


### PR DESCRIPTION
Add a confdir option to bz_locations() that is similar to data/ but intended to be used for configuration files. This can replace docker_support (and later, perhaps, vagrant_support)