### PR TITLE
Bug 1450920 - Don't pass blank API token to JSON-PRC in instant search

### DIFF
--- a/js/instant-search.js
+++ b/js/instant-search.js
@@ -150,10 +150,12 @@ YAHOO.bugzilla.instantSearch = {
           product: YAHOO.bugzilla.instantSearch.getProduct(),
           summary: query,
           limit: 20,
-          include_fields: [ "id", "summary", "status", "resolution", "component" ],
-          Bugzilla_api_token : (BUGZILLA.api_token ? BUGZILLA.api_token : '')
+          include_fields: [ "id", "summary", "status", "resolution", "component" ]
         }
       };
+      if (BUGZILLA.api_token) {
+        jsonObject.params.Bugzilla_api_token = BUGZILLA.api_token;
+      }
 
       YAHOO.bugzilla.instantSearch.dataTable.getDataSource().sendRequest(
         YAHOO.lang.JSON.stringify(jsonObject), 


### PR DESCRIPTION
```
When an API token is seen by JSON-RPC, it will attempt to authenticate
it, including blank tokens (empty strings). Thus, avoid passing an
empty string in the first place.

The pattern to pass an empty string if the absence of
BUGZILLA.api_token is the most common way to include the
Bugzilla_api_token in the JSON-PRC requests. However, most places
which pass a token to JSON-RPC in JavaScript are in contexts where a
user is expected to be logged in, and this is not the case for instant
search.

Although this could have been fixed by patching
Bugzilla::Auth::Login::Cookie::get_login_info to treat empty API
tokens as if none were given, this method was chosen, as this is also
the approach used in the ProdCompSearch extension (where a login
session also does not need to be required), and to avoid possible
breakage in JSON-RPC consumers.
```
