### PR TITLE
Bug 1441063: Fix the unaccepted revision comment (PhabBugz)

### DIFF
--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -293,6 +293,8 @@ sub process_revision_change {
     $phab_users = get_phab_bmo_ids({ phids => \@denied_phids });
     @denied_user_ids = map { $_->{id} } @$phab_users;
 
+    my %reviewers_hash =  map {$_->name => 1} (@{ $revision->reviewers });
+
     foreach my $attachment (@attachments) {
         my ($attach_revision_id) = ($attachment->filename =~ PHAB_ATTACHMENT_PATTERN);
         next if $revision->id != $attach_revision_id;
@@ -333,7 +335,11 @@ sub process_revision_change {
             $comment .= $flag_data->{setter}->name . " has requested changes to the revision.\n";
         }
         foreach my $flag_data (@removed_flags) {
-            $comment .= $flag_data->{setter}->name . " has been removed from the revision.\n";
+            if (exists($reviewers_hash{$flag_data->{setter}->name})) {
+                $comment .= "Flag set by " . $flag_data->{setter}->name . " is no longer active.\n";
+            } else {
+                $comment .= $flag_data->{setter}->name . " has been removed from the revision.\n";
+            }
         }
 
         if ($comment) {

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -293,7 +293,7 @@ sub process_revision_change {
     $phab_users = get_phab_bmo_ids({ phids => \@denied_phids });
     @denied_user_ids = map { $_->{id} } @$phab_users;
 
-    my %reviewers_hash =  map {$_->name => 1} @{ $revision->reviewers };
+    my %reviewers_hash =  map { $_->name => 1 } @{ $revision->reviewers };
 
     foreach my $attachment (@attachments) {
         my ($attach_revision_id) = ($attachment->filename =~ PHAB_ATTACHMENT_PATTERN);
@@ -335,7 +335,7 @@ sub process_revision_change {
             $comment .= $flag_data->{setter}->name . " has requested changes to the revision.\n";
         }
         foreach my $flag_data (@removed_flags) {
-            if (exists($reviewers_hash{$flag_data->{setter}->name})) {
+            if ( exists $reviewers_hash{$flag_data->{setter}->name} ) {
                 $comment .= "Flag set by " . $flag_data->{setter}->name . " is no longer active.\n";
             } else {
                 $comment .= $flag_data->{setter}->name . " has been removed from the revision.\n";

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -293,7 +293,7 @@ sub process_revision_change {
     $phab_users = get_phab_bmo_ids({ phids => \@denied_phids });
     @denied_user_ids = map { $_->{id} } @$phab_users;
 
-    my %reviewers_hash =  map {$_->name => 1} (@{ $revision->reviewers });
+    my %reviewers_hash =  map {$_->name => 1} @{ $revision->reviewers };
 
     foreach my $attachment (@attachments) {
         my ($attach_revision_id) = ($attachment->filename =~ PHAB_ATTACHMENT_PATTERN);


### PR DESCRIPTION
Currently, we're sending the "User removed from revision" comment when
the Accept flag has been removed from a revision. This could happen in a
number of use cases:
1. The reviewer resigned from being a reviewer.
2. The reviewer has been removed from reviewers list.
3. Someone (author, reviewer) removed acceptance of the revision by changing
   its status to "Needs Review".

This patch is sending a "flag is deactivated" or "reviewer removed from
revision" depending on the current status of the reviewer.

Test Plan:
Accept a revision.
Change the revision to "Needs Review".
Check the bug comment.
Accept the revision.
Remove the user from reviewers list.
Check the bug comment.