### PR TITLE
Bug 1443057 - Backport 1136125 to bmo - Reduce memory usage of Bugzilla::CGI->send_cookie()

### DIFF
--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -661,16 +661,7 @@ sub should_set {
 # pass them around to all of the callers. Instead, store them locally here,
 # and then output as required from |header|.
 sub send_cookie {
-    my $self = shift;
-
-    # Move the param list into a hash for easier handling.
-    my %paramhash;
-    my @paramlist;
-    my ($key, $value);
-    while ($key = shift) {
-        $value = shift;
-        $paramhash{$key} = $value;
-    }
+    my ($self, %paramhash) = @_;
 
     # Complain if -value is not given or empty (bug 268146).
     if (!exists($paramhash{'-value'}) || !$paramhash{'-value'}) {
@@ -684,13 +675,7 @@ sub send_cookie {
     $paramhash{'-secure'} = 1
       if lc( $uri->scheme ) eq 'https';
 
-
-    # Move the param list back into an array for the call to cookie().
-    foreach (keys(%paramhash)) {
-        unshift(@paramlist, $_ => $paramhash{$_});
-    }
-
-    push(@{$self->{'Bugzilla_cookie_list'}}, $self->cookie(@paramlist));
+    push(@{$self->{'Bugzilla_cookie_list'}}, $self->cookie(%paramhash));
 }
 
 # Cookies are removed by setting an expiry date in the past.


### PR DESCRIPTION
This is just removing some dumb code that turns an array into a hash using (shift, shift) and a then a hash into an array using unshift... Originally [Bug 1136125](https://bugzilla.mozilla.org/show_bug.cgi?id=1136125).