### PR TITLE
Bug 1472961 - Copy Summary button should copy link as well

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
@@ -8,6 +8,7 @@
 
 [%
   PROCESS global/variables.none.tmpl;
+  USE Bugzilla;
 
   # <title>
   IF bugs.defined;
@@ -89,6 +90,8 @@
   [%# expose useful data to js %]
   BUGZILLA.bug_id = [% bug.id FILTER none %];
   BUGZILLA.bug_title = '[% unfiltered_title FILTER js %]';
+  BUGZILLA.bug_summary = '[% bug.short_desc FILTER js %]';
+  BUGZILLA.bug_url = '[% Bugzilla.cgi.self_url FILTER js %]';
   BUGZILLA.user = {
     id: [% user.id FILTER none %],
     login: '[% user.login FILTER js %]',

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -339,10 +339,6 @@ $(function() {
 
     // copy summary to clipboard
 
-    function clipboardSummary() {
-        return 'Bug ' + BUGZILLA.bug_id + ' - ' + $('#field-value-short_desc').text();
-    }
-
     if ($('#copy-summary').length) {
         var hasExecCopy = false;
         try {
@@ -352,11 +348,24 @@ $(function() {
         }
 
         if (hasExecCopy) {
+            const url = BUGZILLA.bug_url;
+            const text = `Bug ${BUGZILLA.bug_id} - ${BUGZILLA.bug_summary}`;
+            const html = `<a href="${url}">${text}</a>`;
+
+            document.addEventListener('copy', event => {
+                if (event.target.nodeType === 1 && event.target.matches('#clip')) {
+                    event.clipboardData.setData('text/uri-list', url);
+                    event.clipboardData.setData('text/plain', text);
+                    event.clipboardData.setData('text/html', html);
+                    event.preventDefault();
+                }
+            });
+
             $('#copy-summary')
                 .click(function() {
                     // execCommand("copy") only works on selected text
                     $('#clip-container').show();
-                    $('#clip').val(clipboardSummary()).select();
+                    $('#clip').val(text).select();
                     $('#floating-message-text')
                         .text(document.execCommand("copy") ? 'Bug summary copied!' : 'Couldn’t copy bug summary');
                     $('#floating-message').fadeIn(250).delay(2500).fadeOut();
@@ -375,27 +384,6 @@ $(function() {
                 return;
             event.preventDefault();
             lb_show(this);
-        });
-
-    // when copying the bug id and summary, reformat to remove \n and alias
-    $(document).on(
-        'copy', function(event) {
-            var selection = document.getSelection().toString().trim();
-            var match = selection.match(/^(Bug \d+)\s*\n(.+)$/) ||
-                selection.match(/^(Bug \d+)\s+\([^\)]+\)\s*\n(.+)$/);
-            if (match) {
-                var content = match[1] + ' - ' + match[2].trim();
-                if (event.originalEvent.clipboardData) {
-                    event.originalEvent.clipboardData.setData('text/plain', content);
-                }
-                else if (window.clipboardData) {
-                    window.clipboardData.setData('Text', content);
-                }
-                else {
-                    return;
-                }
-                event.preventDefault();
-            }
         });
 
     // action button actions


### PR DESCRIPTION
## Description

* Add bug URL to clipboard along with summary when you click on the Copy Summary button.
* Simplify the code: `window.clipboardData` is IE-only so no longer needed

## Bug

[Bug 1472961 - Copy Summary button should copy link as well](https://bugzilla.mozilla.org/show_bug.cgi?id=1472961)