### PR TITLE
Bug 1200695 - API-key-creation emails should reflect if the action was a result of auth delegation

### DIFF
--- a/template/en/default/email/new-api-key.txt.tmpl
+++ b/template/en/default/email/new-api-key.txt.tmpl
@@ -26,9 +26,17 @@ or update the key at the following URL:
 
 [%+ urlbase %]userprefs.cgi?tab=apikey
 
+[% IF new_key.app_id == Param('mozreview_app_id') %]
+This API key was automatically created by MozReview. If you did not recently log in to
+MozReview, please disable the key at the above URL, and change your password immediately.
+[% ELSIF new_key.app_id == Param('phabricator_app_id') %]
+This API key was automatically created by Mozilla's Phabricator instance. If you did not recently
+log in to Phabricator, please disable the key at the above URL, and change your password immediately.
+[% ELSE %]
 IMPORTANT: If you did not request a new key, your [% terms.Bugzilla %] account
 may have been compromised. In this case, please disable the key at the above
 URL, and change your password immediately.
+[% END %]
 
 For security reasons, we have not included your new key in this e-mail.
 


### PR DESCRIPTION
When a user logs in to MozReview or Phabricator for the first time an api key is created for them. Because the api key is created in the background, the user may be alarmed when they next check their email and see that an api key was created on their Bugzilla account.

This PR updates our email to inform the user if one of our review tools was responsible for creating the api key.

This was tested with the auth delegation test shim in https://bugzilla.mozilla.org/show_bug.cgi?id=1447028:
![bmo-api-email](https://user-images.githubusercontent.com/7828780/37740170-30db7408-2d33-11e8-9315-a4c9bb495569.PNG)
