### PR TITLE
Bug 1469689 - Remove Bugzilla Helper and custom bug entry form links from Browse page

### DIFF
--- a/extensions/BMO/template/en/default/global/choose-product.html.tmpl
+++ b/extensions/BMO/template/en/default/global/choose-product.html.tmpl
@@ -173,12 +173,14 @@
 </section>
 </div>
 
+[% IF NOT is_describe %]
 <div id="guided">
   <a href="enter_bug.cgi?format=guided">
     <img src="extensions/BMO/web/images/guided.png" width="16" height="16">
     Switch to the [% terms.Bugzilla %] Helper</a> |
   <a href="page.cgi?id=custom_forms.html">Custom [% terms.bug %] entry forms</a>
 </div>
+[% END %]
 
 [% PROCESS global/footer.html.tmpl %]
 


### PR DESCRIPTION
## Description

The following footer is only for the [Enter Bug](https://bugzilla.mozilla.org/enter_bug.cgi) page, shouldn’t be on the [Browse](https://bugzilla.mozilla.org/describecomponents.cgi) page.

> Switch to the Bugzilla Helper | Custom bug entry forms

## Bug

[Bug 1469689 - Remove Bugzilla Helper and custom bug entry form links from Browse page](https://bugzilla.mozilla.org/show_bug.cgi?id=1469689)