### PR TITLE
Bug 1474026 - Double HTML escaping in crash signature update

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -383,7 +383,7 @@
           value FILTER bug_list_link;
 
         ELSE;
-          value FILTER truncate(256, '&hellip;') FILTER html;
+          value FILTER truncate(256, '…') FILTER html;
 
         END;
     END;

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -1023,7 +1023,7 @@
 [%
   sub = [];
   IF bug.status_whiteboard != "";
-    sub.push("Whiteboard: " _ bug.status_whiteboard.truncate(256, '&hellip;'));
+    sub.push("Whiteboard: " _ bug.status_whiteboard.truncate(256, '…'));
   END;
   IF bug.cf_crash_signature != "";
     sub.push("crash signature");

--- a/extensions/BugmailFilter/template/en/default/account/prefs/bugmail_filter.html.tmpl
+++ b/extensions/BugmailFilter/template/en/default/account/prefs/bugmail_filter.html.tmpl
@@ -221,7 +221,7 @@ var cpts = new Array();
     [% FOREACH flag = type.flags %]
       [% IF flag_count > 10 && loop.count == 10 %]
         <span id="show_all">
-          &hellip;
+          …
           (<a href="#" onclick="showAllFlags(); return false">show all</a>)
         </span>
         <span id="all_flags" class="bz_default_hidden">


### PR DESCRIPTION
## Description

Just use the Unicode character to avoid double escaping. Tested locally.

## Bug

[Bug 1474026 - Double HTML escaping in crash signature update](https://bugzilla.mozilla.org/show_bug.cgi?id=1474026)