### PR TITLE
Bug 1496004 - Improve layout of attachment detail page, hide comment form when custom form is inserted

### DIFF
--- a/extensions/FlagTypeComment/web/js/ftc.js
+++ b/extensions/FlagTypeComment/web/js/ftc.js
@@ -26,6 +26,9 @@ Bugzilla.FlagTypeComment = class FlagTypeComment {
     if (this.$flags && this.$comment) {
       this.selects = [...this.$flags.querySelectorAll('.flag_select')];
       this.selects.forEach($select => $select.addEventListener('change', () => this.flag_onselect($select)));
+      this.$fieldset_wrapper = this.$flags.parentElement.appendChild(document.createElement('div'));
+      this.$fieldset_wrapper.id = 'approval-request-fieldset-wrapper';
+      this.$comment_wrapper = document.querySelector('#smallCommentFrame') || this.$comment.parentElement;
       this.$comment.form.addEventListener('submit', () => this.form_onsubmit());
     }
   }
@@ -49,7 +52,7 @@ Bugzilla.FlagTypeComment = class FlagTypeComment {
    * @type {Array<HTMLFieldSetElement>}
    */
   get inserted_fieldsets() {
-    return [...this.$flags.parentElement.querySelectorAll('fieldset.approval-request')];
+    return [...this.$fieldset_wrapper.querySelectorAll('fieldset.approval-request')];
   }
 
   /**
@@ -120,7 +123,7 @@ Bugzilla.FlagTypeComment = class FlagTypeComment {
       $fieldset = this.find_available_fieldset(name);
 
       if ($fieldset) {
-        this.$flags.parentElement.appendChild($fieldset);
+        this.$fieldset_wrapper.appendChild($fieldset);
       }
     }
 
@@ -133,6 +136,9 @@ Bugzilla.FlagTypeComment = class FlagTypeComment {
         this.add_comment(text);
       }
     }
+
+    // Hide the original comment form when one or more `<fieldset>`s are inserted
+    this.$comment_wrapper.hidden = this.inserted_fieldsets.length > 0;
   }
 
   /**

--- a/extensions/FlagTypeComment/web/styles/ftc.css
+++ b/extensions/FlagTypeComment/web/styles/ftc.css
@@ -5,12 +5,28 @@
  * This Source Code Form is "Incompatible With Secondary Licenses", as
  * defined by the Mozilla Public License, v. 2.0. */
 
+#approval-request-fieldset-wrapper {
+  margin: 0 0 0 16px;
+}
+
+#approval-request-fieldset-wrapper:empty {
+  display: none;
+}
+
 fieldset.approval-request {
-  margin: 1em 0;
+  margin: 0 0 8px;
+}
+
+fieldset.approval-request:last-child {
+  margin: 0;
 }
 
 fieldset.approval-request legend {
   font-weight: bold;
+}
+
+fieldset.approval-request table {
+  width: 100%;
 }
 
 fieldset.approval-request th {
@@ -36,11 +52,11 @@ fieldset.approval-request input[type="text"] {
 }
 
 fieldset.approval-request input.long[type="text"] {
-  width: 40em;
+  width: 100%;
 }
 
 fieldset.approval-request textarea {
-  width: 40em;
+  width: 100%;
   min-height: 5em;
   font-size: inherit;
   line-height: inherit;
@@ -55,4 +71,10 @@ fieldset.approval-request div {
 fieldset.approval-request table ~ p:last-child {
   margin: .4em;
   text-align: right;
+}
+
+@media screen and (max-width: 1023px) {
+  #approval-request-fieldset-wrapper {
+    margin: 16px 0 0 0;
+  }
 }

--- a/extensions/Review/template/en/default/hook/flag/list-requestee.html.tmpl
+++ b/extensions/Review/template/en/default/hook/flag/list-requestee.html.tmpl
@@ -8,7 +8,7 @@
 
 [% RETURN UNLESS type.name == 'review' %]
 
-<span id="[% fid FILTER none %]_suggestions" style="display: none">
+<span id="[% fid FILTER none %]_suggestions" class="reviewer-suggestions" style="display: none">
   &nbsp;&nbsp;<a href="#" id="[% fid FILTER none %]_suggestions_link">suggested reviewers &#9662;</a>
 </span>
 

--- a/extensions/Review/web/styles/review.css
+++ b/extensions/Review/web/styles/review.css
@@ -8,3 +8,8 @@
 .mentor {
     font-weight: bold;
 }
+
+.reviewer-suggestions {
+  display: block;
+  margin: 4px 0;
+}

--- a/skins/standard/attachment.css
+++ b/skins/standard/attachment.css
@@ -133,13 +133,20 @@ table.attachment_info td {
     display: block;
 }
 
-#smallCommentFrame {
-    margin-right: 1.5em;
-}
-
-#attachment_comments_and_flags, #attachment_actions {
+#attachment_actions {
     clear: both;
     margin-bottom: 1ex;
+}
+
+#attachment_comments_and_flags {
+    display: flex;
+    overflow: hidden;
+    clear: both;
+    margin: 16px 0;
+}
+
+#attachment_comments_and_flags > * {
+    flex: auto;
 }
 
 #attachment_information_read_only .title {
