### PR TITLE
Bug 1380437 - Implement REST API utility methods in global.js to replace bugzilla_ajax(), eliminate JSON-RPC usage

### DIFF
--- a/extensions/Bitly/web/js/bitly.js
+++ b/extensions/Bitly/web/js/bitly.js
@@ -9,7 +9,7 @@ $(function() {
     'use strict';
     var popup, urls = [];
 
-    function execute() {
+    async function execute() {
         var type = $('#bitly-type').val();
 
         if (urls[type]) {
@@ -18,17 +18,15 @@ $(function() {
         }
 
         $('#bitly-url').val('');
-        var request = `${BUGZILLA.config.basepath}rest/bitly/${type}?` +
-                      `url=${encodeURIComponent($('#bitly-shorten').data('url'))}&` +
-                      `Bugzilla_api_token=${encodeURIComponent(BUGZILLA.api_token)}`;
-        $.ajax(request)
-            .done(function(data) {
-                urls[type] = data.url;
-                $('#bitly-url').val(urls[type]).select().focus();
-            })
-            .fail(function(data) {
-                $('#bitly-url').val(data.responseJSON.message);
-            });
+
+        try {
+            const { url } = await Bugzilla.API.get(`bitly/${type}`, { url: $('#bitly-shorten').data('url') });
+
+            urls[type] = url;
+            $('#bitly-url').val(urls[type]).select().focus();
+        } catch ({ message }) {
+            $('#bitly-url').val(message);
+        }
     }
 
     $('#bitly-shorten')

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -162,7 +162,7 @@
 
 [%# === header === %]
 
-<div role="status" id="xhr-error" style="display:none"></div>
+<div role="status" id="io-error" style="display:none"></div>
 <div role="status" id="floating-message" style="display:none">
   <div id="floating-message-text"></div>
 </div>

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -970,7 +970,7 @@ h3.change-name a {
   vertical-align: top;
 }
 
-#xhr-error {
+#io-error {
   margin: 5px 0;
   border-radius: 2px;
   border: 1px solid var(--error-message-foreground-color);

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -266,50 +266,50 @@ $(function() {
         );
     }
 
-    function ccListUpdate() {
-        bugzilla_ajax(
-            {
-                url: `${BUGZILLA.config.basepath}rest/bug_modal/cc/${BUGZILLA.bug_id}`
-            },
-            function(data) {
-                $('#cc-list').html(data.html);
-                $('#cc-latch').data('fetched', true);
-                $('#cc-list .cc-user').hover(
-                    function() {
-                        $('#ccr-' + $(this).data('n')).css('visibility', 'visible');
-                    },
-                    function() {
-                        $('#ccr-' + $(this).data('n')).css('visibility', 'hidden');
+    async function ccListUpdate() {
+        try {
+            const { html } = await Bugzilla.API.get(`bug_modal/cc/${BUGZILLA.bug_id}`);
+
+            $('#io-error').empty().hide();
+            $('#cc-list').html(html);
+            $('#cc-latch').data('fetched', true);
+            $('#cc-list .cc-user').hover(
+                function() {
+                    $('#ccr-' + $(this).data('n')).css('visibility', 'visible');
+                },
+                function() {
+                    $('#ccr-' + $(this).data('n')).css('visibility', 'hidden');
+                }
+            );
+            $('#cc-list .show_usermenu').click(function() {
+                const $this = $(this);
+                return show_usermenu($this.data('user-id'), $this.data('user-email'), $this.data('show-edit'),
+                    $this.data('hide-profile'));
+            });
+            $('#cc-list .cc-remove')
+                .click(function(event) {
+                    event.preventDefault();
+                    $('#top-save-btn').show();
+                    var n = $(this).data('n');
+                    var ccu = $('#ccu-' + n);
+                    if (ccu.hasClass('cc-removed')) {
+                        ccu.removeClass('cc-removed');
+                        $('#cc-' + n).remove();
                     }
-                );
-                $('#cc-list .show_usermenu').click(function() {
-                    const $this = $(this);
-                    return show_usermenu($this.data('user-id'), $this.data('user-email'), $this.data('show-edit'),
-                        $this.data('hide-profile'));
+                    else {
+                        $('#removecc').val('on');
+                        ccu.addClass('cc-removed');
+                        $('<input>').attr({
+                            type: 'hidden',
+                            id: 'cc-' + n,
+                            value: $('#ccr-' + n).data('login'),
+                            name: 'cc'
+                        }).appendTo('#changeform');
+                    }
                 });
-                $('#cc-list .cc-remove')
-                    .click(function(event) {
-                        event.preventDefault();
-                        $('#top-save-btn').show();
-                        var n = $(this).data('n');
-                        var ccu = $('#ccu-' + n);
-                        if (ccu.hasClass('cc-removed')) {
-                            ccu.removeClass('cc-removed');
-                            $('#cc-' + n).remove();
-                        }
-                        else {
-                            $('#removecc').val('on');
-                            ccu.addClass('cc-removed');
-                            $('<input>').attr({
-                                type: 'hidden',
-                                id: 'cc-' + n,
-                                value: $('#ccr-' + n).data('login'),
-                                name: 'cc'
-                            }).appendTo('#changeform');
-                        }
-                    });
-            }
-        );
+        } catch ({ message }) {
+            $('#io-error').html(message).show('fast');
+        }
     }
 
     if (BUGZILLA.user.id) {
@@ -510,7 +510,7 @@ $(function() {
 
     // edit/save mode button
     $('#mode-btn')
-        .click(function(event) {
+        .click(async event => {
             event.preventDefault();
 
             // hide buttons, old error messages
@@ -535,119 +535,119 @@ $(function() {
             $('#mode-btn').prop('disabled', true);
 
             // load the missing select data
-            bugzilla_ajax(
-                {
-                    url: `${BUGZILLA.config.basepath}rest/bug_modal/edit/${BUGZILLA.bug_id}`
-                },
-                function(data) {
-                    $('#mode-btn').hide();
+            try {
+                const data = await Bugzilla.API.get(`bug_modal/edit/${BUGZILLA.bug_id}`);
 
-                    // populate select menus
-                    Object.entries(data.options).forEach(([key, value]) => {
-                        const $select = document.querySelector(`#${key}`);
-                        if (!$select) return;
-                        // It can be radio-button-like UI
-                        const use_buttons = $select.matches('.buttons.toggle');
-                        const is_required = $select.matches('[aria-required="true"]');
-                        const selected = use_buttons ? $select.querySelector('input').value : $select.value;
-                        $select.innerHTML = '';
-                        value.forEach(({ name }) => {
-                            if (is_required && name === '--') {
-                                return;
-                            }
-                            if (use_buttons) {
-                                $select.insertAdjacentHTML('beforeend', `
-                                  <div class="item">
-                                    <input id="${$select.id}_${name}_radio" type="radio" name="${$select.id}"
-                                           value="${name}" ${name === selected ? 'checked' : ''}>
-                                    <label for="${$select.id}_${name}_radio">
-                                    ${$select.id === 'bug_type' ? `
-                                      <span class="bug-type-label iconic-text" data-type="${name}">
-                                        <span class="icon" aria-hidden="true"></span>${name}
-                                      </span>
-                                    ` : `${name}`}
-                                    </label>
-                                  </div>
-                                `);
-                            } else {
-                                $select.insertAdjacentHTML('beforeend', `
-                                  <option value="${name}" ${name === selected ? 'selected' : ''}>${name}</option>
-                                `);
-                            }
-                        });
-                        if ($select.matches('[multiple]') && value.length < 5) {
-                            $select.size = value.length;
+                $('#io-error').empty().hide();
+                $('#mode-btn').hide();
+
+                // populate select menus
+                for (const [key, value] of Object.entries(data.options)) {
+                    const $select = document.querySelector(`#${key}`);
+                    if (!$select) {
+                        continue;
+                    }
+                    // It can be radio-button-like UI
+                    const use_buttons = $select.matches('.buttons.toggle');
+                    const is_required = $select.matches('[aria-required="true"]');
+                    const selected = use_buttons ? $select.querySelector('input').value : $select.value;
+                    $select.innerHTML = '';
+                    for (const { name } of value) {
+                        if (is_required && name === '--') {
+                            continue;
                         }
-                    });
-
-                    // build our product description hash
-                    $.each(data.options.product, function() {
-                        products[this.name] = this.description;
-                    });
-
-                    // keywords is a multi-value autocomplete
-                    keywords = data.keywords;
-                    $('#keywords')
-                        .devbridgeAutocomplete({
-                            appendTo: $('#main-inner'),
-                            forceFixPosition: true,
-                            lookup: function(query, done) {
-                                query = query.toLowerCase();
-                                var matchStart =
-                                    $.grep(keywords, function(keyword) {
-                                        return keyword.toLowerCase().substr(0, query.length) === query;
-                                    });
-                                var matchSub =
-                                    $.grep(keywords, function(keyword) {
-                                        return keyword.toLowerCase().indexOf(query) !== -1 &&
-                                            $.inArray(keyword, matchStart) === -1;
-                                    });
-                                var suggestions =
-                                    $.map($.merge(matchStart, matchSub), function(suggestion) {
-                                        return { value: suggestion };
-                                    });
-                                done({ suggestions: suggestions });
-                            },
-                            tabDisabled: true,
-                            delimiter: /,\s*/,
-                            minChars: 0,
-                            autoSelectFirst: false,
-                            triggerSelectOnValidInput: false,
-                            formatResult: function(suggestion, currentValue) {
-                                // disable <b> wrapping of matched substring
-                                return suggestion.value.htmlEncode();
-                            },
-                            onSearchStart: function(params) {
-                                var that = $(this);
-                                // adding spaces shouldn't initiate a new search
-                                var parts = that.val().split(/,\s*/);
-                                var query = parts[parts.length - 1];
-                                return query === $.trim(query);
-                            },
-                            onSelect: function() {
-                                this.value = this.value + ', ';
-                                this.focus();
-                            }
-                        })
-                        .addClass('bz_autocomplete');
-
-                    $('#cancel-btn').prop('disabled', false);
-                    $('#top-save-btn').show();
-                    $('#cancel-btn').show();
-                    $('#commit-btn').show();
-                },
-                function() {
-                    $('#mode-btn-readonly').show();
-                    $('#mode-btn-loading').hide();
-                    $('#mode-btn').prop('disabled', false);
-                    $('#mode-btn').show();
-                    $('#cancel-btn').hide();
-                    $('#commit-btn').hide();
-
-                    $('.edit-show').hide();
-                    $('.edit-hide').show();
+                        if (use_buttons) {
+                            $select.insertAdjacentHTML('beforeend', `
+                              <div class="item">
+                                <input id="${$select.id}_${name}_radio" type="radio" name="${$select.id}"
+                                        value="${name}" ${name === selected ? 'checked' : ''}>
+                                <label for="${$select.id}_${name}_radio">
+                                ${$select.id === 'bug_type' ? `
+                                  <span class="bug-type-label iconic-text" data-type="${name}">
+                                    <span class="icon" aria-hidden="true"></span>${name}
+                                  </span>
+                                ` : `${name}`}
+                                </label>
+                              </div>
+                            `);
+                        } else {
+                            $select.insertAdjacentHTML('beforeend', `
+                              <option value="${name}" ${name === selected ? 'selected' : ''}>${name}</option>
+                            `);
+                        }
+                    }
+                    if ($select.matches('[multiple]') && value.length < 5) {
+                        $select.size = value.length;
+                    }
                 }
-            );
+
+                // build our product description hash
+                for (const { name, description } of data.options.product) {
+                    products[name] = description;
+                }
+
+                // keywords is a multi-value autocomplete
+                keywords = data.keywords;
+                $('#keywords')
+                    .devbridgeAutocomplete({
+                        appendTo: $('#main-inner'),
+                        forceFixPosition: true,
+                        lookup: function(query, done) {
+                            query = query.toLowerCase();
+                            var matchStart =
+                                $.grep(keywords, function(keyword) {
+                                    return keyword.toLowerCase().substr(0, query.length) === query;
+                                });
+                            var matchSub =
+                                $.grep(keywords, function(keyword) {
+                                    return keyword.toLowerCase().indexOf(query) !== -1 &&
+                                        $.inArray(keyword, matchStart) === -1;
+                                });
+                            var suggestions =
+                                $.map($.merge(matchStart, matchSub), function(suggestion) {
+                                    return { value: suggestion };
+                                });
+                            done({ suggestions });
+                        },
+                        tabDisabled: true,
+                        delimiter: /,\s*/,
+                        minChars: 0,
+                        autoSelectFirst: false,
+                        triggerSelectOnValidInput: false,
+                        formatResult: function(suggestion, currentValue) {
+                            // disable <b> wrapping of matched substring
+                            return suggestion.value.htmlEncode();
+                        },
+                        onSearchStart: function(params) {
+                            var that = $(this);
+                            // adding spaces shouldn't initiate a new search
+                            var parts = that.val().split(/,\s*/);
+                            var query = parts[parts.length - 1];
+                            return query === $.trim(query);
+                        },
+                        onSelect: function() {
+                            this.value = this.value + ', ';
+                            this.focus();
+                        }
+                    })
+                    .addClass('bz_autocomplete');
+
+                $('#cancel-btn').prop('disabled', false);
+                $('#top-save-btn').show();
+                $('#cancel-btn').show();
+                $('#commit-btn').show();
+            } catch ({ message }) {
+                $('#io-error').html(message).show('fast');
+                $('#mode-btn-readonly').show();
+                $('#mode-btn-loading').hide();
+                $('#mode-btn').prop('disabled', false);
+                $('#mode-btn').show();
+                $('#cancel-btn').hide();
+                $('#commit-btn').hide();
+
+                $('.edit-show').hide();
+                $('.edit-hide').show();
+            }
         });
     $('#mode-btn').prop('disabled', false);
 
@@ -675,7 +675,7 @@ $(function() {
 
     // cc toggle (follow/stop following)
     $('#cc-btn')
-        .click(function(event) {
+        .click(async event => {
             event.preventDefault();
             var is_cced = $(event.target).data('is-cced') == '1';
 
@@ -731,36 +731,34 @@ $(function() {
                 $('#add-self-cc').attr('disabled', false);
             }
 
-            bugzilla_ajax(
-                {
-                    url: `${BUGZILLA.config.basepath}rest/bug/${BUGZILLA.bug_id}`,
-                    type: 'PUT',
-                    data: JSON.stringify({ cc: cc_change })
-                },
-                function(data) {
-                    $('#cc-btn').prop('disabled', false);
-                    if (!(data.bugs[0].changes && data.bugs[0].changes.cc))
-                        return;
-                    if (data.bugs[0].changes.cc.added == BUGZILLA.user.login) {
-                        $('#cc-btn')
-                            .text('Stop Following')
-                            .data('is-cced', '1');
-                    }
-                    else if (data.bugs[0].changes.cc.removed == BUGZILLA.user.login) {
-                        $('#cc-btn')
-                            .text('Follow')
-                            .data('is-cced', '0');
-                    }
-                    if ($('#cc-latch').data('expanded'))
-                        ccListUpdate();
-                },
-                function(message) {
-                    $('#cc-btn').prop('disabled', false);
-                    if ($('#cc-latch').data('expanded'))
-                        ccListUpdate();
-                }
-            );
+            try {
+                const { bugs } = await Bugzilla.API.put(`bug/${BUGZILLA.bug_id}`, { cc: cc_change });
+                const { changes } = bugs[0];
 
+                $('#io-error').empty().hide();
+                $('#cc-btn').prop('disabled', false);
+
+                if (!(changes && changes.cc)) {
+                    return;
+                }
+
+                if (changes.cc.added == BUGZILLA.user.login) {
+                    $('#cc-btn').text('Stop Following').data('is-cced', '1');
+                } else if (changes.cc.removed == BUGZILLA.user.login) {
+                    $('#cc-btn').text('Follow').data('is-cced', '0');
+                }
+
+                if ($('#cc-latch').data('expanded')) {
+                    ccListUpdate();
+                }
+            } catch ({ message }) {
+                $('#io-error').html(message).show('fast');
+                $('#cc-btn').prop('disabled', false);
+
+                if ($('#cc-latch').data('expanded')) {
+                    ccListUpdate();
+                }
+            }
         });
 
     // cancel button, reset the ui back to read-only state
@@ -903,18 +901,16 @@ $(function() {
             var prefix = "(In reply to " + comment_author + " from comment #" + comment_no + ")\n";
             var reply_text = "";
 
-            var quoteMarkdown = function($comment) {
+            var quoteMarkdown = async $comment => {
                 const uid = $comment.data('comment-id');
-                bugzilla_ajax(
-                    {
-                        url: `rest/bug/comment/${uid}`,
-                    },
-                    (data) => {
-                        const quoted = data['comments'][uid]['text'].replace(/\n/g, "\n> ");
-                        reply_text = `${prefix}> ${quoted}\n\n`;
-                        populateNewComment();
-                    }
-                );
+
+                try {
+                    const { comments } = await Bugzilla.API.get(`bug/comment/${uid}`, { include_fields: 'text' });
+                    const quoted = comments[uid]['text'].replace(/\n/g, '\n> ');
+
+                    reply_text = `${prefix}> ${quoted}\n\n`;
+                    populateNewComment();
+                } catch (ex) {}
             }
 
             var populateNewComment = function() {
@@ -1141,7 +1137,7 @@ $(function() {
         $(this).data('default', $(this).val());
     });
     $('#product')
-        .change(function(event) {
+        .change(async event => {
             $('#product-throbber').show();
             $('#component, #version, #target_milestone').attr('disabled', true);
 
@@ -1154,74 +1150,72 @@ $(function() {
                 }
             });
 
-            bugzilla_ajax(
-                {
-                    url: `${BUGZILLA.config.basepath}rest/bug_modal/new_product/${BUGZILLA.bug_id}?` +
-                         `product=${encodeURIComponent($('#product').val())}`
-                },
-                function(data) {
-                    $('#product-throbber').hide();
-                    $('#component, #version, #target_milestone').attr('disabled', false);
-                    var is_default = $('#product').val() == $('#product').data('default');
+            try {
+                const product = $('#product').val();
+                const data = await Bugzilla.API.get(`bug_modal/new_product/${BUGZILLA.bug_id}`, { product });
 
-                    // populate selects
-                    $.each(data, function(key, value) {
-                        if (key == 'groups') return;
-                        var el = $('#' + key);
-                        if (!el) return;
-                        el.empty();
-                        var selected = el.data('preselect');
-                        $(value).each(function(i, v) {
-                            el.append($('<option>', { value: v.name, text: v.name }));
-                            if (typeof selected === 'undefined' && v.selected)
-                                selected = v.name;
-                        });
-                        el.val(selected);
-                        el.prop('required', true);
-                        if (is_default) {
-                            el.removeClass('attention');
-                            el.val(el.data('default'));
-                        }
-                        else {
-                            el.addClass('attention');
-                        }
+                $('#io-error').empty().hide();
+                $('#product-throbber').hide();
+                $('#component, #version, #target_milestone').attr('disabled', false);
+                var is_default = $('#product').val() == $('#product').data('default');
+
+                // populate selects
+                $.each(data, function(key, value) {
+                    if (key == 'groups') return;
+                    var el = $('#' + key);
+                    if (!el) return;
+                    el.empty();
+                    var selected = el.data('preselect');
+                    $(value).each(function(i, v) {
+                        el.append($('<option>', { value: v.name, text: v.name }));
+                        if (typeof selected === 'undefined' && v.selected)
+                            selected = v.name;
                     });
+                    el.val(selected);
+                    el.prop('required', true);
+                    if (is_default) {
+                        el.removeClass('attention');
+                        el.val(el.data('default'));
+                    }
+                    else {
+                        el.addClass('attention');
+                    }
+                });
 
-                    // update groups
-                    var dirtyGroups = [];
-                    var any_groups_checked = 0;
+                // update groups
+                var dirtyGroups = [];
+                var any_groups_checked = 0;
+                $('#module-security').find('input[name=groups]').each(function() {
+                    var that = $(this);
+                    var defaultChecked = !!that.attr('checked');
+                    if (defaultChecked !== that.is(':checked')) {
+                        dirtyGroups.push({ name: that.val(), value: that.is(':checked') });
+                    }
+                    if (that.is(':checked')) {
+                        any_groups_checked = 1;
+                    }
+                });
+                $('#module-security .module-content')
+                    .html(data.groups)
+                    .addClass('attention');
+                $.each(dirtyGroups, function() {
+                    $('#module-security').find('input[value=' + this.name + ']').prop('checked', this.value);
+                });
+                // clear any default groups if user was making bug public
+                // unless the group is mandatory for the new product
+                if (!any_groups_checked) {
                     $('#module-security').find('input[name=groups]').each(function() {
                         var that = $(this);
-                        var defaultChecked = !!that.attr('checked');
-                        if (defaultChecked !== that.is(':checked')) {
-                            dirtyGroups.push({ name: that.val(), value: that.is(':checked') });
-                        }
-                        if (that.is(':checked')) {
-                            any_groups_checked = 1;
+                        if (!that.data('mandatory')) {
+                            that.prop('checked', false);
                         }
                     });
-                    $('#module-security .module-content')
-                        .html(data.groups)
-                        .addClass('attention');
-                    $.each(dirtyGroups, function() {
-                        $('#module-security').find('input[value=' + this.name + ']').prop('checked', this.value);
-                    });
-                    // clear any default groups if user was making bug public
-                    // unless the group is mandatory for the new product
-                    if (!any_groups_checked) {
-                        $('#module-security').find('input[name=groups]').each(function() {
-                            var that = $(this);
-                            if (!that.data('mandatory')) {
-                                that.prop('checked', false);
-                            }
-                        });
-                    }
-                },
-                function() {
-                    $('#product-throbber').hide();
-                    $('#component, #version, #target_milestone').attr('disabled', false);
                 }
-            );
+            } catch ({ message }) {
+                $('#io-error').html(message).show('fast');
+                $('#product-throbber').hide();
+                $('#component, #version, #target_milestone').attr('disabled', false);
+            }
         });
 
     // product/component search
@@ -1285,8 +1279,8 @@ $(function() {
 
     // comment preview
     var last_comment_text = '';
-    $('#comment-tabs li').click(function() {
-        var that = $(this);
+    $('#comment-tabs li').click(async event => {
+        var that = $(event.target);
         if (that.attr('aria-selected') === 'true')
             return;
 
@@ -1311,30 +1305,25 @@ $(function() {
             return;
         $('#preview-throbber').show();
         preview.html('');
-        bugzilla_ajax(
-            {
-                url: `${BUGZILLA.config.basepath}rest/bug/comment/render`,
-                type: 'POST',
-                data: { text: comment.val() },
-                hideError: true
-            },
-            function(data) {
-                $('#preview-throbber').hide();
-                preview.html(data.html);
 
-                // Highlight code if possible
-                if (Prism) {
-                  Prism.highlightAllUnder(preview.get(0));
-                }
-            },
-            function(message) {
-                $('#preview-throbber').hide();
-                var container = $('<div/>');
-                container.addClass('preview-error');
-                container.text(message);
-                preview.html(container);
+        try {
+            const { html } = await Bugzilla.API.post('bug/comment/render', { text: comment.val() });
+
+            $('#preview-throbber').hide();
+            preview.html(html);
+
+            // Highlight code if possible
+            if (Prism) {
+                Prism.highlightAllUnder(preview.get(0));
             }
-        );
+        } catch ({ message }) {
+            $('#preview-throbber').hide();
+            var container = $('<div/>');
+            container.addClass('preview-error');
+            container.text(message);
+            preview.html(container);
+        }
+
         last_comment_text = comment.val();
     }).keydown(function(event) {
         var that = $(this);
@@ -1395,7 +1384,7 @@ $(function() {
         });
 
     // Allow to attach pasted text directly
-    document.querySelector('#comment').addEventListener('paste', event => {
+    document.querySelector('#comment').addEventListener('paste', async event => {
       const text = event.clipboardData.getData('text');
       const lines = text.split(/(?:\r\n|\r|\n)/).length;
 
@@ -1415,23 +1404,21 @@ $(function() {
 
       event.preventDefault();
 
-      bugzilla_ajax({
-        type: 'POST',
-        url: `/rest/bug/${BUGZILLA.bug_id}/attachment`,
-        data: {
+      try {
+        await Bugzilla.API.post(`bug/${BUGZILLA.bug_id}/attachment`, {
           // https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding
           data: btoa(encodeURIComponent(text).replace(/%([0-9A-F]{2})/g, (m, p1) => String.fromCharCode(`0x${p1}`))),
           file_name: 'pasted.txt',
           summary,
           content_type: 'text/plain',
           comment: event.target.value.trim(),
-        },
-      }, () => {
+        });
+
         // Reload the page once upload is complete
         location.replace(`${BUGZILLA.config.basepath}show_bug.cgi?id=${BUGZILLA.bug_id}`);
-      }, message => {
+      } catch ({ message }) {
         window.alert(`Couldn’t upload the text as an attachment. Please try again later. Error: ${message}`);
-      });
+      }
     });
 
     restoreEditMode();
@@ -1444,13 +1431,15 @@ function confirmUnsafeURL(url) {
         'The full URL is:\n\n' + url + '\n\nContinue?');
 }
 
-function show_new_changes_indicator() {
-    const url = `${BUGZILLA.config.basepath}rest/bug_user_last_visit/${BUGZILLA.bug_id}`;
+async function show_new_changes_indicator() {
+    const url = `bug_user_last_visit/${BUGZILLA.bug_id}`;
 
-    // Get the last visited timestamp
-    bugzilla_ajax({ url }, data => {
+    try {
+        // Get the last visited timestamp
+        const data = await Bugzilla.API.get(url);
+
         // Save the current timestamp
-        bugzilla_ajax({ url, type: 'POST' });
+        Bugzilla.API.post(url);
 
         if (!data[0] || !data[0].last_visit_ts) {
             return;
@@ -1530,7 +1519,7 @@ function show_new_changes_indicator() {
 
         // TODO: Enable auto-scroll once the modal page layout is optimized
         // scroll_element_into_view($separator);
-    });
+    } catch (ex) {}
 }
 
 // fix url after bug creation/update

--- a/extensions/EditComments/web/js/revisions.js
+++ b/extensions/EditComments/web/js/revisions.js
@@ -39,15 +39,7 @@ Bugzilla.CommentRevisionsManager = class CommentRevisionsManager {
     const change_when = $revision.dataset.revisedTime;
 
     $checkbox.addEventListener('change', () => {
-      bugzilla_ajax({
-        url: `${BUGZILLA.config.basepath}rest/editcomments/revision`,
-        type: 'PUT',
-        data: {
-          comment_id,
-          change_when,
-          is_hidden: $checkbox.checked ? 1 : 0,
-        },
-      });
+      Bugzilla.API.put('editcomments/revision', { comment_id, change_when, is_hidden: $checkbox.checked ? 1 : 0 });
     });
   }
 };

--- a/extensions/GuidedBugEntry/web/js/guided.js
+++ b/extensions/GuidedBugEntry/web/js/guided.js
@@ -115,7 +115,6 @@ var webdev = {
 
 var product = {
   details: false,
-  _counter: 0,
   _loaded: '',
   _preselectedComponent: '',
 
@@ -173,7 +172,7 @@ var product = {
     return result;
   },
 
-  setName: function(productName) {
+  setName: async function(productName) {
     if (productName == this.getName() && this.details)
       return;
 
@@ -215,55 +214,25 @@ var product = {
     // grab the product information
     this.details = false;
     this._loaded = productName;
-    YAHOO.util.Connect.setDefaultPostHeader('application/json; charset=UTF-8');
-    YAHOO.util.Connect.asyncRequest(
-      'POST',
-      `${BUGZILLA.config.basepath}jsonrpc.cgi`,
-      {
-        success: function(res) {
-          try {
-            var data = JSON.parse(res.responseText);
-            if (data.error)
-              throw(data.error.message);
-            if (data.result.products.length == 0)
-              document.location.href = `${BUGZILLA.config.basepath}enter_bug.cgi?format=guided`;
-            product.details = data.result.products[0];
-            bugForm.onProductUpdated();
-          } catch (err) {
-            product.details = false;
-            bugForm.onProductUpdated();
-            if (err) {
-              alert('Failed to retrieve components for product "' +
-                productName + '":' + "\n\n" + err);
-              if (console)
-                console.error(err);
-            }
-          }
-        },
-        failure: function(res) {
-          this._loaded = '';
-          product.details = false;
-          bugForm.onProductUpdated();
-          if (res.responseText) {
-            alert('Failed to retrieve components for product "' +
-              productName + '":' + "\n\n" + res.responseText);
-            if (console)
-              console.error(res);
-          }
-        }
-      },
-      JSON.stringify({
-        version: "1.1",
-        method: "Product.get",
-        id: ++this._counter,
-        params: {
-          names: [productName],
-          exclude_fields: ['internals', 'milestones', 'components.flag_types'],
-          Bugzilla_api_token : (BUGZILLA.api_token ? BUGZILLA.api_token : '')
-        }
+
+    try {
+      const { products } = await Bugzilla.API.get('product', {
+        names: [productName],
+        exclude_fields: ['internals', 'milestones', 'components.flag_types'],
+      });
+
+      if (products.length) {
+        product.details = products[0];
+        bugForm.onProductUpdated();
+      } else {
+        document.location.href = `${BUGZILLA.config.basepath}enter_bug.cgi?format=guided`;
       }
-      )
-    );
+    } catch ({ message }) {
+      this._loaded = '';
+      product.details = false;
+      bugForm.onProductUpdated();
+      alert(`Failed to retrieve components for product "${productName}"\n\n${message}`);
+    }
   }
 };
 
@@ -280,7 +249,6 @@ var otherProducts = {
 // duplicates step
 
 var dupes = {
-  _counter: 0,
   _dataTable: null,
   _dataTableColumns: null,
   _elSummary: null,
@@ -311,37 +279,10 @@ var dupes = {
   },
 
   _initDataTable: function() {
-    var dataSource = new YAHOO.util.XHRDataSource(`${BUGZILLA.config.basepath}jsonrpc.cgi`);
-    dataSource.connTimeout = 15000;
-    dataSource.connMethodPost = true;
-    dataSource.connXhrMode = "cancelStaleRequests";
-    dataSource.maxCacheEntries = 3;
-    dataSource.responseSchema = {
-      resultsList : "result.bugs",
-      metaFields : { error: "error", jsonRpcId: "id" }
-    };
-    // DataSource can't understand a JSON-RPC error response, so
-    // we have to modify the result data if we get one.
-    dataSource.doBeforeParseData =
-      function(oRequest, oFullResponse, oCallback) {
-        if (oFullResponse.error) {
-          oFullResponse.result = {};
-          oFullResponse.result.bugs = [];
-          if (console)
-            console.error("JSON-RPC error:", oFullResponse.error);
-        }
-        return oFullResponse;
-      };
-    dataSource.subscribe('dataErrorEvent',
-      function() {
-        dupes._currentSearchQuery = '';
-      }
-    );
-
     this._dataTable = new YAHOO.widget.DataTable(
       'dupes_list',
       this._dataTableColumns,
-      dataSource,
+      new YAHOO.util.LocalDataSource([]), // Dummy data source
       {
         initialLoad: false,
         MSG_EMPTY: 'No similar issues found.',
@@ -412,7 +353,7 @@ var dupes = {
     el.appendChild(button);
   },
 
-  updateFollowing: function(el, bugID, bugStatus, button, follow) {
+  updateFollowing: async function(el, bugID, bugStatus, button, follow) {
     button.disabled = true;
     button.innerHTML = 'Updating...';
 
@@ -423,34 +364,13 @@ var dupes = {
       ccObject = { remove: [ guided.currentUser ] };
     }
 
-    YAHOO.util.Connect.setDefaultPostHeader('application/json; charset=UTF-8');
-    YAHOO.util.Connect.asyncRequest(
-      'POST',
-      `${BUGZILLA.config.basepath}jsonrpc.cgi`,
-      {
-        success: function(res) {
-          var data = JSON.parse(res.responseText);
-          if (data.error)
-            throw(data.error.message);
-          dupes._buildCcHTML(el, bugID, bugStatus, follow);
-        },
-        failure: function(res) {
-          dupes._buildCcHTML(el, bugID, bugStatus, !follow);
-          if (res.responseText)
-            alert("Update failed:\n\n" + res.responseText);
-        }
-      },
-      JSON.stringify({
-        version: "1.1",
-        method: "Bug.update",
-        id: ++this._counter,
-        params: {
-          ids: [ bugID ],
-          cc : ccObject,
-          Bugzilla_api_token: (BUGZILLA.api_token ? BUGZILLA.api_token : '')
-        }
-      })
-    );
+    try {
+      await Bugzilla.API.put(`bug/${bugID}`, { ids: [bugID], cc: ccObject });
+      dupes._buildCcHTML(el, bugID, bugStatus, follow);
+    } catch ({ message }) {
+      dupes._buildCcHTML(el, bugID, bugStatus, !follow);
+      alert(`Update failed:\n\n${message}`);
+    }
   },
 
   reset: function() {
@@ -524,7 +444,7 @@ var dupes = {
     dupes._elSearch.disabled = dupes._elSummary.value.trim() == '';
   },
 
-  _doSearch: function() {
+  _doSearch: async function() {
     if (dupes.getSummary().length < 4) {
       alert('The summary must be at least 4 characters long.');
       return;
@@ -549,46 +469,36 @@ var dupes = {
         ' width="16" height="11">',
         YAHOO.widget.DataTable.CLASS_LOADING
       );
-      var json_object = {
-          version: "1.1",
-          method: "Bug.possible_duplicates",
-          id: ++dupes._counter,
-          params: {
-              product: product._getNameAndRelated(),
-              summary: dupes.getSummary(),
-              limit: 12,
-              include_fields: [ "id", "summary", "status", "resolution",
-                "update_token", "cc", "component" ],
-              Bugzilla_api_token: (BUGZILLA.api_token ? BUGZILLA.api_token : '')
-          }
-      };
-
-      dupes._dataTable.getDataSource().sendRequest(
-        JSON.stringify(json_object),
-        {
-          success: dupes._onDupeResults,
-          failure: dupes._onDupeResults,
-          scope: dupes._dataTable,
-          argument: dupes._dataTable.getState()
-        }
-      );
 
       Dom.get('dupes_continue_button_top').disabled = true;
       Dom.get('dupes_continue_button_bottom').disabled = true;
       Dom.removeClass('dupes_continue', 'hidden');
+
+      let data;
+
+      try {
+        const { bugs } = await Bugzilla.API.get('bug/possible_duplicates', {
+          product: product._getNameAndRelated(),
+          summary: dupes.getSummary(),
+          limit: 12,
+          include_fields: ['id', 'summary', 'status', 'resolution', 'update_token', 'cc', 'component'],
+        });
+
+        data = { results: bugs };
+      } catch (ex) {
+        dupes._currentSearchQuery = '';
+        data = { error: true };
+      }
+
+      Dom.removeClass('advanced', 'hidden');
+      Dom.removeClass('dupes_continue_button_top', 'hidden');
+      Dom.get('dupes_continue_button_top').disabled = false;
+      Dom.get('dupes_continue_button_bottom').disabled = false;
+      dupes._dataTable.onDataReturnInitializeTable('', data);
     } catch(err) {
       if (console)
         console.error(err.message);
     }
-  },
-
-  _onDupeResults: function(sRequest, oResponse, oPayload) {
-    Dom.removeClass('advanced', 'hidden');
-    Dom.removeClass('dupes_continue_button_top', 'hidden');
-    Dom.get('dupes_continue_button_top').disabled = false;
-    Dom.get('dupes_continue_button_bottom').disabled = false;
-    dupes._dataTable.onDataReturnInitializeTable(sRequest, oResponse,
-      oPayload);
   },
 
   getSummary: function() {

--- a/extensions/MyDashboard/lib/WebService.pm
+++ b/extensions/MyDashboard/lib/WebService.pm
@@ -156,7 +156,14 @@ sub bug_interest_unmark {
 }
 
 sub rest_resources {
-  return [qr{^/bug_interest_unmark$}, {PUT => {method => 'bug_interest_unmark'}}];
+  return [
+    # REST API v1: Expose `bug_interest_unmark` method without prefix for backward compatibility
+    qr{^/(mydashboard/)?bug_interest_unmark$}, {PUT => {method => 'bug_interest_unmark'}},
+    # Other methods are new, so require the prefix
+    qr{^/mydashboard/run_bug_query$}, {GET => {method => 'run_bug_query'}},
+    qr{^/mydashboard/run_flag_query$}, {GET => {method => 'run_flag_query'}},
+    qr{^/mydashboard/run_last_changes$}, {GET => {method => 'run_last_changes'}},
+  ];
 }
 
 1;

--- a/extensions/MyDashboard/web/js/query.js
+++ b/extensions/MyDashboard/web/js/query.js
@@ -22,13 +22,9 @@ $(function() {
                 patterns: { 'gallery-': {} }
             }
         }
-    }).use("node", "datatable", "datatable-sort", "datatable-message",
-        "datatable-datasource", "datasource-io", "datasource-jsonschema", "cookie",
+    }).use("node", "datatable", "datatable-sort", "datatable-message", "cookie",
         "gallery-datatable-row-expansion-bmo", "handlebars", function(Y) {
-        var counter          = 0,
-            bugQueryTable    = null,
-            bugQuery         = null,
-            lastChangesQuery = null,
+        var bugQueryTable    = null,
             lastChangesCache = {},
             default_query    = "assignedbugs";
 
@@ -48,73 +44,9 @@ $(function() {
             }
         }
 
-        var bugQuery = new Y.DataSource.IO({ source: `${BUGZILLA.config.basepath}jsonrpc.cgi` });
-
-        bugQuery.plug(Y.Plugin.DataSourceJSONSchema, {
-            schema: {
-                resultListLocator: "result.result.bugs",
-                resultFields: ["bug_id", "bug_type", "changeddate", "changeddate_fancy",
-                            "bug_status", "short_desc", "changeddate_api" ],
-                metaFields: {
-                    description: "result.result.description",
-                    heading:     "result.result.heading",
-                    buffer:      "result.result.buffer",
-                    mark_read:   "result.result.mark_read"
-                }
-            }
-        });
-
-        bugQuery.on('error', function(e) {
-            try {
-                var response = JSON.parse(e.data.responseText);
-                if (response.error)
-                    e.error.message = response.error.message;
-            } catch(ex) {
-                // ignore
-            }
-        });
-
-        var bugQueryCallback = {
-            success: function(e) {
-                if (e.response) {
-                    Y.one('#query_loading').addClass('bz_default_hidden');
-                    Y.one('#query_count_refresh').removeClass('bz_default_hidden');
-                    Y.one("#query_container .query_description").setHTML(e.response.meta.description);
-                    Y.one("#query_container .query_heading").setHTML(e.response.meta.heading);
-                    Y.one("#query_bugs_found").setHTML(
-                        `<a href="${BUGZILLA.config.basepath}buglist.cgi?${e.response.meta.buffer}" target="_blank">` +
-                        `${e.response.results.length} bugs found</a>`);
-                    bugQueryTable.set('data', e.response.results);
-
-                    var mark_read = e.response.meta.mark_read;
-                    if (mark_read) {
-                        Y.one('#query_markread').setHTML( mark_read );
-                        Y.one('#bar_markread').removeClass('bz_default_hidden');
-                        Y.one('#query_markread_text').setHTML( mark_read );
-                        Y.one('#query_markread').removeClass('bz_default_hidden');
-                    }
-                    else {
-                        Y.one('#bar_markread').addClass('bz_default_hidden');
-                        Y.one('#query_markread').addClass('bz_default_hidden');
-                    }
-                    Y.one('#query_markread_text').addClass('bz_default_hidden');
-                }
-            },
-            failure: function(o) {
-                Y.one('#query_loading').addClass('bz_default_hidden');
-                Y.one('#query_count_refresh').removeClass('bz_default_hidden');
-                if (o.error) {
-                    alert("Failed to load bug list from Bugzilla:\n\n" + o.error.message);
-                } else {
-                    alert("Failed to load bug list from Bugzilla.");
-                }
-            }
-        };
-
-        var updateQueryTable = function(query_name) {
+        var updateQueryTable = async query_name => {
             if (!query_name) return;
 
-            counter = counter + 1;
             lastChangesCache = {};
 
             Y.one('#query_loading').removeClass('bz_default_hidden');
@@ -123,23 +55,37 @@ $(function() {
             bugQueryTable.render("#query_table");
             bugQueryTable.showMessage('loadingMessage');
 
-            var bugQueryParams = {
-                version: "1.1",
-                method:  "MyDashboard.run_bug_query",
-                id:      counter,
-                params:  { query : query_name,
-                        Bugzilla_api_token : (BUGZILLA.api_token ? BUGZILLA.api_token : '')
-                }
-            };
+            try {
+                const { result } = await Bugzilla.API.get('mydashboard/run_bug_query', { query: query_name });
+                const { buffer, bugs, description, heading, mark_read } = result;
 
-            bugQuery.sendRequest({
-                request: JSON.stringify(bugQueryParams),
-                cfg: {
-                    method:  "POST",
-                    headers: { 'Content-Type': 'application/json' }
-                },
-                callback: bugQueryCallback
-            });
+                Y.one('#query_loading').addClass('bz_default_hidden');
+                Y.one('#query_count_refresh').removeClass('bz_default_hidden');
+                Y.one("#query_container .query_description").setHTML(description);
+                Y.one("#query_container .query_heading").setHTML(heading);
+                Y.one("#query_bugs_found").setHTML(`<a href="${BUGZILLA.config.basepath}buglist.cgi?${buffer}" ` +
+                    `target="_blank">${bugs.length} bugs found</a>`);
+
+                bugQueryTable.set('data', bugs);
+                bugQueryTable.render("#query_table");
+
+                if (mark_read) {
+                    Y.one('#query_markread').setHTML(mark_read);
+                    Y.one('#bar_markread').removeClass('bz_default_hidden');
+                    Y.one('#query_markread_text').setHTML(mark_read);
+                    Y.one('#query_markread').removeClass('bz_default_hidden');
+                } else {
+                    Y.one('#bar_markread').addClass('bz_default_hidden');
+                    Y.one('#query_markread').addClass('bz_default_hidden');
+                }
+
+                Y.one('#query_markread_text').addClass('bz_default_hidden');
+            } catch ({ message }) {
+                Y.one('#query_loading').addClass('bz_default_hidden');
+                Y.one('#query_count_refresh').removeClass('bz_default_hidden');
+
+                alert(`Failed to load bug list from Bugzilla:\n\n${message}`);
+            }
         };
 
         var updatedFormatter = function(o) {
@@ -150,25 +96,6 @@ $(function() {
         const link_formatter = ({ data, value }) =>
           `<a href="${BUGZILLA.config.basepath}show_bug.cgi?id=${data.bug_id}" target="_blank">
           ${isNaN(value) ? value.htmlEncode().wbr() : value}</a>`;
-
-        lastChangesQuery = new Y.DataSource.IO({ source: `${BUGZILLA.config.basepath}jsonrpc.cgi` });
-
-        lastChangesQuery.plug(Y.Plugin.DataSourceJSONSchema, {
-            schema: {
-                resultListLocator: "result.results",
-                resultFields: ["last_changes"],
-            }
-        });
-
-        lastChangesQuery.on('error', function(e) {
-            try {
-                var response = JSON.parse(e.data.responseText);
-                if (response.error)
-                    e.error.message = response.error.message;
-            } catch(ex) {
-                // ignore
-            }
-        });
 
         bugQueryTable = new Y.DataTable({
             columns: [
@@ -196,46 +123,22 @@ $(function() {
 
         bugQueryTable.plug(Y.Plugin.DataTableRowExpansion, {
             uniqueIdKey: 'bug_id',
-            template: function(data) {
-                var bug_id = data.bug_id;
+            template: ({ bug_id, changeddate_api }) => {
+                // Note: `async` doesn't work for this `template` function, so use an inner `async` function instead
+                if (!lastChangesCache[bug_id]) {
+                    try {
+                        (async () => {
+                            const { results } =
+                                await Bugzilla.API.get('mydashboard/run_last_changes', { bug_id, changeddate_api });
+                            const { last_changes } = results[0];
 
-                var lastChangesCallback = {
-                    success: function(e) {
-                        if (e.response) {
-                            var last_changes = e.response.results[0].last_changes;
                             last_changes['bug_id'] = bug_id;
                             lastChangesCache[bug_id] = last_changes;
                             Y.one('#last_changes_stub_' + bug_id).setHTML(last_changes_template(last_changes));
-                        }
-                    },
-                    failure: function(o) {
-                        if (o.error) {
-                            alert("Failed to load last changes from Bugzilla:\n\n" + o.error.message);
-                        } else {
-                            alert("Failed to load last changes from Bugzilla.");
-                        }
+                        })();
+                    } catch ({ message }) {
+                        alert(`Failed to load last changes from Bugzilla:\n\n${message}`);
                     }
-                };
-
-                if (!lastChangesCache[bug_id]) {
-                    var lastChangesParams = {
-                        version: "1.1",
-                        method:  "MyDashboard.run_last_changes",
-                        params:  {
-                            bug_id: data.bug_id,
-                            changeddate_api: data.changeddate_api,
-                            Bugzilla_api_token : (BUGZILLA.api_token ? BUGZILLA.api_token : '')
-                        }
-                    };
-
-                    lastChangesQuery.sendRequest({
-                        request: JSON.stringify(lastChangesParams),
-                        cfg: {
-                            method:  "POST",
-                            headers: { 'Content-Type': 'application/json' }
-                        },
-                        callback: lastChangesCallback
-                    });
 
                     return stub_template({bug_id: bug_id});
                 }
@@ -247,10 +150,6 @@ $(function() {
         });
 
         bugQueryTable.plug(Y.Plugin.DataTableSort);
-
-        bugQueryTable.plug(Y.Plugin.DataTableDataSource, {
-            datasource: bugQuery
-        });
 
         // Initial load
         Y.on("contentready", function (e) {
@@ -281,8 +180,8 @@ $(function() {
             for (var i = 0, l = data.size(); i < l; i++) {
                 bug_ids.push(data.item(i).get('bug_id'));
             }
-            YAHOO.bugzilla.bugUserLastVisit.update(bug_ids);
-            YAHOO.bugzilla.bugInterest.unmark(bug_ids);
+            Bugzilla.API.post('bug_user_last_visit', { ids: bug_ids });
+            Bugzilla.API.put('mydashboard/bug_interest_unmark', { bug_ids });
         });
 
         Y.one('#query_buglist').on('click', function(e) {

--- a/js/account.js
+++ b/js/account.js
@@ -88,7 +88,7 @@ $(function() {
     // mfa
 
     $('#mfa-select-totp')
-        .click(function(event) {
+        .click(async event => {
             event.preventDefault();
             $('#mfa').val('TOTP');
 
@@ -102,29 +102,19 @@ $(function() {
             $('#mfa-totp-throbber').show();
             $('#mfa-totp-issued').hide();
 
-            var url = `${BUGZILLA.config.basepath}rest/user/mfa/totp/enroll` +
-                `?Bugzilla_api_token=${encodeURIComponent(BUGZILLA.api_token)}`;
-            $.ajax({
-                "url": url,
-                "contentType": "application/json",
-                "processData": false
-            })
-            .done(function(data) {
+            try {
+                const { png, secret32 } = await Bugzilla.API.get('user/mfa/totp/enroll');
+
                 $('#mfa-totp-throbber').hide();
                 var iframe = $('#mfa-enable-totp-frame').contents();
-                iframe.find('#qr').attr('src', 'data:image/png;base64,' + data.png);
-                iframe.find('#secret').text(data.secret32);
+                iframe.find('#qr').attr('src', `data:image/png;base64,${png}`);
+                iframe.find('#secret').text(secret32);
                 $('#mfa-totp-issued').show();
                 $('#mfa-password').focus();
                 $('#update').attr('disabled', false);
-            })
-            .fail(function(data) {
+            } catch (ex) {
                 $('#mfa-totp-throbber').hide();
-                if (data.statusText === 'abort')
-                    return;
-                var message = data.responseJSON ? data.responseJSON.message : 'Unexpected Error';
-                console.log(message);
-            });
+            }
         });
 
     $('#mfa-select-duo')

--- a/js/field.js
+++ b/js/field.js
@@ -717,11 +717,6 @@ $(function() {
     var options_user = {
         appendTo: $('#main-inner'),
         forceFixPosition: true,
-        serviceUrl: `${BUGZILLA.config.basepath}rest/user/suggest`,
-        params: {
-            Bugzilla_api_token: BUGZILLA.api_token,
-        },
-        paramName: 'match',
         deferRequestBy: 250,
         minChars: 2,
         noCache: true,
@@ -729,16 +724,15 @@ $(function() {
         autoSelectFirst: true,
         preserveInput: true,
         triggerSelectOnValidInput: false,
-        transformResult: function(response) {
-            response = $.parseJSON(response);
-            return {
-                suggestions: $.map(response.users, function({ name, real_name, requests, gravatar } = {}) {
-                    return {
-                        value: name,
-                        data : { email: name, real_name, requests, gravatar }
-                    };
-                })
-            };
+        lookup: (query, done) => {
+            // Note: `async` doesn't work for this `lookup` function, so use a `Promise` chain instead
+            Bugzilla.API.get('user/suggest', { match: query })
+                .then(({ users }) => users.map(({ name, real_name, requests, gravatar }) => ({
+                    value: name,
+                    data: { email: name, real_name, requests, gravatar },
+                })))
+                .catch(() => [])
+                .then(suggestions => done({ suggestions }));
         },
         formatResult: function(suggestion) {
             const $input = this;
@@ -921,7 +915,7 @@ function initDirtyFieldTracking() {
 
 var last_comment_text = '';
 
-function show_comment_preview(bug_id) {
+async function show_comment_preview(bug_id) {
     var Dom = YAHOO.util.Dom;
     var comment = document.getElementById('comment');
     var preview = document.getElementById('comment_preview');
@@ -951,46 +945,24 @@ function show_comment_preview(bug_id) {
     Dom.addClass('comment_preview_text', 'bz_default_hidden');
     Dom.removeClass('comment_preview_loading', 'bz_default_hidden');
 
-    YAHOO.util.Connect.setDefaultPostHeader('application/json', true);
-    YAHOO.util.Connect.asyncRequest('POST', `${BUGZILLA.config.basepath}jsonrpc.cgi`,
-    {
-        success: function(res) {
-            data = JSON.parse(res.responseText);
-            if (data.error) {
-                Dom.addClass('comment_preview_loading', 'bz_default_hidden');
-                Dom.removeClass('comment_preview_error', 'bz_default_hidden');
-                Dom.get('comment_preview_error').innerHTML =
-                    data.error.message.htmlEncode();
-            } else {
-                $comment_body.innerHTML = data.result.html;
+    try {
+        const { html } = await Bugzilla.API.post('bug/comment/render', { id: bug_id, text: comment.value });
 
-                // Highlight code if possible
-                if (Prism) {
-                  Prism.highlightAllUnder($comment_body);
-                }
+        $comment_body.innerHTML = html;
 
-                Dom.addClass('comment_preview_loading', 'bz_default_hidden');
-                Dom.removeClass('comment_preview_text', 'bz_default_hidden');
-                last_comment_text = comment.value;
-            }
-        },
-        failure: function(res) {
-            Dom.addClass('comment_preview_loading', 'bz_default_hidden');
-            Dom.removeClass('comment_preview_error', 'bz_default_hidden');
-            Dom.get('comment_preview_error').innerHTML =
-                res.responseText.htmlEncode();
+        // Highlight code if possible
+        if (Prism) {
+            Prism.highlightAllUnder($comment_body);
         }
-    },
-    JSON.stringify({
-        version: "1.1",
-        method: 'Bug.render_comment',
-        params: {
-            Bugzilla_api_token: BUGZILLA.api_token,
-            id: bug_id,
-            text: comment.value
-        }
-    })
-    );
+
+        Dom.addClass('comment_preview_loading', 'bz_default_hidden');
+        Dom.removeClass('comment_preview_text', 'bz_default_hidden');
+        last_comment_text = comment.value;
+    } catch ({ message }) {
+        Dom.addClass('comment_preview_loading', 'bz_default_hidden');
+        Dom.removeClass('comment_preview_error', 'bz_default_hidden');
+        Dom.get('comment_preview_error').innerHTML = YAHOO.lang.escapeHTML(message);
+    }
 }
 
 function show_comment_edit() {

--- a/js/field.js
+++ b/js/field.js
@@ -717,6 +717,7 @@ $(function() {
     var options_user = {
         appendTo: $('#main-inner'),
         forceFixPosition: true,
+        paramName: 'match',
         deferRequestBy: 250,
         minChars: 2,
         noCache: true,

--- a/js/global.js
+++ b/js/global.js
@@ -155,49 +155,6 @@ function display_value(field, value) {
     return value;
 }
 
-// ajax wrapper, to simplify error handling and auth
-// TODO: Rewrite this method using Promise (Bug 1380437)
-function bugzilla_ajax(request, done_fn, error_fn) {
-    $('#xhr-error').hide('');
-    $('#xhr-error').html('');
-    if (BUGZILLA.api_token) {
-        request.url += (request.url.match('\\?') ? '&' : '?') +
-            'Bugzilla_api_token=' + encodeURIComponent(BUGZILLA.api_token);
-    }
-    if (request.type != 'GET') {
-        request.contentType = 'application/json';
-        request.processData = false;
-        if (request.data && request.data.constructor === Object) {
-            request.data = JSON.stringify(request.data);
-        }
-    }
-    return $.ajax(request)
-        .done(function(data) {
-            if (data.error) {
-                if (!request.hideError) {
-                    $('#xhr-error').html(data.message);
-                    $('#xhr-error').show('fast');
-                }
-                if (error_fn)
-                    error_fn(data.message);
-            }
-            else if (done_fn) {
-                done_fn(data);
-            }
-        })
-        .fail(function(data) {
-            if (data.statusText === 'abort')
-                return;
-            var message = data.responseJSON ? data.responseJSON.message : 'Unexpected Error'; // all errors are unexpected :)
-            if (!request.hideError) {
-                $('#xhr-error').html(message);
-                $('#xhr-error').show('fast');
-            }
-            if (error_fn)
-                error_fn(message);
-        });
-}
-
 // html encoding
 if (!String.prototype.htmlEncode) {
     (function() {

--- a/template/en/default/bug/show-header.html.tmpl
+++ b/template/en/default/bug/show-header.html.tmpl
@@ -68,7 +68,7 @@
       initDirtyFieldTracking();
 
       [% IF user.id %]
-        YAHOO.bugzilla.bugUserLastVisit.update([ [% bug.bug_id FILTER none %] ]);
+        Bugzilla.API.post('bug_user_last_visit/[% bug.bug_id FILTER none %]');
       [% END %]
     });
     BUGZILLA.bug_id = [% bug.id FILTER none %];

--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -54,7 +54,7 @@
   no_yui = 0
   jquery = []
   jquery_css = []
-  generate_api_token = 0
+  generate_api_token = 1
   robots = 'index'
 %]
 


### PR DESCRIPTION
## Description

* Implement the `Bugzilla.API` class offering REST API utility methods that replace `bugzilla_ajax()` originally from `bug_modal.js`
* Use the new, simple utility methods for all the REST API calls
* Replace all the JSON-RPC calls with REST API 🎉 
* Generate an API token on all pages so it can be used for new features on the global header (but the token auth support will be removed soon; see the Notes below)

## Notes

* Tested everything locally except for the PhabBugz review list on My Dashboard, which requires API access
* The `Bugzilla_api_token` param, now appended in `Bugzilla.API._init()`, will be [removed soon](https://bugzilla.mozilla.org/show_bug.cgi?id=1477163) in favour of login cookies

## Bug

[Bug 1380437 - Implement REST API utility methods in global.js to replace bugzilla_ajax(), eliminate JSON-RPC usage](https://bugzilla.mozilla.org/show_bug.cgi?id=1380437)