### PR TITLE
Bug 1445700 -  apache_size_limit should be 800_000 when Linux::Smaps is not installed. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ main_filters: &main_filters
 
 defaults:
   bmo_slim_image: &bmo_slim_image
-    image: mozillabteam/bmo-slim:20180313.1
+    image: mozillabteam/bmo-slim:20180314.1
     user: app
 
   mysql_image: &mysql_image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mozillabteam/bmo-slim:20180313.1
+FROM mozillabteam/bmo-slim:20180314.1
 
 ARG CI
 ARG CIRCLE_SHA1

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -99,7 +99,7 @@ if ( $OSNAME eq 'linux' ) {
     # This isn't strictly needed, but it is nice to have.
     # we use it to make sure jobqueue-workers exit when their parent exits.
     my @extra = qw(Linux::Pdeathsig);
-    $recommends{'Linux::Smaps'} = 1;
+    $recommends{'Linux::Smaps'} = '0.13';
 
     # for some reason, we need these on ubuntu.
     push @extra, qw(

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -99,6 +99,7 @@ if ( $OSNAME eq 'linux' ) {
     # This isn't strictly needed, but it is nice to have.
     # we use it to make sure jobqueue-workers exit when their parent exits.
     my @extra = qw(Linux::Pdeathsig);
+    $recommends{'Linux::Smaps'} = 1;
 
     # for some reason, we need these on ubuntu.
     push @extra, qw(

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -95,19 +95,13 @@ if ( $OSNAME eq 'MSWin32' ) {
     $requires{'DateTime::TimeZone::Local::Win32'} = '1.64';
 }
 
-if ( $OSNAME eq 'linux' ) {
-    # This isn't strictly needed, but it is nice to have.
-    # we use it to make sure jobqueue-workers exit when their parent exits.
-    my @extra = qw(Linux::Pdeathsig);
-
-    # for some reason, we need these on ubuntu.
-    push @extra, qw(
-        Linux::Pid
+if ( $OSNAME eq 'linux' && -f '/etc/debian_version' ) {
+    my @extra = qw(
         Test::Pod::Coverage
         Pod::Coverage::TrustPod
         Test::CPAN::Meta
         Test::Pod
-    ) if -f '/etc/debian_version';
+    );
     $requires{$_} = 0 for @extra;
 }
 
@@ -321,6 +315,14 @@ my %optional_features = (
             runtime => {
                 requires => { 'Linux::Smaps' => '0.13' },
             }
+        },
+    },
+    linux_pdeath => {
+        description => 'Linux::Pdeathsig for a good parent/child relationships',
+        prereqs => {
+            runtime => {
+                requires => { 'Linux::Pdeathsig' => 0 },
+            },
         },
     },
     jobqueue => {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -313,7 +313,7 @@ my %optional_features = (
         description => 'Linux::Smaps for limiting memory usage',
         prereqs => {
             runtime => {
-                requires => { 'Linux::Smaps' => '0.13' },
+                requires => { 'Linux::Smaps' => '0' },
             }
         },
     },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -99,7 +99,6 @@ if ( $OSNAME eq 'linux' ) {
     # This isn't strictly needed, but it is nice to have.
     # we use it to make sure jobqueue-workers exit when their parent exits.
     my @extra = qw(Linux::Pdeathsig);
-    $recommends{'Linux::Smaps'} = '0.13';
 
     # for some reason, we need these on ubuntu.
     push @extra, qw(
@@ -316,6 +315,14 @@ my %optional_features = (
             },
         },
     },
+    linux_smaps => {
+        description => 'Linux::Smaps for limiting memory usage',
+        prereqs => {
+            runtime => {
+                requires => { 'Linux::Smaps' => '0.13' },
+            }
+        },
+    },
     jobqueue => {
         description => 'Mail Queueing',
         prereqs     => {
@@ -363,21 +370,7 @@ for my $file ( glob 'extensions/*/Config.pm' ) {
 }
 
 # BMO Customization
-my @bmo_features = grep {
-    !m{
-        ^
-        (?: pg
-          | oracle
-          | mod_perl
-          | sqlite
-          | auth_ldap
-          | auth_radius
-          | smtp_auth
-          | linux_pid
-          | updates)
-        $
-    }mxs;
-} keys %optional_features;
+my @bmo_features = grep { is_bmo_feature($_) } keys %optional_features;
 
 $optional_features{bmo} = {
     description => 'features that bmo needs',
@@ -428,3 +421,19 @@ META.yml: Makefile.PL
 MAKE
 }
 
+sub is_bmo_feature {
+    local $_ = shift;
+    return 1 if $OSNAME eq 'linux' && /^linux/;
+    return !m{
+        ^
+        (?: pg
+          | oracle
+          | mod_perl
+          | sqlite
+          | auth_ldap
+          | auth_radius
+          | smtp_auth
+          | updates)
+        $
+    }mxs;
+}

--- a/mod_perl.pl
+++ b/mod_perl.pl
@@ -78,8 +78,9 @@ Bugzilla::CGI->compile(qw(:cgi :push));
 # is taking up more than $apache_size_limit of RAM all by itself, not counting RAM it is
 # sharing with the other httpd processes.
 my $limit = Bugzilla->localconfig->{apache_size_limit};
-if ($limit < 400_000) {
-    $limit = 400_000;
+if ($OSNAME eq 'linux' && ! eval { require Linux::Smaps }) {
+    warn "SizeLimit requires Linux::Smaps on linux. size limit set to 800MB";
+    $limit = 800_000;
 }
 Apache2::SizeLimit->set_max_unshared_size($limit);
 

--- a/mod_perl.pl
+++ b/mod_perl.pl
@@ -55,6 +55,7 @@ use Apache2::SizeLimit;
 use ModPerl::RegistryLoader ();
 use File::Basename ();
 use File::Find ();
+use English qw(-no_match_vars $OSNAME);
 
 # This loads most of our modules.
 use Bugzilla ();


### PR DESCRIPTION
So this patch adds Linux::Smaps as a optional feature dependency,
and it also makes Linux::Pdeathsig the same. It then includes all linux_ features into the 'bmo' feature...
What this means is that Linux:: modules are required for bmo but if you want to run this locally on OSX it will still work.

If Linux::Smaps is not found, and we're running on linux, we set a huge apache_size_limit and issue a warning.