### PR TITLE
Bug 1496207 - Allow to request uplift of multiple patches at once by adding checkboxes for other patches

### DIFF
--- a/extensions/BMO/template/en/default/hook/flag/type_comment-form.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/flag/type_comment-form.html.tmpl
@@ -6,6 +6,8 @@
   # defined by the Mozilla Public License, v. 2.0.
   #%]
 
+<meta name="extra-patch-types" content="text/x-phabricator-request">
+
 <template class="approval-request" data-flags="approval‑mozilla‑beta approval‑mozilla‑release">
   <section>
     <header>

--- a/extensions/FlagTypeComment/web/js/ftc.js
+++ b/extensions/FlagTypeComment/web/js/ftc.js
@@ -27,7 +27,7 @@ Bugzilla.FlagTypeComment = class FlagTypeComment {
       const $extra_patch_types = document.querySelector('meta[name="extra-patch-types"]');
 
       this.$form = this.$comment.form;
-      this.bug_id = Number((this.$form.bugid || {}).value || this.$form.querySelector('meta[name="bug_id"]').content);
+      this.bug_id = Number(this.$form.bugid.value);
       this.attachment_id = Number(this.$form.id.value);
       this.extra_patch_types = $extra_patch_types ? $extra_patch_types.content.split(' ') : [];
       this.selects = [...this.$flags.querySelectorAll('.flag_select')];
@@ -236,10 +236,9 @@ Bugzilla.FlagTypeComment = class FlagTypeComment {
   /**
    * Convert the input values into comment text and remove the temporary fieldset before submitting the form.
    * @param {Event} event `submit` event.
-   * @returns {Boolean} Always `false` to prevent the form from being auto-submitted.
+   * @returns {Boolean} `true` when submitting the form normally if no fieldset has been inserted, `false` otherwise.
    */
   async form_onsubmit(event) {
-    // Submit the form normally if no fieldset has been inserted
     if (!this.inserted_fieldsets.length) {
       return true;
     }
@@ -257,7 +256,7 @@ Bugzilla.FlagTypeComment = class FlagTypeComment {
     // Convert the form values to Markdown comment
     this.inserted_fieldsets.forEach($fieldset => this.add_comment(this.create_comment($fieldset)));
 
-    // Send the form via XHR before API requests to make sure the change is notified via email
+    // Submit the form via XHR before API requests to make sure the change is notified via email
     await new Promise(resolve => {
       const request = new XMLHttpRequest();
 

--- a/template/en/default/attachment/edit.html.tmpl
+++ b/template/en/default/attachment/edit.html.tmpl
@@ -50,7 +50,7 @@
 [% editable_or_hide = can_edit ? "" : " bz_hidden_option" %]
 
 <form method="post" action="[% basepath FILTER none %]attachment.cgi" onsubmit="normalizeComments();">
-  <meta name="bug_id" content="[% attachment.bug_id %]">
+  <input type="hidden" name="bugid" value="[% attachment.bug_id %]">
   <input type="hidden" name="id" value="[% attachment.id %]">
   <input type="hidden" name="action" value="update">
   <input type="hidden" name="contenttypemethod" value="manual">

--- a/template/en/default/attachment/edit.html.tmpl
+++ b/template/en/default/attachment/edit.html.tmpl
@@ -50,6 +50,7 @@
 [% editable_or_hide = can_edit ? "" : " bz_hidden_option" %]
 
 <form method="post" action="[% basepath FILTER none %]attachment.cgi" onsubmit="normalizeComments();">
+  <meta name="bug_id" content="[% attachment.bug_id %]">
   <input type="hidden" name="id" value="[% attachment.id %]">
   <input type="hidden" name="action" value="update">
   <input type="hidden" name="contenttypemethod" value="manual">


### PR DESCRIPTION
Allow to make an uplift request of multiple patches. This is done by sending API requests.

## Bugzilla link

[Bug 1496207 - Allow to request uplift of multiple patches at once by adding checkboxes for other patches](https://bugzilla.mozilla.org/show_bug.cgi?id=1496207)