### PR TITLE
Remove XUL from attachment Content Type options; add SVG to standard options; mark PDF viewable

### DIFF
--- a/Bugzilla/Attachment.pm
+++ b/Bugzilla/Attachment.pm
@@ -297,10 +297,8 @@ sub is_viewable {
     # We assume we can view all text and image types.
     return 1 if ($contenttype =~ /^(text|image)\//);
 
-    # Mozilla can view XUL. Note the trailing slash on the Gecko detection to
-    # avoid sending XUL to Safari.
-    return 1 if (($contenttype =~ /^application\/vnd\.mozilla\./)
-                 && ($cgi->user_agent() =~ /Gecko\//));
+    # Modern browsers support PDF as well.
+    return 1 if ($contenttype eq 'application/pdf');
 
     # If it's not one of the above types, we check the Accept: header for any
     # types mentioned explicitly.

--- a/extensions/BMO/template/en/default/hook/attachment/createformcontents-mimetypes.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/attachment/createformcontents-mimetypes.html.tmpl
@@ -1,2 +1,0 @@
-[% mimetypes.push({type => "image/svg+xml", desc => "SVG image"}) %]
-[% mimetypes.push({type => "application/vnd.mozilla.xul+xml", desc => "XUL"}) %]

--- a/template/en/default/attachment/createformcontents.html.tmpl
+++ b/template/en/default/attachment/createformcontents.html.tmpl
@@ -120,6 +120,7 @@
                   {type => "image/gif",  desc => "GIF image"},
                   {type => "image/jpeg", desc => "JPEG image"},
                   {type => "image/png",  desc => "PNG image"},
+                  {type => "image/svg+xml", desc => "SVG image"},
                   {type => "application/pdf", desc => "PDF document"},
                   {type => "application/octet-stream", desc => "binary file"}]
   %]

--- a/template/en/default/attachment/show-multiple.html.tmpl
+++ b/template/en/default/attachment/show-multiple.html.tmpl
@@ -35,7 +35,7 @@
 %]
 [% IF hide_obsolete %]
   <div id="hidden_obsolete_message">
-    Obsolete attachments are hidden. To view all attachments (including obsolete) 
+    Obsolete attachments are hidden. To view all attachments (including obsolete)
     <a href="attachment.cgi?bugid=[% bug.id FILTER html %]&amp;action=viewall">click here</a>.
   </div>
 [% END %]
@@ -106,7 +106,7 @@
     [% END %]
   [% ELSE %]
     <p><b>
-      Attachment cannot be viewed because its MIME type is not text/*, image/*, or application/vnd.mozilla.*.
+      Attachment cannot be viewed because its MIME type is not text/*, image/*, or application/pdf.
       <a href="attachment.cgi?id=[% a.id %]">Download the attachment instead</a>.
     </b></p>
   [% END %]


### PR DESCRIPTION
Fix [Bug 1471417 - Remove XUL from attachment Content Type options; add SVG to standard options; mark PDF viewable](https://bugzilla.mozilla.org/show_bug.cgi?id=1471417).

<img width="400" alt="screen shot 2018-06-26 at 7 53 14 pm" src="https://user-images.githubusercontent.com/2929505/41945340-9a0b057c-797a-11e8-9e65-54f85016163c.png">
