### PR TITLE
Bug 1440829 - Bugzilla comment for Phabricator commit should include entire commit message, not just first line

### DIFF
--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -237,7 +237,7 @@ sub process_revision_change {
 
     my ($timestamp) = Bugzilla->dbh->selectrow_array("SELECT NOW()");
 
-    my $attachment = create_revision_attachment($bug, $revision->id, $revision->title, $timestamp);
+    my $attachment = create_revision_attachment($bug, $revision, $timestamp);
 
     # ATTACHMENT OBSOLETES
 

--- a/extensions/PhabBugz/lib/Revision.pm
+++ b/extensions/PhabBugz/lib/Revision.pm
@@ -29,6 +29,7 @@ use Bugzilla::Extension::PhabBugz::Util qw(
 has id               => ( is => 'ro',   isa => Int );
 has phid             => ( is => 'ro',   isa => Str );
 has title            => ( is => 'ro',   isa => Str );
+has summary          => ( is => 'ro',   isa => Str );
 has status           => ( is => 'ro',   isa => Str );
 has creation_ts      => ( is => 'ro',   isa => Str );
 has modification_ts  => ( is => 'ro',   isa => Str );
@@ -93,6 +94,7 @@ sub BUILDARGS {
     my ( $class, $params ) = @_;
 
     $params->{title}           = $params->{fields}->{title};
+    $params->{summary}         = $params->{fields}->{summary};
     $params->{status}          = $params->{fields}->{status}->{value};
     $params->{creation_ts}     = $params->{fields}->{dateCreated};
     $params->{modification_ts} = $params->{fields}->{dateModified};

--- a/extensions/PhabBugz/lib/Util.pm
+++ b/extensions/PhabBugz/lib/Util.pm
@@ -77,12 +77,12 @@ sub _get_revisions {
 }
 
 sub create_revision_attachment {
-    my ( $bug, $revision_id, $revision_title, $timestamp ) = @_;
+    my ( $bug, $revision, $timestamp ) = @_;
 
     my $phab_base_uri = Bugzilla->params->{phabricator_base_uri};
     ThrowUserError('invalid_phabricator_uri') unless $phab_base_uri;
 
-    my $revision_uri = $phab_base_uri . "D" . $revision_id;
+    my $revision_uri = $phab_base_uri . "D" . $revision->id;
 
     # Check for previous attachment with same revision id.
     # If one matches then return it instead. This is fine as
@@ -102,8 +102,8 @@ sub create_revision_attachment {
             bug         => $bug,
             creation_ts => $timestamp,
             data        => $revision_uri,
-            description => $revision_title,
-            filename    => 'phabricator-D' . $revision_id . '-url.txt',
+            description => $revision->title,
+            filename    => 'phabricator-D' . $revision->id . '-url.txt',
             ispatch     => 0,
             isprivate   => 0,
             mimetype    => PHAB_CONTENT_TYPE,
@@ -111,8 +111,8 @@ sub create_revision_attachment {
     );
 
     # Insert a comment about the new attachment into the database.
-    $bug->add_comment('', { type => CMT_ATTACHMENT_CREATED,
-                            extra_data => $attachment->id });
+    $bug->add_comment($revision->summary, { type       => CMT_ATTACHMENT_CREATED,
+                                            extra_data => $attachment->id });
 
     return $attachment;
 }


### PR DESCRIPTION
…entire commit message, not just first line