### PR TITLE
Bug 1479523 - Disable one-click component watching for logged out users

### DIFF
--- a/extensions/ComponentWatching/web/js/overlay.js
+++ b/extensions/ComponentWatching/web/js/overlay.js
@@ -22,7 +22,12 @@ Bugzilla.ComponentWatching = class ComponentWatching {
   constructor() {
     this.buttons = document.querySelectorAll('button.component-watching');
 
-    this.init();
+    // Check if the user is logged in and the API key is available. If not, remove the Watch buttons.
+    if (BUGZILLA.api_token) {
+      this.init();
+    } else {
+      this.buttons.forEach($button => $button.remove());
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

The new one-click component watching functionality added in #646 should be disabled properly if the user is not logged in. This checks if their API key is available, and if not, simply remove the Watch buttons.

## Bug

[Bug 1479523 - Disable one-click component watching for logged out users](https://bugzilla.mozilla.org/show_bug.cgi?id=1479523)