### PR TITLE
Bug 1260096 - BugUserLastVisit api not working and throwing error code : 32614

### DIFF
--- a/Bugzilla/WebService/Server/REST/Resources/BugUserLastVisit.pm
+++ b/Bugzilla/WebService/Server/REST/Resources/BugUserLastVisit.pm
@@ -32,6 +32,15 @@ sub _rest_resources {
                 },
             },
         },
+        # no bug-id
+        qr{^/bug_user_last_visit$}, {
+            GET => {
+                method => 'get',
+            },
+            POST => {
+                method => 'update',
+            },
+        },
     ];
 }
 

--- a/docs/en/rst/api/core/v1/bug-user-last-visit.rst
+++ b/docs/en/rst/api/core/v1/bug-user-last-visit.rst
@@ -82,7 +82,7 @@ To return more than one specific bug timestamps:
 
    GET /rest/bug_user_last_visit/123?ids=234&ids=456
 
-To return just the most recent 20 timestamps:
+To return all the timestamps stored during the retention period:
 
 .. code-block:: text
 


### PR DESCRIPTION
## Description

* Add a missing REST API route `/bug_user_last_visit` which is [documented](https://bmo.readthedocs.io/en/latest/api/core/v1/bug-user-last-visit.html) and also available as JSON-RPC `BugUserLastVisit.get` and `BugUserLastVisit.update` methods (still used on non-modal bug pages and My Dashboard)
* Update the document to clarify the actual results

## Bug

[Bug 1260096 - BugUserLastVisit api not working and throwing error code : 32614](https://bugzilla.mozilla.org/show_bug.cgi?id=1260096)

## Test

Open a modal bug page, and enter this in the browser’s console:

```javascript
bugzilla_ajax({ url: '/rest/bug_user_last_visit', type: 'GET' }, result => console.log(result));
bugzilla_ajax({ url: '/rest/bug_user_last_visit', type: 'POST', data: { ids: [1,2,3] } }, result => console.log(result));
```