### PR TITLE
bump version to 20180330.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -22,7 +22,7 @@ BEGIN {
     }
 }
 
-our $VERSION = '20180328.1';
+our $VERSION = '20180330.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
the following changes have been pushed to bugzilla.mozilla.org:
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1448681" target="_blank">1448681</a>] Bugmail Message-ID header format changed without changing In-Reply-To/References, breaking threading</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1440829" target="_blank">1440829</a>] Bugzilla comment for Phabricator commit should include entire commit message, not just first line</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1449413" target="_blank">1449413</a>] Refactor circleci container building stuff</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1449156" target="_blank">1449156</a>] Bugzilla::Memcached should use smaller timeouts and ping servers at instantiation time</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1449168" target="_blank">1449168</a>] Remove warning --function from jobqueue worker</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1441063" target="_blank">1441063</a>] Misleading bugzilla comment when asking for re-review</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1200695" target="_blank">1200695</a>] API-key-creation emails should reflect if the action was a result of auth delegation</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1450008" target="_blank">1450008</a>] documentation link in API errors is wrong</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1450010" target="_blank">1450010</a>] The jobqueue supervisor's pidfile should not be stored in the data directory</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1441897" target="_blank">1441897</a>] Improve opengraph metadata for bug pages</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1447027" target="_blank">1447027</a>] Document and tweak vagrant vm to support testing emails</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1441244" target="_blank">1441244</a>] prevent compounding error messages in tests</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1450343" target="_blank">1450343</a>] Make the SES handler use Bugzilla::Logging and log more details</li>
</ul>