### PR TITLE
Bug 1320977 - Add review/feedback/needinfo request counts and block statuses to /rest/user and /rest/user/suggest responses

### DIFF
--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -154,7 +154,7 @@ sub suggest {
     return { users => [] } if length($s) < 3;
 
     my $dbh = Bugzilla->dbh;
-    my @select = ('realname AS real_name', 'login_name AS name');
+    my @select = ('userid AS id', 'realname AS real_name', 'login_name AS name');
     my $order  = 'last_seen_date DESC';
     my $where;
     state $have_mysql = $dbh->isa('Bugzilla::DB::Mysql');
@@ -190,10 +190,14 @@ sub suggest {
 
     my @users = map {
         {
+            id        => $self->type(int    => $_->{id}),
             real_name => $self->type(string => $_->{real_name}),
             name      => $self->type(email  => $_->{name}),
         }
     } @$results;
+
+    Bugzilla::Hook::process('webservice_user_suggest',
+        { webservice => $self, params => $params, users => \@users });
 
     return { users => \@users };
 }

--- a/extensions/Review/Extension.pm
+++ b/extensions/Review/Extension.pm
@@ -25,6 +25,8 @@ use Bugzilla::Search;
 use Bugzilla::User;
 use Bugzilla::User::Setting;
 use Bugzilla::Util qw(clean_text datetime_from diff_arrays);
+use Bugzilla::WebService::Util qw(filter_wants);
+use Scalar::Util qw(blessed);
 
 use constant UNAVAILABLE_RE => qr/\b(?:unavailable|pto|away)\b/i;
 use constant MENTOR_LIMIT   => 10;
@@ -1062,6 +1064,53 @@ sub config_modify_panels {
         default => 0,
         checker => \&check_numeric,
     };
+}
+
+#
+# hooks
+#
+
+sub webservice_user_get {
+    my ($self, $args) = @_;
+    my ($webservice, $params, $users) = @$args{qw(webservice params users)};
+
+    return unless filter_wants($params, 'requests');
+
+    my $ids = [
+        map { blessed($_->{id}) ? $_->{id}->value : $_->{id} }
+        grep { exists $_->{id} }
+        @$users
+    ];
+
+    return unless @$ids;
+
+    my %user_map = map { $_->id => $_ } @{ Bugzilla::User->new_from_list($ids) };
+
+    foreach my $user (@$users) {
+        my $id = blessed($user->{id}) ? $user->{id}->value : $user->{id};
+        my $user_obj = $user_map{$id};
+
+        $user->{requests} = {
+            review   => {
+                blocked => $webservice->type('boolean', $user_obj->reviews_blocked),
+                pending => $webservice->type('int', $user_obj->{review_request_count}),
+            },
+            feedback => {
+                # reviews_blocked includes feedback as well
+                blocked => $webservice->type('boolean', $user_obj->reviews_blocked),
+                pending => $webservice->type('int', $user_obj->{feedback_request_count}),
+            },
+            needinfo => {
+                blocked => $webservice->type('boolean', $user_obj->needinfo_blocked),
+                pending => $webservice->type('int', $user_obj->{needinfo_request_count}),
+            },
+        };
+    }
+}
+
+sub webservice_user_suggest {
+    my ($self, $args) = @_;
+    $self->webservice_user_get($args);
 }
 
 __PACKAGE__->NAME;


### PR DESCRIPTION
Fix [Bug 1320977 - Add review/feedback/needinfo request counts and block statuses to /rest/user and /rest/user/suggest responses](https://bugzilla.mozilla.org/show_bug.cgi?id=1320977)

## Example

`/rest/user/suggest` will look like this:

```json
{
   "users" : [
      {
         "id" : 1,
         "name" : "vagrant@bmo-web.vm",
         "real_name" : "Vagrant Nakamoto",
         "requests" : {
            "feedback" : {
               "blocked" : false,
               "pending" : 0
            },
            "needinfo" : {
               "blocked" : true,
               "pending" : 0
            },
            "review" : {
               "blocked" : false,
               "pending" : 1
            }
         }
      }
   ]
}
```