### PR TITLE
Bug 1471966 - Blue "new changes since" bar disappears too quickly

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -1423,7 +1423,7 @@ function show_new_changes_indicator() {
                     observer.unobserve($separator);
                     $link.remove();
                 }
-            }), { root: $separator.offsetParent });
+            }), { root: document.querySelector('#bugzilla-body') });
 
             observer.observe($separator);
         }


### PR DESCRIPTION
Regressed from #620 even before #605 is live 😞 

The `IntersectionObserver`'s root should be the scroll container, and it's `<main id="bugzilla-body">` in this case. The `offsetParent` property could change when CSS is updated, so just specify the exact element instead.