### PR TITLE
Bug 1461379 - use DBIx::Connector to manage database connections

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2
 
 defaults:
   bmo_slim_image: &bmo_slim_image
-    image: mozillabteam/bmo-slim:20180518.1
+    image: mozillabteam/bmo-slim:20180523.1
     user: app
 
   mysql_image: &mysql_image

--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -893,7 +893,6 @@ sub _cleanup {
     foreach my $dbh ($main, $shadow) {
         next if !$dbh;
         $dbh->bz_rollback_transaction() if $dbh->bz_in_transaction;
-        $dbh->disconnect;
     }
     clear_request_cache();
 

--- a/Bugzilla/DB.pm
+++ b/Bugzilla/DB.pm
@@ -277,6 +277,7 @@ sub _get_no_db_connection {
     my $dbh;
     my %connect_params = %{ Bugzilla->localconfig };
     $connect_params{db_name} = '';
+    local %Connector = ();
     my $conn_success = eval {
         $dbh = _connect(\%connect_params);
     };
@@ -1253,7 +1254,7 @@ sub bz_rollback_transaction {
 # Subclass Helpers
 #####################################################################
 
-my %Cache;
+our %Connector;
 
 sub _build_dbh {
     my ($self) = @_;
@@ -1287,7 +1288,7 @@ sub _build_dbh {
         }
     }
 
-    my $connector = $Cache{"$user.$dsn"} //= DBIx::Connector->new($dsn, $user, $pass, $attributes);
+    my $connector = $Connector{"$user.$dsn"} //= DBIx::Connector->new($dsn, $user, $pass, $attributes);
 
     return $connector->dbh;
 }

--- a/Bugzilla/DB.pm
+++ b/Bugzilla/DB.pm
@@ -11,6 +11,7 @@ use 5.10.1;
 use Moo;
 
 use DBI;
+use DBIx::Connector;
 
 has 'dbh' => (
     is      => 'lazy',
@@ -213,7 +214,6 @@ sub bz_check_server_version {
     my ($self, $db, $output) = @_;
 
     my $sql_vers = $self->bz_server_version;
-    $self->disconnect;
 
     my $sql_want = $db->{db_version};
     my $version_ok = vers_cmp($sql_vers, $sql_want) > -1 ? 1 : 0;
@@ -269,7 +269,6 @@ sub bz_create_database {
         }
     }
 
-    $dbh->disconnect;
 }
 
 # A helper for bz_create_database and bz_check_requirements.
@@ -1254,6 +1253,8 @@ sub bz_rollback_transaction {
 # Subclass Helpers
 #####################################################################
 
+my %Cache;
+
 sub _build_dbh {
     my ($self) = @_;
     my ($dsn, $user, $pass, $override_attrs) =
@@ -1261,7 +1262,7 @@ sub _build_dbh {
 
     # set up default attributes used to connect to the database
     # (may be overridden by DB driver implementations)
-    my $attributes = { RaiseError => 0,
+    my $attributes = { RaiseError => 1,
                        AutoCommit => 1,
                        PrintError => 0,
                        ShowErrorStatement => 1,
@@ -1286,17 +1287,9 @@ sub _build_dbh {
         }
     }
 
-    # connect using our known info to the specified db
-    my $dbh = DBI->connect($dsn, $user, $pass, $attributes)
-        or die "\nCan't connect to the database.\nError: $DBI::errstr\n"
-        . "  Is your database installed and up and running?\n  Do you have"
-        . " the correct username and password selected in localconfig?\n\n";
+    my $connector = $Cache{"$user.$dsn"} //= DBIx::Connector->new($dsn, $user, $pass, $attributes);
 
-    # RaiseError was only set to 0 so that we could catch the
-    # above "die" condition.
-    $dbh->{RaiseError} = 1;
-
-    return $dbh;
+    return $connector->dbh;
 }
 
 #####################################################################

--- a/Bugzilla/DB.pm
+++ b/Bugzilla/DB.pm
@@ -12,6 +12,7 @@ use Moo;
 
 use DBI;
 use DBIx::Connector;
+our %Connector;
 
 has 'dbh' => (
     is      => 'lazy',
@@ -1253,8 +1254,6 @@ sub bz_rollback_transaction {
 #####################################################################
 # Subclass Helpers
 #####################################################################
-
-our %Connector;
 
 sub _build_dbh {
     my ($self) = @_;

--- a/Bugzilla/ModPerl.pm
+++ b/Bugzilla/ModPerl.pm
@@ -74,7 +74,7 @@ __DATA__
 # every process, and Perl has another. (Various Perl modules still use
 # the built-in rand(), even though we never use it in Bugzilla itself,
 # so we need to srand() both of them.)
-PerlChildInitHandler "sub { Bugzilla::RNG::srand(); srand(); }"
+PerlChildInitHandler "sub { Bugzilla::RNG::srand(); srand(); eval { Bugzilla->dbh->ping } }"
 PerlInitHandler Bugzilla::ModPerl::Hostage
 PerlAccessHandler Bugzilla::ModPerl::BlockIP
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mozillabteam/bmo-slim:20180518.1
+FROM mozillabteam/bmo-slim:20180523.1
 
 ARG CI
 ARG CIRCLE_SHA1

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -42,6 +42,7 @@ my %requires = (
     'CPAN::Meta::Requirements' => '2.121',
     'Class::XSAccessor'        => '1.18',
     'DBI'                      => '1.614',
+    'DBIx::Connector'          => 0,
     'Data::Password::passwdqc' => '0.08',
     'Date::Format'             => '2.23',
     'DateTime'                 => '0.75',

--- a/token.cgi
+++ b/token.cgi
@@ -23,7 +23,7 @@ use Date::Format;
 use Date::Parse;
 use JSON qw( decode_json );
 
-my $dbh = Bugzilla->dbh;
+local our $dbh = Bugzilla->dbh;
 local our $cgi = Bugzilla->cgi;
 local our $template = Bugzilla->template;
 local our $vars = {};


### PR DESCRIPTION
This should make it so there is only two connections to the DB per process.

This is related to mozilla/infosec-risk-management-bugzilla#13