### PR TITLE
Bug 1495746 - /app/static/metricsgraphics/css/google-OpenSans.css missing in app container

### DIFF
--- a/public/metricsgraphics/socorro-lens.html
+++ b/public/metricsgraphics/socorro-lens.html
@@ -1,7 +1,7 @@
 <html lang="en">
   <head>
     <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
-    <link href='css/google-OpenSans.css' rel='stylesheet' type='text/css'>
+    <link href='css/google-OpenSans.min.css' rel='stylesheet' type='text/css'>
     <link href='css/google-PTSerif.min.css' rel='stylesheet' type='text/css'>
     <link href='css/font-awesome.min.css' rel='stylesheet' type='text/css'>
     <link href='css/bootstrap.min.css' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
## Description

Fix a wrong CSS path in metricsgraphics.

## Bug

[Bug 1495746 - /app/static/metricsgraphics/css/google-OpenSans.css missing in app container](https://bugzilla.mozilla.org/show_bug.cgi?id=1495746)