### PR TITLE
Bug 1469733 - Fix scrolling glitch on Safari

### DIFF
--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -64,6 +64,12 @@
 
 /* fixed global header (begin) */
     @media screen and (min-width: 800px) {
+        html, body {
+            overflow: hidden; /* Disable bounce effect (Safari) */
+            overscroll-behavior: none;
+            height: 100%;
+        }
+
         #wrapper {
             overflow: hidden;
             width: 100%;
@@ -75,6 +81,8 @@
             overflow-y: scroll;
             -webkit-overflow-scrolling: touch; /* Enable momentum scrolling on iOS */
             scroll-behavior: smooth;
+            overscroll-behavior: contain;
+            will-change: transform; /* Enable smooth scrolling (Safari) */
         }
     }
 /* fixed global header (end) */


### PR DESCRIPTION
## Description

* Solve rough scrolling issue and undesired bounce effect on desktop Safari
* Add [`overscroll-behavior`](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior) for all browsers
* Tested with various browsers on macOS, Windows, Android, iOS

## Bug

[Bug 1469733 - Fix scrolling glitch on Safari](https://bugzilla.mozilla.org/show_bug.cgi?id=1469733)