### PR TITLE
bump version to 20180523.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -22,7 +22,7 @@ BEGIN {
     }
 }
 
-our $VERSION = '20180508.1';
+our $VERSION = '20180523.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1459336" target="_blank">1459336</a>] feed daemon skips setting r+ for accepted revision if the same user already has a flag set even if flag is status of ?</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1460466" target="_blank">1460466</a>] Phab bot does not create r+ for acceptance when there are still blocking reviewers</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1440086" target="_blank">1440086</a>] Refactor PhabBugz extension code to use new User.pm module for better type checking</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1458664" target="_blank">1458664</a>] Feed daemon when adding or updating a new project in Phabricator, it should fix permissions and also make sure phab-bot is project member</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1462686" target="_blank">1462686</a>] Current phabbugz in bmo master still refers to get_phab_bmo_ids() which is no longer part of the code</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1461819" target="_blank">1461819</a>] Plack::Handler::Apache2 accidentally unsets $ENV{MOD_PERL}</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1461400" target="_blank">1461400</a>] Log errors in webservices when undef values are passed to $self-&gt;type()</li>
</ul>