### PR TITLE
Bug 1462685 - Use Phabricators Draft functionality to allow sending of initial revision email after BMO has updated the policies

### DIFF
--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -14,6 +14,7 @@ use IO::Async::Loop;
 use List::Util qw(first);
 use List::MoreUtils qw(any);
 use Moo;
+use Scalar::Util qw(blessed);
 use Try::Tiny;
 
 use Bugzilla::Constants;
@@ -165,6 +166,51 @@ sub feed_query {
         };
         $self->save_last_id($story_id, 'feed');
     }
+
+    # Process any build targets as well.
+    my $dbh = Bugzilla->dbh;
+
+    INFO("Checking for revisions in draft mode");
+    my $build_targets = $dbh->selectall_arrayref(
+        "SELECT name, value FROM phabbugz WHERE name LIKE 'build_target_%'",
+        { Slice => {} }
+    );
+
+    my $delete_build_target = $dbh->prepare(
+        "DELETE FROM phabbugz WHERE name = ? AND VALUE = ?"
+    );
+
+    foreach my $target (@$build_targets) {
+        my ($revision_id) = ($target->{name} =~ /^build_target_(\d+)$/);
+        my $build_target  = $target->{value};
+
+        # FIXME: Remove debugging
+        use Data::Dumper; print STDERR Dumper $target;
+
+        next unless $revision_id && $build_target;
+
+        INFO("Processing revision $revision_id with build target $build_target");
+
+        my $revision =
+          Bugzilla::Extension::PhabBugz::Revision->new_from_query(
+            { 
+              ids => [ int($revision_id) ]
+            }
+        );
+
+        with_writable_database {
+            $self->process_revision_change($revision);
+        };
+
+        # Set the build target to a passing status to
+        # allow the revision to exit draft state
+        request( 'harbormaster.sendmessage', {
+            buildTargetPHID => $build_target,
+            type            => 'pass'
+        } );
+
+        $delete_build_target->execute($target->{name}, $target->{value});
+     }
 }
 
 sub user_query {
@@ -293,7 +339,10 @@ sub process_revision_change {
     my ($self, $revision_phid, $story_text) = @_;
 
     # Load the revision from Phabricator
-    my $revision = Bugzilla::Extension::PhabBugz::Revision->new_from_query({ phids => [ $revision_phid ] });
+    my $revision =
+        blessed $revision_phid
+        ? $revision_phid
+        : Bugzilla::Extension::PhabBugz::Revision->new_from_query({ phids => [ $revision_phid ] });
     
     my $secure_revision =
       Bugzilla::Extension::PhabBugz::Project->new_from_query(

--- a/extensions/PhabBugz/template/en/default/hook/global/user-error-errors.html.tmpl
+++ b/extensions/PhabBugz/template/en/default/hook/global/user-error-errors.html.tmpl
@@ -22,6 +22,10 @@
   [% title = "Invalid Phabricator Revision ID" %]
   You must provide a valid Phabricator revision ID.
 
+[% ELSIF error == "invalid_phabricator_build_target" %]
+  [% title = "Invalid Phabricator Build Target" %]
+  You must provide a valid Phabricator Build Target PHID.
+
 [% ELSIF error == "phabricator_not_enabled" %]
   [% title = "Phabricator Support Not Enabled" %]
   The Phabricator to Bugzilla library, PhabBugz,


### PR DESCRIPTION
To test this you will need to perform some administrative steps as admin on the phabricator instance.

1. More Applications -> Harbormaster -> Manage Build Plans -> Create Build Plan
2. Description: "Wait Until Bugzilla Updates Revision"
3. Create
4. Add Build Step
5. Make HTTP Request
6. URI: "http://bmo.test/rest/phabbugz/build_target/${buildable.revision}/${target.phid}"
7. HTTP Method: "POST"
8. Create New Credential
9. Name: "Phabricator Bot Credential"
10. Login/Username: "phab-bot@bmo.tld"
11. Password: <phab-bot@bmo.tld api key from bmo.test>
12. Create Credential
13. When Complete: "Wait for message"
14. Phabricator -> Herald -> Create Herald Rule
15. New Rule for: "Differential Revisions" and Continue
16. Rule Type: "Global" and Continue
17. Rule Name: "Wait Until Bugzilla Updates Revision"
18. For conditions: When "all of" these conditions are met: "is newly created" "is true"
19. For actions: "Run build plans" "Wait Until Bugzilla Updates Revision"
20. Save Rule
21. You will need to enable the phabricator.show-prototypes config value to true. This will need ot be done from a shell of the running phabricator container.
'/app/phabricator/bin/config set phabricator.show-prototypes true'

To test:

1, Create a test private bug at http://bmo.test and record the bug id
2. In Phabricator create a new revision either through the UI or with arc using the bug id.
3. When the revision is created it should be in a "Draft" state shown by the Draft icon at the top left next to Custom Policy.
4, The "Wait Until Bugzilla Updates Revision" should show as "Building".
5. Once Bugzilla updates the revision with new policies, Bugzilla will submit a "pass" status for the running build.
6. Once that is complete the revision should enter the "Needs Review" state and email should be delivered normally.