### PR TITLE
Bug 1470536 - Add new GeckoView product to easy product selector on Browse and Enter Bug pages

### DIFF
--- a/extensions/BMO/template/en/default/global/choose-product.html.tmpl
+++ b/extensions/BMO/template/en/default/global/choose-product.html.tmpl
@@ -103,8 +103,16 @@
       icon="component.png"
     %]
     [% INCLUDE easyproduct
+      name="GeckoView"
+      icon="firefox_android.png"
+    %]
+    [% INCLUDE easyproduct
       name="Mozilla Localizations"
       icon="localization.png"
+    %]
+    [% INCLUDE easyproduct
+      name="Data Platform and Tools"
+      icon="telemetry.png"
     %]
     [% INCLUDE easyproduct
       name="Thunderbird"
@@ -113,10 +121,6 @@
     [% INCLUDE easyproduct
       name="SeaMonkey"
       icon="seamonkey.png"
-    %]
-    [% INCLUDE easyproduct
-      name="Data Platform and Tools"
-      icon="telemetry.png"
     %]
     <section class="product other">
       <h3>

--- a/extensions/BMO/web/styles/choose_product.css
+++ b/extensions/BMO/web/styles/choose_product.css
@@ -23,7 +23,7 @@
 #product-list .tile {
   display: flex;
   flex-wrap: wrap;
-  justify-content: flex-start;
+  justify-content: center;
   margin: 0 auto;
 }
 


### PR DESCRIPTION
## Description

* Add the new GeckoView product to the New Bug and Browse pages.
* Use the same icon as Firefox for Android, because GeckoView has no logo yet.

## Bug

[Bug 1470536 - Add new GeckoView product to easy product selector on Browse and Enter Bug pages](https://bugzilla.mozilla.org/show_bug.cgi?id=1470536)

## Screenshot

The below is a live mockup created with DevTools.

![screenshot_2018-09-23 browse](https://user-images.githubusercontent.com/2929505/45933405-ed5ba180-bf59-11e8-80f8-3a2d9958ee2c.png)