### PR TITLE
Bug 1472565 - Allow to instantly search recently visited bugs, ID/aliases, keywords, components in the quick search bar

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -39,7 +39,7 @@ $(function() {
                 if ($content.is(':visible')) {
                     e.preventDefault();
                     e.stopPropagation();
-                    var $items = $content.find('[role="menuitem"], [role="option"]');
+                    var $items = $content.find('[role="menuitem"], [role="option"]').filter(':visible');
                     // if none active select the first or last
                     var $link = $items.filter('.active');
                     if ($link.length == 0) {
@@ -103,6 +103,7 @@ $(function() {
         var $div     = $(this);
         var $button  = $div.find('.dropdown-button');
         var $content = $div.find('.dropdown-content');
+        var is_input = $button.eq('input');
         $button.click(function(e) {
             // Do not handle non-primary click.
             if (e.button != 0 || $content.hasClass('hover-display')) {
@@ -111,12 +112,15 @@ $(function() {
             toggleDropDown(e, $button, $content);
         }).keydown(function(e) {
             if (e.keyCode == 13) {
-                if ($button.eq('input') && !$button.val()) {
+                if (is_input) {
                     // prevent the form being submitted if the search bar is empty
-                    e.preventDefault();
+                    if (!$button.val().trim()) {
+                        e.preventDefault();
+                    }
                     // navigate to an active link if any
                     var $link = $content.find('.active');
                     if ($link.length) {
+                        e.preventDefault();
                         if ($link.attr('href')) {
                             location.href = $link.attr('href');
                         } else {
@@ -127,6 +131,11 @@ $(function() {
 
                 // allow enter to toggle menu
                 toggleDropDown(e, $button, $content);
+            } else {
+                // When the search bar contains any term and the pressed key is not Escape, show the dropdown if hidden
+                if (is_input && $button.val().trim() && e.keyCode !== 27 && !$content.is(':visible')) {
+                    toggleDropDown(e, $button, $content, true, false);
+                }
             }
         });
 

--- a/js/models.js
+++ b/js/models.js
@@ -1,0 +1,138 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This Source Code Form is "Incompatible With Secondary Licenses", as
+ * defined by the Mozilla Public License, v. 2.0. */
+
+/**
+ * Reference or define the Bugzilla app namespace.
+ * @namespace
+ */
+var Bugzilla = Bugzilla || {}; // eslint-disable-line no-var
+
+/**
+ * Provide functionality related to bug field data.
+ * @see https://bugzilla.readthedocs.io/en/latest/api/core/v1/field.html
+ */
+Bugzilla.BugFields = class BugFields {
+  /**
+   * Retrieve bug component field values used in the Bugzilla instance.
+   * @returns {Promise.<Object[]>} List of products.
+   * @see https://bugzilla.readthedocs.io/en/latest/api/core/v1/product.html
+   */
+  static async fetch_products() {
+    const cache_key = 'bug_field_products';
+    const products = Bugzilla.Storage.get(cache_key);
+
+    // Use cache if available
+    if (products) {
+      return Promise.resolve(products);
+    }
+
+    try {
+      let { products } = await Bugzilla.API.get('product', {
+        type: 'accessible',
+        include_fields: ['classification', 'name', 'description', 'components.name', 'components.description'],
+      });
+
+      // Exclude products moved to Graveyard
+      products = products.filter(({ classification }) => classification !== 'Graveyard');
+
+      // Cache in local storage for a day
+      Bugzilla.Storage.save(cache_key, products, 24 * 60 * 60 * 1000);
+
+      return Promise.resolve(products);
+    } catch (ex) {
+      return Promise.resolve([]);
+    }
+  }
+
+  /**
+   * Retrieve bug keyword field values used in the Bugzilla instance.
+   * @returns {Promise.<Object[]>} List of keywords.
+   */
+  static async fetch_keywords() {
+    const cache_key = 'bug_field_keywords';
+    const keywords = Bugzilla.Storage.get(cache_key);
+
+    // Use cache if available
+    if (keywords) {
+      return Promise.resolve(keywords);
+    }
+
+    try {
+      const { fields } = await Bugzilla.API.get('field/bug/keywords', { include_fields: 'values' });
+      const keywords = fields[0].values;
+
+      // Cache in local storage for a day
+      Bugzilla.Storage.save(cache_key, keywords, 24 * 60 * 60 * 1000);
+
+      return Promise.resolve(keywords);
+    } catch (ex) {
+      return Promise.resolve([]);
+    }
+  }
+};
+
+/**
+ * Provide functionality related to the current user's data.
+ * @see https://bugzilla.readthedocs.io/en/latest/api/core/v1/user.html
+ */
+Bugzilla.User = class User {
+  /**
+   * Retrieve list of bugs the user has recently accessed.
+   * @returns {Promise.<Object[]>} List of recent bugs, which contain the bug ID, summary, alias and last visit date.
+   * This can be an empty array if the user is not logged in.
+   * @see https://bugzilla.readthedocs.io/en/latest/api/core/v1/bug-user-last-visit.html
+   */
+  static async fetch_recent_bugs() {
+    if (!BUGZILLA.api_token) {
+      return Promise.resolve([]);
+    }
+
+    const cache_key = 'bug_user_last_visit';
+    const bugs = (Bugzilla.data || {})[cache_key];
+
+    // Use cache if available and fresh (retrieved less than a half day ago)
+    if (bugs) {
+      return Promise.resolve(bugs);
+    }
+
+    try {
+      const last_visit = await Bugzilla.API.get('bug_user_last_visit');
+      const last_visit_map = new Map(last_visit.map(({ id, last_visit_ts }) => ([id, new Date(last_visit_ts)])));
+
+      let { bugs } = await Bugzilla.API.get('bug', {
+        id: [...last_visit_map.entries()].sort((a, b) => a[1] < b[1]).map(a => a[0]).slice(0, 800).join(','),
+        include_fields: ['id', 'alias', 'summary', 'type'],
+      });
+
+      // Combine the bugs and last_visit arrays
+      bugs.forEach((bug, i) => bugs[i].last_visit = last_visit_map.get(bug.id));
+
+      // Sort by date in descending order (new to old)
+      bugs = Bugzilla.Array.sort(bugs, 'last_visit', { descending: true });
+
+      // Cache in memory
+      Bugzilla.data = Bugzilla.data || {};
+      Bugzilla.data[cache_key] = bugs;
+
+      return Promise.resolve(bugs);
+    } catch (ex) {
+      return Promise.resolve([]);
+    }
+  }
+
+  /**
+   * Retrieve the user's saved search items which are currently embedded in HTML.
+   * @returns {Promise.<Object[]>} List of saved searches, which contain the name and link. This can be an empty array
+   * if the user is not logged in.
+   */
+  static async fetch_saved_searches() {
+    const searches = [...document.querySelectorAll('#header-search-dropdown section[data-type="saved"] a')]
+      .map(({ text, href }) => ({ name: text, link: href }));
+
+    return Promise.resolve(searches);
+  }
+};

--- a/js/quick-search.js
+++ b/js/quick-search.js
@@ -1,0 +1,350 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This Source Code Form is "Incompatible With Secondary Licenses", as
+ * defined by the Mozilla Public License, v. 2.0. */
+
+/**
+ * Reference or define the Bugzilla app namespace.
+ * @namespace
+ */
+var Bugzilla = Bugzilla || {}; // eslint-disable-line no-var
+
+/**
+ * Enhance the quick search bar on the global header so the user can search/filter their recent bugs, saved searches,
+ * components, keywords and more.
+ */
+Bugzilla.QuickSearch = class QuickSearch {
+  /**
+   * Initialize a new QuickSearch instance.
+   */
+  constructor() {
+    this.$form = document.querySelector('#header-search');
+    this.$searchbox = document.querySelector('#quicksearch_top');
+    this.$dropdown = document.querySelector('#header-search-dropdown');
+    this.sections = {};
+    this.data = { recent: [], shortcuts: [], saved: [], products: [], keywords: [] };
+    this.initialized = false;
+    this.alt_pressed = false;
+
+    this.$dropdown.querySelectorAll('section').forEach($section => this.sections[$section.dataset.type] = $section);
+
+    this.$form.addEventListener('submit', () => this.form_onsubmit());
+    this.$searchbox.addEventListener('focus', () => this.searchbox_onfocus());
+    this.$searchbox.addEventListener('keydown', event => this.searchbox_onkeydown(event));
+    this.$searchbox.addEventListener('keyup', event => this.searchbox_onkeydown(event));
+    this.$searchbox.addEventListener('input', () => this.searchbox_oninput());
+  }
+
+  /**
+   * Get the current search terms entered in the search box.
+   * @type {String}
+   */
+  get input() {
+    return this.$searchbox.value.trim();
+  }
+
+  /**
+   * Show search results in the dropdown menu's specific section.
+   * @param {HTMLElement} $section A section in the dropdown menu.
+   * @param {String} input Search terms.
+   * @param {Object[]} results Search results.
+   * @param {String} results.label Link text.
+   * @param {Boolean} [results.label_encoded] Whether the label can be safely inserted to HTML.
+   * @param {String} results.link Link URL.
+   * @param {String} [results.type] Bug type.
+   * @param {Boolean} [highlight] `true` to highlight search terms, `false` to use the provided label as is, without
+   * escaping any contained HTML tags.
+   */
+  show_results($section, input, results, highlight = true) {
+    const $results = $section.querySelector('ul');
+    const $fragment = document.createDocumentFragment();
+
+    for (const { label, label_encoded = false, link, type } of results) {
+      const $placeholder = document.createElement('ul');
+
+      $placeholder.innerHTML = `
+        <li role="none">
+          <a role="option" href="${BUGZILLA.config.basepath}${link.htmlEncode()}">
+            ${type ? `
+              <span class="bug-type-label iconic" title="${type}" aria-label="${type}" data-type="${type}">
+                <span class="icon" aria-hidden="true"></span>
+              </span>
+            ` : ''}
+            ${highlight ? Bugzilla.String.highlight(label, input) : label_encoded ? label : label.htmlEncode()}
+          </a>
+        </li>
+      `;
+
+      const $a = $fragment.appendChild($placeholder.firstElementChild).querySelector('a');
+
+      // Allow Alt+click on the link to search all bugs matching the criteria (see `searchbox_onkeydown()` below)
+      $a.addEventListener('click', event => {
+        if (this.alt_pressed) {
+          event.preventDefault();
+          location.href = $a.href;
+        }
+      });
+
+      // Activate dropdown menu item effects (see dropdown.js)
+      $a.addEventListener('mouseover', () => $a.classList.add('active'));
+      $a.addEventListener('mouseout', () => $a.classList.remove('active'));
+    }
+
+    $results.innerHTML = '';
+    $results.appendChild($fragment);
+    $section.hidden = !results.length;
+  }
+
+  /**
+   * Show the current search terms on the dropdown list.
+   * @param {String} [input] Search terms.
+   */
+  show_search_terms(input = this.input.trim()) {
+    this.show_results(this.sections.terms, input, input ? [{
+      label: Bugzilla.L10n.get(`search_terms_in_${this.alt_pressed ? 'all' : 'open'}_bugs`, input.htmlEncode()),
+      link: `buglist.cgi?quicksearch=${encodeURIComponent(input)}`,
+      label_encoded: true,
+    }] : [], false);
+  }
+
+  /**
+   * Show filtered recent bugs on the dropdown list.
+   * @param {String} [input] Search terms.
+   */
+  show_recent_bugs(input = this.input.trim()) {
+    let results = this.data.recent;
+
+    if (input && results.length) {
+      results = results
+        .filter(({ id, alias, summary }) => Bugzilla.String.find(`${id} ${alias || ''} ${summary}`, input));
+    }
+
+    this.show_results(this.sections.recent, input, results.slice(0, 5).map(({ id, alias, summary, type }) => ({
+      label: `${id}${alias ? ` (${alias})` : ''} - ${summary}`,
+      link: `show_bug.cgi?id=${id}`,
+      type
+    })));
+  }
+
+  /**
+   * Search bugs from the remote Bugzilla instance. Search for a matching bug ID and aliases if the input is numeric.
+   * Search only for aliases if the input is not numeric.
+   * @param {String} [input] Search terms.
+   * @returns {Promise.<Object[]>} List of bugs.
+   */
+  async fetch_shortcut_bugs(input = this.input.trim()) {
+    if (!input) {
+      return Promise.resolve([]);
+    }
+
+    try {
+      let { bugs } = await Bugzilla.API.get('bug', Object.assign(isNaN(input) ? {
+        f1: 'alias', o1: 'anywordssubstr', v1: input,
+        f2: 'resolution', o2: 'isempty',
+      } : {
+        j_top: 'OR',
+        f1: 'bug_id', o1: 'equals', v1: input,
+        f2: 'OP',
+        f3: 'alias', o3: 'anywordssubstr', v3: input,
+        f4: 'resolution', o4: 'isempty',
+        f5: 'CP',
+      }, {
+        include_fields: 'id,alias,summary,type,last_change_time',
+      }));
+
+      // Sort by last modified date
+      bugs = bugs.sort((a, b) => new Date(a.last_change_time) < new Date(b.last_change_time));
+
+      if (!isNaN(input)) {
+        // Move the bug with the matched ID to first
+        bugs = [bugs.find(bug => bug.id === Number(input)), ...bugs.filter(bug => bug.id !== Number(input))];
+      }
+
+      return Promise.resolve(bugs);
+    } catch (ex) {
+      return Promise.resolve([]);
+    }
+  }
+
+  /**
+   * Show filtered shortcuts bugs, excluding recent bugs, on the dropdown list.
+   * @param {String} [input] Search terms.
+   */
+  show_shortcut_bugs(input = this.input.trim()) {
+    let results = this.data.shortcuts;
+
+    if (input && results.length) {
+      results = results
+        .filter(({ id }) => !this.data.recent.find(bug => bug.id === id))
+        .filter(({ id, alias, summary }) => Bugzilla.String.find(`${id} ${alias || ''} ${summary}`, input));
+    }
+
+    this.show_results(this.sections.shortcuts, input, results.slice(0, 5).map(({ id, alias, summary, type }) => ({
+      label: `${id}${alias ? ` (${alias})` : ''} - ${summary}`,
+      link: `show_bug.cgi?id=${id}`,
+      type
+    })));
+  }
+
+  /**
+   * Show filtered saved search items on the dropdown list.
+   * @param {String} [input] Search terms.
+   */
+  show_saved_searches(input = this.input.trim()) {
+    if (!this.sections.saved) {
+      return;
+    }
+
+    let results = this.data.saved;
+
+    if (input && results.length) {
+      results = results.filter(({ name }) => Bugzilla.String.find(name, input));
+    }
+
+    // If no search terms are provided, show all saved searches as rendered in HTML by default
+    this.show_results(this.sections.saved, input, results.slice(0, input ? 5 : undefined).map(({ name, link }) => ({
+      label: name,
+      link,
+    })));
+  }
+
+  /**
+   * Show filtered products/components on the dropdown list.
+   * @param {String} [input] Search terms.
+   */
+  show_products(input = this.input.trim()) {
+    const results = [];
+
+    if (input) {
+      // Find components by name
+      for (const { name: product, components } of this.data.products) {
+        for (const { name: component } of components) {
+          if (Bugzilla.String.find(`${product} ${component}`, input)) {
+            results.push({ product, component });
+          }
+        }
+      }
+    }
+
+    this.show_results(this.sections.products, input, results.slice(0, 5).map(({ product, component }) => ({
+      label: `${product} :: ${component}`,
+      link: `buglist.cgi?quicksearch=${encodeURIComponent(`product:"${product}" component:"${component}"`)}`,
+    })));
+  }
+
+  /**
+   * Show filtered bug keywords on the dropdown list.
+   * @param {String} [input] Search terms.
+   */
+  show_keywords(input = this.input.trim()) {
+    const results = input ? this.data.keywords.filter(({ name }) => Bugzilla.String.find(name, input)) : [];
+
+    this.show_results(this.sections.keywords, input, results.slice(0, 5).map(({ name }) => ({
+      label: name,
+      link: `buglist.cgi?quicksearch=${encodeURIComponent(`keywords:${name}`)}`,
+    })));
+  }
+
+  /**
+   * When Alt key is pressed, change all the quick search links to allow searching all bugs instead of only open bugs.
+   * This is done by prepending "ALL" to search queries.
+   * @see https://bugzilla.mozilla.org/page.cgi?id=quicksearch.html
+   */
+  toggle_all_bugs_search() {
+    const $search_link = this.sections.terms.querySelector(`a[href^="${BUGZILLA.config.basepath}buglist.cgi"]`);
+    const link_open = `${BUGZILLA.config.basepath}buglist.cgi?quicksearch=`;
+    const link_all = `${link_open}ALL+`;
+
+    // Replace the link label for the current search terms
+    if ($search_link) {
+      $search_link.innerHTML =
+        Bugzilla.L10n.get(`search_terms_in_${this.alt_pressed ? 'all' : 'open'}_bugs`, this.input.htmlEncode());
+    }
+
+    // Replace all the quicksearch URLs
+    for (const $link of this.$dropdown.querySelectorAll(`a[href^="${BUGZILLA.config.basepath}buglist.cgi"]`)) {
+      const href = $link.getAttribute('href');
+      const has_all = href.startsWith(link_all);
+
+      if (this.alt_pressed) {
+        if (!has_all) {
+          $link.setAttribute('href', href.replace(link_open, link_all));
+        }
+      } else {
+        if (has_all) {
+          $link.setAttribute('href', href.replace(link_all, link_open));
+        }
+      }
+    }
+  }
+
+  /**
+   * Called whenever the search form is submitted. If Alt key is pressed, make it an all-bugs quick search.
+   * @returns {Boolean} `true` to allow submitting the form, `false` otherwise.
+   */
+  form_onsubmit() {
+    if (!this.input) {
+      return false;
+    }
+
+    if (this.alt_pressed && !this.input.match(/^ALL\s/)) {
+      this.$searchbox.value = `ALL ${this.input}`;
+    }
+
+    return true;
+  }
+
+  /**
+   * Called whenever the quick search bar gets user focus. Fetch required data to get prepared.
+   */
+  searchbox_onfocus() {
+    if (this.initialized) {
+      return;
+    }
+
+    this.initialized = true;
+
+    Bugzilla.User.fetch_recent_bugs().then(bugs => this.data.recent = bugs).then(() => this.show_recent_bugs());
+    Bugzilla.User.fetch_saved_searches().then(searches => this.data.saved = searches);
+    Bugzilla.BugFields.fetch_products().then(products => this.data.products = products);
+    Bugzilla.BugFields.fetch_keywords().then(keywords => this.data.keywords = keywords);
+  }
+
+  /**
+   * Called whenever any key is pressed on the search bar. Handle Alt key as a trigger like menus in macOS.
+   * @param {KeyboardEvent} event A `keydown` or `keyup` event.
+   */
+  searchbox_onkeydown(event) {
+    if (event.key === 'Alt') {
+      this.alt_pressed = event.type === 'keydown';
+      this.toggle_all_bugs_search();
+    }
+  }
+
+  /**
+   * Called whenever the search terms are updated by the user. Perform searches and show the results.
+   */
+  searchbox_oninput() {
+    // Show local search results immediately
+    this.show_search_terms();
+    this.show_recent_bugs();
+    this.show_saved_searches();
+    this.show_products();
+    this.show_keywords();
+
+    window.clearTimeout(this.timer);
+
+    // Hide the Shortcuts section first
+    this.data.shortcuts = [];
+    this.show_shortcut_bugs();
+
+    // Retrieve remote search results
+    this.timer = window.setTimeout(() => {
+      this.fetch_shortcut_bugs().then(bugs => this.data.shortcuts = bugs).then(() => this.show_shortcut_bugs());
+    }, 200);
+  }
+};
+
+window.addEventListener('DOMContentLoaded', () => new Bugzilla.QuickSearch(), { once: true });

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -1145,7 +1145,7 @@ input[type="radio"]:checked {
   height: 32px;
 }
 
-#header .searchbox-outer .icon {
+#header .searchbox-outer > .icon {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1156,7 +1156,7 @@ input[type="radio"]:checked {
   height: 24px;
 }
 
-#header .searchbox-outer .icon::before {
+#header .searchbox-outer > .icon::before {
   content: '\E8B6';
 }
 
@@ -1229,30 +1229,73 @@ input[type="radio"]:checked {
 
 #header-search-dropdown {
   right: auto;
+  padding: 0 !important;
   min-width: calc(100% + 8px) !important;
-  max-width: calc(200% + 8px) !important;
+  max-width: calc(250% + 8px) !important;
 }
 
 #header-search-dropdown-wrapper {
   overflow-x: hidden;
   overflow-y: scroll;
-  max-height: 400px;
+  max-height: 600px;
+}
+
+#header-search-dropdown-wrapper .icon {
+  margin: 1px;
+  width: 18px;
+  font-size: 18px;
+}
+
+#header-search-dropdown section[data-type="terms"] header .icon::before {
+  content: '\E8B6';
+}
+
+#header-search-dropdown section[data-type="recent"] header .icon::before {
+  content: '\E889';
+}
+
+#header-search-dropdown section[data-type="shortcuts"] header .icon::before {
+  content: '\E3E7';
+}
+
+#header-search-dropdown section[data-type="saved"] header .icon::before {
+  content: '\E866';
+}
+
+#header-search-dropdown section[data-type="products"] header .icon::before {
+  content: '\E54C';
+}
+
+#header-search-dropdown section[data-type="keywords"] header .icon::before {
+  content: '\E54E';
+}
+
+#header-search-dropdown section:not([hidden]) {
+  display: flex;
+  padding: 8px;
+}
+
+#header-search-dropdown section:not(:first-of-type),
+#header-search-dropdown section + section[hidden] + section {
+  border-top: 1px solid var(--menu-border-color);
+}
+
+#header-search-dropdown section[hidden] + section {
+  border: 0;
 }
 
 #header-search-dropdown header {
+  flex: none;
   display: flex;
-  margin: -4px 12px 0;
-  padding: 8px 0 4px;
-  font-size: var(--font-size-small);
+  margin: 2px 4px 0 0;
+  padding: 0;
   color: var(--secondary-label-color);
+  font-size: var(--font-size-small);
 }
 
 #header-search-dropdown header h3 {
-  flex: auto;
-  margin: 0;
-  font-size: inherit;
-  line-height: var(--line-height-comfortable);
-  font-weight: normal;
+  position: absolute;
+  left: -99999px;
 }
 
 #header-search-dropdown header a {
