### PR TITLE
Bug 1503162 - Approval request form is incomplete in some cases

### DIFF
--- a/extensions/FlagTypeComment/template/en/default/flag/type_comment.html.tmpl
+++ b/extensions/FlagTypeComment/template/en/default/flag/type_comment.html.tmpl
@@ -20,8 +20,8 @@
   #   byron jones <glob@mozilla.com>
   #%]
 
-<link rel="stylesheet" href="[% basepath FILTER none %]extensions/FlagTypeComment/web/styles/ftc.css">
-<script [% script_nonce FILTER none %] src="[% basepath FILTER none %]extensions/FlagTypeComment/web/js/ftc.js"></script>
+<link rel="stylesheet" href="[% 'extensions/FlagTypeComment/web/styles/ftc.css' FILTER version %]">
+<script [% script_nonce FILTER none %] src="[% 'extensions/FlagTypeComment/web/js/ftc.js' FILTER version %]"></script>
 
 [% IF ftc_flags.keys.size %]
   [%# plaintext templates from database %]


### PR DESCRIPTION
Add the missing `version` filter to the FlagTypeComment extension assets to prevent old CSS/JavaScript files from being served to users. Note that `basepath` will be prepended in the filter so it’s not necessary in these paths.

## Bug

[Bug 1503162 - Approval request form is incomplete in some cases](https://bugzilla.mozilla.org/show_bug.cgi?id=1503162)