### PR TITLE
block account creartion by mx record in addition to domain name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2
 
 defaults:
   bmo_slim_image: &bmo_slim_image
-    image: mozillabteam/bmo-slim:20181011.1
+    image: mozillabteam/bmo-slim:20181024.1
     user: app
 
   mysql_image: &mysql_image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mozillabteam/bmo-slim:20181011.1
+FROM mozillabteam/bmo-slim:20181024.1
 
 ARG CI
 ARG CIRCLE_SHA1

--- a/extensions/AntiSpam/Config.pm
+++ b/extensions/AntiSpam/Config.pm
@@ -18,6 +18,11 @@ use constant REQUIRED_MODULES => [
         module  => 'Email::Address',
         version => 0,
     },
+    {
+        package => 'Net-DNS',
+        module  => 'Net::DNS',
+        version => 0,
+    }
 ];
 use constant OPTIONAL_MODULES => [];
 


### PR DESCRIPTION
This needs a bit of testing.

The AntiSpam stuff is on the admin.cgi paged (linked there).
Add one of the things returned by 'dig -t mx gmail.com' and then see if account creation is restricted for example mozilla.com. This should all work in the container.

(Until the new deps are built, it will fail because Net::DNS doesn't exist. But by tomorrow running bmo-refresh-bundle should correct that)