### PR TITLE
bump version to 20180328.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -22,7 +22,7 @@ BEGIN {
     }
 }
 
-our $VERSION = '20180327.1';
+our $VERSION = '20180328.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
[release tag](https://github.com/mozilla-bteam/bmo/tree/release-20180328.1)

the following changes have been pushed to bugzilla.mozilla.org:
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1448681" target="_blank">1448681</a>] Bugmail Message-ID header format changed without changing In-Reply-To/References, breaking threading</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1440829" target="_blank">1440829</a>] Bugzilla comment for Phabricator commit should include entire commit message, not just first line</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1449413" target="_blank">1449413</a>] Refactor circleci container building stuff</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1449156" target="_blank">1449156</a>] Bugzilla::Memcached should use smaller timeouts and ping servers at instantiation time</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1449168" target="_blank">1449168</a>] Remove warning --function from jobqueue worker</li>
</ul>
discuss these changes on <a href="https://lists.mozilla.org/listinfo/tools-bmo" target="_blank">mozilla.tools.bmo</a>.
