### PR TITLE
Bug 1419636 - Make Google Analytics use beacon/XHR instead of img tag

### DIFF
--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -39,11 +39,13 @@ sub DEFAULT_CSP {
         script_src  => [ 'self', 'nonce', 'unsafe-inline', 'https://www.google-analytics.com' ],
         frame_src   => [ 'none', ],
         worker_src  => [ 'none', ],
-        img_src     => [ 'self', 'https://secure.gravatar.com', 'https://www.google-analytics.com' ],
+        img_src     => [ 'self', 'https://secure.gravatar.com' ],
         style_src   => [ 'self', 'unsafe-inline' ],
         object_src  => [ 'none' ],
         connect_src => [
             'self',
+            # This is for extensions/GoogleAnalytics using beacon or XHR
+            'https://www.google-analytics.com',
             # This is from extensions/OrangeFactor/web/js/orange_factor.js
             'https://treeherder.mozilla.org/api/failurecount/',
         ],
@@ -70,9 +72,11 @@ sub SHOW_BUG_MODAL_CSP {
     my ($bug_id) = @_;
     my %policy = (
         script_src  => ['self', 'nonce', 'unsafe-inline', 'unsafe-eval', 'https://www.google-analytics.com' ],
-        img_src     => [ 'self', 'https://secure.gravatar.com', 'https://www.google-analytics.com' ],
+        img_src     => [ 'self', 'https://secure.gravatar.com' ],
         connect_src => [
             'self',
+            # This is for extensions/GoogleAnalytics using beacon or XHR
+            'https://www.google-analytics.com',
             # This is from extensions/OrangeFactor/web/js/orange_factor.js
             'https://treeherder.mozilla.org/api/failurecount/',
         ],

--- a/extensions/GoogleAnalytics/web/js/analytics.js
+++ b/extensions/GoogleAnalytics/web/js/analytics.js
@@ -15,6 +15,7 @@ $(function() {
     ga('set', 'anonymizeIp', true);
     ga('set', 'location', meta.data('location'));
     ga('set', 'title', meta.data('title'));
+    ga('set', 'transport', 'beacon');
     // Track page view
     ga('send', 'pageview');
   }


### PR DESCRIPTION
## Description

* Set GA's [`transport`](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#transport) option to use [`navigator.sendBeacon`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon) by default
* Replace the `image-src` CSP directive with `connect-src` to allow beacon or fallback XHR

## Bug

[Bug 1419636 - Make Google Analytics use beacon/XHR instead of img tag](https://bugzilla.mozilla.org/show_bug.cgi?id=1419636)