### PR TITLE
Bug 1433299 - Link in summary is broken

### DIFF
--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -683,15 +683,17 @@ sub create {
                 return $var;
             },
 
-            # Insert `<wbr>` HTML tags to camel and snake case words in the
-            # given string so a long bug summary, for example, will be wrapped
-            # in a preferred manner rather than overflowing or expanding the
-            # parent element. Examples:
+            # Insert `<wbr>` HTML tags to camel and snake case words as well as
+            # words containing dots in the given string so a long bug summary,
+            # for example, will be wrapped in a preferred manner rather than
+            # overflowing or expanding the parent element. This conversion
+            # should exclude existing HTML tags such as links. Examples:
             # * `test<wbr>_switch<wbr>_window<wbr>_content<wbr>.py`
             # * `Test<wbr>Switch<wbr>To<wbr>Window<wbr>Content`
+            # * `<a href="https://www.mozilla.org/">mozilla<wbr>.org</a>`
             wbr => sub {
                 my ($var) = @_;
-                $var =~ s/([a-z])([A-Z\._])/$1<wbr>$2/g;
+                $var =~ s/([a-z])([A-Z\._])(?![^<]*>)/$1<wbr>$2/g;
                 return $var;
             },
 


### PR DESCRIPTION
Fix [Bug 1433299 - Link in summary is broken](https://bugzilla.mozilla.org/show_bug.cgi?id=1433299)

Sorry I couldn't work on this sooner but here's the patch for my regression. I'm not a regex guru so might be wrong. This solution is based on [this Stack Overflow thread](https://stackoverflow.com/q/18621568). Tested locally.