### PR TITLE
Bug 1443058 - Backport 1087400 to bmo - CGI 4.05 throws tons of "CGI::param called in list context" warnings

### DIFF
--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -597,6 +597,8 @@ sub header {
 sub param {
     my $self = shift;
 
+    local $CGI::LIST_CONTEXT_WARN = 0;
+
     # When we are just requesting the value of a parameter...
     if (scalar(@_) == 1) {
         my @result = $self->SUPER::param(@_);

--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -11,6 +11,7 @@ use 5.10.1;
 use strict;
 use warnings;
 
+use Bugzilla::Logging;
 use CGI;
 use base qw(CGI);
 
@@ -597,7 +598,18 @@ sub header {
 sub param {
     my $self = shift;
 
+    # We don't let CGI.pm warn about list context, but we do it ourselves.
     local $CGI::LIST_CONTEXT_WARN = 0;
+    state $has_warned = 0;
+
+    ## no critic (Freenode::Wantarray)
+    if ( wantarray && !$has_warned) {
+        my ( $package, $filename, $line ) = caller;
+        if ( $package ne 'CGI' ) {
+            $has_warned = 1;
+            WARN("Bugzilla::CGI::param called in list context from $package $filename:$line");
+        }
+    }
 
     # When we are just requesting the value of a parameter...
     if (scalar(@_) == 1) {

--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -600,13 +600,12 @@ sub param {
 
     # We don't let CGI.pm warn about list context, but we do it ourselves.
     local $CGI::LIST_CONTEXT_WARN = 0;
-    state $has_warned = 0;
+    state $has_warned = {};
 
     ## no critic (Freenode::Wantarray)
-    if ( wantarray && !$has_warned) {
+    if ( wantarray ) {
         my ( $package, $filename, $line ) = caller;
-        if ( $package ne 'CGI' ) {
-            $has_warned = 1;
+        if ( $package ne 'CGI' && ! $has_warned->{"$filename:$line"}++) {
             WARN("Bugzilla::CGI::param called in list context from $package $filename:$line");
         }
     }

--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -603,12 +603,13 @@ sub param {
     state $has_warned = {};
 
     ## no critic (Freenode::Wantarray)
-    if ( wantarray ) {
+    if ( wantarray && @_ ) {
         my ( $package, $filename, $line ) = caller;
         if ( $package ne 'CGI' && ! $has_warned->{"$filename:$line"}++) {
             WARN("Bugzilla::CGI::param called in list context from $package $filename:$line");
         }
     }
+    ## use critic
 
     # When we are just requesting the value of a parameter...
     if (scalar(@_) == 1) {


### PR DESCRIPTION
This does look bad, but we've had this code in upstream bugzilla for a while. And the warnings tend to be very annoying. Currently this is keeping us on an older version of CGI.pm