### PR TITLE
no bug - silence mojo warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,10 @@ RUN mv /opt/bmo/local /app && \
     chown -R app:app /app && \
     perl -I/app -I/app/local/lib/perl5 -c -E 'use Bugzilla; BEGIN { Bugzilla->extensions }' && \
     perl -c /app/scripts/entrypoint.pl && \
-    setcap 'cap_net_bind_service=+ep' /usr/bin/perl
+    setcap 'cap_net_bind_service=+ep' /usr/bin/perl && \
+    for file in patches/*.patch; do \
+        patch -p0 < $file; \
+    done
 
 USER app
 

--- a/patches/Mojo-IOLoop-Stream.pm.patch
+++ b/patches/Mojo-IOLoop-Stream.pm.patch
@@ -1,0 +1,9 @@
+--- local/lib/perl5/Mojo/IOLoop/Stream.pm	2018-09-09 17:42:26.000000000 +0000
++++ local/lib/perl5/Mojo/IOLoop/Stream.pm.new	2018-10-16 19:21:18.278654000 +0000
+@@ -34,6 +34,7 @@
+ sub is_writing {
+   my $self = shift;
+   return undef unless $self->{handle};
++  no warnings 'uninitialized';
+   return !!length($self->{buffer}) || $self->has_subscribers('drain');
+ }

--- a/patches/Mojo-IOLoop-Stream.pm.patch
+++ b/patches/Mojo-IOLoop-Stream.pm.patch
@@ -1,5 +1,5 @@
---- local/lib/perl5/Mojo/IOLoop/Stream.pm	2018-09-09 17:42:26.000000000 +0000
-+++ local/lib/perl5/Mojo/IOLoop/Stream.pm.new	2018-10-16 19:21:18.278654000 +0000
+--- /app/local/lib/perl5/Mojo/IOLoop/Stream.pm	2018-09-09 17:42:26.000000000 +0000
++++ /app/local/lib/perl5/Mojo/IOLoop/Stream.pm.new	2018-10-16 20:10:06.620747000 +0000
 @@ -34,6 +34,7 @@
  sub is_writing {
    my $self = shift;
@@ -7,3 +7,12 @@
 +  no warnings 'uninitialized';
    return !!length($self->{buffer}) || $self->has_subscribers('drain');
  }
+
+@@ -112,6 +113,7 @@
+
+ sub _write {
+   my $self = shift;
++  no warnings 'uninitialized';
+
+   # Handle errors only when reading (to avoid timing problems)
+   my $handle = $self->{handle};


### PR DESCRIPTION
In perl 5.12, length(undef) was made no longer a warning.
In order to reduce memory usage, mojo undefines the outgoing buffer.
This means on perl <= 5.12, a warning is printed frequently (multiple times
per request).

Mojo support for 5.10 is waning, so for the moment we patch that code to silence
this warning.