### PR TITLE
Bug 1493490 - Remove navigator.buildID usage from Bugzilla Helper

### DIFF
--- a/extensions/GuidedBugEntry/template/en/default/bug/create/comment-guided.txt.tmpl
+++ b/extensions/GuidedBugEntry/template/en/default/bug/create/comment-guided.txt.tmpl
@@ -1,8 +1,6 @@
 [% USE Bugzilla %]
 [% cgi = Bugzilla.cgi %]
 User Agent: [% cgi.param('user_agent') %]
-[% IF cgi.param('build_id') %]
-Build ID: [% cgi.param('build_id') %][% END %]
 [% IF cgi.param('firefox_for_android') %]
 Firefox for Android
 [% END %]

--- a/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
+++ b/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
@@ -351,7 +351,6 @@ Product: <b><span id="dupes_product_name">?</span></b>:
 <input type="hidden" name="comment" id="comment" value="">
 <input type="hidden" name="format" value="guided">
 <input type="hidden" name="user_agent" id="user_agent" value="">
-<input type="hidden" name="build_id" id="build_id" value="">
 
 <ul>
 <li>Please fill out this form clearly, precisely and in as much detail as you can manage.</li>

--- a/extensions/GuidedBugEntry/web/js/guided.js
+++ b/extensions/GuidedBugEntry/web/js/guided.js
@@ -614,9 +614,6 @@ var bugForm = {
   onInit: function() {
     var user_agent = navigator.userAgent;
     Dom.get('user_agent').value = navigator.userAgent;
-    if (navigator.buildID && navigator.buildID != navigator.userAgent) {
-      Dom.get('build_id').value = navigator.buildID;
-    }
     Event.addListener(Dom.get('short_desc'), 'blur', function() {
       Dom.get('dupes_summary').value = Dom.get('short_desc').value;
       guided.setAdvancedLink();

--- a/template/en/default/bug/create/comment-guided.txt.tmpl
+++ b/template/en/default/bug/create/comment-guided.txt.tmpl
@@ -28,7 +28,6 @@
 [% USE Bugzilla %]
 [% cgi = Bugzilla.cgi %]
 User-Agent:       [%+ cgi.user_agent() %]
-Build Identifier: [%+ cgi.param("buildid") %]
 
 [%+ cgi.param("comment") IF cgi.param("comment") %]
 

--- a/template/en/default/bug/create/create-guided.html.tmpl
+++ b/template/en/default/bug/create/create-guided.html.tmpl
@@ -228,33 +228,6 @@ function PutDescription() {
     </td>
   </tr>
 
-  [% IF product.name.match("Firefox|Camino|SeaMonkey") %]
-    [% matches = cgi.user_agent('Gecko/(\d+)') %]
-    [% buildid = cgi.user_agent() IF matches %]
-  [% END %]
-
-  [%# Accept URL parameter build ID for non-browser products %]
-  [% IF cgi.param("buildid") %]
-    [% buildid = cgi.param("buildid") %]
-  [% END %]
-
-  <tr bgcolor="[% tablecolour %]">
-    <td align="right" valign="top">
-      <b>Build Identifier</b>
-    </td>
-    <td valign="top">
-      <input type="text" size="80" name="buildid" value="[% buildid FILTER html %]">
-      <p>
-        This should identify the exact version of the product you were using.
-        If the above field is blank or you know it is incorrect, copy the
-        user agent text from the product's Help | Troubleshooting Information menu
-        (for browsers this will begin with "Mozilla/5.0...").
-        If the product won't start, instead paste the complete URL you downloaded
-        it from.
-      </p>
-    </td>
-  </tr>
-
   <tr>
     <td align="right" valign="top">
       <b>URL</b>


### PR DESCRIPTION
## Description

* Remove one usage of the non-standard `navigator.buildID` DOM property, which will be removed from Firefox in the near future
* Also remove another Build Identifier field based on the browser’s UA string, which isn’t useful because it has been frozen at `Gecko/20100101`.

## Bug

[Bug 1493490 - Remove navigator.buildID usage from Bugzilla Helper](https://bugzilla.mozilla.org/show_bug.cgi?id=1493490)