### PR TITLE
bump version to 20180808.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20180807.1';
+our $VERSION = '20180808.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1480891" target="_blank">1480891</a>] my dashboard does not show the revision id and title for phabricator review requests</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1481893" target="_blank">1481893</a>] After recent push of bug 1478897 bug/revision syncing has been broken due to coding error</li>
</ul>