### PR TITLE
Bug 1440328 - Obfuscate mentor email for users that aren't logged in

### DIFF
--- a/extensions/BMO/template/en/default/pages/user_activity.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/user_activity.html.tmpl
@@ -199,6 +199,7 @@
                change.fieldname == 'reporter' ||
                change.fieldname == 'qa_contact' ||
                change.fieldname == 'cc' ||
+               change.fieldname == 'bug_mentor' ||
                change.fieldname == 'flagtypes.name' %]
         [% display_value(change.fieldname, change_type) FILTER email FILTER html %]
       [% ELSE %]

--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -365,7 +365,7 @@
           ", " UNLESS loop.last;
         END;
 
-      CASE [ 'assigned_to', 'reporter', 'qa_contact', 'cc', 'flagtypes.name' ];
+      CASE [ 'assigned_to', 'reporter', 'qa_contact', 'cc', 'bug_mentor', 'flagtypes.name' ];
         value FILTER email;
 
       CASE 'reporter_accessible';

--- a/extensions/InlineHistory/template/en/default/hook/bug/comments-aftercomments.html.tmpl
+++ b/extensions/InlineHistory/template/en/default/hook/bug/comments-aftercomments.html.tmpl
@@ -155,6 +155,7 @@
            change.fieldname == 'reporter' ||
            change.fieldname == 'qa_contact' ||
            change.fieldname == 'cc' ||
+           change.fieldname == 'bug_mentor' ||
            change.fieldname == 'flagtypes.name' %]
     [% value FILTER email FILTER js %]
   [% ELSIF change.fieldtype == constants.FIELD_TYPE_DATETIME %]

--- a/template/en/default/bug/activity/table.html.tmpl
+++ b/template/en/default/bug/activity/table.html.tmpl
@@ -107,6 +107,7 @@
                change.fieldname == 'reporter' ||
                change.fieldname == 'qa_contact' ||
                change.fieldname == 'cc' ||
+               change.fieldname == 'bug_mentor' ||
                change.fieldname == 'flagtypes.name' %]
         [% display_value(change.fieldname, change_type) FILTER email FILTER html %]
       [% ELSE %]


### PR DESCRIPTION
## Summary
Throughout bugzilla we normally remove the host of an email address
when displaying the page to a user that is not authenticated. This
prevents spam bots and such from scrapping people's emails.

This was not being done for mentor email addresses in the activity
stream and bug history. See Bug 1440328.

This commit properly filters the mentor email addresses in all places
where we commonly filter emails.

## Notice
Filtering in `user_activity.html.tmpl` and `activity_stream.html.tmpl` fixes the immediate problem mentioned in the bug, but I've also filtered in `comments-aftercomments.html.tmpl` and `table.html.tmpl` since those areas looked similar. Please let me know if I should revert those changes.

## User Activity Page
![mentor-activity-old](https://user-images.githubusercontent.com/7828780/37544498-8b4b05d0-293b-11e8-9231-f77388f821d7.PNG)
![mentor-activity-new](https://user-images.githubusercontent.com/7828780/37544514-9cb880ae-293b-11e8-81a5-8b3c83a3521b.PNG)


## User History Page
![mentor-history-old](https://user-images.githubusercontent.com/7828780/37544505-951ebd36-293b-11e8-8376-f863909c3629.PNG)
![mentor-history-new](https://user-images.githubusercontent.com/7828780/37544517-9eecf026-293b-11e8-93dc-6ab9b07c9c17.PNG)

