### PR TITLE
bump version to 20181004.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20181002.1';
+our $VERSION = '20181004.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
the following changes will be pushed to bugzilla.mozilla.org:
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1495349" target="_blank">1495349</a>] Remove Persona extension</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1263502" target="_blank">1263502</a>] Add duplicates to /rest/bug/id</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1495906" target="_blank">1495906</a>] After mojo update /latest/configuration API call no longer works and gives page not found</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1496233" target="_blank">1496233</a>] "Dunno" -&gt; "Don't know" in approval request form</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1489120" target="_blank">1489120</a>] Add a rest API to get triage owners for each product/component pair</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1495901" target="_blank">1495901</a>] SES type checking error</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1495746" target="_blank">1495746</a>] /app/static/metricsgraphics/css/google-OpenSans.css missing in app container</li>
</ul>