### PR TITLE
Bug 1443049 - is_interactive() must be declared before log4perl config is loaded

### DIFF
--- a/Bugzilla/Logging.pm
+++ b/Bugzilla/Logging.pm
@@ -18,7 +18,7 @@ use English qw(-no_match_vars $PROGRAM_NAME);
 
 sub is_interactive {
     state $is_tty = -t STDOUT || -t STDIN;
-    return $is_tty || $ENV{"Bugzilla.pm"} && Bugzilla->usage_mode == Bugzilla::Constants::USAGE_MODE_CMDLINE;
+    return $is_tty || $INC{"Bugzilla.pm"} && Bugzilla->usage_mode == Bugzilla::Constants::USAGE_MODE_CMDLINE;
 }
 
 BEGIN {

--- a/Bugzilla/Logging.pm
+++ b/Bugzilla/Logging.pm
@@ -17,8 +17,7 @@ use Bugzilla::Constants qw(bz_locations);
 use English qw(-no_match_vars $PROGRAM_NAME);
 
 sub is_interactive {
-    state $is_tty = -t STDOUT || -t STDIN;
-    return $is_tty || $INC{"Bugzilla.pm"} && Bugzilla->usage_mode == Bugzilla::Constants::USAGE_MODE_CMDLINE;
+    return exists $ENV{'SERVER_SOFTWARE'} ? 1 : 0;
 }
 
 BEGIN {

--- a/Bugzilla/Logging.pm
+++ b/Bugzilla/Logging.pm
@@ -16,6 +16,11 @@ use File::Spec::Functions qw(rel2abs);
 use Bugzilla::Constants qw(bz_locations);
 use English qw(-no_match_vars $PROGRAM_NAME);
 
+sub is_interactive {
+    state $is_tty = -t STDOUT || -t STDIN;
+    return $is_tty || $ENV{"Bugzilla.pm"} && Bugzilla->usage_mode == Bugzilla::Constants::USAGE_MODE_CMDLINE;
+}
+
 BEGIN {
     my $file = $ENV{LOG4PERL_CONFIG_FILE} // 'log4perl-syslog.conf';
     Log::Log4perl::Logger::create_custom_level('NOTICE', 'WARN', 5, 2);
@@ -104,11 +109,6 @@ sub import {
         },
         $logger
     );
-}
-
-sub is_interactive {
-    state $is_tty = -t STDOUT || -t STDIN;
-    return $is_tty || $ENV{"Bugzilla.pm"} && Bugzilla->usage_mode == Bugzilla::Constants::USAGE_MODE_CMDLINE;
 }
 
 1;


### PR DESCRIPTION
So this function is called as a log filter in the conf/log4perl-*.conf files. So it needs to be defined before those files are loaded.