### PR TITLE
Bug 1487171 - Allow setting bug flags when creating/updating attachment with API

### DIFF
--- a/docs/en/rst/api/core/v1/attachment.rst
+++ b/docs/en/rst/api/core/v1/attachment.rst
@@ -197,7 +197,7 @@ flags             array    Flags objects to add to the attachment. The object
                            format is described in the Flag object below.
 bug_flags         array    Flag objects to add to the attachment's bug. See the
                            ``flags`` param for :ref:`rest_create_bug` for the
-                           objecct format.
+                           object format.
 ================  =======  ======================================================
 
 Flag object:
@@ -317,7 +317,7 @@ flags         array    An array of Flag objects with changes to the flags. The
                        object format is described in the Flag object below.
 bug_flags     array    An optional array of Flag objects with changes to the
                        flags of the attachment's bug. See the ``flags`` param
-                       for :ref:`rest_update_bug` for the objecct format.
+                       for :ref:`rest_update_bug` for the object format.
 ============  =======  ==========================================================
 
 Flag object:

--- a/docs/en/rst/api/core/v1/attachment.rst
+++ b/docs/en/rst/api/core/v1/attachment.rst
@@ -195,6 +195,9 @@ is_private        boolean  ``true`` if the attachment should be private
                            not specified.
 flags             array    Flags objects to add to the attachment. The object
                            format is described in the Flag object below.
+bug_flags         array    Flag objects to add to the attachment's bug. See the
+                           ``flags`` param for :ref:`rest_create_bug` for the
+                           objecct format.
 ================  =======  ======================================================
 
 Flag object:
@@ -312,6 +315,9 @@ is_obsolete   boolean  ``true`` if the attachment is obsolete, ``false``
                        otherwise.
 flags         array    An array of Flag objects with changes to the flags. The
                        object format is described in the Flag object below.
+bug_flags     array    An optional array of Flag objects with changes to the
+                       flags of the attachment's bug. See the ``flags`` param
+                       for :ref:`rest_update_bug` for the objecct format.
 ============  =======  ==========================================================
 
 Flag object:


### PR DESCRIPTION
## Details 

* Allow to set bug flags, needinfo in particular, with the [attachment API methods](https://bmo.readthedocs.io/en/latest/api/core/v1/attachment.html).
* Tested locally with simple data

## Bug

[Bug 1487171 - Allow setting bug flags when creating/updating attachment with API](https://bugzilla.mozilla.org/show_bug.cgi?id=1487171)