### PR TITLE
Bug 1477163 - REST API authentication fails with X-Bugzilla-Token header

### DIFF
--- a/Bugzilla/Auth/Login/Cookie.pm
+++ b/Bugzilla/Auth/Login/Cookie.pm
@@ -33,7 +33,6 @@ sub get_login_info {
     my ($self) = @_;
     my $cgi = Bugzilla->cgi;
     my $dbh = Bugzilla->dbh;
-    my $input = Bugzilla->input_params;
     my ($user_id, $login_cookie, $is_internal);
 
     if (!Bugzilla->request_cache->{auth_no_automatic_login}) {
@@ -59,12 +58,9 @@ sub get_login_info {
         # it is valid.
         if (i_am_webservice()) {
             # API token can be passed as an HTTP request header or URL query
-            # param. For backward compatibility, we support 3 param names.
+            # param.
             my $api_token = $cgi->http('X-Bugzilla-Token')
-                || $input->{'token'}
-                || $input->{'Bugzilla_token'}
-                || $input->{'Bugzilla_api_token'}
-                || '';
+                || Bugzilla->input_params->{'Bugzilla_api_token'} || '';
             if ($api_token) {
                 my ($token_user_id, undef, undef, $token_type)
                     = Bugzilla::Token::GetTokenData($api_token);

--- a/Bugzilla/Auth/Login/Cookie.pm
+++ b/Bugzilla/Auth/Login/Cookie.pm
@@ -33,6 +33,7 @@ sub get_login_info {
     my ($self) = @_;
     my $cgi = Bugzilla->cgi;
     my $dbh = Bugzilla->dbh;
+    my $input = Bugzilla->input_params;
     my ($user_id, $login_cookie, $is_internal);
 
     if (!Bugzilla->request_cache->{auth_no_automatic_login}) {
@@ -57,8 +58,14 @@ sub get_login_info {
         # If the call is for a web service, and an api token is provided, check
         # it is valid.
         if (i_am_webservice()) {
-            if (exists Bugzilla->input_params->{Bugzilla_api_token}) {
-                my $api_token = Bugzilla->input_params->{Bugzilla_api_token};
+            # API token can be passed as an HTTP request header or URL query
+            # param. For backward compatibility, we support 3 param names.
+            my $api_token = $cgi->http('X-Bugzilla-Token')
+                || $input->{'token'}
+                || $input->{'Bugzilla_token'}
+                || $input->{'Bugzilla_api_token'}
+                || '';
+            if ($api_token) {
                 my ($token_user_id, undef, undef, $token_type)
                     = Bugzilla::Token::GetTokenData($api_token);
                 if (!defined $token_type

--- a/js/global.js
+++ b/js/global.js
@@ -160,7 +160,7 @@ function display_value(field, value) {
 function bugzilla_ajax(request, done_fn, error_fn) {
     $('#xhr-error').hide('');
     $('#xhr-error').html('');
-    request.headers = { 'X-Bugzilla-Token': BUGZILLA.api_token };
+    request.headers = Object.assign({ 'X-Bugzilla-Token': BUGZILLA.api_token }, request.headers);
     if (request.type != 'GET') {
         request.contentType = 'application/json';
         request.processData = false;

--- a/js/global.js
+++ b/js/global.js
@@ -160,8 +160,7 @@ function display_value(field, value) {
 function bugzilla_ajax(request, done_fn, error_fn) {
     $('#xhr-error').hide('');
     $('#xhr-error').html('');
-    request.url += (request.url.match('\\?') ? '&' : '?') +
-        'Bugzilla_api_token=' + encodeURIComponent(BUGZILLA.api_token);
+    request.headers = { 'X-Bugzilla-Token': BUGZILLA.api_token };
     if (request.type != 'GET') {
         request.contentType = 'application/json';
         request.processData = false;


### PR DESCRIPTION
## Description

* Add support for auth methods that are supposed to work:
    * `X-Bugzilla-Token` HTTP request header
    * ~`token` and `Bugzilla_token` URL query params~
* Use the `X-Bugzilla-Token` header in `bugzilla_ajax()` (under refactoring in #665)
* The token support could be deprecated but can’t be removed now, as mentioned in the bug, because it’s available via the [API](https://bmo.readthedocs.io/en/latest/api/core/v1/user.html#login).

## Bug

[Bug 1477163 - REST API authentication fails with X-Bugzilla-Token header or token/Bugzilla_token query param](https://bugzilla.mozilla.org/show_bug.cgi?id=1477163)