### PR TITLE
Bug 1490595 - Bugzilla update check should use https

### DIFF
--- a/Bugzilla/Constants.pm
+++ b/Bugzilla/Constants.pm
@@ -210,7 +210,7 @@ sub BUGZILLA_VERSION {
 }
 
 # Location of the remote and local XML files to track new releases.
-use constant REMOTE_FILE => 'http://updates.bugzilla.org/bugzilla-update.xml';
+use constant REMOTE_FILE => 'https://updates.bugzilla.org/bugzilla-update.xml';
 use constant LOCAL_FILE  => 'bugzilla-update.xml'; # Relative to datadir.
 
 # These are unique values that are unlikely to match a string or a number,


### PR DESCRIPTION
## Description

Use HTTPS for the Bugzilla update check URL.

## Bug

[Bug 1490595 - Bugzilla update check should use https](https://bugzilla.mozilla.org/show_bug.cgi?id=1490595)