### PR TITLE
Bug 1495071 - Mojolicious Cleanup

### DIFF
--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -97,12 +97,6 @@ sub _init_bz_cgi_globals {
     # We need to disable output buffering - see bug 179174
     $| = 1;
 
-    # Ignore SIGTERM and SIGPIPE - this prevents DB corruption. If the user closes
-    # their browser window while a script is running, the web server sends these
-    # signals, and we don't want to die half way through a write.
-    $SIG{TERM} = 'IGNORE';
-    $SIG{PIPE} = 'IGNORE';
-
     # We don't precompile any functions here, that's done specially in
     # mod_perl code.
     $invocant->_setup_symbols(qw(:no_xhtml :oldstyle_urls :private_tempfiles

--- a/Bugzilla/Quantum.pm
+++ b/Bugzilla/Quantum.pm
@@ -10,6 +10,8 @@ use Mojo::Base 'Mojolicious';
 
 # Needed for its exit() overload, must happen early in execution.
 use CGI::Compile;
+use utf8;
+use Encode;
 
 use Bugzilla          ();
 use Bugzilla::BugMail ();
@@ -26,6 +28,7 @@ use Module::Runtime qw( require_module );
 use Bugzilla::Util ();
 use Cwd qw(realpath);
 use MojoX::Log::Log4perl::Tiny;
+use Bugzilla::WebService::Server::REST;
 
 has 'static' => sub { Bugzilla::Quantum::Static->new };
 
@@ -36,7 +39,7 @@ sub startup {
     $self->plugin('Bugzilla::Quantum::Plugin::Glue');
     $self->plugin('Bugzilla::Quantum::Plugin::Hostage') unless $ENV{BUGZILLA_DISABLE_HOSTAGE};
     $self->plugin('Bugzilla::Quantum::Plugin::BlockIP');
-    $self->plugin('Bugzilla::Quantum::Plugin::BasicAuth');
+    $self->plugin('Bugzilla::Quantum::Plugin::Helpers');
 
     # hypnotoad is weird and doesn't look for MOJO_LISTEN itself.
     $self->config(
@@ -81,12 +84,19 @@ sub startup {
             }
         );
     }
+    Bugzilla::WebService::Server::REST->preload;
+
+    $self->setup_routes;
+
+    Bugzilla::Hook::process( 'app_startup', { app => $self } );
+}
+
+sub setup_routes {
+    my ($self) = @_;
 
     my $r = $self->routes;
     Bugzilla::Quantum::CGI->load_all($r);
     Bugzilla::Quantum::CGI->load_one( 'bzapi_cgi', 'extensions/BzAPI/bin/rest.cgi' );
-
-    Bugzilla::WebService::Server::REST->preload;
 
     $r->any('/')->to('CGI#index_cgi');
     $r->any('/bug/<id:num>')->to('CGI#show_bug_cgi');
@@ -102,36 +112,18 @@ sub startup {
     $r->any('/extensions/BzAPI/bin/rest.cgi/*PATH_INFO')->to('CGI#bzapi_cgi');
     $r->any('/bzapi/*PATH_INFO')->to('CGI#bzapi_cgi');
 
-    $r->get(
-        '/__lbheartbeat__' => sub {
-            my $c = shift;
-            $c->reply->file( $c->app->home->child('__lbheartbeat__') );
-        },
-    );
+    $r->static_file('/__lbheartbeat__');
+    $r->static_file('/__version__' => 'version.json');
+    $r->static_file('/version.json');
 
-    $r->get(
-        '/__version__' => sub {
-            my $c = shift;
-            $c->reply->file( $c->app->home->child('version.json') );
-        },
-    );
-
-    $r->get(
-        '/version.json' => sub {
-            my $c = shift;
-            $c->reply->file( $c->app->home->child('version.json') );
-        },
-    );
+    $r->page('/review', 'splinter.html');
+    $r->page('/user_profile', 'user_profile.html');
+    $r->page('/userprofile', 'user_profile.html');
+    $r->page('/request_defer', 'request_defer.html');
 
     $r->get('/__heartbeat__')->to('CGI#heartbeat_cgi');
     $r->get('/robots.txt')->to('CGI#robots_cgi');
-
-    $r->any('/review')->to( 'CGI#page_cgi' => { 'id' => 'splinter.html' } );
-    $r->any('/user_profile')->to( 'CGI#page_cgi' => { 'id' => 'user_profile.html' } );
-    $r->any('/userprofile')->to( 'CGI#page_cgi' => { 'id' => 'user_profile.html' } );
-    $r->any('/request_defer')->to( 'CGI#page_cgi' => { 'id' => 'request_defer.html' } );
     $r->any('/login')->to( 'CGI#index_cgi' => { 'GoAheadAndLogIn' => '1' } );
-
     $r->any( '/:new_bug' => [ new_bug => qr{new[-_]bug} ] )->to('CGI#new_bug_cgi');
 
     my $ses_auth = $r->under(
@@ -143,8 +135,6 @@ sub startup {
         }
     );
     $ses_auth->any('/index.cgi')->to('SES#main');
-
-    Bugzilla::Hook::process( 'app_startup', { app => $self } );
 }
 
 1;

--- a/Bugzilla/Quantum.pm
+++ b/Bugzilla/Quantum.pm
@@ -113,8 +113,8 @@ sub setup_routes {
     $r->any('/bzapi/*PATH_INFO')->to('CGI#bzapi_cgi');
 
     $r->static_file('/__lbheartbeat__');
-    $r->static_file('/__version__' => 'version.json');
-    $r->static_file('/version.json');
+    $r->static_file('/__version__' => { file => 'version.json', content_type => 'application/json' });
+    $r->static_file('/version.json', { content_type => 'application/json' });
 
     $r->page('/review', 'splinter.html');
     $r->page('/user_profile', 'user_profile.html');

--- a/Bugzilla/Quantum/CGI.pm
+++ b/Bugzilla/Quantum/CGI.pm
@@ -66,12 +66,12 @@ sub load_one {
             $inner->();
         }
         catch {
-            die $_ unless ref $_ eq 'ARRAY' && $_->[0] eq "EXIT\n";
+            die $_ unless _is_exit($_);
         }
         finally {
             my $error = shift;
             untie *STDOUT;
-            $c->finish unless $error;
+            $c->finish if !$error || _is_exit($error);
             Bugzilla->cleanup;
             CGI::initialize_globals();
         };
@@ -159,6 +159,11 @@ sub _file_to_method {
     $name =~ s/\./_/s;
     $name =~ s/\W+/_/gs;
     return $name;
+}
+
+sub _is_exit {
+    my ($error) = @_;
+    return ref $error eq 'ARRAY' && $error->[0] eq "EXIT\n";
 }
 
 1;

--- a/Bugzilla/Quantum/Plugin/Glue.pm
+++ b/Bugzilla/Quantum/Plugin/Glue.pm
@@ -14,6 +14,7 @@ use Bugzilla::Constants;
 use Bugzilla::Logging;
 use Bugzilla::RNG ();
 use JSON::MaybeXS qw(decode_json);
+use Scope::Guard;
 
 sub register {
     my ( $self, $app, $conf ) = @_;
@@ -42,6 +43,7 @@ sub register {
                 }
             }
             Log::Log4perl::MDC->put( request_id => $c->req->request_id );
+            $c->stash->{cleanup_guard} = Scope::Guard->new( \&Bugzilla::cleanup );
         }
     );
 
@@ -72,7 +74,6 @@ sub register {
               or die $template->error;
         }
     );
-    $app->renderer->default_handler('bugzilla');
 
     $app->log( MojoX::Log::Log4perl::Tiny->new( logger => Log::Log4perl->get_logger( ref $app ) ) );
 }

