### PR TITLE
bump version to 20180703.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -22,7 +22,7 @@ BEGIN {
     }
 }
 
-our $VERSION = '20180629.1';
+our $VERSION = '20180703.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1472326" target="_blank">1472326</a>] group member syncing is currently broken on production bmo</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1472755" target="_blank">1472755</a>] False positives on IP blocking logic</li>
</ul>