### PR TITLE
Bug 1328900 - Create new group called 'disableusers' that can only edit the bugmail and disabledtext fields of a user

### DIFF
--- a/Bugzilla/Install.pm
+++ b/Bugzilla/Install.pm
@@ -204,6 +204,10 @@ use constant SYSTEM_GROUPS => (
         description => 'Can edit or disable users'
     },
     {
+        name        => 'disableusers',
+        description => 'Can disable users'
+    },
+    {
         name        => 'creategroups',
         description => 'Can create and destroy groups'
     },

--- a/admin.cgi
+++ b/admin.cgi
@@ -25,6 +25,7 @@ print $cgi->header();
 $user->in_group('admin')
   || $user->in_group('tweakparams')
   || $user->in_group('editusers')
+  || $user->in_group('disableusers')
   || $user->can_bless
   || (Bugzilla->params->{'useclassification'} && $user->in_group('editclassifications'))
   || $user->in_group('editcomponents')

--- a/editusers.cgi
+++ b/editusers.cgi
@@ -26,15 +26,18 @@ use Bugzilla::Token;
 
 my $user = Bugzilla->login(LOGIN_REQUIRED);
 
-my $cgi       = Bugzilla->cgi;
-my $template  = Bugzilla->template;
-my $dbh       = Bugzilla->dbh;
-my $userid    = $user->id;
-my $editusers = $user->in_group('editusers');
+my $cgi          = Bugzilla->cgi;
+my $template     = Bugzilla->template;
+my $dbh          = Bugzilla->dbh;
+my $userid       = $user->id;
+my $editusers    = $user->in_group('editusers');
+my $disableusers = $user->in_group('disableusers');
+
 local our $vars     = {};
 
 # Reject access if there is no sense in continuing.
 $editusers
