### PR TITLE
no bug - add dependencies needed for monitoring

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2
 
 defaults:
   bmo_slim_image: &bmo_slim_image
-    image: mozillabteam/bmo-slim:20180523.1
+    image: mozillabteam/bmo-slim:20180801.2
     user: app
 
   mysql_image: &mysql_image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mozillabteam/bmo-slim:20180523.1
+FROM mozillabteam/bmo-slim:20180801.2
 
 ARG CI
 ARG CIRCLE_SHA1

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -366,7 +366,7 @@ my %optional_features = (
         description => 'Sentry Support',
         prereqs => {
             runtime => {
-                requires => [ 'Log::Log4perl::Appender::Raven' => '0.006' ],
+                requires => { 'Log::Log4perl::Appender::Raven' => '0.006' },
             },
         },
     },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -374,7 +374,7 @@ my %optional_features = (
         description => 'Data Dog support',
         prereqs => {
             runtime => {
-                requires => { 'DataDog::DogStatsd' => 0.05 },
+                requires => { 'DataDog::DogStatsd' => '0.05' },
             },
         },
     },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -362,6 +362,22 @@ my %optional_features = (
             },
         },
     },
+    sentry => {
+        description => 'Sentry Support',
+        prereqs => {
+            runtime => {
+                requires => [ 'Log::Log4perl::Appender::Raven' => '0.006' ],
+            },
+        },
+    },
+    datadog => {
+        description => 'Data Dog support',
+        prereqs => {
+            runtime => {
+                requires => { 'DataDog::DogStatsd' => 0.05 },
+            },
+        },
+    },
 );
 
 for my $file ( glob 'extensions/*/Config.pm' ) {


### PR DESCRIPTION
This updates the base image and the dependency specification to include the datadog and sentry libs.