### PR TITLE
Bug 1474809 - add "new to bugzilla" tag to non-comment changes

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -222,6 +222,7 @@
           [% IF extra_class %]
             <span class="user-role">([% extra_class.ucfirst FILTER none %])</span>
           [% END %]
+          [% Hook.process('user', 'bug/changes.html.tmpl') %]
         </td>
         <td class="comment-actions">
           <button type="button" class="change-spinner minor" id="as-[% id FILTER none %]">-</button>

--- a/extensions/TagNewUsers/template/en/default/hook/bug/changes-user.html.tmpl
+++ b/extensions/TagNewUsers/template/en/default/hook/bug/changes-user.html.tmpl
@@ -1,0 +1,20 @@
+[%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  #
+  # This Source Code Form is "Incompatible With Secondary Licenses", as
+  # defined by the Mozilla Public License, v. 2.0.
+  #%]
+
+[% RETURN UNLESS user.in_group('canconfirm') %]
+[% IF action.who.is_new %]
+<span class="new_user" title="
+[%- action.who.comment_count FILTER html %] comment[% "s" IF action.who.comment_count != 1 -%]
+, created [%
+IF action.who.creation_age == 0 %]today[%
+ELSIF action.who.creation_age > 365 %]more than a year ago[%
+ELSE %][% action.who.creation_age FILTER html %] day[% "s" IF action.who.creation_age != 1 %] ago[% END %]."
+  >
+(New to [% terms.Bugzilla %])
+</span>
+[% END %]


### PR DESCRIPTION
## Description

Add *(New to Bugzilla)* tag to any changes made by new users, just like comments.

## Bug

[Bug 1474809 - add "new to bugzilla" tag to non-comment changes](https://bugzilla.mozilla.org/show_bug.cgi?id=1474809)

## Screenshot

![bug-1474809-changes-new-user](https://user-images.githubusercontent.com/2929505/43462718-dba262a6-94a4-11e8-94b6-57c2c51c69f6.png)
