### PR TITLE
Bug 1489120 - Add a rest API to get triage owners for each product/component pair

### DIFF
--- a/Bugzilla/WebService/Product.pm
+++ b/Bugzilla/WebService/Product.pm
@@ -215,6 +215,8 @@ sub _component_to_hash {
             $self->type('email', $component->default_assignee->login),
         default_qa_contact =>
             $self->type('email', $component->default_qa_contact->login),
+        triage_owner =>
+            $self->type('email', $component->triage_owner->login),
         sort_key =>  # sort_key is returned to match Bug.fields
             0,
         is_active =>
@@ -547,6 +549,11 @@ default.
 
 C<string> The login name of the user who will be set as the QA Contact for
 new bugs by default.
+
+=item C<triage_owner>
+
+C<string> The login name of the user who is named as the Triage Owner of the
+component.
 
 =item C<sort_key>
 

--- a/docs/en/rst/api/core/v1/product.rst
+++ b/docs/en/rst/api/core/v1/product.rst
@@ -142,6 +142,7 @@ type        string  The group of products to return. Valid values are
                ]
              },
              "default_qa_contact": "",
+             "triage_owner": "",
              "description": "This is a test component."
            }
          ],
@@ -215,6 +216,9 @@ default_assigned_to  string   The login name of the user to whom new bugs
 default_qa_contact   string   The login name of the user who will be set as
                               the QA Contact for new bugs by default. Empty
                               string if the QA contact is not defined.
+triage_owner         string   The login name of the user who is named as the
+                              Triage Owner of the component. Empty string if the
+                              Triage Owner is not defined.
 sort_key             int      Components, when displayed in a list, are sorted
                               first by this integer and then secondly by their
                               name.


### PR DESCRIPTION
## Description

Add the `triage_owner` field to each component returned by `/rest/product` API.

## Bug

[Bug 1489120 - Add a rest API to get triage owners for each product/component pair](https://bugzilla.mozilla.org/show_bug.cgi?id=1489120)