### PR TITLE
Bug 1485303 - lists in component descriptions break describecomponents.cgi layout

### DIFF
--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -960,6 +960,25 @@ div.ui-tooltip {
   color: #666;
 }
 
+.name-info-popup header .description ul,
+.name-info-popup header .description ol {
+  margin: 12px 0;
+  padding: 0;
+}
+
+.name-info-popup header .description li {
+  margin-left: 16px;
+  padding-left: 4px;
+}
+
+.name-info-popup header .description ul li {
+  list-style-type: disc;
+}
+
+.name-info-popup header .description ol li {
+  list-style-type: decimal;
+}
+
 /* product search */
 
 #field-product {

--- a/skins/standard/describecomponents.css
+++ b/skins/standard/describecomponents.css
@@ -36,7 +36,6 @@
 
 .component {
   display: flex;
-  align-items: center;
   margin: 8px 0;
   border: 1px solid #CCC;
   border-radius: 4px;
@@ -52,17 +51,18 @@
 .component header {
   flex: none;
   margin-right: 16px;
-  width: 240px;
+  width: 280px;
 }
 
 .component h2 {
   margin: 0;
-  font-size: 24px;
+  font-size: 20px;
   font-weight: normal;
 }
 
-.component div {
+.component header ~ div {
   flex: auto;
+  margin: 2px 0;
 }
 
 .component p {
@@ -70,7 +70,7 @@
   font-size: 16px;
 }
 
-.component ul {
+.component ul.people {
   display: flex;
   margin: 8px 0 0;
   border-top: 1px solid #DDD;
@@ -80,7 +80,7 @@
   color: #999;
 }
 
-.component li {
+.component ul.people li {
   margin: 0 16px 0 0;
   padding: 0;
 }

--- a/template/en/default/reports/components.html.tmpl
+++ b/template/en/default/reports/components.html.tmpl
@@ -71,12 +71,12 @@
   <section id="[% comp.name FILTER html %]" class="component[%- IF comp.name == component_mark %] highlight[% END %]">
     <header>
       <h2><a href="[% basepath FILTER none %]buglist.cgi?product=[%- product.name FILTER uri %]&amp;component=
-                   [%- comp.name FILTER uri %]&amp;resolution=---">[% comp.name FILTER html %]</a></h2>
+                   [%- comp.name FILTER uri %]&amp;resolution=---">[% comp.name FILTER html FILTER wbr %]</a></h2>
     </header>
     <div>
       <p class="description">[% comp.description FILTER html_light %]</p>
       [% IF show_default_people %]
-      <ul>
+      <ul class="people">
         <li>Assignee: [% INCLUDE global/user.html.tmpl who = comp.default_assignee %]</li>
         [% IF Param("useqacontact") %]
         <li>QA: [% INCLUDE global/user.html.tmpl who = comp.default_qa_contact %]</li>


### PR DESCRIPTION
## Description

* Fix layout on the component description pages, including:
    * [Core](https://bugzilla.mozilla.org/describecomponents.cgi?product=Core): due to the [newly added HTML descriptions](https://bugzilla.mozilla.org/show_bug.cgi?id=1484408)
    * [Websites](https://bugzilla.mozilla.org/describecomponents.cgi?product=Websites): due to the longer domain-based component names
* See [this screenshot](https://screenshots.firefox.com/K4nIt0ik8s8wqomi/bmo-web.vm) for how it works (default assignee and QA are hidden on BMO, shown for demo purpose only)

## Bug

[Bug 1485303 - lists in component descriptions break describecomponents.cgi layout](https://bugzilla.mozilla.org/show_bug.cgi?id=1485303)