### PR TITLE
Bug 1438205 - Preserve comments in progress across page reloads

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -97,8 +97,8 @@ $(function() {
     }
 
     function saveBugComment(text) {
-        if(text.length < 1) return clearSavedBugComment();
-        if(text.length >  65535) return;
+        if (text.length < 1) return clearSavedBugComment();
+        if (text.length >  65535) return;
         let key = `bug-modal-saved-comment-${BUGZILLA.bug_id}`;
         let value = {
             text: text,
@@ -116,7 +116,7 @@ $(function() {
         expireSavedComments();
         let key = `bug-modal-saved-comment-${BUGZILLA.bug_id}`;
         let value = JSON.parse(localStorage.getItem(key));
-        if(value){
+        if (value){
             let commentBox = document.querySelector("textarea#comment");
             commentBox.value = value['text'];
             if (BUGZILLA.user.settings.autosize_comments) {
@@ -128,13 +128,13 @@ $(function() {
     function expireSavedComments() {
         const AGE_THRESHOLD = 7 * 24 * 60 * 60 * 1000; // 7 days in milliseconds.
         let expiredKeys = [];
-        for(let i = 0; i < localStorage.length; i++) {
+        for (let i = 0; i < localStorage.length; i++) {
             let key = localStorage.key(i);
-            if(key.match(/^bug-modal-saved-comment-/)) {
+            if (key.match(/^bug-modal-saved-comment-/)) {
                 let value = JSON.parse(localStorage.getItem(key));
                 let savedAt = value['savedAt'] || 0;
                 let age = Date.now() - savedAt;
-                if(age < 0 || age > AGE_THRESHOLD) {
+                if (age < 0 || age > AGE_THRESHOLD) {
                     expiredKeys.push(key);
                 }
             }

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -1331,6 +1331,7 @@ $(function() {
     // finally switch to edit mode if we navigate back to a page that was editing
     $(window).on('pageshow', restoreEditMode);
     $(window).on('pageshow', restoreSavedBugComment);
+    $(window).on('focus', restoreSavedBugComment);
     restoreEditMode();
     restoreSavedBugComment();
 });

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -96,6 +96,54 @@ $(function() {
         $('#editing').val('');
     }
 
+    function saveBugComment(text) {
+        if(text.length < 1) return clearSavedBugComment();
+        if(text.length >  65535) return;
+        let key = `bug-modal-saved-comment-${BUGZILLA.bug_id}`;
+        let value = {
+            text: text,
+            savedAt: Date.now()
+        };
+        localStorage.setItem(key, JSON.stringify(value));
+    }
+
+    function clearSavedBugComment() {
+        let key = `bug-modal-saved-comment-${BUGZILLA.bug_id}`;
+        localStorage.removeItem(key);
+    }
+
+    function restoreSavedBugComment() {
+        expireSavedComments();
+        let key = `bug-modal-saved-comment-${BUGZILLA.bug_id}`;
+        let value = JSON.parse(localStorage.getItem(key));
+        if(value){
+            let commentBox = document.querySelector("textarea#comment");
+            commentBox.value = value['text'];
+            if (BUGZILLA.user.settings.autosize_comments) {
+                autosize.update(commentBox);
+            }
+        }
+    }
+
+    function expireSavedComments() {
+        const AGE_THRESHOLD = 7 * 24 * 60 * 60 * 1000; // 7 days in milliseconds.
+        let expiredKeys = [];
+        for(let i = 0; i < localStorage.length; i++) {
+            let key = localStorage.key(i);
+            if(key.match(/^bug-modal-saved-comment-/)) {
+                let value = JSON.parse(localStorage.getItem(key));
+                let savedAt = value['savedAt'] || 0;
+                let age = Date.now() - savedAt;
+                if(age < 0 || age > AGE_THRESHOLD) {
+                    expiredKeys.push(key);
+                }
+            }
+        }
+        expiredKeys.forEach((key) => {
+            localStorage.removeItem(key);
+        });
+    }
+
     // expand/colapse module
     $('.module-latch')
         .click(function(event) {
@@ -586,6 +634,8 @@ $(function() {
                     .toArray()
                     .join(' ')
             );
+
+            clearSavedBugComment();
         })
         .attr('disabled', false);
 
@@ -1272,9 +1322,17 @@ $(function() {
             }
         });
 
+    // Save comments in progress
+    $('#comment')
+        .on('input', function(event) {
+            saveBugComment(event.target.value);
+        });
+
     // finally switch to edit mode if we navigate back to a page that was editing
     $(window).on('pageshow', restoreEditMode);
+    $(window).on('pageshow', restoreSavedBugComment);
     restoreEditMode();
+    restoreSavedBugComment();
 });
 
 function confirmUnsafeURL(url) {


### PR DESCRIPTION
### How it works
- When you input (type or copy paste) into the comment box, we save the text of the box into localStorage.
- When the bug page loads, or tab is switched to (if 2 tabs with the same bug are open) we populate the comment box with the saved text, if it exists.
- When you save a bug we clear the localStorage.
- This solves the problem mentioned in https://bugzilla.mozilla.org/show_bug.cgi?id=1438205 and just in general allows people to start typing a comment, close the page, and come back to it tomorrow.