### PR TITLE
Bug 1450283 - JobQueue should treat "no jobs" as a trace-level message, and all other logs as info

### DIFF
--- a/Bugzilla/JobQueue.pm
+++ b/Bugzilla/JobQueue.pm
@@ -101,7 +101,7 @@ sub debug {
     my $caller_pkg = caller;
     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
     my $logger = Log::Log4perl->get_logger($caller_pkg);
-    if ($args[0] && $args[0] =~ /found no jobs/) {
+    if ($args[0] && $args[0] eq "TheSchwartz::work_once found no jobs") {
         $logger->trace(@args);
     }
     else {

--- a/Bugzilla/JobQueue.pm
+++ b/Bugzilla/JobQueue.pm
@@ -101,7 +101,12 @@ sub debug {
     my $caller_pkg = caller;
     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
     my $logger = Log::Log4perl->get_logger($caller_pkg);
-    $logger->info(@args);
+    if ($args[0] && $args[0] =~ /found no jobs/) {
+        $logger->debug(@args);
+    }
+    else {
+        $logger->info(@args);
+    }
 }
 
 sub work {

--- a/Bugzilla/JobQueue.pm
+++ b/Bugzilla/JobQueue.pm
@@ -102,7 +102,7 @@ sub debug {
     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
     my $logger = Log::Log4perl->get_logger($caller_pkg);
     if ($args[0] && $args[0] =~ /found no jobs/) {
-        $logger->debug(@args);
+        $logger->trace(@args);
     }
     else {
         $logger->info(@args);


### PR DESCRIPTION
docker-compose up --build produces a lot less output with this (tested).