### PR TITLE
Bug 1481207 - POST /rest/bug_user_last_visit returns random number instead of bug ID

### DIFF
--- a/Bugzilla/WebService/BugUserLastVisit.pm
+++ b/Bugzilla/WebService/BugUserLastVisit.pm
@@ -52,7 +52,7 @@ sub update {
         push(
             @results,
             $self->_bug_user_last_visit_to_hash(
-                $bug, $last_visit_ts, $params
+                $bug_id, $last_visit_ts, $params
             ));
     }
     $dbh->bz_commit_transaction();


### PR DESCRIPTION
## Description

The `id` property returned by `/rest/bug_user_last_visit` should be a bug ID.

## Bug

[Bug 1481207 - POST /rest/bug_user_last_visit returns random number instead of bug ID](https://bugzilla.mozilla.org/show_bug.cgi?id=1481207)