### PR TITLE
no bug - untaint default values in localconfig

### DIFF
--- a/Bugzilla/Install/Localconfig.pm
+++ b/Bugzilla/Install/Localconfig.pm
@@ -211,6 +211,7 @@ sub _read_localconfig_from_env {
         else {
             my $default = $var->{default};
             $localconfig{$name} = ref($default) eq 'CODE' ? $default->() : $default;
+            untaint($localconfig{$name});
         }
     }
 


### PR DESCRIPTION
Some default values are tainted. We untaint environmental variables already, so we should untaint these too.