### PR TITLE
Bug 1455772 - Label bug bounty form credit fields

### DIFF
--- a/extensions/BMO/template/en/default/pages/attachment_bounty_form.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/attachment_bounty_form.html.tmpl
@@ -211,12 +211,12 @@ function validateAndSubmit() {
   </div>
 
   <div class="form_section">
-    <label for="credit_2" class="field_label">Credit</label>
+    <label for="credit_2" class="field_label">Credit Twitter</label>
     <input type="text" name="credit_2" id="credit_2" size="80" value="[% form.credit.1 FILTER html %]">
   </div>
 
   <div class="form_section">
-    <label for="credit_3" class="field_label">Credit</label>
+    <label for="credit_3" class="field_label">Credit URL</label>
     <input type="text" name="credit_3" id="credit_3" size="80" value="[% form.credit.2 FILTER html %]">
   </div>
 


### PR DESCRIPTION
Labels the additional credit fields as Twitter and URL.

## Before
![before-bounty](https://user-images.githubusercontent.com/7828780/39153876-74a5f3ec-471a-11e8-85a5-a22d9c1906e5.PNG)


## After
![bounty-after](https://user-images.githubusercontent.com/7828780/39153872-723a3cda-471a-11e8-8cf2-f93cbb9e92d1.PNG)


### Remains the same
The attachment itself remains the same, but, people will likely begin putting better values there as we would want. 
![bounty-attachment](https://user-images.githubusercontent.com/7828780/39153866-6fd539fe-471a-11e8-8e50-63572d69f9ab.PNG)
