### PR TITLE
Bug 1399721 - change canonical from bugzil.la to bugzilla.mozilla.org

### DIFF
--- a/Bugzilla/Install/Localconfig.pm
+++ b/Bugzilla/Install/Localconfig.pm
@@ -164,6 +164,10 @@ use constant LOCALCONFIG_VARS => (
         default => _migrate_param( "urlbase", "" ),
     },
     {
+        name    => 'canonical_urlbase',
+        default => '',
+    },
+    {
         name    => 'attachment_base',
         default => _migrate_param( "attachment_base", '' ),
     },
@@ -294,13 +298,14 @@ sub _read_localconfig_from_file {
 
 sub read_localconfig {
     my ($include_deprecated) = @_;
+    my $config = $ENV{LOCALCONFIG_ENV}
+        ? _read_localconfig_from_env()
+        : _read_localconfig_from_file($include_deprecated);
 
-    if ($ENV{LOCALCONFIG_ENV}) {
-        return _read_localconfig_from_env();
-    }
-    else {
-        return _read_localconfig_from_file($include_deprecated);
-    }
+    # Use the site's URL as the default Canonical URL
+    $config->{canonical_urlbase} //= $config->{urlbase};
+
+    return $config;
 }
 
 #

--- a/README.rst
+++ b/README.rst
@@ -252,8 +252,11 @@ BUGZILLA_UNSAFE_AUTH_DELEGATION
 
 BMO_urlbase
   The public url for this instance. Note that if this begins with https://
-  abd BMO_inbound_proxies is set to '*' Bugzilla will believe the connection to it
+  and BMO_inbound_proxies is set to '*' Bugzilla will believe the connection to it
   is using SSL.
+
+BMO_canonical_urlbase
+  The public url for the production instance, if different from urlbase above.
 
 BMO_attachment_base
   This is the url for attachments.

--- a/extensions/BMO/template/en/default/hook/global/header-additional_header.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/global/header-additional_header.html.tmpl
@@ -21,7 +21,7 @@
 
 <link rel="shortcut icon" href="extensions/BMO/web/images/favicon.ico">
 [% IF bug %]
-<link id="shorturl" rev="canonical" href="https://bugzil.la/[% bug.bug_id FILTER uri %]">
+<link rel="canonical" href="[% Bugzilla.localconfig.canonical_urlbase FILTER none %]show_bug.cgi?id=[% bug.bug_id FILTER uri %]">
 [% END %]
 
 [%# *** Bug List Navigation *** %]

--- a/template/en/default/setup/strings.txt.pl
+++ b/template/en/default/setup/strings.txt.pl
@@ -233,6 +233,10 @@ END
     localconfig_urlbase => <<'END',
 The URL that is the common initial leading part of all URLs.
 END
+    localconfig_canonical_urlbase => <<'END',
+The URL that is the canonical initial leading part of all URLs.
+This will be the production url for a dev site, for instance.
+END
     localconfig_use_suexec => <<'END',
 Set this to 1 if Bugzilla runs in an Apache SuexecUserGroup environment.
 


### PR DESCRIPTION
## Description

* Cherry-pick #603 that has been backed out in #626
* Stop using `bugzil.la` as canonical URL, which is actually marked up with wrong HTML

## Bug

[Bug 1399721 - change canonical from bugzil.la to bugzilla.mozilla.org](https://bugzilla.mozilla.org/show_bug.cgi?id=1399721)