### PR TITLE
Bug 1494645 - Allow customizing HTML <title> of search results

### DIFF
--- a/buglist.cgi
+++ b/buglist.cgi
@@ -590,9 +590,6 @@ if ($format->{'extension'} eq 'ics') {
 }
 
 if ($format->{'extension'} eq 'atom') {
-    # The title of the Atom feed will be the same one as for the bug list.
-    $vars->{'title'} = $cgi->param('title');
-
     # This is the list of fields that are needed by the Atom filter.
     my @required_atom_columns = (
       'short_desc',
@@ -1059,6 +1056,10 @@ $vars->{'defaultsavename'} = $cgi->param('query_based_on');
 # If we did a quick search then redisplay the previously entered search
 # string in the text field.
 $vars->{'quicksearch'} = $searchstring;
+
+# Allow to custimize the title of HTML page and Atom feed. Also allow to pass
+# the title from HTML page to Atom feed through a link.
+$vars->{'title'} = $cgi->param('title');
 
 ################################################################################
 # HTTP Header Generation

--- a/template/en/default/list/list.html.tmpl
+++ b/template/en/default/list/list.html.tmpl
@@ -30,11 +30,11 @@
 
 [% PROCESS "global/field-descs.none.tmpl" %]
 
-[% title = "$terms.Bug List" %]
-[% IF searchname || defaultsavename %]
-  [% title = title _ ": " _ (searchname OR defaultsavename) FILTER html %]
-[% ELSIF quicksearch %]
-  [% title = title _ ": " _ quicksearch FILTER html %]
+[% DEFAULT title = "$terms.Bug List" %]
+[% IF searchname || defaultsavename || quicksearch %]
+  [% title = title _ ": " _ (searchname || defaultsavename || quicksearch) FILTER html %]
+[% ELSE %]
+  [% title = title FILTER html %]
 [% END %]
 
 [% qorder = order FILTER uri IF order %]


### PR DESCRIPTION
## Description

Allow to customize the `buglist.cgi` title using `&title=foobar` param.

## Bug

[Bug 1494645 - Allow customizing HTML <title> of search results](https://bugzilla.mozilla.org/show_bug.cgi?id=1494645)