### PR TITLE
Bug 1478013 - Importance, Status and Platform section labels in show bug view are linked but not clickable

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -463,17 +463,18 @@
         container = 1
         hide_on_view = bug.priority == "--" && bug.bug_severity == "normal"
         help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#priority"
-        label_for = "priority"
     %]
       [% INCLUDE bug_modal/field.html.tmpl
           field = bug_fields.priority
           field_type = constants.FIELD_TYPE_SINGLE_SELECT
+          aria_label = bug_fields.priority.description
           no_indent = 1
           inline = 1
       %]
       [% INCLUDE bug_modal/field.html.tmpl
           field = bug_fields.bug_severity
           field_type = constants.FIELD_TYPE_SINGLE_SELECT
+          aria_label = bug_fields.bug_severity.description
           inline = 1
       %]
       [% UNLESS cf_hidden_in_product('cf_rank', bug.product, bug.component, bug) %]
@@ -497,7 +498,6 @@
           label        = "Status"
           hide_on_edit = 1
           help         = "https://wiki.mozilla.org/BMO/UserGuide/BugStatuses"
-          label_for    = "bug_status"
       %]
         [% bug.bug_status FILTER html %]
         [%+ bug.resolution FILTER html IF bug.resolution %]
@@ -549,6 +549,7 @@
       prefix = prefix
       field  = bug_fields.bug_status
       field_type = constants.FIELD_TYPE_SINGLE_SELECT
+      aria_label = bug_fields.bug_status.description
       editable = bug.choices.bug_status.size > 1
       values = bug.choices.bug_status
       inline = 1
@@ -559,6 +560,7 @@
       prefix = prefix
       field  = bug_fields.resolution
       field_type = constants.FIELD_TYPE_SINGLE_SELECT
+      aria_label = bug_fields.resolution.description
       editable = bug.choices.resolution.size > (bug.resolution == "" ? 0 : 1)
       values = bug.choices.resolution
       inline = 1
@@ -838,17 +840,18 @@
         hide_on_view = (bug.rep_platform == 'All' && bug.op_sys == 'All')
           || (bug.rep_platform == 'Unspecified' && bug.op_sys == 'Unspecified')
         help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#rep_platform"
-        label_for = "rep_platform"
     %]
       [% INCLUDE bug_modal/field.html.tmpl
           field = bug_fields.rep_platform
           field_type = constants.FIELD_TYPE_SINGLE_SELECT
+          aria_label = bug_fields.rep_platform.description
           inline = 1
           no_indent = 1
       %]
       [% INCLUDE bug_modal/field.html.tmpl
           field = bug_fields.op_sys
           field_type = constants.FIELD_TYPE_SINGLE_SELECT
+          aria_label = bug_fields.op_sys.description
           inline = 1
       %]
       [% WRAPPER bug_modal/field.html.tmpl

--- a/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
@@ -11,6 +11,7 @@
   # field_type: (const) constants.FIELD_TYPE_*
   # no_label: (boolean) don't output label
   # label: (string) field label text (default: field_descs.${$field.name}
+  # aria_label: (string) invisible aria-label attribute
   # view_only: (boolean) don't allow editing (default: determined from bug.check_can_change_field)
   # edit_only: (boolean) always render the edit ui
   # container: (boolean) output just a label and the content (eg. for multiple fields next to one label)
@@ -34,7 +35,6 @@
   #   class: (string) optional button class
   #   caption: (string) button caption
   #   hidden: (boolean) don't show the button (default: false)
-  # label_for: (string) optional label for identifier
   #%]
 
 [%
@@ -109,17 +109,15 @@ END;
         [% aria_labelledby_id = "${name}-help-link" %]
         [% aria_labelledby_html = BLOCK %]aria-labelledby="[% aria_labelledby_id FILTER html %]"[% END %]
       [% END %]
-      [%~ IF label_for %]
-        <label for="[% label_for FILTER html %]">
-      [% END %]
       [%~ label _ ":" FILTER html IF label %]
-      [%~ IF label_for %]
-        </label>
-      [% END ~%]
       [%~ IF help.defined %]
         </a>
       [% END %]
     </div>
+  [% END %]
+
+  [% IF aria_label.defined %]
+    [% aria_labelledby_html = BLOCK %]aria-label="[% aria_label FILTER html %]"[% END %]
   [% END %]
 
   [%# read-only html %]


### PR DESCRIPTION
## Description

* Remove `<label>` inside `<a>` so the help link works as expected
* Use the `aria-label` attribute instead to make `<select>` accessible

## Bug

[Bug 1478013 - Importance, Status and Platform section labels in show bug view are linked but not clickable](https://bugzilla.mozilla.org/show_bug.cgi?id=1478013)