### PR TITLE
Bug 1479563 - Wrap labels in Requests dropdown list

### DIFF
--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -1923,8 +1923,13 @@ a.controller {
 }
 
 .dropdown-panel .notifications label {
+  display: -webkit-box;
   overflow: hidden;
   max-height: 40px;
+  white-space: normal;
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 .dropdown-panel .notifications strong {


### PR DESCRIPTION
## Description

* Fix a regression from from #646 where labels in the dropdown list are not wrapped properly
* Add an ellipsis at the end of labels (not yet supported in Firefox)

## Bug

[Bug 1479563 - Wrap labels in Requests dropdown list](https://bugzilla.mozilla.org/show_bug.cgi?id=1479563)

## Screenshot

Firefox (left) and Chrome (right)

<img width="896" alt="screen shot 2018-07-30 at 4 00 38 pm" src="https://user-images.githubusercontent.com/2929505/43420611-4b7f0996-9412-11e8-814f-7e17ec910a21.png">