### PR TITLE
Bug 1493996 - Stop using YAHOO.lang.*, remove String.prototype.trim polyfill

### DIFF
--- a/extensions/BMO/template/en/default/bug/create/create-swag.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-swag.html.tmpl
@@ -468,7 +468,7 @@ function showGear() {
     count += needed[id];
     html += '<tr>' +
             '<td>' + needed[id] + ' x&nbsp;</td>' +
-            '<td>' + YAHOO.lang.escapeHTML(item.name) + '</td>' +
+            '<td>' + item.name.htmlEncode() + '</td>' +
             '<td><button onclick="removeGear(\'' + id + '\');return false">Remove</button></td>' +
             '</tr>';
     text += needed[id] + ' x ' + id + ' ' + item.name + "\n";
@@ -478,7 +478,7 @@ function showGear() {
     count += item.quantity;
     html += '<tr>' +
             '<td>' + item.quantity + ' x&nbsp;</td>' +
-            '<td>(' + item.type + ') ' + YAHOO.lang.escapeHTML(item.name) + '</td>' +
+            '<td>(' + item.type + ') ' + item.name.htmlEncode() + '</td>' +
             '<td><button onclick="removeFreeform(\'' + i + '\');return false">Remove</button></td>' +
             '</tr>';
     text += item.quantity + ' x (' + item.type + ') ' + item.name + "\n";

--- a/extensions/EditTable/web/js/edit_table.js
+++ b/extensions/EditTable/web/js/edit_table.js
@@ -10,7 +10,6 @@ function EditTable(parent_el, table_data) {
     this.parent_el = YAHOO.util.Dom.get(parent_el);
     this.table_data = table_data;
     this.field_count = table_data.fields.length;
-    if (!JSON) JSON = YAHOO.lang.JSON;
 
     this.render = function() {
         // create table

--- a/extensions/GuidedBugEntry/web/js/guided.js
+++ b/extensions/GuidedBugEntry/web/js/guided.js
@@ -179,8 +179,8 @@ var product = {
 
     // display the product name
     Dom.get('product').value = productName;
-    Dom.get('product_label').innerHTML = YAHOO.lang.escapeHTML(productName);
-    Dom.get('dupes_product_name').innerHTML = YAHOO.lang.escapeHTML(productName);
+    Dom.get('product_label').innerHTML = productName.htmlEncode();
+    Dom.get('dupes_product_name').innerHTML = productName.htmlEncode();
     Dom.get('list_comp').href = `${BUGZILLA.config.basepath}describecomponents.cgi?` +
                                 `product=${encodeURIComponent(productName)}`;
     guided.setAdvancedLink();
@@ -222,7 +222,7 @@ var product = {
       {
         success: function(res) {
           try {
-            var data = YAHOO.lang.JSON.parse(res.responseText);
+            var data = JSON.parse(res.responseText);
             if (data.error)
               throw(data.error.message);
             if (data.result.products.length == 0)
@@ -252,7 +252,7 @@ var product = {
           }
         }
       },
-      YAHOO.lang.JSON.stringify({
+      JSON.stringify({
         version: "1.1",
         method: "Product.get",
         id: ++this._counter,
@@ -429,7 +429,7 @@ var dupes = {
       `${BUGZILLA.config.basepath}jsonrpc.cgi`,
       {
         success: function(res) {
-          var data = YAHOO.lang.JSON.parse(res.responseText);
+          var data = JSON.parse(res.responseText);
           if (data.error)
             throw(data.error.message);
           dupes._buildCcHTML(el, bugID, bugStatus, follow);
@@ -440,7 +440,7 @@ var dupes = {
             alert("Update failed:\n\n" + res.responseText);
         }
       },
-      YAHOO.lang.JSON.stringify({
+      JSON.stringify({
         version: "1.1",
         method: "Bug.update",
         id: ++this._counter,
@@ -521,7 +521,7 @@ var dupes = {
 
   _onSummaryKeyUp: function(e) {
     // disable search button until there's a query
-    dupes._elSearch.disabled = YAHOO.lang.trim(dupes._elSummary.value) == '';
+    dupes._elSearch.disabled = dupes._elSummary.value.trim() == '';
   },
 
   _doSearch: function() {
@@ -564,7 +564,7 @@ var dupes = {
       };
 
       dupes._dataTable.getDataSource().sendRequest(
-        YAHOO.lang.JSON.stringify(json_object),
+        JSON.stringify(json_object),
         {
           success: dupes._onDupeResults,
           failure: dupes._onDupeResults,
@@ -592,7 +592,7 @@ var dupes = {
   },
 
   getSummary: function() {
-    var summary = YAHOO.lang.trim(this._elSummary.value);
+    var summary = this._elSummary.value.trim();
     // work around chrome bug
     if (summary == dupes._elSummary.getAttribute('placeholder')) {
       return '';

--- a/extensions/MyDashboard/web/js/flags.js
+++ b/extensions/MyDashboard/web/js/flags.js
@@ -11,7 +11,7 @@ $(function () {
     YUI({
         base: 'js/yui3/',
         combine: false
-    }).use("node", "datatable", "datatable-sort", "json-stringify", "escape",
+    }).use("node", "datatable", "datatable-sort",
         "datatable-datasource", "datasource-io", "datasource-jsonschema", function(Y) {
         // Common
         var counter = 0;
@@ -62,7 +62,7 @@ $(function () {
                 }
             };
 
-            var stringified = Y.JSON.stringify(json_object);
+            var stringified = JSON.stringify(json_object);
 
             Y.one('#' + type + '_loading').removeClass('bz_default_hidden');
             Y.one('#' + type + '_count_refresh').addClass('bz_default_hidden');
@@ -106,13 +106,13 @@ $(function () {
         };
 
         var updatedFormatter = function(o) {
-            return '<span title="' + Y.Escape.html(o.value) + '">' +
-                Y.Escape.html(o.data.updated_fancy) + '</span>';
+            return '<span title="' + o.value.htmlEncode() + '">' +
+                o.data.updated_fancy.htmlEncode() + '</span>';
         };
 
         var requesteeFormatter = function(o) {
             return o.value
-                ? Y.Escape.html(o.value)
+                ? o.value.htmlEncode()
                 : '<i>anyone</i>';
         };
 
@@ -126,10 +126,10 @@ $(function () {
                     'bug=' + encodeURIComponent(o.data.bug_id) +
                     '&attachment=' + encodeURIComponent(o.data.attach_id) +
                     '" target="_blank" title="Review this patch">' +
-                    Y.Escape.html(o.value) + '</a>';
+                    o.value.htmlEncode() + '</a>';
             }
             else {
-                return Y.Escape.html(o.value);
+                return o.value.htmlEncode();
             }
         };
 
@@ -137,7 +137,7 @@ $(function () {
         dataSource.requestee = new Y.DataSource.IO({ source: `${BUGZILLA.config.basepath}jsonrpc.cgi` });
         dataSource.requestee.on('error', function(e) {
             try {
-                var response = Y.JSON.parse(e.data.responseText);
+                var response = JSON.parse(e.data.responseText);
                 if (response.error)
                     e.error.message = response.error.message;
             } catch(ex) {
@@ -186,7 +186,7 @@ $(function () {
         dataSource.requester = new Y.DataSource.IO({ source: `${BUGZILLA.config.basepath}jsonrpc.cgi` });
         dataSource.requester.on('error', function(e) {
             try {
-                var response = Y.JSON.parse(e.data.responseText);
+                var response = JSON.parse(e.data.responseText);
                 if (response.error)
                     e.error.message = response.error.message;
             } catch(ex) {

--- a/extensions/MyDashboard/web/js/query.js
+++ b/extensions/MyDashboard/web/js/query.js
@@ -22,9 +22,9 @@ $(function() {
                 patterns: { 'gallery-': {} }
             }
         }
-    }).use("node", "datatable", "datatable-sort", "datatable-message", "json-stringify",
+    }).use("node", "datatable", "datatable-sort", "datatable-message",
         "datatable-datasource", "datasource-io", "datasource-jsonschema", "cookie",
-        "gallery-datatable-row-expansion-bmo", "handlebars", "escape", function(Y) {
+        "gallery-datatable-row-expansion-bmo", "handlebars", function(Y) {
         var counter          = 0,
             bugQueryTable    = null,
             bugQuery         = null,
@@ -66,7 +66,7 @@ $(function() {
 
         bugQuery.on('error', function(e) {
             try {
-                var response = Y.JSON.parse(e.data.responseText);
+                var response = JSON.parse(e.data.responseText);
                 if (response.error)
                     e.error.message = response.error.message;
             } catch(ex) {
@@ -133,7 +133,7 @@ $(function() {
             };
 
             bugQuery.sendRequest({
-                request: Y.JSON.stringify(bugQueryParams),
+                request: JSON.stringify(bugQueryParams),
                 cfg: {
                     method:  "POST",
                     headers: { 'Content-Type': 'application/json' }
@@ -143,8 +143,8 @@ $(function() {
         };
 
         var updatedFormatter = function(o) {
-            return '<span title="' + Y.Escape.html(o.value) + '">' +
-                Y.Escape.html(o.data.changeddate_fancy) + '</span>';
+            return '<span title="' + o.value.htmlEncode() + '">' +
+                o.data.changeddate_fancy.htmlEncode() + '</span>';
         };
 
 
@@ -159,7 +159,7 @@ $(function() {
 
         lastChangesQuery.on('error', function(e) {
             try {
-                var response = Y.JSON.parse(e.data.responseText);
+                var response = JSON.parse(e.data.responseText);
                 if (response.error)
                     e.error.message = response.error.message;
             } catch(ex) {
@@ -224,7 +224,7 @@ $(function() {
                     };
 
                     lastChangesQuery.sendRequest({
-                        request: Y.JSON.stringify(lastChangesParams),
+                        request: JSON.stringify(lastChangesParams),
                         cfg: {
                             method:  "POST",
                             headers: { 'Content-Type': 'application/json' }

--- a/extensions/Review/web/js/review_history.js
+++ b/extensions/Review/web/js/review_history.js
@@ -121,7 +121,7 @@ $(function () {
                 };
 
                 flagDS.sendRequest({
-                    request: Y.JSON.stringify({
+                    request: JSON.stringify({
                         version: '1.1',
                         method: 'Review.flag_activity',
                         params: {
@@ -143,7 +143,7 @@ $(function () {
         function fetch_flags(flag_ids) {
             return new Y.Promise(function (resolve, reject) {
                 flagDS.sendRequest({
-                    request: Y.JSON.stringify({
+                    request: JSON.stringify({
                         version: '1.1',
                         method: 'Review.flag_activity',
                         params: {
@@ -182,7 +182,7 @@ $(function () {
                 }));
 
                 bugDS.sendRequest({
-                    request: Y.JSON.stringify({
+                    request: JSON.stringify({
                         version: '1.1',
                         method: 'Bug.get',
                         params: {
@@ -223,7 +223,7 @@ $(function () {
                 }));
 
                 attachmentDS.sendRequest({
-                    request: Y.JSON.stringify({
+                    request: JSON.stringify({
                         version: '1.1',
                         method: 'Bug.attachments',
                         params: {
@@ -385,9 +385,9 @@ $(function () {
 
     }, '0.0.1', {
         requires: [
-            "node", "datatype-date", "datatable", "datatable-sort", "datatable-message", "json-stringify",
+            "node", "datatype-date", "datatable", "datatable-sort", "datatable-message",
             "datatable-datasource", "datasource-io", "datasource-jsonschema", "cookie",
-            "gallery-datatable-row-expansion-bmo", "handlebars", "escape", "promise"
+            "gallery-datatable-row-expansion-bmo", "handlebars", "promise"
         ]
     });
 });

--- a/extensions/Splinter/web/splinter.js
+++ b/extensions/Splinter/web/splinter.js
@@ -1204,7 +1204,7 @@ Splinter.ReviewStorage.LocalReviewStorage.prototype = {
         if (reviewInfosText == null) {
             this._reviewInfos = [];
         } else {
-            this._reviewInfos = YAHOO.lang.JSON.parse(reviewInfosText);
+            this._reviewInfos = JSON.parse(reviewInfosText);
         }
     },
 
@@ -1263,14 +1263,14 @@ Splinter.ReviewStorage.LocalReviewStorage.prototype = {
         }
 
         this._reviewInfos.push(reviewInfo);
-        localStorage.splinterReviews = YAHOO.lang.JSON.stringify(this._reviewInfos);
+        localStorage.splinterReviews = JSON.stringify(this._reviewInfos);
     },
 
     _deleteReviewInfo : function(bug, attachment) {
         var reviewIndex = this._findReview(bug, attachment);
         if (reviewIndex >= 0) {
             this._reviewInfos.splice(reviewIndex, 1);
-            localStorage.splinterReviews = YAHOO.lang.JSON.stringify(this._reviewInfos);
+            localStorage.splinterReviews = JSON.stringify(this._reviewInfos);
         }
     },
 

--- a/extensions/TrackingFlags/web/js/admin.js
+++ b/extensions/TrackingFlags/web/js/admin.js
@@ -16,8 +16,6 @@ Event.onDOMReady(function() {
         filter_flag_list(Dom.get('filter').checked);
     }
     else {
-        if (!JSON)
-            JSON = YAHOO.lang.JSON;
         Event.addListener('flag_name', 'change', change_flag_name, Dom.get('flag_name'));
         Event.addListener('flag_desc', 'change', change_string_value, Dom.get('flag_desc'));
         Event.addListener('flag_type', 'change', change_select_value, Dom.get('flag_type'));
@@ -118,7 +116,7 @@ function update_flag_values() {
             var group = groups[j];
             optionEl = document.createElement('option');
             optionEl.value = group.id;
-            optionEl.innerHTML = YAHOO.lang.escapeHTML(group.name);
+            optionEl.innerHTML = group.name.htmlEncode();
             optionEl.selected = group.id == value.setter_group_id;
             selectEl.appendChild(optionEl);
         }
@@ -426,7 +424,7 @@ function filter_flag_list(show_disabled) {
 // utils
 
 function change_string_value(e, o) {
-    o.value = YAHOO.lang.trim(o.value);
+    o.value = o.value.trim();
     tag_missing_value(o);
 }
 

--- a/js/bug.js
+++ b/js/bug.js
@@ -41,7 +41,7 @@ YAHOO.bugzilla.dupTable = {
                                    "update_token" ]
             }
         };
-        var post_data = YAHOO.lang.JSON.stringify(json_object);
+        var post_data = JSON.stringify(json_object);
 
         var callback = {
             success: dataTable.onDataReturnInitializeTable,
@@ -136,7 +136,6 @@ YAHOO.bugzilla.dupTable = {
 
 (function(){
     'use strict';
-    var JSON = YAHOO.lang.JSON;
 
     YAHOO.bugzilla.bugUserLastVisit = {
         update: function(bug_ids) {

--- a/js/comment-tagging.js
+++ b/js/comment-tagging.js
@@ -111,7 +111,7 @@ YAHOO.bugzilla.commentTagging = {
         var bz_ctag_error = Dom.get('bz_ctag_error');
         var tags_container = Dom.get('ct_' + comment_no);
         tags_container.parentNode.appendChild(bz_ctag_error, tags_container);
-        Dom.get('bz_ctag_error_msg').innerHTML = YAHOO.lang.escapeHTML(error);
+        Dom.get('bz_ctag_error_msg').innerHTML = error.htmlEncode();
         Dom.removeClass(bz_ctag_error, 'bz_default_hidden');
     },
 
@@ -257,7 +257,7 @@ YAHOO.bugzilla.commentTagging = {
         // add new tags
         var new_tags = new Array();
         for (var i = 0, l = add_tags.length; i < l; i++) {
-            var tag = YAHOO.lang.trim(add_tags[i]);
+            var tag = add_tags[i].trim();
             // validation
             if (tag == '')
                 continue;
@@ -313,7 +313,7 @@ YAHOO.bugzilla.commentTagging = {
         {
             success: function(res) {
                 YAHOO.bugzilla.commentTagging.decPending(comment_id);
-                data = YAHOO.lang.JSON.parse(res.responseText);
+                data = JSON.parse(res.responseText);
                 if (data.error) {
                     YAHOO.bugzilla.commentTagging.handleRpcError(
                         comment_id, comment_no, data.error.message, noRefreshOnError);
@@ -330,7 +330,7 @@ YAHOO.bugzilla.commentTagging = {
                     comment_id, comment_no, res.responseText, noRefreshOnError);
             }
         },
-        YAHOO.lang.JSON.stringify({
+        JSON.stringify({
             version: "1.1",
             method: 'Bug.comments',
             params: {
@@ -349,7 +349,7 @@ YAHOO.bugzilla.commentTagging = {
         {
             success: function(res) {
                 YAHOO.bugzilla.commentTagging.decPending(comment_id);
-                data = YAHOO.lang.JSON.parse(res.responseText);
+                data = JSON.parse(res.responseText);
                 if (data.error) {
                     YAHOO.bugzilla.commentTagging.handleRpcError(comment_id, comment_no, data.error.message);
                     return;
@@ -363,7 +363,7 @@ YAHOO.bugzilla.commentTagging = {
                 YAHOO.bugzilla.commentTagging.handleRpcError(comment_id, comment_no, res.responseText);
             }
         },
-        YAHOO.lang.JSON.stringify({
+        JSON.stringify({
             version: "1.1",
             method: 'Bug.update_comment_tags',
             params: {

--- a/js/field.js
+++ b/js/field.js
@@ -55,16 +55,16 @@ function validateEnterBug(theform) {
 
     // These are checked in the reverse order that they appear on the page,
     // so that the one closest to the top of the form will be focused.
-    if (attach_data.value && YAHOO.lang.trim(attach_desc.value) == '') {
+    if (attach_data.value && attach_desc.value.trim() == '') {
         _errorFor(attach_desc, 'attach_desc');
         focus_me = attach_desc;
     }
     var check_description = status_comment_required[bug_status.value];
-    if (check_description && YAHOO.lang.trim(description.value) == '') {
+    if (check_description && description.value.trim() == '') {
         _errorFor(description, 'description');
         focus_me = description;
     }
-    if (YAHOO.lang.trim(short_desc.value) == '') {
+    if (short_desc.value.trim() == '') {
         _errorFor(short_desc);
         focus_me = short_desc;
     }
@@ -926,12 +926,12 @@ function show_comment_preview(bug_id) {
     YAHOO.util.Connect.asyncRequest('POST', `${BUGZILLA.config.basepath}jsonrpc.cgi`,
     {
         success: function(res) {
-            data = YAHOO.lang.JSON.parse(res.responseText);
+            data = JSON.parse(res.responseText);
             if (data.error) {
                 Dom.addClass('comment_preview_loading', 'bz_default_hidden');
                 Dom.removeClass('comment_preview_error', 'bz_default_hidden');
                 Dom.get('comment_preview_error').innerHTML =
-                    YAHOO.lang.escapeHTML(data.error.message);
+                    data.error.message.htmlEncode();
             } else {
                 document.getElementById('comment_preview_text').innerHTML = data.result.html;
                 Dom.addClass('comment_preview_loading', 'bz_default_hidden');
@@ -943,10 +943,10 @@ function show_comment_preview(bug_id) {
             Dom.addClass('comment_preview_loading', 'bz_default_hidden');
             Dom.removeClass('comment_preview_error', 'bz_default_hidden');
             Dom.get('comment_preview_error').innerHTML =
-                YAHOO.lang.escapeHTML(res.responseText);
+                res.responseText.htmlEncode();
         }
     },
-    YAHOO.lang.JSON.stringify({
+    JSON.stringify({
         version: "1.1",
         method: 'Bug.render_comment',
         params: {

--- a/js/global.js
+++ b/js/global.js
@@ -196,17 +196,6 @@ function bugzilla_ajax(request, done_fn, error_fn) {
         });
 }
 
-// polyfill .trim
-if (!String.prototype.trim) {
-    (function() {
-        // Make sure we trim BOM and NBSP
-        var rtrim = /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g;
-        String.prototype.trim = function() {
-            return this.replace(rtrim, '');
-        };
-    })();
-}
-
 // html encoding
 if (!String.prototype.htmlEncode) {
     (function() {

--- a/js/instant-search.js
+++ b/js/instant-search.js
@@ -158,7 +158,7 @@ YAHOO.bugzilla.instantSearch = {
       }
 
       YAHOO.bugzilla.instantSearch.dataTable.getDataSource().sendRequest(
-        YAHOO.lang.JSON.stringify(jsonObject),
+        JSON.stringify(jsonObject),
         {
           success: YAHOO.bugzilla.instantSearch.onSearchResults,
           failure: YAHOO.bugzilla.instantSearch.onSearchResults,
@@ -178,7 +178,7 @@ YAHOO.bugzilla.instantSearch = {
   },
 
   getContent: function() {
-    var content = YAHOO.lang.trim(this.elContent.value);
+    var content = this.elContent.value.trim();
     // work around chrome bug
     if (content == YAHOO.bugzilla.instantSearch.elContent.getAttribute('placeholder')) {
       return '';

--- a/template/en/default/reports/report-table.html.tmpl
+++ b/template/en/default/reports/report-table.html.tmpl
@@ -119,7 +119,7 @@ YAHOO.util.Event.addListener(window, "load", function() {
          sortOptions: { defaultDir: YAHOO.widget.DataTable.CLASS_DESC, sortFunction:totalNumberSorter }}
       ];
   this.parseString = function(str) {
-    return YAHOO.lang.trim(str);
+    return str.trim();
   };
 
   this.parseNumber = function(str) {


### PR DESCRIPTION
## Description

`YAHOO.lang` and `String.prototype.trim` polyfill are no longer needed. 

* YUI 2 `YAHOO.lang.JSON` and YUI 3 `Y.JSON` -> native `JSON`
* YUI 2 `YAHOO.lang.trim()` -> `String.prototype.trim()`
* YUI 2 `YAHOO.lang.escapeHTML()` and YUI 3 `Y.Escape.html()` -> `String.prototype.htmlEncode()` (Bugzilla’s own polyfill)

## Bug

[Bug 1493996 - Stop using YAHOO.lang.*, remove String.prototype.trim polyfill](https://bugzilla.mozilla.org/show_bug.cgi?id=1493996)