### PR TITLE
Bug 1451599 - Move guidelines checkbox on signup page to the left

### DIFF
--- a/extensions/BMO/template/en/default/account/create.html.tmpl
+++ b/extensions/BMO/template/en/default/account/create.html.tmpl
@@ -156,10 +156,10 @@ function onSubmit() {
     </tr>
     <tr>
     <td colspan="2">
+      <input type="checkbox" id="etiquette" value="agreed">
       I have read <a href="page.cgi?id=etiquette.html">[% terms.Bugzilla %] Etiquette</a>
       and the <a href="https://www.mozilla.org/about/governance/policies/participation/">Mozilla Community Participation Guidelines</a>
       and agree to abide by them.
-      <input type="checkbox" id="etiquette" value="agreed">
     </td>
     </tr>
     <tr>


### PR DESCRIPTION
On the right the checkbox would be in a weird place if text had
overflowed on a smaller screen. Being on the left is also standard
practice.

## Before
![before-checkbox](https://user-images.githubusercontent.com/7828780/38638690-0e1bc3ee-3d9d-11e8-9773-d24e0c0ae754.PNG)


## After
![after-checkbox](https://user-images.githubusercontent.com/7828780/38638694-0f9f3944-3d9d-11e8-8dc7-cf0f339c6b71.PNG)
