### PR TITLE
Bug 1494065 - Add a basic test using Test::Mojo

### DIFF
--- a/Bugzilla/Quantum.pm
+++ b/Bugzilla/Quantum.pm
@@ -34,7 +34,7 @@ sub startup {
 
     DEBUG('Starting up');
     $self->plugin('Bugzilla::Quantum::Plugin::Glue');
-    $self->plugin('Bugzilla::Quantum::Plugin::Hostage');
+    $self->plugin('Bugzilla::Quantum::Plugin::Hostage') unless $ENV{BUGZILLA_DISABLE_HOSTAGE};
     $self->plugin('Bugzilla::Quantum::Plugin::BlockIP');
     $self->plugin('Bugzilla::Quantum::Plugin::BasicAuth');
 

--- a/Bugzilla/Test/Util.pm
+++ b/Bugzilla/Test/Util.pm
@@ -12,9 +12,10 @@ use strict;
 use warnings;
 
 use base qw(Exporter);
-our @EXPORT = qw(create_user);
+our @EXPORT = qw(create_user issue_api_key);
 
 use Bugzilla::User;
+use Bugzilla::User::APIKey;
 
 sub create_user {
     my ($login, $password, %extra) = @_;
@@ -27,6 +28,23 @@ sub create_user {
         extern_id     => undef,
         %extra,
     });
+}
+
+sub issue_api_key {
+    my ($login, $given_api_key) = @_;
+    my $user = Bugzilla::User->check({ name => $login });
+
+    my $params = {
+        user_id     => $user->id,
+        description => 'Bugzilla::Test::Util::issue_api_key',
+        api_key     => $given_api_key,
+    };
+
+    if ($given_api_key) {
+        return Bugzilla::User::APIKey->create_special($params);
+    } else {
+        return Bugzilla::User::APIKey->create($params);
+    }
 }
 
 1;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -92,13 +92,14 @@ my %requires = (
 
 my %build_requires = ( 'ExtUtils::MakeMaker' => '7.22', );
 my %test_requires = (
-    'Test::More'                      => 0,
-    'Pod::Coverage'                   => 0,
-    'Test::WWW::Selenium'             => 0,
-    'Test::Selenium::Firefox'         => 0,
-    'Test::Perl::Critic::Progressive' => 0,
-    'Perl::Critic::Freenode'          => 0,
     'Capture::Tiny'                   => 0,
+    'DBD::SQLite'                     => '1.29',
+    'Perl::Critic::Freenode'          => 0,
+    'Pod::Coverage'                   => 0,
+    'Test::More'                      => 0,
+    'Test::Perl::Critic::Progressive' => 0,
+    'Test::Selenium::Firefox'         => 0,
+    'Test::WWW::Selenium'             => 0,
 );
 my %recommends = ( Safe => '2.30',);
 

--- a/t/mojo-example.t
+++ b/t/mojo-example.t
@@ -1,0 +1,70 @@
+#!/usr/bin/perl
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+use strict;
+use warnings;
+use 5.10.1;
+use lib qw( . lib local/lib/perl5 );
+
+BEGIN {
+    $ENV{LOG4PERL_CONFIG_FILE}     = 'log4perl-t.conf';
+    # There's a plugin called Hostage that makes the application require specific Host: headers.
+    # we disable that for these tests.
+    $ENV{BUGZILLA_DISABLE_HOSTAGE} = 1;
+}
+
+# this provides a default urlbase.
+# Most localconfig options the other Bugzilla::Test::Mock* modules take care for us.
+use Bugzilla::Test::MockLocalconfig ( urlbase => 'http://bmo-web.vm' );
+
+# This configures an in-memory sqlite database.
+use Bugzilla::Test::MockDB;
+
+# This redirects reads and writes from the config file (data/params)
+use Bugzilla::Test::MockParams (
+    phabricator_enabled => 1,
+    announcehtml        => '<div id="announcement">Mojo::Test is awesome</div>',
+);
+
+# Util provides a few functions more making mock data in the DB.
+use Bugzilla::Test::Util qw(create_user issue_api_key);
+
+use Test2::V0;
+use Test2::Tools::Mock;
+use Test::Mojo;
+
+my $api_user = create_user('api@mozilla.org', '*');
+my $api_key  = issue_api_key('api@mozilla.org')->api_key;
+
+# Mojo::Test loads the application and provides methods for
+# testing requests without having to run a server.
+my $t = Test::Mojo->new('Bugzilla::Quantum');
+
+# Method chaining is used extensively.
+$t->get_ok('/__lbheartbeat__')->status_is(200)->content_is('httpd OK');
+
+# this won't work until we can mock memcached.
+# $t->get_ok('/__heartbeat__')->status_is(200);
+
+# we can use json_is or json_like to check APIs.
+# The first pair to json_like is a JSON pointer (RFC 6901)
+$t->get_ok('/bzapi/configuration')->status_is(200)->json_like( '/announcement' => qr/Mojo::Test is awesome/ );
+
+# for web requests, you use text_like (or text_is) with CSS selectors.
+$t->get_ok('/')->status_is(200)->text_like( '#announcement' => qr/Mojo::Test is awesome/ );
+
+$t->get_ok('/rest/whoami' => { 'X-Bugzilla-API-Key' => $api_key });
+$t->status_is(200);
+$t->json_is('/name' => $api_user->login);
+$t->json_is('/id' => $api_user->id);
+
+$t->get_ok('/rest/whoami');
+$t->status_is(200);
+$t->json_is('/name' => '');
+$t->json_is('/id' => 0);
+
+done_testing;

--- a/t/mojo-example.t
+++ b/t/mojo-example.t
@@ -44,6 +44,9 @@ my $api_key  = issue_api_key('api@mozilla.org')->api_key;
 # testing requests without having to run a server.
 my $t = Test::Mojo->new('Bugzilla::Quantum');
 
+# we ensure this file exists so the /__lbhearbeat__ test passes.
+$t->app->home->child('__lbheartbeat__')->spurt('httpd OK');
+
 # Method chaining is used extensively.
 $t->get_ok('/__lbheartbeat__')->status_is(200)->content_is('httpd OK');
 

--- a/t/mojo-example.t
+++ b/t/mojo-example.t
@@ -57,11 +57,14 @@ $t->get_ok('/bzapi/configuration')->status_is(200)->json_like( '/announcement' =
 # for web requests, you use text_like (or text_is) with CSS selectors.
 $t->get_ok('/')->status_is(200)->text_like( '#announcement' => qr/Mojo::Test is awesome/ );
 
+# Chaining is not magical, you can break up longer lines
+# by calling methods on $t, as below.
 $t->get_ok('/rest/whoami' => { 'X-Bugzilla-API-Key' => $api_key });
 $t->status_is(200);
 $t->json_is('/name' => $api_user->login);
 $t->json_is('/id' => $api_user->id);
 
+# Each time you call $t->get_ok, post_ok, etc the previous request is cleared.
 $t->get_ok('/rest/whoami');
 $t->status_is(200);
 $t->json_is('/name' => '');


### PR DESCRIPTION
This PR adds a new test case that uses Mojo::Test. It's a very simple test, but it is well-commented (I hope) and can be used as an example for future work.

One part that is missing that @mars-f will want to see is how to mock the datadog object -- but that part is easy to explain.