### PR TITLE
Bug 1456886 - Client side link previews

### DIFF
--- a/Bugzilla/Hook.pm
+++ b/Bugzilla/Hook.pm
@@ -438,14 +438,6 @@ Sometimes this is C<undef>, meaning that we are parsing text that is
 not a bug comment (but could still be some other part of a bug, like
 the summary line).
 
-=item C<user>
-
-The L<Bugzilla::User> object representing the user who will see the text.
-This is useful to determine how much confidential information can be displayed
-to the user.
-
-=back
-
 =head2 bug_start_of_update
 
 This happens near the beginning of L<Bugzilla::Bug/update>, after L<Bugzilla::Object/update>

--- a/Bugzilla/Hook.pm
+++ b/Bugzilla/Hook.pm
@@ -438,6 +438,8 @@ Sometimes this is C<undef>, meaning that we are parsing text that is
 not a bug comment (but could still be some other part of a bug, like
 the summary line).
 
+=back
+
 =head2 bug_start_of_update
 
 This happens near the beginning of L<Bugzilla::Bug/update>, after L<Bugzilla::Object/update>

--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -250,7 +250,7 @@
         class="lightbox"><img src="extensions/BugModal/web/image.png" width="16" height="16"></a>
     [% END %]
   [% END %]
-  [%~ comment.body_full FILTER quoteUrls(bug, comment) ~%]</pre>
+  [%~ comment.body_full FILTER quoteUrls2(bug, comment) ~%]</pre>
 [% END %]
 
 [%

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -1331,6 +1331,7 @@ $(function() {
     function smartLinkPreviews() {
         const getHrefIdParam = anchor => (new URL(anchor.href)).searchParams.get("id");
         const filterUnique = (value, index, array) => value && array.indexOf(value) === index;
+        const reduceListToMap = (all, one) => { all[one['id']] = one; return all; };
 
         const findLinkElements = pathname => {
             return (
@@ -1371,7 +1372,7 @@ $(function() {
                 throw new Error(`/rest/bug?ids=${bugIds} response not ok`);
             })
             .then(responseJson => {
-                return responseJson.bugs.reduce((all, one) => all[one['id']] = one, {});
+                return responseJson.bugs.reduce(reduceListToMap, {});
             })
             .then(bugs => {
                 bugLinks.forEach(bugLink => {
@@ -1446,11 +1447,7 @@ $(function() {
             })
             .then(attachments => {
                 // Remove undefined attachments and convert from list to dictonary mapped by id. 
-                return (
-                    attachments
-                    .filter(filterUnique)
-                    .reduce((all, one) => { all[one['id']] = one; return all; }, {})
-                );
+                return attachments.filter(filterUnique).reduce(reduceListToMap, {});
             })
             .then(attachments => {
                 // Now we have all attachment data the user is able to see.

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -1328,12 +1328,161 @@ $(function() {
             saveBugComment(event.target.value);
         });
 
+    function smartLinkPreviews() {
+        const getHrefIdParam = anchor => (new URL(anchor.href)).searchParams.get("id");
+        const filterUnique = (value, index, array) => value && array.indexOf(value) === index;
+
+        const findLinkElements = pathname => {
+            return (
+                Array
+                .from(document.querySelectorAll('.comment-text a'))
+                .filter(anchor => {
+                    return (
+                        anchor.hostname === window.location.hostname &&
+                        anchor.pathname === pathname &&
+                        /^\d+$/.test(getHrefIdParam(anchor))
+                    )
+                })
+                .map(anchor => {
+                    return {
+                        id: getHrefIdParam(anchor),
+                        element: anchor
+                    }
+                })
+            )
+        };
+
+        const enhanceBugLinks = () => {
+            let bugLinks = findLinkElements('/show_bug.cgi');
+            let bugIds = bugLinks.map((bug) => parseInt(bug['id'])).filter(filterUnique).join(',');
+            let params = $.param({
+                Bugzilla_api_token: BUGZILLA.api_token,
+                id: bugIds,
+                include_fields: 'id,summary,status,resolution,is_open'
+            });
+
+            if(!bugIds) return;
+
+            fetch(`/rest/bug?${params}`)
+            .then(response => {
+                if(response.ok){
+                    return response.json();
+                }
+                throw new Error(`/rest/bug?ids=${bugIds} response not ok`);
+            })
+            .then(responseJson => {
+                return responseJson.bugs.reduce((all, one) => all[one['id']] = one, {});
+            })
+            .then(bugs => {
+                bugLinks.forEach(bugLink => {
+                    let bug = bugs[bugLink['id']];
+                    if(!bug) return;
+
+                    bugLink.element.setAttribute(
+                        "title", `${bug.status} ${bug.resolution} - ${bug.summary}`
+                    );
+                    bugLink.element.classList.add('bz_bug_link');
+                    bugLink.element.classList.add(`bz_status_${bug.status}`);
+                    if(!bug.is_open) {
+                        bugLink.element.classList.add('bz_closed');
+                    }
+                    $(bugLink.element).tooltip({
+                        position: { my: "left top+8", at: "left bottom", collision: "flipfit" },
+                        show: { effect: 'none' },
+                        hide: { effect: 'none' }
+                    });
+                });
+            })
+            .catch(e => console.log(e));
+        };
+
+        const enhanceAttachmentLinks = () => {
+            let attachmentLinks = findLinkElements('/attachment.cgi');
+            let attachmentIds = (
+                attachmentLinks.map(attachment => parseInt(attachment['id'])).filter(filterUnique)
+            );
+            let params = $.param({
+                Bugzilla_api_token: BUGZILLA.api_token,
+                include_fields: 'id,description,is_obsolete'
+            });
+
+            if(!attachmentIds) return;
+
+            // Fetch all attachments for this bug only. This endpoint filters out
+            // attachments the user can't see for us (e.g. ones marked private).
+            // This one request will likely retrieve most of the attachments we need.
+            fetch(`/rest/bug/${BUGZILLA.bug_id}/attachment?${params}`)
+            .then(response => {
+                if(response.ok){
+                    return response.json();
+                }
+                throw Error(`/rest/bug/${BUGZILLA.bug_id}/attachment response not ok`);
+            })
+            .then(responseJson => {
+                return responseJson['bugs'][BUGZILLA.bug_id] || [];
+            })
+            .then(attachments => {
+                // The BMO rest API that lets us batch request attachment ids unfortunatley
+                // fails the whole batch if the user is unable to view any of the attachments.
+                // So, we query each attachment id individually and group them as a promsie.
+                let missingAttachments = (
+                    attachmentIds
+                    .filter(id => !attachments.map(attachment => attachment.id).includes(id))
+                    .map(attachmentId => {
+                        return (
+                            fetch(`/rest/bug/attachment/${attachmentId}?${params}`)
+                            .then((response) => {
+                                // It's ok if the request failed.
+                                return response.json();
+                            })
+                            .then(responseJson => {
+                                // May be undefined.
+                                return responseJson['attachments'][attachmentId];
+                            })
+                        );
+                    })
+                );
+                return Promise.all(attachments.concat(missingAttachments));
+            })
+            .then(attachments => {
+                // Remove undefined attachments and convert from list to dictonary mapped by id. 
+                return (
+                    attachments
+                    .filter(filterUnique)
+                    .reduce((all, one) => { all[one['id']] = one; return all; }, {})
+                );
+            })
+            .then(attachments => {
+                // Now we have all attachment data the user is able to see.
+                attachmentLinks.forEach(attachmentLink => {
+                    let attachment = attachments[attachmentLink.id];
+                    if(!attachment) return;
+
+                    attachmentLink.element.setAttribute("title",  attachment.description);
+                    if(attachment.is_obsolete){
+                        attachmentLink.element.classList.add('bz_obsolete');
+                    }
+                    $(attachmentLink.element).tooltip({
+                        position: { my: "left top+8", at: "left bottom", collision: "flipfit" },
+                        show: { effect: 'none' },
+                        hide: { effect: 'none' }
+                    });
+                });
+            })
+            .catch(e => console.log(e));
+        };
+
+        enhanceBugLinks();
+        enhanceAttachmentLinks();
+    }
+
     // finally switch to edit mode if we navigate back to a page that was editing
     $(window).on('pageshow', restoreEditMode);
     $(window).on('pageshow', restoreSavedBugComment);
     $(window).on('focus', restoreSavedBugComment);
     restoreEditMode();
     restoreSavedBugComment();
+    smartLinkPreviews();
 });
 
 function confirmUnsafeURL(url) {

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -1471,7 +1471,6 @@ $(function() {
             })
             .catch(e => console.log(e));
         };
-
         enhanceBugLinks();
         enhanceAttachmentLinks();
     }

--- a/t/008filter.t
+++ b/t/008filter.t
@@ -214,7 +214,7 @@ sub directive_ok {
     # Note: If a single directive prints two things, and only one is 
     # filtered, we may not catch that case.
     return 1 if $directive =~ /FILTER\ (html|csv|js|base64|css_class_quote|ics|
-                                        quoteUrls|time|uri|xml|lower|html_light|
+                                        quoteUrls|quoteUrls2|time|uri|xml|lower|html_light|
                                         obsolete|inactive|closed|unitconvert|
                                         txt|html_linebreak|none|json|null|id|
                                         markdown)\b/x;


### PR DESCRIPTION
## Adds client side link previews
- Adds a new backend comment render function (creativiely named `quoteUrls2`) which does renders comments with an anonymous user. This allows us to cache the result for all users.
  - Extension hooks work as expected (e.g. CVE and hg.m.o autolinking).
  - Rendered public bugs/attachment links will work as before.
  - Rendered private bugs/attachment links will behave as though the user is unable to view that resource. Mainly, the title of the bug/attachment won't be there.

- Adds client side code which fetches data for the bug and attachment links in all comments on a bug page. 
  - It fetches this data as the logged in user, so if the user is able to see a bug/attachment then the link tooltip will be added.

## Notice
@dylanwh, right now the frontend code fetches data for _all_ bug/attachment links on the page, this include public ones which technically have already been rendered and had their tooltip added, since I didn't change get_bug_link and get_attachment_link to output plain links. 

### The reason I didn't change get_bug/attachment_link:
- Didn't want to duplicate that code since passing an anonymous user has the same effect.
- For bug links specifically, on production BMO bugs which you cannot see but are closed are strikethrough'd, but, if we go the frontend only route then the users will not know the open/closed status of bugs they can't see which I think would be confusing, especially in the context of some comments and what people have come to expect using bmo. Same thing for obsolete attachments.

### The reason the frontend code queries all the bugs/attachments instead of just the private ones:
I think we should filter out to only bugs with no tooltip and private bug links. Not doing that currently because the impact is minimal (I batch requests and request only the subset of data needed using the `include_fields` param) and because I didn't know which route you wanted to take.
- If left to me I think we should add a class to private links generated by get_bug/attachment_links when the anonymous user is unable to view that link. That would let the frontend code filter by things which have no class (i.e. markdown links) and things with this class (i.e. private links).