### PR TITLE
Bug 1209148 - Stop using short-life token for internal REST API auth, which is problematic especially on My Dashboard, and rely on login cookie instead

### DIFF
--- a/Bugzilla/Auth/Verify/DB.pm
+++ b/Bugzilla/Auth/Verify/DB.pm
@@ -92,14 +92,6 @@ sub check_credentials {
     $user->update();
   }
 
-  if (i_am_webservice() && $user->settings->{api_key_only}->{value} eq 'on') {
-
-    # api-key verification happens in Auth/Login/APIKey
-    # token verification happens in Auth/Login/Cookie
-    # if we get here from an api call then we must be using user/pass
-    return {failure => AUTH_ERROR, user_error => 'invalid_auth_method',};
-  }
-
   return $login_data;
 }
 

--- a/Bugzilla/Install.pm
+++ b/Bugzilla/Install.pm
@@ -187,12 +187,6 @@ sub SETTINGS {
       category => 'Reviews and Needinfo'
     },
     {
-      name     => 'api_key_only',
-      options  => ['on', 'off'],
-      default  => 'off',
-      category => 'API'
-    },
-    {
       name     => 'use_elasticsearch',
       options  => ['on', 'off'],
       default  => 'off',
@@ -212,6 +206,14 @@ sub SETTINGS {
     },
   ];
 }
