### PR TITLE
Bug 1503182 - Fix data type of native bug count API return value

### DIFF
--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -632,7 +632,7 @@ sub search {
             return $data;
         }
         else {
-            return { bug_count => $data };
+            return { bug_count => $self->type('int', $data) };
         }
     }
 

--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -632,7 +632,7 @@ sub search {
             return $data;
         }
         else {
-            return { bug_count => $self->type('int', $data) };
+            return { bug_count => $self->type('int', scalar @$data) };
         }
     }
 


### PR DESCRIPTION
* Fix the data type of the [native bug count API](https://bugzilla.mozilla.org/rest/bug?keywords=intermittent-failure&chfieldfrom=-1y&count_only=true) return value. It has to be an integer, not a string. 
* The change is only for REST and JSON-RPC. I’m not familiar with XML-RPC and it’s going away anyway, so I’ll keep it as-is.

## Bug

[Bug 1503182 - Fix data type of native bug count API return value](https://bugzilla.mozilla.org/show_bug.cgi?id=1503182)