### PR TITLE
Bug 1469920 - Update schema: add a nickname to profiles table

### DIFF
--- a/Bugzilla/DB/Schema.pm
+++ b/Bugzilla/DB/Schema.pm
@@ -924,6 +924,8 @@ use constant ABSTRACT_SCHEMA => {
             cryptpassword  => {TYPE => 'varchar(128)'},
             realname       => {TYPE => 'varchar(255)', NOTNULL => 1,
                                DEFAULT => "''"},
+            nickname       => {TYPE => 'varchar(255)', NOTNULL => 1,
+                               DEFAULT => "''"},
             disabledtext   => {TYPE => 'MEDIUMTEXT', NOTNULL => 1,
                                DEFAULT => "''"},
             disable_mail   => {TYPE => 'BOOLEAN', NOTNULL => 1,

--- a/Bugzilla/DB/Schema.pm
+++ b/Bugzilla/DB/Schema.pm
@@ -946,6 +946,7 @@ use constant ABSTRACT_SCHEMA => {
                                         TYPE => 'UNIQUE'},
             profiles_extern_id_idx => {FIELDS => ['extern_id'],
                                        TYPE   => 'UNIQUE'}
+            profiles_nickname_idx  => ['nickname'],
         ],
     },
 

--- a/Bugzilla/DB/Schema.pm
+++ b/Bugzilla/DB/Schema.pm
@@ -945,7 +945,7 @@ use constant ABSTRACT_SCHEMA => {
             profiles_login_name_idx => {FIELDS => ['login_name'],
                                         TYPE => 'UNIQUE'},
             profiles_extern_id_idx => {FIELDS => ['extern_id'],
-                                       TYPE   => 'UNIQUE'}
+                                       TYPE   => 'UNIQUE'},
             profiles_nickname_idx  => ['nickname'],
         ],
     },

--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -767,6 +767,10 @@ sub update_table_definitions {
     $dbh->bz_add_column('components', 'triage_owner_id',
                         {TYPE => 'INT3'});
 
+    $dbh->bz_add_column('profiles', 'nickname',
+                        {TYPE => 'varchar(255)', NOTNULL => 1, DEFAULT => "''"});
+    $dbh->bz_add_index('profiles', 'profiles_nickname_idx', [qw(nickname)]);
+
     ################################################################
     # New --TABLE-- changes should go *** A B O V E *** this point #
     ################################################################


### PR DESCRIPTION
I want to have a non-unique nickname field on the profiles table so I can do searches for ':bz', ':dkl', etc faster. This just adds it to the schema and doesn't use the new field at all.