### PR TITLE
Bug 1442099 - Add memcached tracing to help debug weirdness in cloud env

### DIFF
--- a/Bugzilla/Memcached.pm
+++ b/Bugzilla/Memcached.pm
@@ -272,7 +272,7 @@ sub _inc_prefix {
     delete Bugzilla->request_cache->{"memcached_prefix_$name"};
 
     # BMO - log that we've wiped the cache
-    NOTICE("$name cache cleared"));
+    INFO("$name cache cleared");
 }
 
 sub _global_prefix {

--- a/Bugzilla/Memcached.pm
+++ b/Bugzilla/Memcached.pm
@@ -11,6 +11,8 @@ use 5.10.1;
 use strict;
 use warnings;
 
+use Bugzilla::Logging;
+use Log::Log4perl qw(:easy);
 use Bugzilla::Error;
 use Scalar::Util qw(blessed);
 use List::Util qw(sum);
@@ -300,17 +302,20 @@ sub _set {
                                           param    => "value" });
     }
 
-    $key = $self->_encode_key($key)
+    my $enc_key = $self->_encode_key($key)
         or return;
-    return $self->{memcached}->set($key, $value);
+    TRACE("set $enc_key");
+    return $self->{memcached}->set($enc_key, $value);
 }
 
 sub _get {
     my ($self, $key) = @_;
 
-    $key = $self->_encode_key($key)
+    my $enc_key = $self->_encode_key($key)
         or return;
-    return $self->{memcached}->get($key);
+    my $val = $self->{memcached}->get($key);
+    TRACE("get $enc_key: " . (defined $val ? "HIT" : "MISS"));
+    return $val;
 }
 
 sub _delete {

--- a/Bugzilla/Memcached.pm
+++ b/Bugzilla/Memcached.pm
@@ -35,7 +35,7 @@ sub _new {
     my $servers = Bugzilla->localconfig->{memcached_servers};
     if (Bugzilla->feature('memcached') && $servers) {
         $self->{namespace} = Bugzilla->localconfig->{memcached_namespace};
-        TRACE("connecting  servers: $servers, namespace: $self->{namespace}");
+        TRACE("connecting servers: $servers, namespace: $self->{namespace}");
         $self->{memcached} = Cache::Memcached::Fast->new({
             servers   => [ split(/[, ]+/, $servers) ],
             namespace => $self->{namespace},
@@ -272,9 +272,7 @@ sub _inc_prefix {
     delete Bugzilla->request_cache->{"memcached_prefix_$name"};
 
     # BMO - log that we've wiped the cache
-    openlog('apache', 'cons,pid', 'local4');
-    syslog('notice', encode_utf8("[memcached] $name cache cleared"));
-    closelog();
+    NOTICE("$name cache cleared"));
 }
 
 sub _global_prefix {

--- a/Bugzilla/Memcached.pm
+++ b/Bugzilla/Memcached.pm
@@ -35,11 +35,15 @@ sub _new {
     my $servers = Bugzilla->localconfig->{memcached_servers};
     if (Bugzilla->feature('memcached') && $servers) {
         $self->{namespace} = Bugzilla->localconfig->{memcached_namespace};
+        TRACE("connecting  servers: $servers, namespace: $self->{namespace}");
         $self->{memcached} = Cache::Memcached::Fast->new({
             servers   => [ split(/[, ]+/, $servers) ],
             namespace => $self->{namespace},
             max_size  => 1024 * 1024 * 4,
         });
+    }
+    else {
+        TRACE("memcached feature is not enabled");
     }
     return bless($self, $class);
 }


### PR DESCRIPTION
This adds TRACE-level logging to _set() and _get(), to help @Micheletto debug something in the new env. 

By default this will have almost no impact -- TRACE is not logged by default. Of course it's not free, but this is fine I think. :)

<img width="935" alt="screen shot 2018-02-28 at 22 26 50" src="https://user-images.githubusercontent.com/47717/36825697-dad99ad8-1cd6-11e8-9835-585e3e02d646.png">
