### PR TITLE
Bug 1466737 - "use my platform" should default to x86_64 on Mac OS X

### DIFF
--- a/Bugzilla/UserAgent.pm
+++ b/Bugzilla/UserAgent.pm
@@ -26,6 +26,7 @@ use constant PLATFORMS_MAP => (
     qr/\(.*[ix0-9]86 (?:on |\()x86_64.*\)/ => ["IA32", "x86", "PC"],
     qr/\(.*amd64.*\)/ => ["AMD64", "x86_64", "PC"],
     qr/\(.*x86_64.*\)/ => ["AMD64", "x86_64", "PC"],
+    qr/\(.*Intel Mac OS X.*\)/ => ["x86_64"],
     # Intel IA64
     qr/\(.*IA64.*\)/ => ["IA64", "PC"],
     # Intel x86


### PR DESCRIPTION
## Description

* On the Enter Bug page, select the `x86_64` platform on Intel Mac by default.
* Tested with Firefox, Chrome and Safari.

## Bug

[Bug 1466737 - "use my platform" should default to x86_64 on Mac OS X](https://bugzilla.mozilla.org/show_bug.cgi?id=1466737)