### PR TITLE
Bug 1453759 - Port OrangeFactor extension to treeherder

### DIFF
--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -42,6 +42,11 @@ sub DEFAULT_CSP {
         img_src     => [ 'self', 'https://secure.gravatar.com', 'https://www.google-analytics.com' ],
         style_src   => [ 'self', 'unsafe-inline' ],
         object_src  => [ 'none' ],
+        connect_src => [
+            'self',
+            # This is from extensions/OrangeFactor/web/js/orange_factor.js
+            'https://treeherder.mozilla.org/api/failurecount/',
+        ],
         form_action => [
             'self',
             # used in template/en/default/search/search-google.html.tmpl
@@ -69,7 +74,7 @@ sub SHOW_BUG_MODAL_CSP {
         connect_src => [
             'self',
             # This is from extensions/OrangeFactor/web/js/orange_factor.js
-            'https://brasstacks.mozilla.com/orangefactor/api/count',
+            'https://treeherder.mozilla.org/api/failurecount/',
         ],
         frame_src   => [ 'self', ],
         worker_src  => [ 'none', ],

--- a/extensions/OrangeFactor/Extension.pm
+++ b/extensions/OrangeFactor/Extension.pm
@@ -17,6 +17,8 @@ use Bugzilla::User::Setting;
 use Bugzilla::Constants;
 use Bugzilla::Attachment;
 
+use DateTime;
+
 our $VERSION = '1.0';
 
 sub template_before_process {
@@ -38,6 +40,8 @@ sub template_before_process {
     my $bug = exists $vars->{'bugs'} ? $vars->{'bugs'}[0] : $vars->{'bug'};
     if ($bug && grep($_->name eq 'intermittent-failure', @{ $bug->keyword_objects })) {
         $vars->{'orange_factor'} = 1;
+        $vars->{'date_start'} = ( DateTime->now() - DateTime::Duration->new( days => 7 ) )->ymd();
+        $vars->{'date_end'} = DateTime->now->ymd();
     }
 }
 

--- a/extensions/OrangeFactor/template/en/default/hook/bug/edit-after_custom_fields.html.tmpl
+++ b/extensions/OrangeFactor/template/en/default/hook/bug/edit-after_custom_fields.html.tmpl
@@ -17,9 +17,14 @@
     <td>
       [% IF cgi.user_agent.match('(?i)gecko') %]
         <canvas id="orange-graph" class="bz_default_hidden"></canvas>
-        <span id="orange-count"></span>
+        <span id="orange-count"
+              style="display:none;"
+              data-date-start="[% date_start FILTER html %]"
+              data-date-end="[% date_end FILTER html %]"
+              data-bug-id="[% bug.bug_id FILTER html %]">
+        </span>
       [% END %]
-      (<a href="https://brasstacks.mozilla.com/orangefactor/?display=Bug&bugid=[% bug.bug_id FILTER uri %]"
+      (<a href="https://treeherder.mozilla.org/intermittent-failures.html#/bugdetails?startday=[% date_start FILTER uri %]&endday=[% date_end FILTER uri %]&tree=trunk&bug=[% bug.bug_id FILTER uri %]"
           title="Click to load Orange Factor page for this [% terms.bug %]">link</a>)
     </td>
   </tr>

--- a/extensions/OrangeFactor/template/en/default/hook/bug_modal/edit-details_rhs.html.tmpl
+++ b/extensions/OrangeFactor/template/en/default/hook/bug_modal/edit-details_rhs.html.tmpl
@@ -16,10 +16,15 @@
   %]
     [% IF cgi.user_agent.match('(?i)gecko') %]
       <canvas id="orange-graph" style="display:none;"></canvas>
-      <span id="orange-count" style="display:none;"></span>
+      <span id="orange-count"
+            style="display:none;"
+            data-date-start="[% date_start FILTER html %]"
+            data-date-end="[% date_end FILTER html %]"
+            data-bug-id="[% bug.bug_id FILTER html %]">
+      </span>
     [% END %]
     <span id="orange-link">
-      (<a href="https://brasstacks.mozilla.com/orangefactor/?display=Bug&bugid=[% bug.bug_id FILTER uri %]"
+      (<a href="https://treeherder.mozilla.org/intermittent-failures.html#/bugdetails?startday=[% date_start FILTER uri %]&endday=[% date_end FILTER uri %]&tree=trunk&bug=[% bug.bug_id FILTER uri %]"
           title="Click to load Orange Factor page for this [% terms.bug %]">link</a>)
     </span>
   [% END %]


### PR DESCRIPTION
Upgrades the OrangeFactor extension to use the new TreeHerder failures page and api, since https://brasstacks.mozilla.com/orangefactor/ will be decommissioned soon.

The functionality remains the same as before.






