### PR TITLE
Bug 1454250 - landfill.bugzilla.org - Software error at "bugzilla-4.4-branch"

### DIFF
--- a/docs/en/rst/about/index.rst
+++ b/docs/en/rst/about/index.rst
@@ -18,7 +18,7 @@ Evaluating Bugzilla
 ###################
 
 If you want to try out Bugzilla to see if it meets your needs, you can do so
-on `Landfill <https://landfill.bugzilla.org/bugzilla-4.4-branch/>`_, our test
+on `Landfill <https://landfill.bugzilla.org/bugzilla-5.0-branch/>`_, our test
 server. The `Bugzilla FAQ <https://wiki.mozilla.org/Bugzilla:FAQ>`_ may also
 be helpful, as it answers a number of questions people sometimes have about
 whether Bugzilla is for them.


### PR DESCRIPTION
This pull request fixes the [**landfill.bugzilla.org software error bug** *at Bugzilla Documentation*](https://bugzilla.mozilla.org/show_bug.cgi?id=1454250). 🔧 

I changed the version `4.4` to the latest version `5.0`.