### PR TITLE
Bug 1479535 - BUGZILLA.bug_url is wrong on bug page after POSTed

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -1423,16 +1423,12 @@ function show_new_changes_indicator() {
 }
 
 // fix url after bug creation/update
-if (history && history.replaceState) {
-    var href = document.location.href;
-    if (!href.match(/show_bug\.cgi/)) {
-        history.replaceState(null, BUGZILLA.bug_title, `${BUGZILLA.config.basepath}show_bug.cgi?id=${BUGZILLA.bug_id}`);
-        document.title = BUGZILLA.bug_title;
-    }
-    if (href.match(/show_bug\.cgi\?.*list_id=/)) {
-        href = href.replace(/[\?&]+list_id=(\d+|cookie)/, '');
-        history.replaceState(null, BUGZILLA.bug_title, href);
-    }
+if (location.pathname !== `${BUGZILLA.config.basepath}show_bug.cgi` || location.search.includes('list_id')) {
+    const canonical_url = `${BUGZILLA.config.basepath}show_bug.cgi?id=${BUGZILLA.bug_id}`;
+
+    history.replaceState(null, BUGZILLA.bug_title, canonical_url);
+    document.querySelector('meta[property="og:url"]').content = BUGZILLA.bug_url = canonical_url;
+    document.title = BUGZILLA.bug_title;
 }
 
 // lightbox


### PR DESCRIPTION
## Description

POSTed bug page’s canonical URL replacement should be done to `BUGZILLA.bug_url` and `<meta property=“og:url”>` as well.

## Bug

[Bug 1479535 - BUGZILLA.bug_url is wrong on bug page after POSTed](https://bugzilla.mozilla.org/show_bug.cgi?id=1479535)