### PR TITLE
Bug 1499417 - Change BMO docs links from bmo.readthedocs.org to .io

### DIFF
--- a/conf/checksetup_answers.txt
+++ b/conf/checksetup_answers.txt
@@ -25,4 +25,4 @@ $answer{'insidergroup'}         = 'admin';
 $answer{'defaultpriority'}      = '--';
 $answer{'defaultseverity'}      = 'normal';
 $answer{'skin'}                 = 'Mozilla';
-$answer{'docs_urlbase'}         = 'https://bmo.readthedocs.org/en/latest/';
+$answer{'docs_urlbase'}         = 'https://bmo.readthedocs.io/en/latest/';

--- a/contribute.json
+++ b/contribute.json
@@ -18,7 +18,7 @@
     ],
     "participate": {
         "home": "https://wiki.mozilla.org/BMO",
-        "docs": "https://bmo.readthedocs.org",
+        "docs": "https://bmo.readthedocs.io",
         "irc": "irc://irc.mozilla.org/#bmo",
         "irc-contacts": [
             "dkl",

--- a/extensions/ContributorEngagement/template/en/default/contributor/email.txt.tmpl
+++ b/extensions/ContributorEngagement/template/en/default/contributor/email.txt.tmpl
@@ -34,7 +34,7 @@ https://wiki.mozilla.org/Try#Getting_access_to_the_Try_Server
 
 And you can learn more about how Mozilla uses Mercurial here:
 
-http://mozilla-version-control-tools.readthedocs.org/en/latest/hgmozilla/index.html
+http://mozilla-version-control-tools.readthedocs.io/en/latest/hgmozilla/index.html
 
 While that's underway, we'd be happy to work with you on something
 new; you can take a look at our list of Good First [% terms.bugs %],

--- a/template/en/default/account/prefs/apikey.html.tmpl
+++ b/template/en/default/account/prefs/apikey.html.tmpl
@@ -17,7 +17,7 @@
   you record what each key is used for.<br>
   <br>
   Documentation on how to log in is available
-  <a href="https://bmo.readthedocs.org/en/latest/api/core/v1/general.html#authentication">
+  <a href="https://bmo.readthedocs.io/en/latest/api/core/v1/general.html#authentication">
     here</a>.
 </p>
 

--- a/vagrant_support/checksetup_answers.j2
+++ b/vagrant_support/checksetup_answers.j2
@@ -36,6 +36,6 @@ $answer{'insidergroup'}         = 'admin';
 $answer{'defaultpriority'}      = '--';
 $answer{'defaultseverity'}      = 'normal';
 $answer{'skin'}                 = 'Mozilla';
-$answer{'docs_urlbase'}         = 'https://bmo.readthedocs.org/en/latest/';
+$answer{'docs_urlbase'}         = 'https://bmo.readthedocs.io/en/latest/';
 $answer{'ses_username'}         = 'ses';
 $answer{'ses_password'}         = 'secret';


### PR DESCRIPTION
Change the Read the Docs domain from .org to .io to avoid a redirect.

## Bug

[Bug 1499417 - Change BMO docs links from bmo.readthedocs.org to .io](https://bugzilla.mozilla.org/show_bug.cgi?id=1499417) 