+    || $disableusers
     || $user->can_bless()
     || ThrowUserError("auth_failure", {group  => "editusers",
                                        reason => "cant_bless",
@@ -51,6 +54,7 @@ my $token          = $cgi->param('token');
 
 # Prefill template vars with data used in all or nearly all templates
 $vars->{'editusers'} = $editusers;
+$vars->{'disableusers'} = $disableusers;
 mirrorListSelectionValues();
 
 Bugzilla::Hook::process('admin_editusers_action',
@@ -246,11 +250,8 @@ if ($action eq 'search') {
     my $changes = {};
     if ($editusers) {
         $otherUser->set_login($cgi->param('login'));
-        $otherUser->set_name($cgi->param('name'));
         $otherUser->set_password($cgi->param('password'))
             if $cgi->param('password');
-        $otherUser->set_disabledtext($cgi->param('disabledtext'));
-        $otherUser->set_disable_mail($cgi->param('disable_mail'));
         $otherUser->set_extern_id($cgi->param('extern_id'))
             if defined($cgi->param('extern_id'));
         $otherUser->set_password_change_required($cgi->param('password_change_required'));
@@ -262,8 +263,15 @@ if ($action eq 'search') {
         if ($user->in_group('bz_can_disable_mfa') && $otherUser->mfa && $cgi->param('mfa') eq '') {
             $otherUser->set_mfa('');
         }
-        $changes = $otherUser->update();
     }
+
+    if ($editusers || $disableusers) {
+        $otherUser->set_name($cgi->param('name'));
+        $otherUser->set_disabledtext($cgi->param('disabledtext'));
+        $otherUser->set_disable_mail($cgi->param('disable_mail'));
+    }
+
+    $changes = $otherUser->update();
 
     # Update group settings.
     my $sth_add_mapping = $dbh->prepare(
@@ -850,7 +858,9 @@ sub edit_processing {
     my $user = Bugzilla->user;
     my $template = Bugzilla->template;
 
-    $user->in_group('editusers') || $user->can_see_user($otherUser)
+    $user->in_group('editusers')
+        || $user->in_group('disableusers')
+        || $user->can_see_user($otherUser)
         || ThrowUserError('auth_failure', {reason => "not_visible",
                                            action => "modify",
                                            object => "user"});

--- a/template/en/default/admin/admin.html.tmpl
+++ b/template/en/default/admin/admin.html.tmpl
@@ -56,7 +56,7 @@
         You can also automate this check by running <tt>sanitycheck.pl</tt> from a cron job.
         A notification will be sent per email to the specified user if errors are detected.</dd>
 
-        [% class = (user.in_group('editusers') || user.can_bless) ? "" : "forbidden" %]
+        [% class = (user.in_group('editusers') || user.in_group('disableusers') || user.can_bless) ? "" : "forbidden" %]
         <dt id="users" class="[% class %]"><a href="editusers.cgi">Users</a></dt>
         <dd class="[% class %]">Create new user accounts or edit existing ones. You can
         also add and remove users from groups (also known as "user privileges").</dd>

--- a/template/en/default/admin/users/edit.html.tmpl
+++ b/template/en/default/admin/users/edit.html.tmpl
@@ -68,9 +68,10 @@ $(function() {
 <form method="post" action="editusers.cgi">
 <table class="main">
   [% PROCESS admin/users/userdata.html.tmpl
-    editform  = 1
-    editusers = editusers
-    otheruser = otheruser
+    editform     = 1
+    editusers    = editusers
+    disableusers = disableusers
+    otheruser    = otheruser
   %]
   [% IF groups.size %]
     <tr>

--- a/template/en/default/admin/users/userdata.html.tmpl
+++ b/template/en/default/admin/users/userdata.html.tmpl
@@ -54,7 +54,7 @@
 <tr>
   <th><label for="name">Real name:</label></th>
   <td>
-    [% IF editusers %]
+    [% IF editusers || disableusers %]
       <input size="64" maxlength="255" name="name"
              autocomplete="off"
              id="name" value="[% otheruser.name FILTER html %]">
@@ -94,7 +94,9 @@
       [% END %]
     </td>
   </tr>
+[% END %]
 
+[% IF editusers || disableusers %]
   <tr>
     <th><label for="disable_mail">[% terms.Bug %]mail Disabled:</label></th>
     <td>
@@ -122,30 +124,31 @@
       explain why.)
     </td>
   </tr>
-  [% IF editform %]
-    <tr>
-      <th><label for="mfa">Two-factor Auth:</label></th>
-      <td>
-        [% IF user.in_group('bz_can_disable_mfa') %]
-          [% IF otheruser.mfa %]
-            <select name="mfa" value="mfa">
-              <option value="">Disable</option>
-              [% SWITCH otheruser.mfa %]
-                [% CASE "TOTP" %]
-                  <option value="TOTP" selected>Enabled - TOTP</option>
-                [% CASE "Duo" %]
-                  <option value="Duo" selected>Enabled - Duo Security</option>
-              [% END %]
-            </select>
-          [% ELSE %]
-            Disabled
-          [% END %]
+[% END %]
+
+[% IF editform && editusers %]
+  <tr>
+    <th><label for="mfa">Two-factor Auth:</label></th>
+    <td>
+      [% IF user.in_group('bz_can_disable_mfa') %]
+        [% IF otheruser.mfa %]
+          <select name="mfa" value="mfa">
+            <option value="">Disable</option>
+            [% SWITCH otheruser.mfa %]
+              [% CASE "TOTP" %]
+                <option value="TOTP" selected>Enabled - TOTP</option>
+              [% CASE "Duo" %]
+                <option value="Duo" selected>Enabled - Duo Security</option>
+            [% END %]
+          </select>
         [% ELSE %]
-          [% otheruser.mfa ? "Enabled - " _ otheruser.mfa : "Disabled" FILTER html %]
+          Disabled
         [% END %]
-      </td>
-    </tr>
-  [% END %]
+      [% ELSE %]
+        [% otheruser.mfa ? "Enabled - " _ otheruser.mfa : "Disabled" FILTER html %]
+      [% END %]
+    </td>
+  </tr>
 [% END %]
 
 [% Hook.process('end') %]

--- a/template/en/default/global/site-navigation.html.tmpl
+++ b/template/en/default/global/site-navigation.html.tmpl
@@ -69,22 +69,22 @@
   [% END %]
 
   [%# *** Bugzilla Administration Tools *** %]
-  [% IF user.login %] 
-    [% '<link rel="Administration" title="Parameters"    
+  [% IF user.login %]
+    [% '<link rel="Administration" title="Parameters"
               href="editparams.cgi">' IF user.in_group('tweakparams') %]
-    [% '<link rel="Administration" title="Users"    
-              href="editusers.cgi">' IF user.in_group('editusers') %]
+    [% '<link rel="Administration" title="Users"
+              href="editusers.cgi">' IF user.in_group('editusers') || user.in_group('disableusers') %]
     [% '<link rel="Administration" title="Products" href="editproducts.cgi">'
        IF user.in_group('editcomponents') || user.get_products_by_permission("editcomponents").size %]
-    [% '<link rel="Administration" title="Flag Types"   
+    [% '<link rel="Administration" title="Flag Types"
               href="editflagtypes.cgi">' IF user.in_group('editcomponents') %]
-    [% '<link rel="Administration" title="Groups"        
+    [% '<link rel="Administration" title="Groups"
               href="editgroups.cgi">' IF user.in_group('creategroups') %]
-    [% '<link rel="Administration" title="Keywords"      
+    [% '<link rel="Administration" title="Keywords"
               href="editkeywords.cgi">' IF user.in_group('editkeywords') %]
-    [% '<link rel="Administration" title="Whining"       
+    [% '<link rel="Administration" title="Whining"
               href="editwhines.cgi">' IF user.in_group('bz_canusewhines') %]
-    [% '<link rel="Administration" title="Sanity Check"  
+    [% '<link rel="Administration" title="Sanity Check"
               href="sanitycheck.cgi">' IF user.in_group('editcomponents') %]
-  [% END %]  
+  [% END %]
 [% END %]

--- a/template/en/default/global/user.html.tmpl
+++ b/template/en/default/global/user.html.tmpl
@@ -28,7 +28,7 @@
     [% IF user.id %]
       <a class="email" href="mailto:[% who.email FILTER html %]"
          onclick="return show_usermenu([% who.id FILTER none %], '[% who.email FILTER js %]',
-                  [% user.in_group('editusers') || user.bless_groups.size > 0 ? "true" : "false" %]);"
+                  [% user.in_group('editusers') || user.in_group('disableusers') || user.bless_groups.size > 0 ? "true" : "false" %]);"
         title="[% who.identity FILTER html %]">
     [%- END -%]
     [% IF who %]


### PR DESCRIPTION
```
patching file admin.cgi
patching file editusers.cgi
Hunk #3 FAILED at 237.
1 out of 6 hunks FAILED -- saving rejects to file editusers.cgi.rej
patching file extensions/BugModal/template/en/default/bug_modal/user.html.tmpl
Hunk #1 FAILED at 46.
1 out of 1 hunk FAILED -- saving rejects to file extensions/BugModal/template/en/default/bug_modal/user.html.tmpl.rej
patching file extensions/SecureMail/template/en/default/hook/admin/users/userdata-end.html.tmpl
Hunk #1 FAILED at 8.
1 out of 1 hunk FAILED -- saving rejects to file extensions/SecureMail/template/en/default/hook/admin/users/userdata-end.html.tmpl.rej
patching file template/en/default/admin/admin.html.tmpl
patching file template/en/default/admin/users/edit.html.tmpl
patching file template/en/default/admin/users/userdata.html.tmpl
can't find file to patch at input line 327
Skipping patch.
1 out of 1 hunk ignored
patching file template/en/default/global/header.html.tmpl
Hunk #1 FAILED at 322.
1 out of 1 hunk FAILED -- saving rejects to file template/en/default/global/header.html.tmpl.rej
patching file template/en/default/global/site-navigation.html.tmpl
patching file template/en/default/global/user.html.tmpl

```