### PR TITLE
Bug 1450325 - add unsubscribe link to html bug email template

### DIFF
--- a/extensions/BMO/template/en/default/email/bugmail.html.tmpl
+++ b/extensions/BMO/template/en/default/email/bugmail.html.tmpl
@@ -112,7 +112,7 @@
       [% END %]
     </ul>
     Configure your email settings at 
-    <a href="[% urlbase %]userprefs.cgi?tab=email">[% urlbase %]userprefs.cgi?tab=email</a>.
+    <a href="[% urlbase FILTER none %]userprefs.cgi?tab=email">[% urlbase %]userprefs.cgi?tab=email</a>.
   </div>
 
   <div itemscope itemtype="http://schema.org/EmailMessage">

--- a/extensions/BMO/template/en/default/email/bugmail.html.tmpl
+++ b/extensions/BMO/template/en/default/email/bugmail.html.tmpl
@@ -112,7 +112,7 @@
       [% END %]
     </ul>
     Configure your email settings at 
-    <a href="[% urlbase FILTER none %]userprefs.cgi?tab=email">[% urlbase %]userprefs.cgi?tab=email</a>.
+    <a href="[% urlbase FILTER none %]userprefs.cgi?tab=email">[% urlbase FILTER none %]userprefs.cgi?tab=email</a>.
   </div>
 
   <div itemscope itemtype="http://schema.org/EmailMessage">

--- a/extensions/BMO/template/en/default/email/bugmail.html.tmpl
+++ b/extensions/BMO/template/en/default/email/bugmail.html.tmpl
@@ -111,7 +111,10 @@
         [% END %]
       [% END %]
     </ul>
+    Configure your email settings at 
+    <a href="[% urlbase %]userprefs.cgi?tab=email">[% urlbase %]userprefs.cgi?tab=email</a>.
   </div>
+
   <div itemscope itemtype="http://schema.org/EmailMessage">
     <div itemprop="action" itemscope itemtype="http://schema.org/ViewAction">
       [%# Filtering of the URL param is not required & would break the URL when the comment anchor is set %]


### PR DESCRIPTION
## Overview

Adds a link to unsubscribe from all emails in the html format of the bugmail template. The plaintext format already contained a link and message to configure email settings.

![bmo-unsubscribe-email](https://user-images.githubusercontent.com/7828780/38585071-89ef1938-3ce6-11e8-9a5d-e600138599e3.PNG)

### BMO extension template vs default template

Running a diff between the `email/bugmail.html.tmpl` in the BMO extension vs the default template shows that there are a lot of changes between these two. So at this time it seems easier to keep both templates. **Question:** Should I also add an unsubscribe link to the default template since this is a generic improvement?