### PR TITLE
Bug 1480473 - Component description page: highlighted component lacks padding

### DIFF
--- a/skins/standard/describecomponents.css
+++ b/skins/standard/describecomponents.css
@@ -46,8 +46,6 @@
 }
 
 .component.highlight {
-  margin: 0;
-  padding: 1em 0;
   background-color: lightgreen;
 }
 


### PR DESCRIPTION
## Description

Remove unnecessary, legacy rules so there will always be paddings within `<section class="component">`.

## Bug

[Bug 1480473 - Component description page: highlighted component lacks padding](https://bugzilla.mozilla.org/show_bug.cgi?id=1480473)