### PR TITLE
Bug 1493295 - Add short URL to each bug

### DIFF
--- a/extensions/BMO/template/en/default/hook/global/header-additional_header.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/global/header-additional_header.html.tmpl
@@ -22,6 +22,7 @@
 <link rel="shortcut icon" href="extensions/BMO/web/images/favicon.ico">
 [% IF bug %]
 <link rel="canonical" href="[% Bugzilla.localconfig.canonical_urlbase FILTER none %]show_bug.cgi?id=[% bug.bug_id FILTER uri %]">
+<link rel="shorturl" href="[% Bugzilla.localconfig.canonical_urlbase FILTER none %][% bug.bug_id FILTER uri %]">
 [% END %]
 
 [%# *** Bug List Navigation *** %]


### PR DESCRIPTION
## Description

Add the short URL, just like canonical URL added in #727. Example:

```html
<link rel="shorturl" href="https://bugzilla.mozilla.org/1399721">
```

## Bug

[Bug 1493295 - Add short URL to each bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1493295)