### PR TITLE
Bug 1475593 - Bugzilla Emails received when patches are attached in Phabricator

### DIFF
--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -433,9 +433,9 @@ sub process_revision_change {
     my ($timestamp) = Bugzilla->dbh->selectrow_array("SELECT NOW()");
 
     INFO('Checking for revision attachment');
-    my $attachment = create_revision_attachment($bug, $revision, $timestamp, $revision->author->bugzilla_user);
-    INFO('Attachment ' . $attachment->id . ' created or already exists.');
-    
+    my $rev_attachment = create_revision_attachment($bug, $revision, $timestamp, $revision->author->bugzilla_user);
+    INFO('Attachment ' . $rev_attachment->id . ' created or already exists.');
+
     # ATTACHMENT OBSOLETES
 
     # fixup attachments on current bug
@@ -576,7 +576,7 @@ sub process_revision_change {
     # Email changes for this revisions bug and also for any other
     # bugs that previously had these revision attachments
     foreach my $bug_id ($revision->bug_id, keys %other_bugs) {
-        Bugzilla::BugMail::Send($bug_id, { changer => Bugzilla->user });
+        Bugzilla::BugMail::Send($bug_id, { changer => $rev_attachment->attacher });
     }
 
     Bugzilla->set_user($old_user);


### PR DESCRIPTION
Attachments created by Phabricator are created as the user performing
the action as the creator; however the user's email preferences where
not honoured.  This resulted in emails being sent for these changes even
when the user has "don't email me about change I make" set.