### PR TITLE
[WIP] Bug 1449282 - add jobqueue_status api

### DIFF
--- a/Bugzilla/WebService/Server/REST/Resources/Bugzilla.pm
+++ b/Bugzilla/WebService/Server/REST/Resources/Bugzilla.pm
@@ -49,6 +49,11 @@ sub _rest_resources {
             GET => {
                 method => 'parameters'
             }
+        },
+        qr{^/jobqueue_status$}, {
+            GET => {
+                method => 'jobqueue_status'
+            }
         }
     ];
     return $rest_resources;

--- a/docs/en/rst/api/core/v1/bugzilla.rst
+++ b/docs/en/rst/api/core/v1/bugzilla.rst
@@ -300,3 +300,32 @@ name             type    description
 ===============  ======  ====================================================
 last_audit_time  string  The maximum of the at_time from the audit_log.
 ===============  ======  ====================================================
+
+Job Queue Status
+----------------
+
+Reports the status of the job queue.
+
+**Request**
+
+.. code-block:: text
+
+   GET /rest/jobqueue_status
+
+This method requires an authenticated user. 
+
+**Response**
+
+.. code-block:: js
+
+   {
+     "total": 12,
+     "errors": 0
+   }
+
+===============  =======  ====================================================
+name             type     description
+===============  =======  ====================================================
+total            integer  The total number of jobs in the job queue.
+errors           integer  The number of errors produced by jobs in the queue.
+===============  =======  ====================================================


### PR DESCRIPTION
## In Progress 

Adds a new REST api endpoint that reports the status of jobs
in the jobqueue.

![bmo-job-queue](https://user-images.githubusercontent.com/7828780/38252980-83469322-3723-11e8-904f-20ae8e68f704.PNG)
