### PR TITLE
no bug - Fix SyntaxError in global.js

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -219,7 +219,7 @@ const detect_blocked_gravatars = () => {
  */
 const adjust_scroll_onload = () => {
     if (location.hash) {
-        const $target = document.querySelector(location.hash);
+        const $target = document.querySelector(CSS.escape(location.hash));
 
         if ($target) {
             window.setTimeout(() => scroll_element_into_view($target), 50);


### PR DESCRIPTION
The error is dumped in the console while using the [Bugzilla Helper](https://bugzilla.mozilla.org/enter_bug.cgi?format=guided). I'm sure this doesn't cause any negative impact on the current UI, but it's a mistake in my code. Let's fix it.

```
SyntaxError: '#h=dupes%7CFirefox' is not a valid selector
```