### PR TITLE
bump version to 20180629.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -22,7 +22,7 @@ BEGIN {
     }
 }
 
-our $VERSION = '20180627.1';
+our $VERSION = '20180629.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1471417" target="_blank">1471417</a>] Remove XUL from attachment Content Type options; add SVG to standard options; mark PDF viewable</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1344080" target="_blank">1344080</a>] Module headers should be minified when the module is open</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1469378" target="_blank">1469378</a>] Update feed daemon to only manage subscribers on a revision if the bug is private, otherwise leave it alone</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1469373" target="_blank">1469373</a>] Phabbugz fails with undefined error when phab user without linked BMO account accepts BMO linked revision</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1472048" target="_blank">1472048</a>] Remove Metrics Code</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1471966" target="_blank">1471966</a>] Blue "new changes since" bar disappears too quickly</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1472196" target="_blank">1472196</a>] Disable use of editbugs as edit policy since group member syncing is currently broken on prod bmo</li>
</ul>