### PR TITLE
Bug 1470275 - Copy Summary button should give some feedback

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -357,7 +357,9 @@ $(function() {
                     // execCommand("copy") only works on selected text
                     $('#clip-container').show();
                     $('#clip').val(clipboardSummary()).select();
-                    document.execCommand("copy");
+                    $('#floating-message-text')
+                        .text(document.execCommand("copy") ? 'Bug summary copied!' : 'Couldn’t copy bug summary');
+                    $('#floating-message').fadeIn(250).delay(2500).fadeOut();
                     $('#clip-container').hide();
                 });
         }


### PR DESCRIPTION
## Description

Add a small but clear UI feedback for the Copy Summary button not to confuse users.

## Bug

[Bug 1470275 - Copy Summary button should give some feedback](https://bugzilla.mozilla.org/show_bug.cgi?id=1470275)

## Screenshot

![screen shot 2018-06-21 at 17 19 24](https://user-images.githubusercontent.com/2929505/41746237-9c21d6bc-7577-11e8-8040-877a11f2044c.png)