### PR TITLE
Bug 1373280 - Highlight private comments in new bug modal UI

### DIFF
--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -626,6 +626,11 @@ body.platform-Win32 .comment-text, body.platform-Win64 .comment-text {
     width: 99% !important;
 }
 
+.comment-text.bz_private {
+    color: darkred;
+    border: 1px dashed darkred;
+}
+
 .comment-tags {
     padding: 0 8px 2px 8px !important;
 }


### PR DESCRIPTION
Prior to this commit, the only indication that a comment was private was the small "Private" tag in the comment header. This commit restores the red font color to private comments and adds a small dashed border for those that have trouble seeing the color red.

![private2](https://user-images.githubusercontent.com/7828780/39151858-6b698aba-4714-11e8-817d-5748839b6c38.PNG)

