### PR TITLE
improve error reporting from Bugzilla::DB

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -676,6 +676,7 @@ sub clear_request_cache {
     my (undef, %option) = @_;
     my $request_cache = request_cache();
     my @except        = $option{except} ? @{ $option{except} } : ();
+
     %{ $request_cache } = map { $_ => $request_cache->{$_} } @except;
 }
 

--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -676,7 +676,6 @@ sub clear_request_cache {
     my (undef, %option) = @_;
     my $request_cache = request_cache();
     my @except        = $option{except} ? @{ $option{except} } : ();
-
     %{ $request_cache } = map { $_ => $request_cache->{$_} } @except;
 }
 


### PR DESCRIPTION
When working on the issue in #833, I noted the error reporting had gotten worse with the introduction of DBIx::Connector This patch improves error reporting from the delegated methods,
and also improves the exception thrown by the "connected in the middle of a transaction" problem (without fixing the problem in #833). I hope this makes it easier to determine the correctness of the other patch.