### PR TITLE
Bug 1320977 - performance tweaks

### DIFF
--- a/Bugzilla/User/Setting.pm
+++ b/Bugzilla/User/Setting.pm
@@ -13,8 +13,6 @@ use strict;
 use warnings;
 
 use base qw(Exporter);
-
-
 # Module stuff
 @Bugzilla::User::Setting::EXPORT = qw(
     get_all_settings
@@ -25,6 +23,7 @@ use base qw(Exporter);
 
 use Bugzilla::Error;
 use Bugzilla::Util qw(trick_taint get_text);
+use Module::Runtime qw(require_module);
 
 ###############################
 ###  Module Initialization  ###
@@ -104,9 +103,8 @@ sub new {
         $self->{'category'}      = shift;
     }
     if ($subclass) {
-        eval('require ' . $class . '::' . $subclass);
-        $@ && ThrowCodeError('setting_subclass_invalid',
-                             {'subclass' => $subclass});
+        eval { require_module( $class . '::' . $subclass ) }
+            || ThrowCodeError( 'setting_subclass_invalid', { 'subclass' => $subclass } );
         $class = $class . '::' . $subclass;
     }
     bless($self, $class);

--- a/extensions/Review/Extension.pm
+++ b/extensions/Review/Extension.pm
@@ -27,7 +27,6 @@ use Bugzilla::User::Setting;
 use Bugzilla::Util qw(clean_text datetime_from diff_arrays);
 use Bugzilla::WebService::Util qw(filter_wants);
 use Scalar::Util qw(blessed);
-use JSON::MaybeXS;
 
 use constant UNAVAILABLE_RE => qr/\b(?:unavailable|pto|away)\b/i;
 use constant MENTOR_LIMIT   => 10;
@@ -1093,22 +1092,25 @@ sub webservice_user_get {
 
         $user->{requests} = {
             review   => {
-                blocked =>  $user_obj->reviews_blocked ? JSON->true : JSON->false,
-                pending => int($user_obj->{review_request_count}),
+                blocked => $webservice->type('boolean', $user_obj->reviews_blocked),
+                pending => $webservice->type('int', $user_obj->{review_request_count}),
             },
             feedback => {
                 # reviews_blocked includes feedback as well
-                blocked => $user_obj->reviews_blocked ? JSON::->true : JSON->false,
-                pending => int($user_obj->{feedback_request_count}),
+                blocked => $webservice->type('boolean', $user_obj->reviews_blocked),
+                pending => $webservice->type('int', $user_obj->{feedback_request_count}),
             },
             needinfo => {
-                blocked => $user_obj->needinfo_blocked ? JSON->true : JSON->false,
-                pending => int($user_obj->{needinfo_request_count}),
+                blocked => $webservice->type('boolean', $user_obj->needinfo_blocked),
+                pending => $webservice->type('int', $user_obj->{needinfo_request_count}),
             },
         };
     }
 }
 
-*webservice_user_suggest = \&webservice_user_get;
+sub webservice_user_suggest {
+    my ($self, $args) = @_;
+    $self->webservice_user_get($args);
+}
 
 __PACKAGE__->NAME;

--- a/extensions/Review/Extension.pm
+++ b/extensions/Review/Extension.pm
@@ -27,6 +27,7 @@ use Bugzilla::User::Setting;
 use Bugzilla::Util qw(clean_text datetime_from diff_arrays);
 use Bugzilla::WebService::Util qw(filter_wants);
 use Scalar::Util qw(blessed);
+use JSON::MaybeXS;
 
 use constant UNAVAILABLE_RE => qr/\b(?:unavailable|pto|away)\b/i;
 use constant MENTOR_LIMIT   => 10;
@@ -1092,25 +1093,22 @@ sub webservice_user_get {
 
         $user->{requests} = {
             review   => {
-                blocked => $webservice->type('boolean', $user_obj->reviews_blocked),
-                pending => $webservice->type('int', $user_obj->{review_request_count}),
+                blocked =>  $user_obj->reviews_blocked ? JSON->true : JSON->false,
+                pending => int($user_obj->{review_request_count}),
             },
             feedback => {
                 # reviews_blocked includes feedback as well
-                blocked => $webservice->type('boolean', $user_obj->reviews_blocked),
-                pending => $webservice->type('int', $user_obj->{feedback_request_count}),
+                blocked => $user_obj->reviews_blocked ? JSON::->true : JSON->false,
+                pending => int($user_obj->{feedback_request_count}),
             },
             needinfo => {
-                blocked => $webservice->type('boolean', $user_obj->needinfo_blocked),
-                pending => $webservice->type('int', $user_obj->{needinfo_request_count}),
+                blocked => $user_obj->needinfo_blocked ? JSON->true : JSON->false,
+                pending => int($user_obj->{needinfo_request_count}),
             },
         };
     }
 }
 
-sub webservice_user_suggest {
-    my ($self, $args) = @_;
-    $self->webservice_user_get($args);
-}
+*webservice_user_suggest = \&webservice_user_get;
 
 __PACKAGE__->NAME;

--- a/mod_perl.pl
+++ b/mod_perl.pl
@@ -67,6 +67,9 @@ use Bugzilla::Install::Requirements ();
 use Bugzilla::Util ();
 use Bugzilla::RNG ();
 use Bugzilla::ModPerl ();
+use Mojo::Loader qw(find_modules);
+use Module::Runtime qw(require_module);
+use Bugzilla::WebService::Server::REST;
 
 # Make warnings go to the virtual host's log and not the main
 # server log.
@@ -102,6 +105,10 @@ if ($ENV{LOCALCONFIG_ENV}) {
 Bugzilla::Extension->load_all();
 
 Bugzilla->preload_features();
+
+require_module($_) for find_modules('Bugzilla::User::Setting');
+
+Bugzilla::WebService::Server::REST->preload;
 
 # Force instantiation of template so Bugzilla::Template::PreloadProvider can do its magic.
 Bugzilla->preload_templates;

--- a/rest.cgi
+++ b/rest.cgi
@@ -24,6 +24,7 @@ BEGIN {
     }
 }
 use Bugzilla::WebService::Server::REST;
+
 Bugzilla->usage_mode(USAGE_MODE_REST);
 local @INC = (bz_locations()->{extensionsdir}, @INC);
 my $server = new Bugzilla::WebService::Server::REST;


### PR DESCRIPTION
In #672 performance regressed a bit, so let's win that back here.
The theme of this change is to load bugzilla classes earlier. It seems to save about 40ms per API call.

Before:

![screen shot 2018-07-27 at 14 54 13](https://user-images.githubusercontent.com/47717/43341276-f85459a4-91ac-11e8-8c52-53fc65d1ef78.png)

After
![screen shot 2018-07-27 at 14 54 02](https://user-images.githubusercontent.com/47717/43341287-014895a2-91ad-11e8-86d1-6aee78700073.png)
