### PR TITLE
Bug 1136271 - Make user profile page visible to anyone for easier sharing

### DIFF
--- a/extensions/BMO/template/en/default/pages/group_members.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/group_members.html.tmpl
@@ -82,7 +82,7 @@
                       <a href="editusers.cgi?action=edit&amp;userid=[% member.id FILTER none %]"
                         target="_blank">
                     [% ELSE %]
-                      <a href="user_profile?login=[% member.login FILTER uri %]"
+                      <a href="user_profile?user_id=[% member.id FILTER none %]"
                         target="_blank">
                     [% END %]
                       <span [% 'class="bz_inactive"' UNLESS member.is_enabled %]>

--- a/extensions/BMO/web/js/edituser_menu.js
+++ b/extensions/BMO/web/js/edituser_menu.js
@@ -10,7 +10,7 @@ function show_usermenu(id, email, show_edit) {
         {
             name: "Profile",
             callback: function () {
-                var href = "user_profile?login=" + encodeURIComponent(email);
+                var href = "user_profile?user_id=" + id;
                 window.open(href, "_blank");
             }
         },

--- a/extensions/Gravatar/template/en/default/hook/bug/comments-user-image.html.tmpl
+++ b/extensions/Gravatar/template/en/default/hook/bug/comments-user-image.html.tmpl
@@ -8,11 +8,7 @@
 
 [% IF user.settings.show_gravatars.value == 'On' %]
   [% IF who.last_activity_ts %]
-    [% IF user.id %]
-      <a href="user_profile?login=[% who.login FILTER uri %]">
-    [% ELSE %]
-      <a href="user_profile?user_id=[% who.id FILTER uri %]">
-    [% END %]
+    <a href="user_profile?user_id=[% who.id FILTER none %]">
   [% END %]
   <img alt="User image" align="middle" src="[% who.gravatar FILTER none %]" width="32" height="32" border="0">
   [% "</a>" IF who.last_activity_ts %]

--- a/extensions/UserProfile/template/en/default/hook/account/prefs/account-start.html.tmpl
+++ b/extensions/UserProfile/template/en/default/hook/account/prefs/account-start.html.tmpl
@@ -6,6 +6,6 @@
   # defined by the Mozilla Public License, v. 2.0.
   #%]
 
-<a href="user_profile?login=[% user.login FILTER uri %]">
+<a href="user_profile?user_id=[% user.id FILTER none %]">
   [% terms.Bugzilla %] User Profile
 </a><br><hr>

--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -326,14 +326,14 @@
         </button>
         <ul class="dropdown-content left" id="header-account-menu" role="menu" style="display:none;">
           <li role="presentation">
-            <div href="user_profile" class="account-label">
+            <div class="account-label">
               <div class="name">[% user.name FILTER html %]</div>
               <div class="email">[% user.login FILTER html %]</div>
             </div>
           </li>
           <li role="separator" class="dropdown-separator"></li>
           <li role="presentation">
-            <a href="user_profile" role="menuitem" tabindex="-1">My Profile</a>
+            <a href="user_profile?user_id=[% user.id FILTER none %]" role="menuitem" tabindex="-1">My Profile</a>
           </li>
           <li role="presentation">
             <a href="page.cgi?id=user_activity.html&amp;action=run&amp;who=[% user.login FILTER uri %]" role="menuitem"


### PR DESCRIPTION
## Description

Given that the `/user_profile` URL is not shareable and `/user_profile?login={USER_EMAIL}` is not visible to unauthenticated users, simply use `/user_profile?user_id={USER_ID}` to work around the issue. We could eventually replace it with `/user/{USER_NICK}` and redesign the page.

## Bug

[Bug 1136271 - Make user profile page visible to anyone for easier sharing](https://bugzilla.mozilla.org/show_bug.cgi?id=1136271#c6)