### PR TITLE
Bug 1446156 - mkdir template_cache: Permission denied

### DIFF
--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -1074,6 +1074,8 @@ our %_templates_to_precompile;
 sub precompile_templates {
     my ($output) = @_;
 
+    return unless is_webserver_group();
+
     # Remove the compiled templates.
     my $cache_dir = bz_locations()->{'template_cache'};
     my $datadir = bz_locations()->{'datadir'};

--- a/checksetup.pl
+++ b/checksetup.pl
@@ -156,12 +156,14 @@ unless ($ENV{LOCALCONFIG_ENV}) {
 }
 my $lc_hash = Bugzilla->localconfig;
 
-# when not on windows, if we're root, and 
-unless (ON_WINDOWS) {
-    if ($EUID == 0 && $lc_hash->{webservergroup}) {
-        $EGID = getgrnam($lc_hash->{webservergroup});
-        umask 002;
-    }
+if ( $EUID == 0 && $lc_hash->{webservergroup} && !ON_WINDOWS ) {
+    # So checksetup was run as root, and we have a webserver group set.
+    # Let's assume the user wants us to make files that are writable
+    # by the webserver group.
+
+    $EGID = getgrnam $lc_hash->{webservergroup}; ## no critic (Variables::RequireLocalizedPunctuationVars)
+    umask 002
+        or die "failed to set umask 002: $!";
 }
 
 unless ($switch{'no-database'}) {

--- a/checksetup.pl
+++ b/checksetup.pl
@@ -30,6 +30,7 @@ use Pod::Usage;
 # Bug 1270550 - Tie::Hash::NamedCapture must be loaded before Safe.
 use Tie::Hash::NamedCapture;
 use Safe;
+use English qw(-no_match_vars $EUID $EGID);
 
 use Bugzilla::Constants;
 use Bugzilla::Install::Requirements;
@@ -154,6 +155,14 @@ unless ($ENV{LOCALCONFIG_ENV}) {
     update_localconfig({ output => !$silent, use_defaults => $switch{'default-localconfig'} });
 }
 my $lc_hash = Bugzilla->localconfig;
+
+# when not on windows, if we're root, and 
+unless (ON_WINDOWS) {
+    if ($EUID == 0 && $lc_hash->{webservergroup}) {
+        $EGID = getgrnam($lc_hash->{webservergroup});
+        umask 002;
+    }
+}
 
 unless ($switch{'no-database'}) {
     die "urlbase is not set\n" unless $lc_hash->{urlbase};


### PR DESCRIPTION
This seems to make bugzilla-dev happy.
I've verified other files created by checksetup end up with correct permissions (e.g. version.json)