### PR TITLE
Bug 1497234 - Remove Personas Plus GitHub link from Custom Bug Entry Forms index

### DIFF
--- a/extensions/BMO/template/en/default/bug/create/custom_forms.none.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/custom_forms.none.tmpl
@@ -168,12 +168,6 @@ custom_forms = {
        title => "Intern Requests",
     },
   ]
-  "Mozilla Labs" => [
-    {
-      link  => "https://github.com/mozilla/personas-plus/issues",
-      title => "Report issue with Personas Plus on Github"
-    }
-  ],
   "Legal" => [
     {
       title => 'Mozilla Foundation Vendor Request',


### PR DESCRIPTION
## Description

Personas Plus has retired, and the GitHub issue link under the Mozilla Labs product should be removed.

## Bug

[Bug 1497234 - Remove Personas Plus GitHub link from Custom Bug Entry Forms index](https://bugzilla.mozilla.org/show_bug.cgi?id=1497234)