### PR TITLE
Bug 1440239 - PhabBugz - Assign a secure-revision.

### DIFF
--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -26,6 +26,7 @@ use Bugzilla::Extension::PhabBugz::Util qw(
     edit_revision_policy
     get_bug_role_phids
     get_phab_bmo_ids
+    get_project_phid
     get_security_sync_groups
     is_attachment_phab_revision
     make_revision_public
@@ -170,6 +171,8 @@ sub process_revision_change {
         $self->logger->debug('Bug is public so setting view/edit public');
         $revision->set_policy('view', 'public');
         $revision->set_policy('edit', 'users');
+        my $secure_project_phid = get_project_phid('secure-revision');
+        $revision->remove_project($secure_project_phid);
     }
     # else bug is private.
     else {
@@ -211,6 +214,9 @@ sub process_revision_change {
                 $revision->set_policy('view', $new_policy->phid);
                 $revision->set_policy('edit', $new_policy->phid);
             }
+
+            my $secure_project_phid = get_project_phid('secure-revision');
+            $revision->add_project($secure_project_phid);
 
             my $subscribers = get_bug_role_phids($bug);
             $revision->set_subscribers($subscribers);

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -21,7 +21,6 @@ use Bugzilla::Extension::PhabBugz::Policy;
 use Bugzilla::Extension::PhabBugz::Revision;
 use Bugzilla::Extension::PhabBugz::Util qw(
     add_security_sync_comments
-    create_private_revision_policy
     create_revision_attachment
     edit_revision_policy
     get_bug_role_phids

--- a/extensions/PhabBugz/lib/Project.pm
+++ b/extensions/PhabBugz/lib/Project.pm
@@ -232,6 +232,20 @@ sub update {
         }
     }
 
+    if ($self->{add_projects}) {
+        push(@{ $data->{transactions} }, {
+            type => 'projects.add',
+            value => $self->{add_projects}
+        });
+    }
+
+    if ($self->{remove_projects}) {
+        push(@{ $data->{transactions} }, {
+            type => 'projects.remove',
+            value => $self->{remove_projects}
+        });
+    }
+
     my $result = request( 'project.edit', $data );
 
     return $result;
@@ -265,6 +279,24 @@ sub remove_member {
     $self->{remove_members} ||= [];
     my $member_phid = blessed $member ? $member->phab_phid : $member;
     push( @{ $self->{remove_members} }, $member_phid );
+}
+
+sub add_project {
+    my ($self, $project) = @_;
+    $self->{add_projects} ||= [];
+    my $project_phid = blessed $project ? $project->phid : $project;
+    $project_phid = get_project_phid($project);
+    return undef unless $project_phid;
+    push(@{ $self->{add_projects} }, $project_phid);
+}
+
+sub remove_project {
+    my ($self, $project) = @_;
+    $self->{add_projects} ||= [];
+    my $project_phid = blessed $project ? $project->phid : $project;
+    $project_phid = get_project_phid($project);
+    return undef unless $project_phid;
+    push(@{ $self->{remove_projects} }, $project_phid);
 }
 
 sub set_members {

--- a/extensions/PhabBugz/lib/Project.pm
+++ b/extensions/PhabBugz/lib/Project.pm
@@ -281,24 +281,6 @@ sub remove_member {
     push( @{ $self->{remove_members} }, $member_phid );
 }
 
-sub add_project {
-    my ($self, $project) = @_;
-    $self->{add_projects} ||= [];
-    my $project_phid = blessed $project ? $project->phid : $project;
-    $project_phid = get_project_phid($project);
-    return undef unless $project_phid;
-    push(@{ $self->{add_projects} }, $project_phid);
-}
-
-sub remove_project {
-    my ($self, $project) = @_;
-    $self->{add_projects} ||= [];
-    my $project_phid = blessed $project ? $project->phid : $project;
-    $project_phid = get_project_phid($project);
-    return undef unless $project_phid;
-    push(@{ $self->{remove_projects} }, $project_phid);
-}
-
 sub set_members {
     my ( $self, $members ) = @_;
     $self->{set_members} = [ map { $_->phab_phid } @$members ];

--- a/extensions/PhabBugz/lib/Revision.pm
+++ b/extensions/PhabBugz/lib/Revision.pm
@@ -9,6 +9,7 @@ package Bugzilla::Extension::PhabBugz::Revision;
 
 use 5.10.1;
 use Moo;
+use Scalar::Util 'blessed';
 use Types::Standard -all;
 use Type::Utils;
 
@@ -248,6 +249,20 @@ sub update {
         }
     }
 
+    if ($self->{add_projects}) {
+        push(@{ $data->{transactions} }, {
+            type => 'projects.add',
+            value => $self->{add_projects}
+        });
+    }
+
+    if ($self->{remove_projects}) {
+        push(@{ $data->{transactions} }, {
+            type => 'projects.remove',
+            value => $self->{remove_projects}
+        });
+    }
+
     my $result = request( 'differential.revision.edit', $data );
 
     return $result;
@@ -387,6 +402,22 @@ sub set_policy {
     my ( $self, $name, $policy ) = @_;
     $self->{set_policy} ||= {};
     $self->{set_policy}->{$name} = $policy;
+}
+
+sub add_project {
+    my ( $self, $project ) = @_;
+    $self->{add_projects} ||= [];
+    my $project_phid = blessed $project ? $project->phid : $project;
+    return undef unless $project_phid;
+    push @{ $self->{add_projects} }, $project_phid;
+}
+
+sub remove_project {
+    my ( $self, $project ) = @_;
+    $self->{remove_projects} ||= [];
+    my $project_phid = blessed $project ? $project->phid : $project;
+    return undef unless $project_phid;
+    push @{ $self->{remove_projects} }, $project_phid;
 }
 
 1;

--- a/extensions/PhabBugz/lib/Util.pm
+++ b/extensions/PhabBugz/lib/Util.pm
@@ -276,7 +276,7 @@ sub get_project_phid {
     my $memcache = Bugzilla->memcached;
 
     # Check memcache
-    my $project_phid = $memcache->get({ key => "phab_project_phid_" . $project });
+    my $project_phid = $memcache->get_config({ key => "phab_project_phid_" . $project });
     if (!$project_phid) {
         my $data = {
             queryKey => 'all',
@@ -290,7 +290,7 @@ sub get_project_phid {
             unless (exists $result->{result}{data} && @{ $result->{result}{data} });
 
         $project_phid = $result->{result}{data}[0]{phid};
-        $memcache->set({ key => "phab_project_phid_" . $project, value => $project_phid });
+        $memcache->set_config({ key => "phab_project_phid_" . $project, data => $project_phid });
     }
     return $project_phid;
 }

--- a/extensions/PhabBugz/lib/Util.pm
+++ b/extensions/PhabBugz/lib/Util.pm
@@ -273,19 +273,26 @@ sub add_comment_to_revision {
 
 sub get_project_phid {
     my $project = shift;
+    my $memcache = Bugzilla->memcached;
 
-    my $data = {
-        queryKey => 'all',
-        constraints => {
-            name => $project
-        }
-    };
+    # Check memcache
+    my $project_phid = $memcache->get({ key => "phab_project_phid_" . $project });
+    if (not length $project_phid) {
+        my $data = {
+            queryKey => 'all',
+            constraints => {
+                name => $project
+            }
+        };
 
-    my $result = request('project.search', $data);
-    return undef
-        unless (exists $result->{result}{data} && @{ $result->{result}{data} });
+        my $result = request('project.search', $data);
+        return undef
+            unless (exists $result->{result}{data} && @{ $result->{result}{data} });
 
-    return $result->{result}{data}[0]{phid};
+        $project_phid = $result->{result}{data}[0]{phid};
+        $memcache->set({ key => "phab_project_phid_" . $project, value => $project_phid });
+    }
+    return $project_phid;
 }
 
 sub create_project {

--- a/extensions/PhabBugz/lib/Util.pm
+++ b/extensions/PhabBugz/lib/Util.pm
@@ -277,7 +277,7 @@ sub get_project_phid {
 
     # Check memcache
     my $project_phid = $memcache->get({ key => "phab_project_phid_" . $project });
-    if (not length $project_phid) {
+    if (!$project_phid) {
         my $data = {
             queryKey => 'all',
             constraints => {

--- a/extensions/Push/lib/Connector/Phabricator.pm
+++ b/extensions/Push/lib/Connector/Phabricator.pm
@@ -106,6 +106,11 @@ sub send {
               $bug->id
             ));
             make_revision_public($revision_phid);
+            # remove "secure-revision" tag
+            my $rev_obj = Bugzilla::Extension::PhabBugz::Revision->new_from_query({ phids => [ $revision_id ] });
+            my $secure_project_phid = get_project_phid('secure-revision');
+            $revision->remove_project($secure_project_phid);
+            $rev_obj->update();
         }
         elsif ( !$is_public && $group_change ) {
             Bugzilla->audit(sprintf(
@@ -115,6 +120,11 @@ sub send {
             ));
             my $policy_phid = create_private_revision_policy( $bug, \@set_groups );
             edit_revision_policy( $revision_phid, $policy_phid, $subscribers );
+            # add "secure-revision" tag
+            my $rev_obj = Bugzilla::Extension::PhabBugz::Revision->new_from_query({ phids => [ $revision_id ] });
+            my $secure_project_phid = get_project_phid('secure-revision');
+            $revision->add_project($secure_project_phid);
+            $rev_obj->update();
         }
         elsif ( !$is_public && !$group_change ) {
             Bugzilla->audit(sprintf(

--- a/extensions/Push/lib/Connector/Phabricator.pm
+++ b/extensions/Push/lib/Connector/Phabricator.pm
@@ -20,11 +20,19 @@ use Bugzilla::User;
 
 use Bugzilla::Extension::PhabBugz::Constants;
 use Bugzilla::Extension::PhabBugz::Util qw(
-  add_comment_to_revision create_private_revision_policy
-  edit_revision_policy get_attachment_revisions get_bug_role_phids
-  intersect make_revision_public
-  make_revision_private set_revision_subscribers
-  get_security_sync_groups add_security_sync_comments);
+  add_comment_to_revision
+  add_security_sync_comments
+  create_private_revision_policy
+  edit_revision_policy
+  get_attachment_revisions
+  get_bug_role_phids
+  get_project_phid
+  get_security_sync_groups
+  intersect
+  make_revision_public
+  make_revision_private
+  set_revision_subscribers
+);
 use Bugzilla::Extension::Push::Constants;
 use Bugzilla::Extension::Push::Util qw(is_public);
 
@@ -96,8 +104,13 @@ sub send {
         $subscribers = get_bug_role_phids($bug);
     }
 
+    my $secure_project_phid = get_project_phid('secure-revision');
+
     foreach my $revision (@revisions) {
         my $revision_phid = $revision->{phid};
+
+        my $rev_obj = Bugzilla::Extension::PhabBugz::Revision->new_from_query({ phids => [ $revision_phid ] });
+        my $revision_updated;
 
         if ( $is_public && $group_change ) {
             Bugzilla->audit(sprintf(
@@ -106,11 +119,8 @@ sub send {
               $bug->id
             ));
             make_revision_public($revision_phid);
-            # remove "secure-revision" tag
-            my $rev_obj = Bugzilla::Extension::PhabBugz::Revision->new_from_query({ phids => [ $revision_id ] });
-            my $secure_project_phid = get_project_phid('secure-revision');
-            $revision->remove_project($secure_project_phid);
-            $rev_obj->update();
+            $rev_obj->remove_project($secure_project_phid);
+            $revision_updated = 1;
         }
         elsif ( !$is_public && $group_change ) {
             Bugzilla->audit(sprintf(
@@ -120,11 +130,8 @@ sub send {
             ));
             my $policy_phid = create_private_revision_policy( $bug, \@set_groups );
             edit_revision_policy( $revision_phid, $policy_phid, $subscribers );
-            # add "secure-revision" tag
-            my $rev_obj = Bugzilla::Extension::PhabBugz::Revision->new_from_query({ phids => [ $revision_id ] });
-            my $secure_project_phid = get_project_phid('secure-revision');
-            $revision->add_project($secure_project_phid);
-            $rev_obj->update();
+            $rev_obj->add_project($secure_project_phid);
+            $revision_updated = 1;
         }
         elsif ( !$is_public && !$group_change ) {
             Bugzilla->audit(sprintf(
@@ -134,6 +141,7 @@ sub send {
             ));
             set_revision_subscribers( $revision_phid, $subscribers );
         }
+        $rev_obj->update() if $revision_updated;
     }
 
     return PUSH_RESULT_OK;


### PR DESCRIPTION
Phabricator's Herald has a "Secure Email" rule and Phabricator sends a
restricted email notification if a revision belongs to the newly created
"secure-revision" group project.

With this patch Bugzilla will automatically assign a secure revision to
the "secure-revision" group project.

Additionally:
The get_project_phid is modified and is now caching the response in
memcached.