### PR TITLE
Bug 1452096 - Some custom dropdown UI widgets stay fixed and don't move with scroll

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -559,6 +559,8 @@ $(function() {
                     keywords = data.keywords;
                     $('#keywords')
                         .devbridgeAutocomplete({
+                            appendTo: $('#main-inner'),
+                            forceFixPosition: true,
                             lookup: function(query, done) {
                                 query = query.toLowerCase();
                                 var matchStart =

--- a/extensions/BugModal/web/comments.js
+++ b/extensions/BugModal/web/comments.js
@@ -355,6 +355,8 @@ $(function() {
 
     $('#ctag-add')
         .devbridgeAutocomplete({
+            appendTo: $('#main-inner'),
+            forceFixPosition: true,
             serviceUrl: function(query) {
                 return 'rest/bug/comment/tags/' + encodeURIComponent(query);
             },

--- a/extensions/BugModal/web/common_bug_modal.js
+++ b/extensions/BugModal/web/common_bug_modal.js
@@ -509,6 +509,8 @@ $(function() {
                     keywords = data.keywords;
                     $('#keywords')
                         .devbridgeAutocomplete({
+                            appendTo: $('#main-inner'),
+                            forceFixPosition: true,
                             lookup: function(query, done) {
                                 query = query.toLowerCase();
                                 var matchStart =

--- a/extensions/ProdCompSearch/web/js/prod_comp_search.js
+++ b/extensions/ProdCompSearch/web/js/prod_comp_search.js
@@ -66,6 +66,8 @@ $(function() {
                 params.Bugzilla_api_token = BUGZILLA.api_token;
             }
             that.devbridgeAutocomplete({
+                appendTo: $('#main-inner'),
+                forceFixPosition: true,
                 serviceUrl: function(query) {
                     return 'rest/prod_comp_search/' + encodeURIComponent(query);
                 },

--- a/js/comment-tagging.js
+++ b/js/comment-tagging.js
@@ -35,6 +35,8 @@ YAHOO.bugzilla.commentTagging = {
         if (!can_edit) return;
 
         $('#bz_ctag_add').devbridgeAutocomplete({
+            appendTo: $('#main-inner'),
+            forceFixPosition: true,
             serviceUrl: function(query) {
                 return 'rest/bug/comment/tags/' + encodeURIComponent(query);
             },

--- a/js/field.js
+++ b/js/field.js
@@ -713,6 +713,8 @@ $(function() {
     }
 
     var options_user = {
+        appendTo: $('#main-inner'),
+        forceFixPosition: true,
         serviceUrl: 'rest/elastic/suggest_users',
         params: {
             Bugzilla_api_token: BUGZILLA.api_token,
@@ -792,6 +794,8 @@ $(function() {
         .each(function() {
             var that = $(this);
             that.devbridgeAutocomplete({
+                appendTo: $('#main-inner'),
+                forceFixPosition: true,
                 lookup: function(query, done) {
                     var values = BUGZILLA.autocomplete_values[that.data('values')];
                     query = query.toLowerCase();

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -1308,6 +1308,7 @@ hr {
 }
 
 #main-inner {
+    position: relative;
     margin: 15px 0;
 }
 


### PR DESCRIPTION
## Description

Fix the autocomplete dropdown lists displayed at a wrong, fixed position when the page is scrolled down. Given the fixed global header, these widgets has to be attached to the main scroll area instead of `<body>`. See the [README of the jQuery plug-in](https://github.com/devbridge/jQuery-Autocomplete) for the option details.

## Bug

[Bug 1452096 - Some custom dropdown UI widgets stay fixed and don't move with scroll](https://bugzilla.mozilla.org/show_bug.cgi?id=1452096)