### PR TITLE
Bug 1482338 - "Search Bugs" field has "cursor: pointer" style while it's text field

### DIFF
--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -262,6 +262,7 @@
         box-shadow: none;
         font-size: 14px !important;
         line-height: 32px;
+        cursor: text;
     }
 
     #header #quicksearch_top:hover {


### PR DESCRIPTION
## Description

Fix the cursor on the global header’s searchbar, that should be an I-beam instead of hand/pointer.

## Bug

[Bug 1482338 - “Search Bugs” field has “cursor: pointer” style while it’s text field](https://bugzilla.mozilla.org/show_bug.cgi?id=1482338)