### PR TITLE
Bug 1448681 - Bugmail Message-ID header format changed without changing In-Reply-To/References, breaking threading

### DIFF
--- a/Bugzilla/Mailer.pm
+++ b/Bugzilla/Mailer.pm
@@ -252,15 +252,14 @@ sub build_thread_marker {
         $sitespec = "-$2$sitespec"; # Put the port number back in, before the '@'
     }
 
-    my $threadingmarker;
+    my $threadingmarker = "References: <bug-$bug_id-$user_id$sitespec>";
     if ($is_new) {
-        $threadingmarker = "Message-ID: <bug-$bug_id-$user_id$sitespec>";
+        $threadingmarker .= "\nMessage-ID: <bug-$bug_id-$user_id$sitespec>";
     }
     else {
         my $rand_bits = generate_random_password(10);
-        $threadingmarker = "Message-ID: <bug-$bug_id-$user_id-$rand_bits$sitespec>" .
-                           "\nIn-Reply-To: <bug-$bug_id-$user_id$sitespec>" .
-                           "\nReferences: <bug-$bug_id-$user_id$sitespec>";
+        $threadingmarker .= "\nMessage-ID: <bug-$bug_id-$user_id-$rand_bits$sitespec>" .
+                            "\nIn-Reply-To: <bug-$bug_id-$user_id$sitespec>";
     }
 
     return $threadingmarker;


### PR DESCRIPTION
Add a `References` header to emails for new bugs to allow threading in situations where our `Message-ID` is overwritten (eg. SES).