### PR TITLE
no bug - Include Bugzilla::Error in PhabBugz's WebService.pm.

### DIFF
--- a/extensions/PhabBugz/lib/WebService.pm
+++ b/extensions/PhabBugz/lib/WebService.pm
@@ -14,6 +14,7 @@ use warnings;
 use base qw(Bugzilla::WebService);
 
 use Bugzilla::Constants;
+use Bugzilla::Error;
 use Bugzilla::User;
 use Bugzilla::Util qw(detaint_natural datetime_from time_ago trick_taint);
 use Bugzilla::WebService::Constants;


### PR DESCRIPTION
The ThrowUserError() calls in PhabBugz's WebService.pm were
causing errors as Bugzilla::Error wasn't being imported.