### PR TITLE
Bug 1497070 - In-page links are broken due to <base href> added during Mojo migration

### DIFF
--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -98,7 +98,6 @@
       <meta charset="UTF-8">
     [% END %]
     [% USE Bugzilla %]
-    <base href="[% urlbase FILTER html %]">
 
     [% IF Bugzilla.cgi.should_block_referrer %]
       <meta name="referrer" content="origin">


### PR DESCRIPTION
## Description

Remove `<base href>` introduced during the Mojo migration (#517). It was originally added in #603 but backed out in #626.

## Bug

[Bug 1497070 - In-page links are broken due to <base href> added during Mojo migration](https://bugzilla.mozilla.org/show_bug.cgi?id=1497070)