### PR TITLE
Bug 1441181 - Step 5 - Add logging to jobqueue

### DIFF
--- a/Bugzilla/JobQueue.pm
+++ b/Bugzilla/JobQueue.pm
@@ -11,6 +11,7 @@ use 5.10.1;
 use strict;
 use warnings;
 
+use Bugzilla::Logging;
 use Bugzilla::Constants;
 use Bugzilla::Error;
 use Bugzilla::Install::Util qw(install_string);
@@ -94,6 +95,14 @@ sub insert {
     return $retval;
 }
 
+sub debug {
+    my ($self, @args) = @_;
+    my $caller_pkg = caller;
+    local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
+    my $logger = Log::Log4perl->get_logger($caller_pkg);
+    $logger->debug(@args);
+}
+
 sub work {
     my ($self, $delay) = @_;
     $delay ||= 5;
@@ -109,6 +118,7 @@ sub work {
             }
         }
     );
+    DEBUG("working every $delay seconds");
     $loop->add($timer);
     $timer->start;
     Future->wait_any(map { catch_signal($_) } qw( INT TERM HUP ))->get;

--- a/Bugzilla/JobQueue/Runner.pm
+++ b/Bugzilla/JobQueue/Runner.pm
@@ -20,6 +20,7 @@ use File::Basename;
 use File::Copy;
 use Pod::Usage;
 
+use Bugzilla::Logging;
 use Bugzilla::Constants;
 use Bugzilla::DaemonControl qw(:utils);
 use Bugzilla::JobQueue;
@@ -220,9 +221,11 @@ sub run_worker {
     my $worker_exit_f = $loop->new_future;
     my $worker = IO::Async::Process->new(
         code => sub {
+            DEBUG("starting worker");
             my $jq = Bugzilla->job_queue();
             $jq->set_verbose($self->{debug});
             foreach my $module (values %{ Bugzilla::JobQueue->job_map() }) {
+                DEBUG("JobQueue can do $module");
                 require_module($module);
                 $jq->can_do($module);
             }


### PR DESCRIPTION
This is just logging statements, and overloading the debug() method which is implemented by TheSchwartz. The local assignment tells log4perl to ignore the function itself and report from whence the debug() function is called.