### PR TITLE
Bug 1501133 - Attachment flags layout on new bug page is broken

### DIFF
--- a/skins/standard/attachment.css
+++ b/skins/standard/attachment.css
@@ -145,7 +145,12 @@ table.attachment_info td {
     margin: 16px 0;
 }
 
-#attachment_comments_and_flags > * {
+#attachment_comments_and_flags #attachment_flags {
+    display: flex;
+}
+
+#attachment_comments_and_flags > *,
+#attachment_comments_and_flags #attachment_flags > * {
     flex: auto;
 }
 
@@ -217,14 +222,6 @@ textarea.bz_private {
 div#update_container {
     clear: both;
     padding: 1.5em 0;
-}
-
-#attachment_flags {
-    display: flex;
-}
-
-#attachment_flags > * {
-    flex: auto;
 }
 
 #attachment_flags p {
@@ -495,7 +492,7 @@ div#update_container {
 
 @media screen and (max-width: 1023px) {
   #attachment_comments_and_flags,
-  #attachment_flags {
+  #attachment_comments_and_flags #attachment_flags {
     display: block;
   }
 


### PR DESCRIPTION
Fix the [broken attachment flags layout](https://twitter.com/brianskold/status/1054536937741017088) regressed in #788. The CSS flexbox should be applied only to the attachment edit/details page.

## Bug

[Bug 1501133 - Attachment flags layout on new bug page is broken](https://bugzilla.mozilla.org/show_bug.cgi?id=1501133)