### PR TITLE
bump version to 20180717.2

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -22,7 +22,7 @@ BEGIN {
     }
 }
 
-our $VERSION = '20180717.1';
+our $VERSION = '20180717.2';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
the following changes will be pushed to bugzilla.mozilla.org:
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1473798" target="_blank">1473798</a>] Add and remove members of a phabricator project instead of setting exact list</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1474617" target="_blank">1474617</a>] conduit-suite phabricator local development instance missing some default configuration</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1476052" target="_blank">1476052</a>] Bugzilla mishandles diff attachments that are UTF-8 and contain U+FFFF</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1472961" target="_blank">1472961</a>] Copy Summary button should copy link as well</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1260096" target="_blank">1260096</a>] BugUserLastVisit api not working and throwing error code : 32614</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1474026" target="_blank">1474026</a>] Double HTML escaping in crash signature update</li>
</ul>