### PR TITLE
no bug - add X-Bugzilla-Type to secbugsreport email

### DIFF
--- a/scripts/secbugsreport.pl
+++ b/scripts/secbugsreport.pl
@@ -62,7 +62,8 @@ my $email = Email::MIME->create(
     header_str => [
         From    => Bugzilla->params->{'mailfrom'},
         To      => Bugzilla->params->{report_secbugs_emails},
-        Subject => "Security Bugs Report for $report_week"
+        Subject => "Security Bugs Report for $report_week",
+        'X-Bugzilla-Type' => 'admin'
     ],
     attributes => {
         content_type => 'text/html',


### PR DESCRIPTION
Adds X-Bugzilla-Type to secbugsreport email which fixes some warnings that perl was outputting.