### PR TITLE
bump version to 20181017.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20181010.1';
+our $VERSION = '20181017.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
the following changes will be pushed to bugzilla.mozilla.org:
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1354589" target="_blank">1354589</a>] Implement OAuth2 on BMO</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1498206" target="_blank">1498206</a>] Replace LWP::UserAgent with Mojo::UserAgent in phabbugz extension</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1498436" target="_blank">1498436</a>] Move site-wide message to global header</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1498362" target="_blank">1498362</a>] Shutter the "Powered By Mozilla" form</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1009716" target="_blank">1009716</a>] Add (Cmd|Ctrl)+Enter shortcut for submitting from text areas.</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1499262" target="_blank">1499262</a>] Bugzilla::DB should gracefully handle disconnection events that happen during transactions</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1497077" target="_blank">1497077</a>] Convert links to absolute path</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1499417" target="_blank">1499417</a>] Change BMO docs links from bmo.readthedocs.org to .io</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1499269" target="_blank">1499269</a>] Refactor common parts of the feed daemon and improve timeout logging</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1496004" target="_blank">1496004</a>] Improve layout of attachment detail page, hide comment form when custom form is inserted</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1495741" target="_blank">1495741</a>] memory issues</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1482644" target="_blank">1482644</a>] Improve "Too many requests" page with an explaination</li>
</ul>

