### PR TITLE
Bug 1493847 - Fix buglist.cgi link label on product/component dropdown lists

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -391,7 +391,7 @@
           <li role="separator"></li>
           <div class="actions">
             <div><a href="buglist.cgi?product=[% bug.product FILTER uri %]&amp;bug_status=__open__"
-                    target="_blank" role="menuitem" tabindex="-1">See All [% terms.Bugs %] in This Product</a></div>
+                    target="_blank" role="menuitem" tabindex="-1">See Open [% terms.Bugs %] in This Product</a></div>
             <div><a href="enter_bug.cgi?product=[% bug.product FILTER uri %]"
                     target="_blank" role="menuitem" tabindex="-1">File New [% terms.Bug %] in This Product</a></div>
             <div><button disabled type="button" class="minor component-watching" role="menuitem" tabindex="-1"
@@ -449,7 +449,7 @@
           <div class="actions">
             <div><a href="buglist.cgi?product=[% bug.product FILTER uri %]&amp;
                           [%~ %]component=[% bug.component FILTER uri %]&amp;bug_status=__open__"
-                    target="_blank" role="menuitem" tabindex="-1">See All [% terms.Bugs %] in This Component</a></div>
+                    target="_blank" role="menuitem" tabindex="-1">See Open [% terms.Bugs %] in This Component</a></div>
             <div><a href="enter_bug.cgi?product=[% bug.product FILTER uri %]&amp;
                           [%~ %]component=[% bug.component FILTER uri %]"
                     target="_blank" role="menuitem" tabindex="-1">File New [% terms.Bug %] in This Component</a></div>


### PR DESCRIPTION
## Description

Fix wrong link label on the dropdown lists.

## Bug

[Bug 1493847 - Fix buglist.cgi link label on product/component dropdown lists](https://bugzilla.mozilla.org/show_bug.cgi?id=1493847)