### PR TITLE
Bug 1432095 - OpenGraph image not loaded

### DIFF
--- a/extensions/OpenGraph/template/en/default/hook/robots-end.txt.tmpl
+++ b/extensions/OpenGraph/template/en/default/hook/robots-end.txt.tmpl
@@ -1,0 +1,4 @@
+[%# comment lines are required to produce line breaks %]
+#
+Allow: /extensions/OpenGraph/web/
+#

--- a/extensions/SiteMapIndex/template/en/default/hook/robots-end.txt.tmpl
+++ b/extensions/SiteMapIndex/template/en/default/hook/robots-end.txt.tmpl
@@ -1,2 +1,5 @@
+[%# comment lines are required to produce line breaks %]
+#
 Allow: /data/SiteMapIndex/sitemap*.xml.gz
 Sitemap: [% SITEMAP_URL %]
+#

--- a/template/en/default/robots.txt.tmpl
+++ b/template/en/default/robots.txt.tmpl
@@ -19,6 +19,8 @@ Disallow: /show_bug.cgi*format=multiple*
 Allow: /describecomponents.cgi
 Allow: /describekeywords.cgi
 
+[% FILTER remove('#.*') %]
 [% Hook.process("end") %]
+[% END %]
 
 [% END %]


### PR DESCRIPTION
## Description

Add `Allow: /extensions/OpenGraph/web/` to `robots.txt` so Twitter and other crawlers can fetch the OpenGraph logo image.

## Bug

[Bug 1432095 - OpenGraph image not loaded](https://bugzilla.mozilla.org/show_bug.cgi?id=1432095)