### PR TITLE
Bug 1471044 - Allow some model classes to have dynamic column names  with class method DYNAMIC_COLUMNS

### DIFF
--- a/Bugzilla/Group.pm
+++ b/Bugzilla/Group.pm
@@ -67,6 +67,11 @@ use constant UPDATE_COLUMNS => qw(
 use constant GROUP_PARAMS => qw(chartgroup insidergroup timetrackinggroup
                                 querysharegroup);
 
+
+sub DYNAMIC_COLUMNS {
+    return Bugzilla->usage_mode == USAGE_MODE_CMDLINE;
+}
+
 ###############################
 ####      Accessors      ######
 ###############################


### PR DESCRIPTION
When working on #282 I kept encountering the fragility of our model system.

This fragility involves two things:

1) Extensions adding new columns to model objects
2) The use of those model objects in checksetup.

In particular, the SecureMail extension causes this problem because (at checksetup-time) we need to lookup certain Group objects.

Thus I propose to

1) allow model classes to take their list of columns from the informations schema (exposed via `bz_table_columns_real`)
2) Have Bugzilla::Group do this when being used in a commandline (e.g. checksetup) context.