### PR TITLE
bump version to 20180925.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20180918.1';
+our $VERSION = '20180925.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
The following changes will be pushed to bugzilla.mozilla.org:
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1487422" target="_blank">1487422</a>] Remove Phabricator section from MyDashboard and related WebService API</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1490687" target="_blank">1490687</a>] Stop setting r+s on Phabricator attachments</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1490708" target="_blank">1490708</a>] Ensure we always call DBIx::Connector-&gt;dbh before any DBI method</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1491973" target="_blank">1491973</a>] Add GeckoView to BMO::Data special casing</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1345673" target="_blank">1345673</a>] Open Bugzilla History in a New Window or Tab</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1490901" target="_blank">1490901</a>] ReviewBoard stub attachments no longer make a redirect, download a text file instead</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1455495" target="_blank">1455495</a>] Replace apache with Mojolicious</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1492850" target="_blank">1492850</a>] Remove places where headers are printed</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1468489" target="_blank">1468489</a>] Documentation points to https://landfill.bugzilla.org that is no longer maintained and will be shut down</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1492511" target="_blank">1492511</a>] Code to updating subscriber values for current private bugs is throwing errors in the phabbugz log</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1470536" target="_blank">1470536</a>] Add new GeckoView product to easy product selector on Browse and Enter Bug pages</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1492346" target="_blank">1492346</a>] scripts/syncflags.pl should also add the target product to any tracking flags that the source product is a member of</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1492926" target="_blank">1492926</a>] Handle DBIx::Connectors more appropriately</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1473417" target="_blank">1473417</a>] Show often/recently used products/components on New Bug page</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1490595" target="_blank">1490595</a>] Bugzilla update check should use https</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1491850" target="_blank">1491850</a>] restoreSavedBugComment takes a really long time (100ms)</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1493295" target="_blank">1493295</a>] Add short URL to each bug</li>
</ul>
discuss these changes on <a href="https://lists.mozilla.org/listinfo/tools-bmo" target="_blank">mozilla.tools.bmo</a>.
