### PR TITLE
Bug 1482447 - nofollow external markdown links and fixes

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -812,8 +812,12 @@ sub check_rate_limit {
 }
 
 sub markdown_parser {
-    return request_cache->{markdown_parser}
-        ||= Bugzilla::Markdown::GFM::Parser->new( {extensions => [qw( autolink tagfilter table strikethrough)] } );
+    return request_cache->{markdown_parser} ||= Bugzilla::Markdown::GFM::Parser->new(
+        {
+            validate_utf8 => 1,
+            extensions => [qw( autolink tagfilter table strikethrough )]
+        }
+    );
 }
 
 # Private methods


### PR DESCRIPTION
Reorders the flow of renderComment to fix 4 things:

- Garbage unicode characters (e.g emoji) are rendered after going
through the markdown parser. This is fixed now. [Bug 1482474](https://bugzilla.mozilla.org/show_bug.cgi?id=1482474)

- The ability to nofollow external user created markdown links with
simple regex matching.

- Fixes a bug where full bug links would be linkified by both
renderComment and the markdown autolinker, causing an invalid anchor tag
to be rendered on the page.

- Fixes a "bug" where users are unable to use full bug links as the link
in a markdown link tag e.g. `[my bug](http://bmo.test/show_bug.cgi?id=1)`.
Users can now do this if they want. The tooltip will be added by the
frontend.

This PR was inspired by #711 and #713 :)