@@ -1268,15 +1311,21 @@ input[type="radio"]:checked {
 }
 
 #header-search-dropdown ul {
+  flex: auto;
+  overflow: hidden;
   margin: 0;
   padding: 0;
-  list-style: none;
 }
 
 #header-search-dropdown a {
   overflow: hidden;
+  padding: 2px 8px !important;
   white-space: nowrap !important;
   text-overflow: ellipsis;
+}
+
+#header-search-dropdown a .bug-type-label {
+  margin-left: -4px;
 }
 
 #header-tools-menu-button {

--- a/template/en/default/global/header-search-dropdown.html.tmpl
+++ b/template/en/default/global/header-search-dropdown.html.tmpl
@@ -24,11 +24,32 @@
 
 <div id="header-search-dropdown" class="dropdown-content right" role="listbox" style="display: none;">
   <div id="header-search-dropdown-wrapper">
+    <section data-type="terms" hidden>
+      <header>
+        <span class="icon" aria-hidden="true"></span>
+        <h3>Terms</h3>
+      </header>
+      <ul role="none"></ul>
+    </section>
+    <section data-type="recent" hidden>
+      <header>
+        <span class="icon" aria-hidden="true"></span>
+        <h3>Recent</h3>
+      </header>
+      <ul role="none"></ul>
+    </section>
+    <section data-type="shortcuts" hidden>
+      <header>
+        <span class="icon" aria-hidden="true"></span>
+        <h3>Shortcuts</h3>
+      </header>
+      <ul role="none"></ul>
+    </section>
     [% IF user.showmybugslink OR user.queries.size OR user.queries_subscribed.size %]
