### PR TITLE
Add data-no-csrf to 'safe' forms

### DIFF
--- a/template/en/default/bug/choose.html.tmpl
+++ b/template/en/default/bug/choose.html.tmpl
@@ -24,7 +24,7 @@
    title = "Search by $terms.bug number"
  %]
 
-<form method="get" action="show_bug.cgi">
+<form method="get" action="show_bug.cgi" data-no-csrf>
   <p>
     You may find a single [% terms.bug %] by entering its [% terms.bug %] id here:
     <input name="id" size="6">

--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -244,7 +244,7 @@
 <header id="header" role="banner">
   <div class="inner">
     <h1 id="header-title" class="title"><a href="./" title="Go to home page">[% terms.Bugzilla %]</a></h1>
-    <form role="search" id="header-search" class="quicksearch" action="buglist.cgi">
+    <form role="search" id="header-search" class="quicksearch" action="buglist.cgi" data-no-csrf>
       <section class="searchbox-outer dropdown" role="combobox" aria-expanded="false" aria-haspopup="listbox"
                aria-owns="header-search-dropdown">
         <h2>Quick Search</h2>

--- a/template/en/default/index.html.tmpl
+++ b/template/en/default/index.html.tmpl
@@ -53,7 +53,7 @@
              href="?GoAheadAndLogIn=1"><span>Log In</span></a>
            [% END %]
 
-        <form id="quicksearchForm" name="quicksearchForm" action="buglist.cgi">
+        <form id="quicksearchForm" name="quicksearchForm" action="buglist.cgi" data-no-csrf>
           <div>
             <input id="quicksearch_main" type="text" name="quicksearch" autofocus
               placeholder="Enter [% terms.abug %] number or some search terms"

--- a/template/en/default/list/change-columns.html.tmpl
+++ b/template/en/default/list/change-columns.html.tmpl
@@ -51,7 +51,7 @@
   [% available_columns.$column_desc = column %]
 [% END %]
 
-<form name="changecolumns" action="colchange.cgi" onsubmit="change_submit();">
+<form name="changecolumns" action="colchange.cgi" onsubmit="change_submit();" data-no-csrf>
   <input type="hidden" name="rememberedquery" value="[% buffer FILTER html %]">
     <table>
       <tr>

--- a/template/en/default/list/list.html.tmpl
+++ b/template/en/default/list/list.html.tmpl
@@ -175,14 +175,14 @@
   <tr>
     [% IF bugs.size > 0 %]
       <td valign="middle" class="bz_query_buttons">
-        <form method="post" action="show_bug.cgi">
+        <form method="post" action="show_bug.cgi" data-no-csrf>
           [% FOREACH id = buglist %]
             <input type="hidden" name="id" value="[% id FILTER html %]">
           [% END %]
           <input type="hidden" name="format" value="multiple">
           <input type="submit" id="long_format" value="Long Format">
         </form>
-        <form method="post" action="show_bug.cgi">
+        <form method="post" action="show_bug.cgi" data-no-csrf>
             <input type="hidden" name="ctype" value="xml">
           [% FOREACH id = buglist %]
             <input type="hidden" name="id" value="[% id FILTER html %]">
@@ -192,7 +192,7 @@
         </form>
 
         [% IF user.is_timetracker %]
-          <form method="post" action="summarize_time.cgi">
+          <form method="post" action="summarize_time.cgi" data-no-csrf>
             <input type="hidden" name="id" value="[% buglist_joined FILTER html %]">
             <input type="submit" id="timesummary" value="Time Summary">
           </form>

--- a/template/en/default/pages/quicksearch.html.tmpl
+++ b/template/en/default/pages/quicksearch.html.tmpl
@@ -31,7 +31,7 @@
 <p>Type in one or more words (or pieces of words) to search for:</p>
 
 <form name="f" action="buglist.cgi" method="get"
-      class='quicksearch_check_empty'>
+      class='quicksearch_check_empty' data-no-csrf>
   <input type="text" size="40" name="quicksearch">
   <input type="submit" value="Search" id="find">
 </form>

--- a/template/en/default/reports/duplicates.html.tmpl
+++ b/template/en/default/reports/duplicates.html.tmpl
@@ -60,7 +60,7 @@
 
 <h3 id="params">Change Parameters</h3>
 
-<form method="get" action="duplicates.cgi">
+<form method="get" action="duplicates.cgi" data-no-csrf>
   <input type="hidden" name="sortby" value="[% sortby FILTER html %]">
   <input type="hidden" name="reverse" value="[% reverse FILTER html %]">
   <input type="hidden" name="bug_id" value="[% bug_ids_string FILTER html %]">
@@ -127,7 +127,7 @@
   <input type="submit" id="change" value="Change">
 </form>
 
-<form method="post" action="buglist.cgi">
+<form method="post" action="buglist.cgi" data-no-csrf>
   <input type="hidden" name="bug_id" value="[% bug_ids_string FILTER html %]">
   Or just give this to me as a <input type="submit" id="list" 
                                       value="[% terms.bug %] list">.

--- a/template/en/default/reports/old-charts.html.tmpl
+++ b/template/en/default/reports/old-charts.html.tmpl
@@ -32,7 +32,7 @@
     <img src="[% url_image FILTER html %]">
     <br clear="both">
   [% ELSE %]
-    <form id="choose_product" method="get" action="reports.cgi">
+    <form id="choose_product" method="get" action="reports.cgi" data-no-csrf>
       <table border="1" cellpadding="5" cellspacing="2">
         <tr>
           <th>Product:</th>

--- a/template/en/default/search/search-advanced.html.tmpl
+++ b/template/en/default/search/search-advanced.html.tmpl
@@ -60,7 +60,7 @@ function remove_token() {
 <p id="search_help">Hover your mouse over each field label to get help for that field.</p>
 
 <form method="post" action="buglist.cgi" name="queryform" id="queryform"
-      onsubmit="remove_token()">
+      onsubmit="remove_token()" data-no-csrf>
 
 [% PROCESS search/form.html.tmpl %]
 

--- a/template/en/default/search/search-google.html.tmpl
+++ b/template/en/default/search/search-google.html.tmpl
@@ -31,7 +31,7 @@
   Google only indexes publicly viewable [% terms.bugs %] and all may not be represented.
 <p>
 
-<form method="get" action="https://www.google.com/search">
+<form method="get" action="https://www.google.com/search" data-no-csrf>
 <input type="hidden" name="sitesearch" value="bugzilla.mozilla.org">
   <nobr>
     <input type="text" name="q" size="60" maxlength="255" value="">

--- a/template/en/default/search/search-specific.html.tmpl
+++ b/template/en/default/search/search-specific.html.tmpl
@@ -39,7 +39,7 @@ For example, if the [% terms.bug %] you are looking for is a browser crash when 
 for "crash secure SSL flash".
 </p>
 
-<form name="queryform" method="get" action="buglist.cgi">
+<form name="queryform" method="get" action="buglist.cgi" data-no-csrf>
 <input type="hidden" name="query_format" value="specific">
 <input type="hidden" name="order" value="relevance desc">
 


### PR DESCRIPTION
This is to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1446431
The data-no-csrf attribute is used to signify that a form is 'safe' (ie doesnt actually make any permanent changes) and so doesnt need an anti-csrf token.
If any of the forms I've changed do actually make permanent changes then please flag them to me :)
They may be other forms that need this attribute but hopefully this is a good start.