@@ -187,8 +194,15 @@ table.attachment_info td {
     float: left;
 }
 
-#smallCommentFrame textarea {
+#smallCommentFrame {
+  margin: 0 0 0 16px;
+}
+
+#smallCommentFrame #comment,
+#smallCommentFrame #comment_preview {
     display: block;
+    box-sizing: border-box;
+    width: 100% !important;
 }
 
 textarea.bz_private {
@@ -206,7 +220,11 @@ div#update_container {
 }
 
 #attachment_flags {
-    margin-bottom: 1em;
+    display: flex;
+}
+
+#attachment_flags > * {
+    flex: auto;
 }
 
 #attachment_flags p {
@@ -473,4 +491,15 @@ div#update_container {
 
 #att-error-message:empty {
   margin: 0;
+}
+
+@media screen and (max-width: 1023px) {
+  #attachment_comments_and_flags,
+  #attachment_flags {
+    display: block;
+  }
+
+  #smallCommentFrame {
+    margin: 16px 0 0 0;
+  }
 }

--- a/template/en/default/attachment/edit.html.tmpl
+++ b/template/en/default/attachment/edit.html.tmpl
@@ -260,6 +260,11 @@
         [% END %]
       </div>
       <div id="attachment_comments_and_flags">
+        <div id="attachment_flags">
+          [% IF attachment.flag_types.size > 0 %]
+            [% PROCESS "flag/list.html.tmpl" flag_types = attachment.flag_types, read_only_flags = !can_edit %]
+          [% END %]
+        </div>
         [% IF user.id %]
           <div id="smallCommentFrame">
             <label for="comment">Comment (on the [% terms.bug %]):</label>
@@ -274,25 +279,17 @@
             [% Hook.process('after_comment_textarea') %]
           </div>
         [% END %]
-        <div id="attachment_flags">
-          [% IF attachment.flag_types.size > 0 %]
-              [% PROCESS "flag/list.html.tmpl" flag_types = attachment.flag_types
-                                               read_only_flags = !can_edit
-              %]
-
-          [% END %]
-        </div>
-
-        [% Hook.process('form_before_submit') %]
-
-        [% IF user.id %]
-          <div id="update_container">
-            <input type="submit" value="Submit" id="update">
-          </div>
-        [% END %]
       </div>
     </div>
   </div>
+
+  [% Hook.process('form_before_submit') %]
+
+  [% IF user.id %]
+    <div id="update_container">
+      <input type="submit" value="Submit" id="update">
+    </div>
+  [% END %]
 </form>
 
 <div id="attachment_actions">


### PR DESCRIPTION
## Description

* Hide the original comment form when the custom flag request form is inserted
* Improved the page layout to prevent the flags and form from going below the fold

## Bug

[Bug 1496004 - Improve layout of attachment detail page, hide comment form when custom form is inserted](https://bugzilla.mozilla.org/show_bug.cgi?id=1496004)

## Screenshots

* [Default](https://screenshots.firefox.com/L98zPjdU6WP2Iy8T/bmo-web.vm)
* [Form inserted](https://screenshots.firefox.com/0c625eM6JudauKdS/bmo-web.vm)