### PR TITLE
Bug 1497437 - The crash graph should display Exact Match results by default

### DIFF
--- a/public/metricsgraphics/socorro-lens.html
+++ b/public/metricsgraphics/socorro-lens.html
@@ -31,8 +31,8 @@
         <option value='esr' title='Show crashes on ESR only'>esr</option>
       </select>
       <select name='match' id='match' title='Select whether to match signatures exactly or similarly'>
-        <option value='exact' title='Match signatures exactly'>Exact Match</option>
-        <option value='like' title='Match signatures similarly' selected=selected>Like Match</option>
+        <option value='exact' title='Match signatures exactly' selected>Exact Match</option>
+        <option value='like' title='Match signatures similarly'>Like Match</option>
       </select>
     </div>
     <div style="width:300px; height:75px; color:red; text-align:center; visibility:hidden;" id='warn'></div>
@@ -174,7 +174,7 @@
         });
       }
 
-      function loadGraph(search, match) {
+      function loadGraph(search, match = 'exact') {
         // Get all signatures from the Bugzilla page
         var signatures = getSignaturesFromURL(search, match);
         // Initialize chart data


### PR DESCRIPTION
## Description

Change the graph’s default matching condition from Like Match (“signature contains X”) to Exact Match (“signature is X”) to avoid confusion.

## Bug

[Bug 1497437 - The crash graph should display Exact Match results by default](https://bugzilla.mozilla.org/show_bug.cgi?id=1497437)