### PR TITLE
Bug 1344080 - Module headers should be minified when the module is open

### DIFF
--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -153,6 +153,12 @@ a.activity-ref {
     font-weight: normal;
     padding-right: 5px;
     color: #666;
+    opacity: 1;
+    transition: all .2s;
+}
+
+.module-spinner[aria-expanded="true"] ~ .module-subtitle {
+    opacity: 0;
 }
 
 .module .fields-lhs {


### PR DESCRIPTION
## Description

The human-readable summary on a module header should be hidden when the module is open, because it basically shows duplicated info.

## Bug

[Bug 1344080 - Module headers should be minified when the module is open](https://bugzilla.mozilla.org/show_bug.cgi?id=1344080)

## Screenshots

![screen shot 2018-06-27 at 09 52 19](https://user-images.githubusercontent.com/2929505/41978480-f902dd50-79ef-11e8-9540-28c6fd29920c.png)
![screen shot 2018-06-27 at 09 52 39](https://user-images.githubusercontent.com/2929505/41978481-f9237d8a-79ef-11e8-80b6-02d4cdcb007b.png)