### PR TITLE
 bump version to 20180801.1 

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20180717.2';
+our $VERSION = '20180801.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
the following changes will be pushed to bugzilla.mozilla.org:
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1476288" target="_blank">1476288</a>] Replace moz_nick with (new, revised) nick and also attempt to disallow duplicate nicks</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1472954" target="_blank">1472954</a>] Implement one-click component watching on bug modal and component description pages</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1136271" target="_blank">1136271</a>] Make user profile page visible to anyone for easier sharing</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1475593" target="_blank">1475593</a>] Bugzilla Emails received when patches are attached in Phabricator</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1476841" target="_blank">1476841</a>] Various code cleanups ahead of the Mojolicious patch</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1477894" target="_blank">1477894</a>] get_attachment_revisions() should be returning an empty list, instead of a list of [0]</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1478012" target="_blank">1478012</a>] Phab allows projects to have empty descriptions so Project.pm in PhabBugz should allow the same</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1419636" target="_blank">1419636</a>] Make Google Analytics use beacon/XHR instead of img tag</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1478540" target="_blank">1478540</a>] Update User.pm to load more than 100 users by using the paging functionality of Conduit API</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1478983" target="_blank">1478983</a>] WebService endpoint to check if a user can enter a bug into a given product</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1479523" target="_blank">1479523</a>] Disable one-click component watching for logged out users</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1320977" target="_blank">1320977</a>] Add review/feedback/needinfo request counts and block statuses to /rest/user and /rest/user/suggest responses</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1475687" target="_blank">1475687</a>] Remove https://bugzilla.mozilla.org/form.reps.it custom form</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1466737" target="_blank">1466737</a>] "use my platform" should default to x86_64 on Mac OS X</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1479563" target="_blank">1479563</a>] Wrap labels in Requests dropdown list</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1432095" target="_blank">1432095</a>] OpenGraph image not loaded</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1478013" target="_blank">1478013</a>] Importance, Status and Platform section labels in show bug view are linked but not clickable</li>
</ul>