### PR TITLE
test - Generate API token by default

### DIFF
--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -53,7 +53,7 @@
   no_yui = 0
   jquery = []
   jquery_css = []
-  generate_api_token = 0
+  generate_api_token = 1
   robots = 'index'
 %]
 


### PR DESCRIPTION
I’m wondering if this causes test failures.