### PR TITLE
Bug 1345673 - Open Bugzilla History in a New Window or Tab

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -448,7 +448,7 @@ $(function() {
     $('#action-history')
         .click(function(event) {
             event.preventDefault();
-            document.location.href = 'show_activity.cgi?id=' + BUGZILLA.bug_id;
+            window.open(`show_activity.cgi?id=${BUGZILLA.bug_id}`, '_blank');
         });
 
     // use scrollTo for in-page activity links


### PR DESCRIPTION
## Description

Open the bug activity page in a new tab when the History menu item on bug modal is clicked.

## Bug

[Bug 1345673 - Open Bugzilla History in a New Window or Tab](https://bugzilla.mozilla.org/show_bug.cgi?id=1345673)