### PR TITLE
no bug - use more generous timeouts

### DIFF
--- a/Bugzilla/Quantum/Plugin/Glue.pm
+++ b/Bugzilla/Quantum/Plugin/Glue.pm
@@ -31,28 +31,6 @@ sub register {
         }
     }
 
-    # hypnotoad is weird and doesn't look for MOJO_LISTEN itself.
-    $app->config(
-        hypnotoad => {
-            proxy => 1,
-            listen => [ $ENV{MOJO_LISTEN} ],
-        },
-    );
-
-    # Make sure each httpd child receives a different random seed (bug 476622).
-    # Bugzilla::RNG has one srand that needs to be called for
-    # every process, and Perl has another. (Various Perl modules still use
-    # the built-in rand(), even though we never use it in Bugzilla itself,
-    # so we need to srand() both of them.)
-    # Also, ping the dbh to force a reconnection.
-    Mojo::IOLoop->next_tick(
-        sub {
-            Bugzilla::RNG::srand();
-            srand();
-            try { Bugzilla->dbh->ping };
-        }
-    );
-
     $app->hook(
         before_dispatch => sub {
             my ($c) = @_;


### PR DESCRIPTION
this makes all the mojo timeouts larger -- except for 'clients' which should be smaller because we're so synchronous. It also puts them into environmental variables so ops can tweak them. 

Note some of the code has moved to the main application class to make future people less likely to not notice these values.