### PR TITLE
Bug 1444088 - review link for patches on the requests page no longer shows up

### DIFF
--- a/extensions/Splinter/template/en/default/hook/request/queue-after_column.html.tmpl
+++ b/extensions/Splinter/template/en/default/hook/request/queue-after_column.html.tmpl
@@ -1,4 +1,4 @@
-[% IF column == 'attachment' && request.ispatch %]
+[% IF column == 'attachment' && request.attach_ispatch %]
   &nbsp;
   <a href="[% Bugzilla.splinter_review_url(request.bug_id, request.attach_id) FILTER none %]">[review]</a>
 [% END %]


### PR DESCRIPTION
Fix [Bug 1444088 - review link for patches on the requests page no longer shows up](https://bugzilla.mozilla.org/show_bug.cgi?id=1444088)

## Description

This is a fallout from #372. I changed `ispatch` to `attach_ispatch` but forgot to look at hooks linked from the [request templates](https://github.com/mozilla-bteam/bmo/tree/master/template/en/default/request) and this is the only one needs to be updated.