### PR TITLE
add shadowdb username and password in localconfig param override

### DIFF
--- a/Bugzilla/DB.pm
+++ b/Bugzilla/DB.pm
@@ -111,8 +111,13 @@ sub connect_shadow {
     my $connect_params = dclone(Bugzilla->localconfig);
     $connect_params->{db_host} = Bugzilla->get_param_with_override('shadowdbhost');
     $connect_params->{db_name} = Bugzilla->get_param_with_override('shadowdb');
-    $connect_params->{db_port} = Bugzilla->get_param_with_override('shadowport');
-    $connect_params->{db_sock} = Bugzilla->get_param_with_override('shadowsock');
+    $connect_params->{db_port} = Bugzilla->get_param_with_override('shadowdbport');
+    $connect_params->{db_sock} = Bugzilla->get_param_with_override('shadowdbsock');
+
+    if ( Bugzilla->localconfig->{'shadowdb_user'} && Bugzilla->localconfig->{'shadowdb_pass'} ) {
+        $connect_params->{db_user} = Bugzilla->localconfig->{'shadowdb_user'};
+        $connect_params->{db_pass} = Bugzilla->localconfig->{'shadowdb_pass'};
+    }
 
     return _connect($connect_params);
 }

--- a/Bugzilla/Install/Localconfig.pm
+++ b/Bugzilla/Install/Localconfig.pm
@@ -175,6 +175,14 @@ use constant LOCALCONFIG_VARS => (
         name => 'inbound_proxies',
         default => _migrate_param( 'inbound_proxies', '' ),
     },
+    {
+        name => 'shadowdb_user',
+        default => '',
+    },
+    {
+        name => 'shadowdb_pass',
+        default => '',
+    }
 );
 
 

--- a/template/en/default/setup/strings.txt.pl
+++ b/template/en/default/setup/strings.txt.pl
@@ -269,6 +269,12 @@ END
 This is the max amount of unshared memory the apache process is allowed to use
 before Apache::SizeLimit kills it. This is only applicable when run under mod_perl.
 EOT
+    localconfig_shadowdb_user => <<EOT,
+The username used to authenticate to the shadow db. 
+EOT
+    localconfig_shadowdb_pass => <<EOT,
+The password used to authenticate to the shadow db.
+EOT
     max_allowed_packet => <<EOT,
 WARNING: You need to set the max_allowed_packet parameter in your MySQL
 configuration to at least ##needed##. Currently it is set to ##current##.


### PR DESCRIPTION
Adds a localconfig option to specify a username and password to use when connecting to the shadow db. If not provided, the default dbuser an dbpass will be used.
Also fixes a typo with setting the shadowport and shadowsock.