+
+sub REMOVED_SETTINGS {
+  return [
+    {
+      name => 'api_key_only',
+    },
+  ];
+};
 
 use constant SYSTEM_GROUPS => (
   {name => 'admin',        description => 'Administrators'},
@@ -298,6 +300,11 @@ sub update_settings {
   my @settings = @{SETTINGS()};
   foreach my $params (@settings) {
     add_setting($params);
+  }
+
+  @settings = @{REMOVED_SETTINGS()};
+  foreach my $params (@settings) {
+    remove_setting($params);
   }
 }
 

--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -1021,12 +1021,6 @@ sub create {
         return $cookie ? issue_hash_token(['login_request', $cookie]) : '';
       },
 
-      'get_api_token' => sub {
-        return '' unless Bugzilla->user->id;
-        my $cache = Bugzilla->request_cache;
-        return $cache->{api_token} //= issue_api_token();
-      },
-
       # A way for all templates to get at Field data, cached.
       'bug_fields' => sub {
         my $cache = Bugzilla->request_cache;

--- a/Bugzilla/Token.pm
+++ b/Bugzilla/Token.pm
@@ -26,7 +26,7 @@ use JSON qw(encode_json decode_json);
 
 use base qw(Exporter);
 
-@Bugzilla::Token::EXPORT = qw(issue_api_token issue_session_token
+@Bugzilla::Token::EXPORT = qw(issue_session_token
   issue_short_lived_session_token
   issue_auth_delegation_token check_auth_delegation_token
   check_token_data delete_token
@@ -42,22 +42,6 @@ use constant TOKEN_LENGTH => 22;
 ################################################################################
 # Public Functions
 ################################################################################
-
-# Create a token used for internal API authentication
-sub issue_api_token {
-
-  # Generates a random token, adds it to the tokens table if one does not
-  # already exist, and returns the token to the caller.
-  my $dbh     = Bugzilla->dbh;
-  my $user    = Bugzilla->user;
-  my ($token) = $dbh->selectrow_array("
-        SELECT token FROM tokens
-         WHERE userid = ? AND tokentype = 'api_token'
-               AND ("
-      . $dbh->sql_date_math('issuedate', '+', (MAX_TOKEN_AGE * 24 - 12), 'HOUR')
-      . ") > NOW()", undef, $user->id);
-  return $token // _create_token($user->id, 'api_token', '');
-}
 
 sub issue_auth_delegation_token {
   my ($uri)    = @_;
@@ -620,14 +604,6 @@ Bugzilla::Token - Provides different routines to manage tokens.
 =head1 SUBROUTINES
 
 =over
-
-=item C<issue_api_token($login_name)>
-
- Description: Creates a token that can be used for API calls on the web page.
-
- Params:      None.
-
- Returns:     The token.
 
 =item C<issue_new_user_account_token($login_name)>
 

--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -713,7 +713,6 @@ sub possible_duplicates {
     limit              => Optional [Int],
     summary            => Optional [Str],
     include_fields     => Optional [ArrayRef [Str]],
-    Bugzilla_api_token => Optional [Str]
   ];
 
   ThrowCodeError('param_invalid',

--- a/extensions/BMO/lib/Reports/Groups.pm
+++ b/extensions/BMO/lib/Reports/Groups.pm
@@ -242,10 +242,6 @@ sub members_report {
             $rh_user->{groups}    = [$rh->{name}];
             $rh_user->{lastseeon} = $member->last_seen_date;
             $rh_user->{mfa}       = $member->mfa;
-            $rh_user->{api_key_only}
-              = $member->settings->{api_key_only}->{value} eq 'on'
-              ? JSON::true
-              : JSON::false;
           }
           $users{$login} = $rh_user;
         }

--- a/extensions/BMO/template/en/default/bug/create/create-automative.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-automative.html.tmpl
@@ -68,7 +68,6 @@ function validateAndSubmit() {
 
 [% PROCESS global/header.html.tmpl
    title = "Automation Request Form"
-   generate_api_token = 1
    style = inline_style
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',

--- a/extensions/BMO/template/en/default/bug/create/create-blocklist.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-blocklist.html.tmpl
@@ -120,7 +120,6 @@ window.addEventListener("DOMContentLoaded", function() {
 
 [% PROCESS global/header.html.tmpl
    title = "Blocklist Policy Request Form"
-   generate_api_token = 1
    style = inline_style
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',

--- a/extensions/BMO/template/en/default/bug/create/create-client-bounty.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-client-bounty.html.tmpl
@@ -97,7 +97,6 @@ function validateAndSubmit() {
 
 [% PROCESS global/header.html.tmpl
    title = "Client Bounty Form"
-   generate_api_token = 1
    style = inline_style
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',

--- a/extensions/BMO/template/en/default/bug/create/create-costume.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-costume.html.tmpl
@@ -117,7 +117,6 @@ YAHOO.util.Event.onDOMReady(function() {
 
 [% PROCESS global/header.html.tmpl
    title = "Firefox Costume Request Form"
-   generate_api_token = 1
    style = inline_style
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',

--- a/extensions/BMO/template/en/default/bug/create/create-creative.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-creative.html.tmpl
@@ -103,7 +103,6 @@ function toggleTypeOther(element) {
 
 [% PROCESS global/header.html.tmpl
    title = "Creative Initiation Form"
-   generate_api_token = 1
    style = inline_style
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',

--- a/extensions/BMO/template/en/default/bug/create/create-crm.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-crm.html.tmpl
@@ -62,7 +62,6 @@ $(document).ready(function() {
 
 [% PROCESS global/header.html.tmpl
    title              = "CRM/Email Marketing Request"
-   generate_api_token = 1
    style_urls         = [ "skins/standard/attachment.css",
                           "js/jquery/plugins/datetimepicker/datetimepicker.css" ]
    style              = inline_style

--- a/extensions/BMO/template/en/default/bug/create/create-data-compliance.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-data-compliance.html.tmpl
@@ -62,7 +62,6 @@
 
 [% PROCESS global/header.html.tmpl
    title = "Data Compliance Form"
-   generate_api_token = 1
    style = inline_css
    style_urls = [ 'skins/standard/enter_bug.css' ]
    javascript = inline_javascript

--- a/extensions/BMO/template/en/default/bug/create/create-finance.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-finance.html.tmpl
@@ -62,7 +62,6 @@
 
 [% PROCESS global/header.html.tmpl
    title = "Finance"
-   generate_api_token = 1
    style = inline_style
    style_urls = [ 'skins/standard/enter_bug.css' ]
    javascript = inline_js

--- a/extensions/BMO/template/en/default/bug/create/create-fsa-budget.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-fsa-budget.html.tmpl
@@ -68,7 +68,6 @@ function validateAndSubmit() {
 
 [% PROCESS global/header.html.tmpl
    title = "FSA Budget Request Form"
-   generate_api_token = 1
    style = inline_style
    style_urls = [ 'skins/standard/enter_bug.css' ]
    javascript = inline_javascript

--- a/extensions/BMO/template/en/default/bug/create/create-intern.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-intern.html.tmpl
@@ -74,7 +74,6 @@ $(document).ready(function() {
 
 [% PROCESS global/header.html.tmpl
    title              = "Mozilla Corporation Intern Requests"
-   generate_api_token = 1
    style_urls         = [ 'skins/standard/attachment.css' ]
    javascript_urls    = []
    style              = inline_style

--- a/extensions/BMO/template/en/default/bug/create/create-ipp.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-ipp.html.tmpl
@@ -51,7 +51,6 @@ function validateAndSubmit() {
 
 [% PROCESS global/header.html.tmpl
    title = "Internet Public Policy Issue"
-   generate_api_token = 1
    style = inline_style
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',

--- a/extensions/BMO/template/en/default/bug/create/create-itrequest.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-itrequest.html.tmpl
@@ -81,7 +81,6 @@
 
 [% PROCESS global/header.html.tmpl
    title = "Mozilla Corporation/Foundation IT Requests"
-   generate_api_token = 1
    javascript = inline_javascript
    javascript_urls = [ 'js/field.js' ]
 %]

--- a/extensions/BMO/template/en/default/bug/create/create-legal.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-legal.html.tmpl
@@ -37,7 +37,6 @@ label.required:before {
 
 [% PROCESS global/header.html.tmpl
    title = "Mozilla Corporation Legal Requests"
-   generate_api_token = 1
    style = inline_style
    style_urls = [ 'skins/standard/attachment.css',
                   'skins/standard/create_bug.css' ]

--- a/extensions/BMO/template/en/default/bug/create/create-mozlist.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-mozlist.html.tmpl
@@ -10,7 +10,6 @@
 
 [% PROCESS global/header.html.tmpl
    title = "Mozilla Discussion Forum"
-   generate_api_token = 1
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',
                        'js/field.js' ]
    style = ".mandatory{color:var(--required-label-color);font-size:var(--font-size-small);}"

--- a/extensions/BMO/template/en/default/bug/create/create-mozpr.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-mozpr.html.tmpl
@@ -264,7 +264,6 @@ function validate_form() {
 
 [% PROCESS global/header.html.tmpl
    title = "PR Project Form"
-   generate_api_token = 1
    style = inline_style
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',

--- a/extensions/BMO/template/en/default/bug/create/create-name-clearance.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-name-clearance.html.tmpl
@@ -58,7 +58,6 @@ $(function() {
 
 [% PROCESS global/header.html.tmpl
    title              = "Name Clearance"
-   generate_api_token = 1
    style              = inline_style
    javascript         = inline_javascript
 %]

--- a/extensions/BMO/template/en/default/bug/create/create-nda.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-nda.html.tmpl
@@ -49,7 +49,6 @@ $(function() {
 
 [% PROCESS global/header.html.tmpl
    title              = "NDA Request Form"
-   generate_api_token = 1
    style              = inline_style
    javascript         = inline_javascript
 %]

--- a/extensions/BMO/template/en/default/bug/create/create-recruiting.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-recruiting.html.tmpl
@@ -52,7 +52,6 @@ function jobDescToggle(what) {
 
 [% PROCESS global/header.html.tmpl
    title              = "Mozilla Corporation HR and Recruiting Requests"
-   generate_api_token = 1
    style_urls         = [ 'skins/standard/attachment.css' ]
    javascript_urls    = [ 'js/attachment.js', 'js/field.js' ]
    style              = inline_style

--- a/extensions/BMO/template/en/default/bug/create/create-swag.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-swag.html.tmpl
@@ -494,7 +494,6 @@ function showGear() {
 
 [% PROCESS global/header.html.tmpl
    title = "Mozilla Gear"
-   generate_api_token = 1
    style = inline_style
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',

--- a/extensions/BMO/template/en/default/bug/create/create-user-engagement.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-user-engagement.html.tmpl
@@ -69,7 +69,6 @@ function toggleGoalOther() {
 
 [% PROCESS global/header.html.tmpl
    title = "User Engagement Form"
-   generate_api_token = 1
    style = inline_style
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',

--- a/extensions/BMO/template/en/default/bug/create/create-web-bounty.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-web-bounty.html.tmpl
@@ -54,7 +54,6 @@ function validateAndSubmit() {
 
 [% PROCESS global/header.html.tmpl
    title = "Web Bounty Form"
-   generate_api_token = 1
    style = inline_style
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',

--- a/extensions/BMO/template/en/default/global/choose-product.html.tmpl
+++ b/extensions/BMO/template/en/default/global/choose-product.html.tmpl
@@ -43,8 +43,7 @@
   cgi = Bugzilla.cgi;
   classification = cgi.param('classification');
 
-  PROCESS global/header.html.tmpl
-    generate_api_token = 1;
+  PROCESS global/header.html.tmpl;
 %]
 
 [% IF NOT is_describe %]

--- a/extensions/BMO/template/en/default/pages/attachment_bounty_form.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/attachment_bounty_form.html.tmpl
@@ -105,7 +105,6 @@ function validateAndSubmit() {
 
 [% PROCESS global/header.html.tmpl
    title = "Bounty Attachment Form"
-   generate_api_token = 1
    style = inline_style
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',

--- a/extensions/BMO/template/en/default/pages/group_members.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/group_members.html.tmpl
@@ -96,7 +96,6 @@
                     <td nowrap>
                       [% IF member.mfa %]
                         [% member.mfa FILTER html %]
-                        [% " (weakened)" IF member.settings.api_key_only.value == "off" %]
                       [% ELSE %]
                         -
                       [% END %]

--- a/extensions/BMO/template/en/default/pages/group_membership.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/group_membership.html.tmpl
@@ -8,7 +8,6 @@
 
 [% PROCESS global/header.html.tmpl
   title = "Group Membership Report"
-  generate_api_token = 1
   style_urls = [ "extensions/BMO/web/styles/reports.css" ]
   javascript_urls = [ "js/field.js" ]
 %]

--- a/extensions/BMO/template/en/default/pages/triage_owners.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/triage_owners.html.tmpl
@@ -26,7 +26,6 @@
                       "extensions/BMO/web/js/triage_owners.js" ]
   style_urls = [ "skins/standard/buglist.css",
                  "extensions/BMO/web/styles/triage_reports.css" ]
-  generate_api_token = 1
 %]
 
 <noscript>

--- a/extensions/BMO/template/en/default/pages/triage_reports.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/triage_reports.html.tmpl
@@ -40,7 +40,6 @@ var selected_components = [
 
 [% INCLUDE global/header.html.tmpl
   title = "Unconfirmed Reports"
-  generate_api_token = 1
   javascript = js_data
   javascript_urls = [ "js/field.js", "js/productform.js",
                       "extensions/BMO/web/js/triage_reports.js" ]

--- a/extensions/BMO/template/en/default/pages/user_activity.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/user_activity.html.tmpl
@@ -14,7 +14,6 @@
 
 [% INCLUDE global/header.html.tmpl
   title = "User Activity Report" _ who_title
-  generate_api_token = 1
   javascript_urls = [ "js/field.js" ]
   style_urls = [ "extensions/BMO/web/styles/reports.css" ]
 

--- a/extensions/Bitly/template/en/default/hook/global/header-start.html.tmpl
+++ b/extensions/Bitly/template/en/default/hook/global/header-start.html.tmpl
@@ -11,5 +11,4 @@
   jquery.push('bPopup');
   style_urls.push('extensions/Bitly/web/styles/bitly.css');
   javascript_urls.push('extensions/Bitly/web/js/bitly.js');
-  generate_api_token = 1;
 %]

--- a/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
@@ -23,8 +23,6 @@
   filtered_desc = bug.short_desc FILTER html;
   title = title _ filtered_desc;
 
-  generate_api_token = 1;
-
   # these aren't always defined
   UNLESS bodyclasses.defined;
     bodyclasses = [];

--- a/extensions/ComponentWatching/template/en/default/hook/reports/components-start.html.tmpl
+++ b/extensions/ComponentWatching/template/en/default/hook/reports/components-start.html.tmpl
@@ -8,5 +8,4 @@
 
 [%
   javascript_urls.push('extensions/ComponentWatching/web/js/overlay.js');
-  generate_api_token = 1;
 %]

--- a/extensions/ComponentWatching/web/js/overlay.js
+++ b/extensions/ComponentWatching/web/js/overlay.js
@@ -22,8 +22,8 @@ Bugzilla.ComponentWatching = class ComponentWatching {
     this._method = 'component-watching';
     this.buttons = document.querySelectorAll('button.component-watching');
 
-    // Check if the user is logged in and the API key is available. If not, remove the Watch buttons.
-    if (BUGZILLA.api_token) {
+    // Check if the user is logged in. If not, remove the Watch buttons.
+    if (BUGZILLA.user.login) {
       this.init();
     } else {
       this.buttons.forEach($button => $button.remove());

--- a/extensions/EditComments/template/en/default/pages/comment-revisions.html.tmpl
+++ b/extensions/EditComments/template/en/default/pages/comment-revisions.html.tmpl
@@ -12,7 +12,6 @@
     title           = "$terms.Bug $bug.id Comment $comment.count Edit History"
     style_urls      = ['extensions/EditComments/web/styles/revisions.css']
     javascript_urls = (user.is_insider ? ['extensions/EditComments/web/js/revisions.js'] : [])
-    generate_api_token = 1
 %]
 
 <h2>[% "$terms.Bug $bug.id Comment $comment.count" FILTER none %] Edit History</h2>

--- a/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
+++ b/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
@@ -16,7 +16,6 @@
 
 [% PROCESS global/header.html.tmpl
    title = "Enter A Bug"
-   generate_api_token = 1
    javascript_urls = js_urls
    style_urls = [ 'extensions/GuidedBugEntry/web/style/guided.css' ]
 %]

--- a/extensions/MozProjectReview/template/en/default/bug/create/create-moz-project-review.html.tmpl
+++ b/extensions/MozProjectReview/template/en/default/bug/create/create-moz-project-review.html.tmpl
@@ -10,7 +10,6 @@
 
 [% PROCESS global/header.html.tmpl
    title = "Mozilla Project Review"
-   generate_api_token = 1
    style_urls = [ 'skins/standard/create_bug.css',
                   'extensions/MozProjectReview/web/style/moz_project_review.css'
                   'js/jquery/plugins/datetimepicker/datetimepicker.css' ]

--- a/extensions/MyDashboard/template/en/default/pages/mydashboard.html.tmpl
+++ b/extensions/MyDashboard/template/en/default/pages/mydashboard.html.tmpl
@@ -10,7 +10,6 @@
 
 [% PROCESS global/header.html.tmpl
   title = "My Dashboard"
-  generate_api_token = 1
   style_urls = [ "skins/yui3.css",
                  "extensions/MyDashboard/web/styles/mydashboard.css",
                  "extensions/ProdCompSearch/web/styles/prod_comp_search.css" ]

--- a/extensions/REMO/template/en/default/bug/create/create-mozreps.html.tmpl
+++ b/extensions/REMO/template/en/default/bug/create/create-mozreps.html.tmpl
@@ -21,7 +21,6 @@
 
 [% PROCESS global/header.html.tmpl
    title              = "Mozilla Reps - Application Form"
-   generate_api_token = 1
    style_urls         = [ "extensions/REMO/web/styles/moz_reps.css" ]
    jquery             = []
    javascript_urls    = [ "extensions/REMO/web/js/moz_reps.js", "js/field.js" ]

--- a/extensions/REMO/template/en/default/bug/create/create-remo-budget.html.tmpl
+++ b/extensions/REMO/template/en/default/bug/create/create-remo-budget.html.tmpl
@@ -10,7 +10,6 @@
 
 [% PROCESS global/header.html.tmpl
    title = "Mozilla Reps Budget Request Form"
-   generate_api_token = 1
    style_urls = [ 'extensions/REMO/web/styles/moz_reps.css' ]
    javascript_urls = [ 'extensions/REMO/web/js/form_validate.js',
                        'js/field.js' ]

--- a/extensions/REMO/template/en/default/bug/create/create-remo-swag.html.tmpl
+++ b/extensions/REMO/template/en/default/bug/create/create-remo-swag.html.tmpl
@@ -10,7 +10,6 @@
 
 [% PROCESS global/header.html.tmpl
    title = "Mozilla Reps Swag Request Form"
-   generate_api_token = 1
    javascript_urls = [ 'extensions/REMO/web/js/swag.js',
                        'extensions/REMO/web/js/form_validate.js',
                        'js/field.js' ]

--- a/extensions/REMO/template/en/default/pages/remo-form-payment.html.tmpl
+++ b/extensions/REMO/template/en/default/pages/remo-form-payment.html.tmpl
@@ -22,7 +22,6 @@
 
 [% PROCESS global/header.html.tmpl
    title = "Mozilla Reps Payment Form"
-   generate_api_token = 1
    style_urls = [ 'extensions/REMO/web/styles/moz_reps.css' ]
    javascript_urls = [ 'extensions/REMO/web/js/form_validate.js',
                        'extensions/REMO/web/js/payment.js',

--- a/extensions/Review/template/en/default/pages/review_history.html.tmpl
+++ b/extensions/Review/template/en/default/pages/review_history.html.tmpl
@@ -10,7 +10,6 @@
 
 [% PROCESS global/header.html.tmpl
   title = "Review History"
-  generate_api_token = 1
   style_urls = [ "extensions/Review/web/styles/review_history.css" ]
   javascript_urls = [ 'js/yui3/yui/yui-min.js',
             'extensions/Review/web/js/review_history.js',

--- a/extensions/Splinter/template/en/default/pages/splinter.html.tmpl
+++ b/extensions/Splinter/template/en/default/pages/splinter.html.tmpl
@@ -25,7 +25,6 @@
 
 [% PROCESS global/header.html.tmpl
   title = "Patch Review"
-  generate_api_token = 1
   header = "Patch Review"
   style_urls = [ "extensions/Splinter/web/splinter.css" ]
   javascript_urls = [ "js/yui.js",

--- a/extensions/UserProfile/template/en/default/pages/user_profile.html.tmpl
+++ b/extensions/UserProfile/template/en/default/pages/user_profile.html.tmpl
@@ -15,7 +15,6 @@
 [% END %]
 [% PROCESS global/header.html.tmpl
    title = "User Profile: $filtered_identity"
-   generate_api_token = 1
    style_urls = [ "extensions/UserProfile/web/styles/user_profile.css" ]
    javascript_urls = [ "js/field.js" ]
 %]

--- a/js/util.js
+++ b/js/util.js
@@ -391,7 +391,6 @@ Bugzilla.API = class API {
    */
   static _init(endpoint, method = 'GET', params = {}) {
     const url = new URL(`${BUGZILLA.config.basepath}rest/${endpoint}`, location.origin);
-    const token = BUGZILLA.api_token;
 
     if (method === 'GET') {
       for (const [key, value] of Object.entries(params)) {
@@ -408,11 +407,6 @@ Bugzilla.API = class API {
           url.searchParams.set(key, value);
         }
       }
-    }
-
-    /** @todo Remove this once Bug 1477163 is solved */
-    if (token) {
-      url.searchParams.set('Bugzilla_api_token', token);
     }
 
     return new Request(url, {

--- a/template/en/default/account/prefs/mfa.html.tmpl
+++ b/template/en/default/account/prefs/mfa.html.tmpl
@@ -74,23 +74,6 @@
       </div>
     </div>
 
-    <p class="mfa-api-blurb">
-      [% IF user.settings.api_key_only.value == 'on' %]
-        Enabling two-factor authentication has also required systems that
-        interface with [% terms.Bugzilla %]'s API to use <a href="[% basepath FILTER none %]userprefs.cgi?tab=apikey">API keys</a>
-        for authentication.<br>
-        <br>
-        While not recommended, this limitation can be lifted by changing the
-        <a href="[% basepath FILTER none %]userprefs.cgi?tab=settings#api_key_only">Require API key authentication for API requests</a>
-        preference.
-      [% ELSE %]
-        Systems that interface with [% terms.Bugzilla %]'s API are not required to use API keys.<br>
-        Change the
-        <a href="[% basepath FILTER none %]userprefs.cgi?tab=settings#api_key_only">Require API key authentication for API requests</a>
-        preference to enforce API key usage.
-      [% END %]
-    </p>
-
     [% IF user.mfa  %]
       <p class="mfa-disable-blurb">
         You will need to disable your two-factor authentication in order to change to a different method.
@@ -269,20 +252,6 @@
       Two-factor authentication settings will not be updated until you
       <b>Submit Changes</b>.
     </p>
-
-    <p class="mfa-api-blurb" style="display:none">
-      Enabling two-factor authentication will also require systems that
-      interface with [% terms.Bugzilla %]'s API to use <a href="[% basepath FILTER none %]userprefs.cgi?tab=apikey">API keys</a>
-      for authentication.  While not recommended, this limitation can be lifted by changing the
-      <a href="[% basepath FILTER none %]userprefs.cgi?tab=settings#api_key_only">Require API key authentication for API requests</a>
-      preference after 2FA is enabled.
-    </p>
-
-    <p>
-      <em>Warning:</em> Changing your Two-factor authentication settings will
-      automatically log out other login sessions except for the current one.
-    </p>
-
   </div>
 
 </div>

--- a/template/en/default/account/prefs/prefs.html.tmpl
+++ b/template/en/default/account/prefs/prefs.html.tmpl
@@ -41,7 +41,6 @@
   PROCESS global/header.html.tmpl
     title              = "User Preferences"
     subheader          = filtered_login
-    generate_api_token = 1
     style_urls         = ['skins/standard/admin.css']
     javascript_urls    = ['js/field.js', 'js/TUI.js', 'js/account.js']
     jquery             = ['bPopup'],

--- a/template/en/default/account/prefs/settings.html.tmpl
+++ b/template/en/default/account/prefs/settings.html.tmpl
@@ -70,9 +70,6 @@
               </option>
             [% END %]
           </select>
-          [% IF setting_name == "api_key_only" %]
-            [% INCLUDE "mfa/protected.html.tmpl" %]
-          [% END %]
         </td>
       </tr>
     [% END %]

--- a/template/en/default/admin/components/create.html.tmpl
+++ b/template/en/default/admin/components/create.html.tmpl
@@ -28,7 +28,6 @@
 [% PROCESS global/header.html.tmpl
   javascript_urls = [ "js/field.js" ]
   title = title
-  generate_api_token = 1
 %]
 
 <form method="post" action="[% basepath FILTER none %]editcomponents.cgi">

--- a/template/en/default/admin/components/edit.html.tmpl
+++ b/template/en/default/admin/components/edit.html.tmpl
@@ -33,7 +33,6 @@
 [% END %]
 [% PROCESS global/header.html.tmpl
   title = title
-  generate_api_token = 1
   javascript_urls = [ "js/field.js" ]
 %]
 

--- a/template/en/default/admin/groups/create.html.tmpl
+++ b/template/en/default/admin/groups/create.html.tmpl
@@ -29,7 +29,6 @@
   title = "Add group"
   subheader = "This page allows you to define a new user group."
   doc_section = "groups.html#create-groups"
-  generate_api_token = 1
   javascript_urls = [ "js/field.js" ]
 %]
 

--- a/template/en/default/admin/groups/edit.html.tmpl
+++ b/template/en/default/admin/groups/edit.html.tmpl
@@ -45,7 +45,6 @@
         padding-right: .5em;
     }
   "
-  generate_api_token = 1
   javascript_urls = [ "js/field.js" ]
 %]
 

--- a/template/en/default/admin/products/create.html.tmpl
+++ b/template/en/default/admin/products/create.html.tmpl
@@ -24,7 +24,6 @@
 
 [% PROCESS global/header.html.tmpl
   title = title
-  generate_api_token = 1
   style_urls = ['skins/standard/admin.css']
 %]
 

--- a/template/en/default/admin/sudo.html.tmpl
+++ b/template/en/default/admin/sudo.html.tmpl
@@ -22,7 +22,6 @@
 
 [% PROCESS global/header.html.tmpl
    title = "Begin sudo session"
-   generate_api_token = 1
    style_urls = ['skins/standard/admin.css']
    doc_section = "useradmin.html#impersonatingusers"
  %]

--- a/template/en/default/attachment/create.html.tmpl
+++ b/template/en/default/attachment/create.html.tmpl
@@ -33,7 +33,6 @@
   title = title
   header = header
   subheader = subheader
-  generate_api_token = 1
   style_urls = [ 'skins/standard/attachment.css' ]
   javascript_urls = [ "js/attachment.js", 'js/field.js', "js/TUI.js" ]
   doc_section = "attachments.html"

--- a/template/en/default/attachment/edit.html.tmpl
+++ b/template/en/default/attachment/edit.html.tmpl
@@ -37,7 +37,6 @@
   title = title
   header = header
   subheader = subheader
-  generate_api_token = 1
   doc_section = "attachments.html"
   javascript_urls = ['js/attachment.js', 'js/field.js']
   style_urls = ['skins/standard/attachment.css']

--- a/template/en/default/bug/create/create.html.tmpl
+++ b/template/en/default/bug/create/create.html.tmpl
@@ -30,7 +30,6 @@
 
 [% PROCESS global/header.html.tmpl
   title = title
-  generate_api_token = 1
   style_urls = [ 'skins/standard/attachment.css',
                  'skins/standard/enter_bug.css',
                  'skins/standard/create_bug.css' ]

--- a/template/en/default/bug/show-header.html.tmpl
+++ b/template/en/default/bug/show-header.html.tmpl
@@ -38,7 +38,6 @@
   [% title = title _ "($filtered_alias) " %]
 [% END %]
 [% title = title _ filtered_desc %]
-[% generate_api_token = 1 %]
 [% header = "$terms.Bug&nbsp;$bug.bug_id" %]
 [% javascript_urls = [ "js/field.js" ] %]
 [% javascript_urls.push("js/bug.js") IF user.id  %]

--- a/template/en/default/bug/summarize-time.html.tmpl
+++ b/template/en/default/bug/summarize-time.html.tmpl
@@ -29,7 +29,6 @@
 
 [% PROCESS global/header.html.tmpl
     title = title
-    generate_api_token = 1
     header = header
     style_urls = ["skins/standard/summarize-time.css"]
     doc_section = "timetracking.html"

--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -35,7 +35,6 @@
   # style_urls: list. List of URLs to CSS style sheets.
   # message: string. A message to display to the user. May contain HTML.
   # atomlink: Atom link URL, May contain HTML
-  # generate_api_token: generate a token which can be used to make authenticated webservice calls
   # no_body: if true the body element will not be generated
   # allow_mobile: allow special CSS and viewport for detected mobile user agents
   # use_login_page: display a link to the full login page, rather than an inline login.
@@ -54,7 +53,6 @@
   no_yui = 0
   jquery = []
   jquery_css = []
-  generate_api_token = 1
   robots = 'index'
 %]
 
@@ -140,11 +138,6 @@
         };
     %]
     [% Hook.process("start") %]
-    [%
-       IF generate_api_token;
-        js_BUGZILLA.api_token = get_api_token();
-       END;
-    %]
 
     <meta name="viewport" content="width=1024">
     <meta name="color-scheme" content="dark light">

--- a/template/en/default/global/setting-descs.none.tmpl
+++ b/template/en/default/global/setting-descs.none.tmpl
@@ -57,7 +57,6 @@
    "bugmail_new_prefix"               => "Add 'New:' to subject line of email sent when a new $terms.bug is filed",
    "possible_duplicates"              => "Display possible duplicates when reporting a new $terms.bug",
    "requestee_cc"                     => "Automatically add me to the CC list of $terms.bugs I am requested to review",
-   "api_key_only"                     => "Require API key authentication for API requests",
    "use_elasticsearch"                => "Use elasticsearch for $terms.bug searches when possible",
                    }
 %]

--- a/template/en/default/list/list.html.tmpl
+++ b/template/en/default/list/list.html.tmpl
@@ -47,7 +47,6 @@
 [% url_filtered_title = title FILTER uri %]
 [% PROCESS global/header.html.tmpl
   title = title
-  generate_api_token = dotweak
   style = style
   atomlink = basepath _ "buglist.cgi?$urlquerypart&title=$url_filtered_title&ctype=atom"
   javascript_urls = [ "js/field.js", "js/buglist.js" ]

--- a/template/en/default/request/queue.html.tmpl
+++ b/template/en/default/request/queue.html.tmpl
@@ -25,7 +25,6 @@
 
 [% PROCESS global/header.html.tmpl
   title="Request Queue"
-  generate_api_token = 1
   onload="var f = document.request_form; selectProduct(f.product, f.component, null, null, 'Any');"
   javascript_urls=["js/productform.js", "js/field.js"]
   style_urls = ['skins/standard/buglist.css']

--- a/template/en/default/search/search-advanced.html.tmpl
+++ b/template/en/default/search/search-advanced.html.tmpl
@@ -42,7 +42,6 @@ function remove_token() {
 
 [% PROCESS global/header.html.tmpl
   title = "Search for $terms.bugs"
-  generate_api_token = 1
   onload = "doOnSelectProduct(0);"
   javascript = js_data
   javascript_urls = [ "js/productform.js", "js/TUI.js", "js/field.js", "js/advanced-search.js" ]

--- a/template/en/default/search/search-create-series.html.tmpl
+++ b/template/en/default/search/search-create-series.html.tmpl
@@ -32,7 +32,6 @@
 
 [% PROCESS global/header.html.tmpl
   title = "Create New Data Set"
-  generate_api_token = 1
   onload = "doOnSelectProduct(0);"
   javascript = js_data
   javascript_urls = [ "js/productform.js", "js/TUI.js", "js/field.js", "js/advanced-search.js" ]

--- a/template/en/default/search/search-instant.html.tmpl
+++ b/template/en/default/search/search-instant.html.tmpl
@@ -10,7 +10,6 @@
 
 [% PROCESS global/header.html.tmpl
   title = "Instant Search"
-  generate_api_token = 1
   javascript_urls = [ 'extensions/GuidedBugEntry/web/js/products.js',
                       'js/instant-search.js', ]
 %]

--- a/template/en/default/search/search-report-graph.html.tmpl
+++ b/template/en/default/search/search-report-graph.html.tmpl
@@ -31,7 +31,6 @@ var queryform = "reportform"
 
 [% PROCESS global/header.html.tmpl
   title = "Generate Graphical Report"
-  generate_api_token = 1
   onload = "doOnSelectProduct(0); chartTypeChanged()"
   javascript = js_data
   javascript_urls = [ "js/productform.js", "js/TUI.js", "js/field.js", "js/advanced-search.js" ]

--- a/template/en/default/search/search-report-table.html.tmpl
+++ b/template/en/default/search/search-report-table.html.tmpl
@@ -31,7 +31,6 @@ var queryform = "reportform"
 
 [% PROCESS global/header.html.tmpl
   title = "Generate Tabular Report"
-  generate_api_token = 1
   onload = "doOnSelectProduct(0)"
   javascript = js_data
   javascript_urls = [ "js/productform.js", "js/TUI.js", "js/field.js", "js/advanced-search.js" ]


### PR DESCRIPTION
## Description

* Internal `Bugzilla_api_token` is problematic and redundant. The existing login cookie can be used instead for API auth.
* Public `Bugzilla_token` is a different thing, and it should not be affected by this change.

## Bug

[Bug 1209148 - Stop using short-life token for internal REST API auth, which is problematic especially on My Dashboard, and rely on login cookie instead](https://bugzilla.mozilla.org/show_bug.cgi?id=1209148)