### PR TITLE
Bug 1482644 - Improve "Too many requests" page with an explaination

### DIFF
--- a/Bugzilla/Quantum/Plugin/BlockIP.pm
+++ b/Bugzilla/Quantum/Plugin/BlockIP.pm
@@ -35,7 +35,7 @@ sub _before_routes {
     $c->block_ip($ip);
     $c->res->code(429);
     $c->res->message('Too Many Requests');
-    $c->render(handler => 'bugzilla', template => 'global/ip-blocked');
+    $c->render(handler => 'bugzilla', template => 'global/ip-blocked', block_timeout => BLOCK_TIMEOUT);
   }
 }
 

--- a/Bugzilla/Quantum/Plugin/BlockIP.pm
+++ b/Bugzilla/Quantum/Plugin/BlockIP.pm
@@ -35,8 +35,7 @@ sub _before_routes {
     $c->block_ip($ip);
     $c->res->code(429);
     $c->res->message('Too Many Requests');
-    $c->res->body('Too Many Requests');
-    $c->finish;
+    $c->render(handler => 'bugzilla', template => 'global/ip-blocked');
   }
 }
 

--- a/template/en/default/global/ip-blocked.html.tmpl
+++ b/template/en/default/global/ip-blocked.html.tmpl
@@ -1,0 +1,15 @@
+[% PROCESS global/variables.none.tmpl %]
+
+[% title = "Too Many Requests" %]
+
+[% PROCESS global/header.html.tmpl
+           robots = 'noindex' %]
+
+<h1>[% title FILTER html %]</h1>
+
+<p>
+    We’re sorry, but you have sent too many requests to us recently.
+    You will be unblocked in 60 minutes.
+</p>
+
+[% PROCESS global/footer.html.tmpl %]

--- a/template/en/default/global/ip-blocked.html.tmpl
+++ b/template/en/default/global/ip-blocked.html.tmpl
@@ -9,7 +9,7 @@
 
 <p>
     We’re sorry, but you have sent too many requests to us recently.
-    You will be unblocked in 60 minutes.
+    You will be unblocked in [% block_timeout / 60 FILTER none %] minutes.
 </p>
 
 [% PROCESS global/footer.html.tmpl %]


### PR DESCRIPTION
This is just a proposal, I think we'd need higher approval to use recaptcha.

Also I'd check for the do-not-track header and not load recaptcha if found.