### PR TITLE
Bug 1479535 - BUGZILLA.bug_url is wrong on bug page after POSTed, Copy Summary doesn’t work as expected

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
@@ -92,7 +92,7 @@
   BUGZILLA.bug_id = [% bug.id FILTER none %];
   BUGZILLA.bug_title = '[% unfiltered_title FILTER js %]';
   BUGZILLA.bug_summary = '[% bug.short_desc FILTER js %]';
-  BUGZILLA.bug_url = '[% Bugzilla.cgi.self_url FILTER js %]';
+  BUGZILLA.bug_url = '[% Bugzilla.localconfig.canonical_urlbase _ "show_bug.cgi?id=" _ bug.id FILTER js %]';
   BUGZILLA.user = {
     id: [% user.id FILTER none %],
     login: '[% user.login FILTER js %]',

--- a/extensions/OpenGraph/template/en/default/hook/global/header-start.html.tmpl
+++ b/extensions/OpenGraph/template/en/default/hook/global/header-start.html.tmpl
@@ -9,8 +9,8 @@
 [% USE Bugzilla %]
 <meta property="og:type" content="website">
 <meta property="og:title" content="[% title FILTER none %]">
-<meta property="og:url" content="[% Bugzilla.cgi.self_url FILTER html %]">
 [% IF bug %]
+<meta property="og:url" content="[% Bugzilla.localconfig.canonical_urlbase FILTER none %]show_bug.cgi?id=[% bug.bug_id FILTER uri %]">
 <meta property="og:description"
       content="[% bug.bug_status FILTER html %] ([% bug.assigned_to.login FILTER email FILTER html %]) in [% bug.product FILTER html %] - [% bug.component FILTER html %]. Last updated [% bug.delta_ts FILTER time('%Y-%m-%d') %].">
 [% ELSIF error_message %]


### PR DESCRIPTION
#681 wasn’t the right solution for the issue, so let’s do this.

* Avoid using `Bugzilla.cgi.self_url` because it will be `post_bug.cgi` after POSTed.
* Embed the correct `<meta property="og:url">` only on bug pages, just like `<link rel="canonical">`, because the page’s canonical URL cannot be determined in some cases, e.g. search results.
* Use the same, correct URL for `BUGZILLA.bug_url` in JavaScript.

## Bug

[Bug 1479535 - BUGZILLA.bug_url is wrong on bug page after POSTed, Copy Summary doesn’t work as expected](https://bugzilla.mozilla.org/show_bug.cgi?id=1479535)