### PR TITLE
Bug 1465889 - form.dev-engagement-event field should be red instead of black

### DIFF
--- a/extensions/BMO/template/en/default/bug/create/create-dev-engagement-event.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-dev-engagement-event.html.tmpl
@@ -142,7 +142,7 @@
     <option value="Yes">Yes</option>
     <option value="No">No</option>
   </select>
-  <div id="developer_event_warning" class="bz_default_hidden">
+  <div id="developer_event_warning" class="warning bz_default_hidden">
     The Developer Events Team only participates in developer events.
     Form submission has been disabled.
   </div>


### PR DESCRIPTION
Fix [Bug 1465889 - form.dev-engagement-event field should be red instead of black](https://bugzilla.mozilla.org/show_bug.cgi?id=1465889)

## Description

Simply adding a missing `warning` class to the template. Tested locally.