-      <section id="header-search-dropdown-saved">
+      <section data-type="saved">
         <header>
+          <span class="icon" aria-hidden="true"></span>
           <h3>Saved Searches</h3>
-          <a href="[% basepath FILTER none %]userprefs.cgi?tab=saved-searches">Edit</a>
         </header>
         <ul role="none">
           [% IF user.showmybugslink %][% filtered_username = user.login FILTER uri %]
@@ -47,5 +68,19 @@
         </ul>
       </section>
     [% END %]
+    <section data-type="products" hidden>
+      <header>
+        <span class="icon" aria-hidden="true"></span>
+        <h3>Products &amp; Components</h3>
+      </header>
+      <ul role="none"></ul>
+    </section>
+    <section data-type="keywords" hidden>
+      <header>
+        <span class="icon" aria-hidden="true"></span>
+        <h3>Keywords</h3>
+      </header>
+      <ul role="none"></ul>
+    </section>
   </div>
 </div>

--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -132,6 +132,10 @@
                     "You must select a Component for this $terms.bug",
                 description_required =>
                     "You must enter a Description for this $terms.bug",
+                search_terms_in_all_bugs =>
+                    "Search <strong>%s</strong> in All $terms.Bugs",
+                search_terms_in_open_bugs =>
+                    "Search <strong>%s</strong> in Open $terms.Bugs",
                 short_desc_required =>
                     "You must enter a Summary for this $terms.bug",
                 version_required =>
@@ -183,7 +187,7 @@
     [% FOREACH jq_name = jquery.unique %]
       [% starting_js_urls.push("js/jquery/plugins/$jq_name/${jq_name}-min.js") %]
     [% END %]
-    [% starting_js_urls.push('js/global.js', 'js/util.js', 'js/dropdown.js') %]
+    [% starting_js_urls.push('js/global.js', 'js/util.js', 'js/models.js', 'js/dropdown.js', 'js/quick-search.js') %]
 
     [% FOREACH asset_url = starting_js_urls %]
       [% PROCESS format_js_link %]


### PR DESCRIPTION
## Description

Enhance the quick search bar on the global navigation so it will be able to show/filter the user’s recently visited bugs, saved searches, components and keywords as well as [possible duplicates](https://bmo.readthedocs.io/en/latest/api/core/v1/bug.html#possible-duplicates) as you type. See [this screenshot](https://twitter.com/BugzillaUX/status/1013919072252096512) in action.

## Bug

[Bug 1472565 - Allow to instantly search recently visited bugs, possible duplicates, keywords, components in the quick search bar](https://bugzilla.mozilla.org/show_bug.cgi?id=1472565)