### PR TITLE
bump version to 20181010.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2
 
 defaults:
   bmo_slim_image: &bmo_slim_image
-    image: mozillabteam/bmo-slim:20180918.1
+    image: mozillabteam/bmo-slim:20181008.1
     user: app
 
   mysql_image: &mysql_image

--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20181005.1';
+our $VERSION = '20181010.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mozillabteam/bmo-slim:20180918.1
+FROM mozillabteam/bmo-slim:20181008.1
 
 ARG CI
 ARG CIRCLE_SHA1


### PR DESCRIPTION
the following changes will be pushed to bugzilla.mozilla.org:
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1496803" target="_blank">1496803</a>] Suggested component links ignore cloned bug data</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1497234" target="_blank">1497234</a>] Remove Personas Plus GitHub link from Custom Bug Entry Forms index</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1497070" target="_blank">1497070</a>] In-page links are broken due to &lt;base href&gt; added during Mojo migration</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1497437" target="_blank">1497437</a>] The crash graph should display Exact Match results by default</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=623384" target="_blank">623384</a>] Use Module::Runtime instead of eval { require } or eval "use"</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1496832" target="_blank">1496832</a>] Add monitoring and preventative measures for feed daemon becoming unresponsive</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1497343" target="_blank">1497343</a>] Add some rudimentary type checking to  Bugzilla::WebServe::Util::validate()</li>
</ul>
