### PR TITLE
Bug 1490708 - Ensure we always call DBIx::Connector->dbh before any DBI method

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -72,6 +72,7 @@ my %requires = (
     'Moo'                      => '2.002004',
     'MooX::StrictConstructor'  => '0.008',
     'Mozilla::CA'              => '20160104',
+    'Package::Stash'           => '0.37',
     'Parse::CPAN::Meta'        => '1.44',
     'Role::Tiny'               => '2.000003',
     'Scope::Guard'             => '0.21',


### PR DESCRIPTION
The code didn't allow a way of doing this without a lot of work.

So I had to take the following approach:
The 'dbh' attribute is now a method that delegates to DBIx::Connector's dbh
method. Per the docs, ->dbh() "Returns the connection's database handle. It will
use a an existing handle if there is one, if the process has not been forked or
a new thread spawned, and if the database is pingable. Otherwise, it will
instantiate, cache, and return a new handle."

Then there is the matter of the 'handles' on dbh. I've used Package::Stash to
insert proxy methods into the class when it is loaded.