### PR TITLE
Bug 1470343 - GitHub PR diff is not decoded in UTF-8

### DIFF
--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -1212,7 +1212,7 @@ sub _attachment_fetch_github_pr_diff {
         warn "Github fetch error: $pr_diff, " . $response->status_line;
         return "Error retrieving Github pull request diff for " . $self->data;
     }
-    return $response->content;
+    return $response->decoded_content;
 }
 
 # redirect automatically to github urls


### PR DESCRIPTION
## Description

Decode GitHub pull request diff properly.

## Bug

[Bug 1470343 - GitHub PR diff is not decoded in UTF-8](https://bugzilla.mozilla.org/show_bug.cgi?id=1470343)

## Screenshot

Notice that **Couldn’t copy bug summary** is displayed as expected, compared to the [current view](https://bugzilla.mozilla.org/attachment.cgi?id=8986913&action=edit).

![screen shot 2018-06-21 at 21 02 21](https://user-images.githubusercontent.com/2929505/41752599-65d2188c-7596-11e8-8754-8ff3bfb4ca3e.png)