### PR TITLE
Bug 1469911 - Make user autocompletion faster

### DIFF
--- a/Bugzilla/DB.pm
+++ b/Bugzilla/DB.pm
@@ -350,6 +350,11 @@ sub import {
     $Exporter::ExportLevel-- if $is_exporter;
 }
 
+sub sql_prefix_match {
+    my ($self, $column, $str) = @_;
+    return "$column LIKE " . $self->quote("$str%");
+}
+
 sub sql_istrcmp {
     my ($self, $left, $right, $op) = @_;
     $op ||= "=";

--- a/Bugzilla/DB.pm
+++ b/Bugzilla/DB.pm
@@ -353,7 +353,7 @@ sub import {
 sub sql_prefix_match {
     my ($self, $column, $str) = @_;
     my $must_escape = $str =~ s/([_%!])/!$1/g;
-    my $escape      = $must_escape ? q/ESCAPE '!'/ : '');
+    my $escape      = $must_escape ? q/ESCAPE '!'/ : '';
     my $quoted_str  = $self->quote("$str%");
     return "$column LIKE $quoted_str $escape";
 }

--- a/Bugzilla/DB.pm
+++ b/Bugzilla/DB.pm
@@ -353,9 +353,9 @@ sub import {
 sub sql_prefix_match {
     my ($self, $column, $str) = @_;
     my $must_escape = $str =~ s/([_%!])/!$1/g;
-    my $escape      = $must_escape ? q/ESCAPE '!'/ : q//);
-    my $quoted_str  = $self->quote(qq/$str%/)
-    return qq/$column LIKE $quoted_str $escape/;
+    my $escape      = $must_escape ? q/ESCAPE '!'/ : '');
+    my $quoted_str  = $self->quote("$str%");
+    return "$column LIKE $quoted_str $escape";
 }
 
 sub sql_istrcmp {

--- a/Bugzilla/DB.pm
+++ b/Bugzilla/DB.pm
@@ -352,8 +352,10 @@ sub import {
 
 sub sql_prefix_match {
     my ($self, $column, $str) = @_;
-    my $escape = $str =~ s/([_%!])/!$1/gs;
-    return "$column LIKE " . $self->quote("$str%") . ( $escape ? " ESCAPE '!'" : '');
+    my $must_escape = $str =~ s/([_%!])/!$1/g;
+    my $escape      = $must_escape ? q/ESCAPE '!'/ : q//);
+    my $quoted_str  = $self->quote(qq/$str%/)
+    return qq/$column LIKE $quoted_str $escape/;
 }
 
 sub sql_istrcmp {

--- a/Bugzilla/DB.pm
+++ b/Bugzilla/DB.pm
@@ -352,7 +352,8 @@ sub import {
 
 sub sql_prefix_match {
     my ($self, $column, $str) = @_;
-    return "$column LIKE " . $self->quote("$str%");
+    my $escape = $str =~ s/([_%!])/!$1/gs;
+    return "$column LIKE " . $self->quote("$str%") . ( $escape ? " ESCAPE '!'" : '');
 }
 
 sub sql_istrcmp {

--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -3914,7 +3914,7 @@ sub _migrate_group_owners {
 
 sub _migrate_nicknames {
     my $dbh = Bugzilla->dbh;
-    my $sth = $dbh->prepare('SELECT userid FROM profiles WHERE is_enabled = 1 AND NOT nickname');
+    my $sth = $dbh->prepare('SELECT userid FROM profiles WHERE realname LIKE "%:%" AND is_enabled = 1 AND NOT nickname');
     $sth->execute();
     while (my ($user_id) = $sth->fetchrow_array) {
         my $user = Bugzilla::User->new($user_id);

--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -773,6 +773,7 @@ sub update_table_definitions {
 
     $dbh->bz_add_index('profiles', 'profiles_realname_ft_idx',
                        {TYPE => 'FULLTEXT', FIELDS => ['realname']});
+    _migrate_nicknames();
 
     ################################################################
     # New --TABLE-- changes should go *** A B O V E *** this point #
@@ -3909,6 +3910,17 @@ sub _migrate_group_owners {
     $dbh->bz_add_column('groups', 'owner_user_id', {TYPE => 'INT3'});
     my $nobody = Bugzilla::User->check('nobody@mozilla.org');
     $dbh->do('UPDATE groups SET owner_user_id = ?', undef, $nobody->id);
+}
+
+sub _migrate_nicknames {
+    my $dbh = Bugzilla->dbh;
+    my $sth = $dbh->prepare('SELECT userid FROM profiles WHERE is_enabled = 1 AND NOT nickname');
+    $sth->execute();
+    while (my ($user_id) = $sth->fetchrow_array) {
+        my $user = Bugzilla::User->new($user_id);
+        $user->set_name($user->name);
+        $user->update();
+    }
 }
 
 sub _migrate_preference_categories {

--- a/Bugzilla/User.pm
+++ b/Bugzilla/User.pm
@@ -484,7 +484,6 @@ sub set_login {
 sub set_name {
     my ($self, $name) = @_;
     $self->set('realname', $name);
-    return if $self->login =~ /\.(?:bugs|tld)$/;
     delete $self->{identity};
     my ($nick) = extract_nicks($name);
     if (!$nick) {

--- a/Bugzilla/User.pm
+++ b/Bugzilla/User.pm
@@ -486,7 +486,7 @@ sub _generate_nickname {
     my ($name, $login) = @_;
     my ($nick) = extract_nicks($name);
     if (!$nick) {
-        $nick = (split(/@/, $login, 2))[0];
+        $nick = "";
     }
     return $nick;
 }
@@ -746,10 +746,7 @@ sub nick {
 
     return "" unless $self->id;
     return $self->{nickname} if $self->{nickname};
-
-    my $nick = (split(/@/, $self->login, 2))[0];
-    WARN("Falling back to old-style nickname ($nick) because nickname field not populated");
-    return $nick;
+    return $self->{nick} //= (split(/@/, $self->login, 2))[0];
 }
 
 sub queries {

--- a/Bugzilla/User.pm
+++ b/Bugzilla/User.pm
@@ -22,6 +22,7 @@ use Bugzilla::Field;
 use Bugzilla::Group;
 use Bugzilla::Hook;
 use Bugzilla::BugUserLastVisit;
+use Bugzilla::Logging;
 
 use DateTime::TimeZone;
 use List::Util qw(max);
@@ -739,7 +740,16 @@ sub nick {
     my $self = shift;
 
     return "" unless $self->id;
-    return $self->{nickname};
+
+    if (!defined $self->{nick}) {
+        $self->{nick} = (split(/@/, $self->login, 2))[0];
+    }
+
+    if ($self->{nick} ne $self->{nickname}) {
+        DEBUG(sprintf "%s has old-style nick %s, and new-style nick %s (realname: %s)", $self->login, $self->{nick}, $self->{nickname}, $self->name);
+    }
+
+    return $self->{nick};
 }
 
 sub queries {

--- a/Bugzilla/User.pm
+++ b/Bugzilla/User.pm
@@ -80,7 +80,8 @@ sub DB_COLUMNS {
         'profiles.password_change_required',
         'profiles.password_change_reason',
         'profiles.mfa',
-        'profiles.mfa_required_date'
+        'profiles.mfa_required_date',
+        'profiles.nickname'
     ),
 }
 
@@ -94,6 +95,7 @@ use constant VALIDATORS => {
     disabledtext             => \&_check_disabledtext,
     login_name               => \&check_login_name_for_creation,
     realname                 => \&_check_realname,
+    nickname                 => \&_check_realname,
     extern_id                => \&_check_extern_id,
     is_enabled               => \&_check_is_enabled,
     password_change_required => \&Bugzilla::Object::check_boolean,
@@ -114,6 +116,7 @@ sub UPDATE_COLUMNS {
         password_change_reason
         mfa
         mfa_required_date
+        nickname
     );
     push(@cols, 'cryptpassword') if exists $self->{cryptpassword};
     return @cols;
@@ -481,7 +484,18 @@ sub set_login {
 sub set_name {
     my ($self, $name) = @_;
     $self->set('realname', $name);
+    return if $self->login =~ /\.(?:bugs|tld)$/;
     delete $self->{identity};
+    my ($nick) = extract_nicks($name);
+    if (!$nick) {
+        $nick = (split(/@/, $self->login, 2))[0];
+    }
+    $self->set('nickname', $nick);
+}
+
+sub set_nick {
+    my ($self, $nick) = @_;
+    $self->set('nickname', $nick);
 }
 
 sub set_password {
@@ -726,12 +740,7 @@ sub nick {
     my $self = shift;
 
     return "" unless $self->id;
-
-    if (!defined $self->{nick}) {
-        $self->{nick} = (split(/@/, $self->login, 2))[0];
-    }
-
-    return $self->{nick};
+    return $self->{nickname};
 }
 
 sub queries {

--- a/Bugzilla/User.pm
+++ b/Bugzilla/User.pm
@@ -22,7 +22,6 @@ use Bugzilla::Field;
 use Bugzilla::Group;
 use Bugzilla::Hook;
 use Bugzilla::BugUserLastVisit;
-use Bugzilla::Logging;
 
 use DateTime::TimeZone;
 use List::Util qw(max);

--- a/Bugzilla/WebService/Server/REST/Resources/User.pm
+++ b/Bugzilla/WebService/Server/REST/Resources/User.pm
@@ -20,6 +20,11 @@ BEGIN {
 
 sub _rest_resources {
     my $rest_resources = [
+        qr{^/user/suggest$}, {
+            GET => {
+                method => 'suggest',
+            },
+        },
         qr{^/valid_login$}, {
             GET => {
                 method => 'valid_login'

--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -172,6 +172,13 @@ sub suggest {
             $order = 'relevance DESC';
             $where = $match;
         }
+        elsif ($have_mysql && $s =~ /^[[:upper:]]/) {
+            my $match = sprintf 'MATCH(realname) AGAINST (%s) ', $dbh->quote($s);
+            $where = join ' OR ',
+                $match,
+                $dbh->sql_prefix_match( nickname => $s ),
+                $dbh->sql_prefix_match( login_name => $s );
+        }
         else {
             $where = join ' OR ', $dbh->sql_prefix_match( nickname => $s ), $dbh->sql_prefix_match( login_name => $s );
         }

--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -24,6 +24,7 @@ use Bugzilla::WebService::Util qw(filter filter_wants validate
 use Bugzilla::Hook;
 
 use List::Util qw(first);
+use Taint::Util qw(untaint);
 
 # Don't need auth to login
 use constant LOGIN_EXEMPT => {
@@ -147,7 +148,7 @@ sub suggest {
     ThrowUserError('user_access_by_match_denied')
       unless Bugzilla->user->id;
 
-    trick_taint($params->{s});
+    untaint($params->{s});
     my $s = $params->{s};
     trim($s);
 

--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -142,14 +142,14 @@ sub suggest {
 
     Bugzilla->switch_to_shadow_db();
 
-    ThrowCodeError('params_required', { function => 'User.suggest_users', params => ['s'] })
-      unless defined $params->{s};
+    ThrowCodeError('params_required', { function => 'User.suggest_users', params => ['match'] })
+      unless defined $params->{match};
 
     ThrowUserError('user_access_by_match_denied')
       unless Bugzilla->user->id;
 
-    untaint($params->{s});
-    my $s = $params->{s};
+    untaint($params->{match});
+    my $s = $params->{match};
     trim($s);
 
     my $dbh = Bugzilla->dbh;

--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -142,7 +142,7 @@ sub suggest {
 
     Bugzilla->switch_to_shadow_db();
 
-    ThrowCodeError('params_required', { function => 'User.suggest_users', params => ['match'] })
+    ThrowCodeError('params_required', { function => 'User.suggest', params => ['match'] })
       unless defined $params->{match};
 
     ThrowUserError('user_access_by_match_denied')
@@ -151,6 +151,7 @@ sub suggest {
     untaint($params->{match});
     my $s = $params->{match};
     trim($s);
+    return { users => [] } if length($s) < 3;
 
     my $dbh = Bugzilla->dbh;
     my @select = ('realname AS real_name', 'login_name AS name');
@@ -180,7 +181,7 @@ sub suggest {
     }
     $where = "($where) AND is_enabled = 1";
 
-    my $sql = "SELECT " . join(", ", @select) . " FROM profiles WHERE $where ORDER BY $order";
+    my $sql = "SELECT " . join(", ", @select) . " FROM profiles WHERE $where ORDER BY $order LIMIT 25";
     my $results = $dbh->selectall_arrayref($sql, { Slice => {} });
 
     my @users = map {

--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -170,7 +170,7 @@ sub suggest {
             my $match = sprintf 'MATCH(realname) AGAINST (%s) ', $dbh->quote($s);
             push @select, "$match AS relevance";
             $order = 'relevance DESC';
-            $where = "$match";
+            $where = $match;
         }
         else {
             $where = join(' OR ',

--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -173,15 +173,12 @@ sub suggest {
             $where = $match;
         }
         else {
-            $where = join(' OR ',
-                $dbh->sql_prefix_match(nickname => $s),
-                $dbh->sql_prefix_match(login_name => $s),
-            );
+            $where = join ' OR ', $dbh->sql_prefix_match( nickname => $s ), $dbh->sql_prefix_match( login_name => $s );
         }
     }
     $where = "($where) AND is_enabled = 1";
 
-    my $sql = "SELECT " . join(", ", @select) . " FROM profiles WHERE $where ORDER BY $order LIMIT 25";
+    my $sql = 'SELECT ' . join(', ', @select) . " FROM profiles WHERE $where ORDER BY $order LIMIT 25";
     my $results = $dbh->selectall_arrayref($sql, { Slice => {} });
 
     my @users = map {

--- a/js/field.js
+++ b/js/field.js
@@ -719,7 +719,7 @@ $(function() {
         params: {
             Bugzilla_api_token: BUGZILLA.api_token,
         },
-        paramName: 's',
+        paramName: 'match',
         deferRequestBy: 250,
         minChars: 2,
         noCache: true,

--- a/js/field.js
+++ b/js/field.js
@@ -715,11 +715,11 @@ $(function() {
     var options_user = {
         appendTo: $('#main-inner'),
         forceFixPosition: true,
-        serviceUrl: 'rest/elastic/suggest_users',
+        serviceUrl: 'rest/user/suggest',
         params: {
             Bugzilla_api_token: BUGZILLA.api_token,
         },
-        paramName: 'match',
+        paramName: 's',
         deferRequestBy: 250,
         minChars: 2,
         noCache: true,


### PR DESCRIPTION
This optimizes the common case of username lookup to be fast at the expense of slightly different behavior.

For bare words consisting of ASCII characters, a prefix match against login_name and the new nickname field is attempted.
For words containing @, only the login_name is considered.
For words beginning with :, only the nickname is considered.

Multiple words, or non-ASCII characters will use a fulltext search against the realname field.
This means 'Mark Cote' will correctly find @markrcote. 

The time savings of this on bugzilla-dev appears to be about 600ms

Prod:
![screen shot 2018-07-03 at 10 41 57](https://user-images.githubusercontent.com/47717/42244405-ebcf450e-7ee2-11e8-96ec-fdc8bd099d11.png)

Dev:
![screen shot 2018-07-03 at 10 41 46](https://user-images.githubusercontent.com/47717/42244408-ef8005a8-7ee2-11e8-88f6-44765a208cf3.png)
