### PR TITLE
Bug 1466159 - crash graph is wrong

### DIFF
--- a/static/metricsgraphics/socorro-lens.html
+++ b/static/metricsgraphics/socorro-lens.html
@@ -96,7 +96,7 @@
 
       function getSignaturesFromURL(search, match) {
         var index = search.indexOf("?s=");
-        search = search.substring(index + 3);
+        search = search.substring(index + 3).replace(/\+/g, '%20');
         var signatures = [];
         if (search.indexOf("\\") !== -1) {
           signatures = search.split("\\");


### PR DESCRIPTION
Fix [Bug 1466159 - crash graph is wrong](https://bugzilla.mozilla.org/show_bug.cgi?id=1466159)

## Description

White spaces in `location.search` are represented as `+` signs in this case, which have to be replaced with white spaces again. Tested locally.

Note: I think the code needs a refactoring with [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL) and [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams), but it’s a separate issue.