### PR TITLE
Bug 1441181 - Step 6 - Add concurrency 

### DIFF
--- a/jobqueue.pl
+++ b/jobqueue.pl
@@ -40,6 +40,8 @@ jobqueue.pl - Runs jobs in the background for Bugzilla.
              process id. Defaults to F<data/jobqueue.pl.pid>.
    -n name   What should this process call itself in the system log?
              Defaults to the full path you used to invoke the script.
+   -j jobs   How many child processes should be run?
+             Defaults to 1.
 
    COMMANDS:
    start     Starts a new jobqueue daemon if there isn't one running already


### PR DESCRIPTION
(Originally #439, which was accidentally merged to the wrong branch)

Documentation of the things this is using:

[Future::Utils::fmap_void is described here](https://metacpan.org/pod/Future::Utils#APPLYING-A-FUNCTION-TO-A-LIST).

The main loop of the master is basically this future:

```perl
fmap_void { $self->run_worker("work") }
    concurrent => $jobs,
    generate   => sub { !$signal_f->is_ready };
```

So until the `$signal_f` future is ready (done, canceled, or failed), the fmap_void ensures that least `$jobs` of the `run_worker()` futures are pending. The result of `fmap_void` is a single future.
It's `fmap_void` because it does not collect the (potentially infinite) number of generated `run_worker()` futures.