### PR TITLE
Bug 1480891 my dashboard does not show the revision id and title for phabricator review requests

### DIFF
--- a/extensions/MyDashboard/web/js/flags.js
+++ b/extensions/MyDashboard/web/js/flags.js
@@ -143,10 +143,23 @@ $(function () {
                 Y.Escape.html(o.data.author_name) + '</span>';
         };
 
-        var phabRevisionFormatter = function(o) {
-            return '<a href="' + o.data.url + '" target="_blank" ' +
-                'title="' + Y.Escape.html(o.data.title) + '">D' +
-                o.data.id + '</a>';
+        var phabRowFormatter = function(o) {
+            var row = o.cell.ancestor();
+
+            // space in the 'flags' tables is tight
+            // render requests as two rows - diff title on first row, columns
+            // on second
+
+            row.insert(
+                '<tr class="' + row.getAttribute('class') + '">' +
+                '<td class="yui3-datatable-cell" colspan="4">' +
+                '<a href="' + o.data.url + '" target="_blank">' +
+                Y.Escape.html(o.data.title) + '</a></td></tr>',
+                'after');
+
+            o.cell.setHTML('<a href="' + o.data.url + '">D' + o.data.id + '</a>');
+
+            return false;
         };
 
         // Reviews
@@ -165,9 +178,9 @@ $(function () {
             dataTable.reviews = new Y.DataTable({
                 columns: [
                     { key: 'author_email', label: 'Requester', sortable: true,
-                        formattter: phabAuthorFormatter, allowHTML: true },
+                        formatter: phabAuthorFormatter, allowHTML: true },
                     { key: 'id', label: 'Revision', sortable: true,
-                        formatter: phabRevisionFormatter, allowHTML: true },
+                        nodeFormatter: phabRowFormatter, allowHTML: true },
                     { key: 'bug_id', label: 'Bug', sortable: true,
                         formatter: bugLinkFormatter, allowHTML: true },
                     { key: 'updated', label: 'Updated', sortable: true,

--- a/extensions/MyDashboard/web/js/flags.js
+++ b/extensions/MyDashboard/web/js/flags.js
@@ -143,24 +143,10 @@ $(function () {
                 Y.Escape.html(o.data.author_name) + '</span>';
         };
 
-        var phabRowFormatter = function(o) {
-            var row = o.cell.ancestor();
-
-            // space in the 'flags' tables is tight
-            // render requests as two rows - diff title on first row, columns
-            // on second
-
-            row.insert(
-                '<tr class="' + row.getAttribute('class') + '">' +
-                '<td class="yui3-datatable-cell" colspan="4">' +
-                '<a href="' + o.data.url + '" target="_blank">' +
-                Y.Escape.html('D' + o.data.id + ' - ' + o.data.title) +
-                '</a></td></tr>',
-                'before');
-
-            o.cell.set('text', o.data.status == 'added' ? 'pending' : o.data.status);
-
-            return false;
+        var phabRevisionFormatter = function(o) {
+            return '<a href="' + o.data.url + '" target="_blank" ' +
+                'title="' + Y.Escape.html(o.data.title) + '">D' +
+                o.data.id + '</a>';
         };
 
         // Reviews
@@ -180,6 +166,8 @@ $(function () {
                 columns: [
                     { key: 'author_email', label: 'Requester', sortable: true,
                         formattter: phabAuthorFormatter, allowHTML: true },
+                    { key: 'id', label: 'Revision', sortable: true,
+                        formatter: phabRevisionFormatter, allowHTML: true },
                     { key: 'bug_id', label: 'Bug', sortable: true,
                         formatter: bugLinkFormatter, allowHTML: true },
                     { key: 'updated', label: 'Updated', sortable: true,


### PR DESCRIPTION
simplified what was there by just adding a new Revision column with the ID as a link directly to the revision in Phab instead of adding a new row. If you hover the link, the revision summary is displayed.