### PR TITLE
bump to version 20180910.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20180820.1';
+our $VERSION = '20180910.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
[release tag](https://github.com/mozilla-bteam/bmo/tree/release-20180910.1)

the following changes have been pushed to bugzilla.mozilla.org:
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1399721" target="_blank">1399721</a>] change canonical from bugzil.la to bugzilla.mozilla.org</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1486369" target="_blank">1486369</a>] please enable "due date" for Firefox -&gt; Security: Review Request component</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1488292" target="_blank">1488292</a>] Remove MozReview extension from BMO code tree as MozReview is being decommissioned</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1479466" target="_blank">1479466</a>] Security-bug email reports</li>
</ul>
discuss these changes on <a href="https://lists.mozilla.org/listinfo/tools-bmo" target="_blank">mozilla.tools.bmo</a>.