--- a/Bugzilla/Quantum/Plugin/Helpers.pm
+++ b/Bugzilla/Quantum/Plugin/Helpers.pm
@@ -4,7 +4,7 @@
 #
 # This Source Code Form is "Incompatible With Secondary Licenses", as
 # defined by the Mozilla Public License, v. 2.0.
-package Bugzilla::Quantum::Plugin::BasicAuth;
+package Bugzilla::Quantum::Plugin::Helpers;
 use 5.10.1;
 use Mojo::Base qw(Mojolicious::Plugin);
 
@@ -14,7 +14,7 @@ use Carp;
 sub register {
     my ( $self, $app, $conf ) = @_;
 
-    $app->renderer->add_helper(
+    $app->helper(
         basic_auth => sub {
             my ( $c, $realm, $auth_user, $auth_pass ) = @_;
             my $req = $c->req;
@@ -33,6 +33,27 @@ sub register {
             }
 
             return 1;
+        }
+    );
+    $app->routes->add_shortcut(
+        static_file => sub {
+            my ($r, $path, $real_file) = @_;
+            unless ($real_file) {
+                $real_file = $path;
+                $real_file =~ s!^/!!;
+            }
+
+            return $r->get($path => sub {
+                my ($c) = @_;
+                $c->reply->file( $c->app->home->child($real_file) );
+            })
+        }
+    );
+    $app->routes->add_shortcut(
+        page => sub {
+            my ($r, $path, $id) = @_;
+
+            return $r->any($path)->to('CGI#page_cgi' => { id => $id });
         }
     );
 }

--- a/Bugzilla/Quantum/Plugin/Helpers.pm
+++ b/Bugzilla/Quantum/Plugin/Helpers.pm
@@ -37,15 +37,18 @@ sub register {
     );
     $app->routes->add_shortcut(
         static_file => sub {
-            my ($r, $path, $real_file) = @_;
-            unless ($real_file) {
-                $real_file = $path;
-                $real_file =~ s!^/!!;
+            my ($r, $path, $option) = @_;
+            my $file = $option->{file};
+            my $content_type = $option->{content_type} // 'text/plain';
+            unless ($file) {
+                $file = $path;
+                $file =~ s!^/!!;
             }
 
             return $r->get($path => sub {
                 my ($c) = @_;
-                $c->reply->file( $c->app->home->child($real_file) );
+                $c->res->headers->content_type($content_type);
+                $c->reply->file( $c->app->home->child($file) );
             })
         }
     );

--- a/scripts/entrypoint.pl
+++ b/scripts/entrypoint.pl
@@ -167,9 +167,10 @@ sub cmd_test_selenium {
         httpd_url => $conf->{browser_url},
         prove_dir => '/app/qa/t',
         prove_cmd => [
-            'prove', '-qf', '-Ilib', '-I/app',
-            '-I/app/local/lib/perl5',
-            sub { glob 'test_*.t' }
+            'sleep 10',
+            # 'prove', '-qf', '-Ilib', '-I/app',
+            # '-I/app/local/lib/perl5',
+            # sub { glob 'test_*.t' }
         ],
     );
     exit Future->wait_any($prove_exit_f, $httpd_exit_f)->get;

--- a/scripts/entrypoint.pl
+++ b/scripts/entrypoint.pl
@@ -167,10 +167,9 @@ sub cmd_test_selenium {
         httpd_url => $conf->{browser_url},
         prove_dir => '/app/qa/t',
         prove_cmd => [
-            'sleep 10',
-            # 'prove', '-qf', '-Ilib', '-I/app',
-            # '-I/app/local/lib/perl5',
-            # sub { glob 'test_*.t' }
+            'prove', '-qf', '-Ilib', '-I/app',
+            '-I/app/local/lib/perl5',
+            sub { glob 'test_*.t' }
         ],
     );
     exit Future->wait_any($prove_exit_f, $httpd_exit_f)->get;


### PR DESCRIPTION
There are some things that should've been in the first patch but were missed:

1. Calling $c->finish in the finally block should not happen if an exception has been raised.
2. Bugzilla->cleanup() should be called at the same time the mojolicious stash is cleared.
3. Code referencing the shutdownhtml should be removed
4. The conditionals that ran code in Bugzilla.pm when it was not run under mod_perl should instead check where the Bugzilla.pm module was loaded from.
5. Revert the default template from #770 
6. Also removed some stuff that manipulates the PATH and signals, which we shouldn't do