### PR TITLE
Bug 1457550 - Update scripts/remove-non-public-data.pl suitability for current BMO infrastructure.

### DIFF
--- a/scripts/remove-non-public-data.pl
+++ b/scripts/remove-non-public-data.pl
@@ -174,7 +174,7 @@ foreach my $table (@tables) {
     else {
         print "dropping $table\n";
         drop_referencing($table);
-        $dbh->do("DROP TABLE $table");
+        $dbh->do("DROP TABLE IF EXISTS $table");
     }
 }
 

--- a/scripts/sanitizeme.pl
+++ b/scripts/sanitizeme.pl
@@ -26,7 +26,6 @@ use strict;
 use warnings;
 use lib qw(. lib local/lib/perl5);
 
-
 use Bugzilla;
 use Bugzilla::Bug;
 use Bugzilla::Constants;


### PR DESCRIPTION
The only remaining issue with this script was that it would sometimes die about tables that were already dropped. This fixes that problem.