### PR TITLE
Bug 1501849 - Speed up IP blocked page: pre-render template

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,9 @@ defaults:
       command: |
         [[ -f build_info/only_version_changed.txt ]] && exit 0
         mv /opt/bmo/local /app/local
+        for file in patches/*.patch; do
+            patch -p0 < $file
+        done
         perl -MSys::Hostname -i -pE 's/bmo.test/hostname() . ":$ENV{PORT}"/ges' $BZ_QA_CONF_FILE
         perl checksetup.pl --no-database --default-localconfig
         mkdir artifacts

--- a/Bugzilla/Quantum.pm
+++ b/Bugzilla/Quantum.pm
@@ -37,13 +37,13 @@ sub startup {
   my ($self) = @_;
 
   DEBUG('Starting up');
+  $self->plugin('Bugzilla::Quantum::Plugin::BlockIP');
   $self->plugin('Bugzilla::Quantum::Plugin::Glue');
   $self->plugin('Bugzilla::Quantum::Plugin::Hostage')
     unless $ENV{BUGZILLA_DISABLE_HOSTAGE};
   $self->plugin('Bugzilla::Quantum::Plugin::SizeLimit')
     unless $ENV{BUGZILLA_DISABLE_SIZELIMIT};
   $self->plugin('ForwardedFor') if Bugzilla->has_feature('better_xff');
-  $self->plugin('Bugzilla::Quantum::Plugin::BlockIP');
   $self->plugin('Bugzilla::Quantum::Plugin::Helpers');
 
   # hypnotoad is weird and doesn't look for MOJO_LISTEN itself.

--- a/Bugzilla/Quantum/CGI.pm
+++ b/Bugzilla/Quantum/CGI.pm
@@ -27,6 +27,9 @@ my %SEEN;
 sub load_all {
   my ($class, $r) = @_;
 
+  Bugzilla->cleanup;
+  CGI::initialize_globals();
+
   foreach my $file (glob '*.cgi') {
     my $name = _file_to_method($file);
     $class->load_one($name, $file);

--- a/Bugzilla/Quantum/CGI.pm
+++ b/Bugzilla/Quantum/CGI.pm
@@ -27,9 +27,6 @@ my %SEEN;
 sub load_all {
   my ($class, $r) = @_;
 
-  Bugzilla->cleanup;
-  CGI::initialize_globals();
-
   foreach my $file (glob '*.cgi') {
     my $name = _file_to_method($file);
     $class->load_one($name, $file);
@@ -64,6 +61,7 @@ sub load_one {
     $c->stash->{cleanup_guard}->dismiss;
     Bugzilla->usage_mode(USAGE_MODE_BROWSER);
     try {
+      CGI::initialize_globals();
       Bugzilla->init_page();
       $inner->();
     }
@@ -75,7 +73,6 @@ sub load_one {
       untie *STDOUT;
       $c->finish if !$error || _is_exit($error);
       Bugzilla->cleanup;
-      CGI::initialize_globals();
     };
   };
 

--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -49,7 +49,7 @@ use constant FORMAT_3_SIZE => [19,28,28];
 use constant FORMAT_DOUBLE => '%19s %-55s';
 use constant FORMAT_2_SIZE => [19,55];
 
-my %SHARED_PROVIDERS;
+our %SHARED_PROVIDERS;
 
 # Pseudo-constant.
 sub SAFE_URL_REGEXP {


### PR DESCRIPTION
By moving BlockIP plugin first, it is ensured to execute first.
This is a slight speed gain. The primary speed gain is by caching
the content of the template.

Before: 429 Too Many Requests (0.031951s, 31.298/s)
After:  429 Too Many Requests (0.000182s, 5494.505/s)