### PR TITLE
Bug 1442650 - Cookies dont always have httponly flag set (add debugging)

### DIFF
--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -14,6 +14,7 @@ use warnings;
 use CGI;
 use base qw(CGI);
 
+use Bugzilla::Logging;
 use Bugzilla::Constants;
 use Bugzilla::Error;
 use Bugzilla::Util;
@@ -675,6 +676,11 @@ sub send_cookie {
     # Complain if -value is not given or empty (bug 268146).
     if (!exists($paramhash{'-value'}) || !$paramhash{'-value'}) {
         ThrowCodeError('cookies_need_value');
+    }
+
+    unless ($paramhash{'-httponly'}) {
+        my ($pkg, $file, $line) = caller(2);
+        WARN("$paramhash{'-name'} set without -httponly, called in package $pkg, file $file, line $line");
     }
 
     # Add the default path and the domain in.

--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -679,7 +679,7 @@ sub send_cookie {
     }
 
     unless ($paramhash{'-httponly'}) {
-        my ($pkg, $file, $line) = caller(2);
+        my ($pkg, $file, $line) = caller(1);
         WARN("$paramhash{'-name'} set without -httponly, called in package $pkg, file $file, line $line");
     }
 


### PR DESCRIPTION
Bug 1442650 - Cookies dont always have httponly flag set (add debugging)