### PR TITLE
bump version to 20180530.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -22,7 +22,7 @@ BEGIN {
     }
 }
 
-our $VERSION = '20180529.2';
+our $VERSION = '20180530.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
[release tag](https://github.com/mozilla-bteam/bmo/tree/release-20180530.1)

the following changes have been pushed to bugzilla.mozilla.org:
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1462685" target="_blank">1462685</a>] Use Phabricators Draft functionality to allow sending of initial revision email after BMO has updated the policies</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1464226" target="_blank">1464226</a>] quicksearch can't search for "Resolution:---"</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1464312" target="_blank">1464312</a>] Write script to undo the INACTIVE changes on bugs</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1465225" target="_blank">1465225</a>] New changes for draft revisions can miss setting permissions on revisions without a bug id associated</li>
</ul>
discuss these changes on <a href="https://lists.mozilla.org/listinfo/tools-bmo" target="_blank">mozilla.tools.bmo</a>.