### PR TITLE
Bug 1436619 - http:// in URL field

### DIFF
--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -1678,12 +1678,8 @@ sub _check_assigned_to {
 sub _check_bug_file_loc {
     my ($invocant, $url) = @_;
     $url = '' if !defined($url);
-    # On bug entry, if bug_file_loc is "http://", the default, use an
-    # empty value instead. However, on bug editing people can set that
-    # back if they *really* want to.
-    if (!ref $invocant && $url eq 'http://') {
-        $url = '';
-    }
+    # TODO: Add validation. It has to be loose, since we have accepted `data:`,
+    # `javascript:` and any other values on the URL field.
     return $url;
 }
 

--- a/enter_bug.cgi
+++ b/enter_bug.cgi
@@ -306,7 +306,7 @@ else {
 
     $vars->{'alias'}          = formvalue('alias');
     $vars->{'short_desc'}     = formvalue('short_desc');
-    $vars->{'bug_file_loc'}   = formvalue('bug_file_loc', "http://");
+    $vars->{'bug_file_loc'}   = formvalue('bug_file_loc');
     $vars->{'keywords'}       = formvalue('keywords');
     $vars->{'dependson'}      = formvalue('dependson');
     $vars->{'blocked'}        = formvalue('blocked');

--- a/extensions/BMO/template/en/default/bug/create/create-client-bounty.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-client-bounty.html.tmpl
@@ -165,7 +165,7 @@ function validateAndSubmit() {
     The full URL (hostname/subpage) where the issue exists (if the URL is especially long
     please just include it in the comments)
   </div>
-  <input type="text" name="bug_file_loc" id="bug_file_loc" size="80">
+  <input type="text" name="bug_file_loc" id="bug_file_loc" size="80" placeholder="https://">
 </div>
 
 <div class="form_section">

--- a/extensions/BMO/template/en/default/bug/create/create-doc.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-doc.html.tmpl
@@ -139,7 +139,7 @@ function validateAndSubmit() {
   <th>Page to Update</th>
   <td>
     <input type="text" name="bug_file_loc" id="short_desc" size="60"
-           value="[% bug_file_loc FILTER html %]">
+           value="[% bug_file_loc FILTER html %]" placeholder="https://">
   </td>
 </tr>
 

--- a/extensions/BMO/template/en/default/bug/create/create-itrequest.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-itrequest.html.tmpl
@@ -177,7 +177,7 @@
         <td align="right"><strong>URL&nbsp;(optional):</strong></td>
         <td colspan="3">
           <input name="bug_file_loc" size="60"
-                value="[% bug_file_loc FILTER html %]">
+                value="[% bug_file_loc FILTER html %]" placeholder="https://">
         </td>
       </tr>
 

--- a/extensions/BMO/template/en/default/bug/create/create-legal.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-legal.html.tmpl
@@ -179,7 +179,7 @@ label.required:before {
       <label for="bug_file_loc">URL:</label>
     </th>
     <td>
-      <input type="text" name="bug_file_loc" id="bug_file_loc" size="60">
+      <input type="text" name="bug_file_loc" id="bug_file_loc" size="60" placeholder="https://">
     </td>
   </tr>
 

--- a/extensions/BMO/template/en/default/bug/create/create-mobile-compat.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-mobile-compat.html.tmpl
@@ -123,7 +123,7 @@ function validateAndSubmit() {
   <th class="required">Full Web Page Address</th>
   <td>
     <input type="text" name="bug_file_loc" id="bug_file_loc" size="60"
-      placeholder="e.g. http://www.example.com/page.html">
+      placeholder="https://">
   </td>
 </tr>
 

--- a/extensions/BMO/template/en/default/bug/create/create-mozlist.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-mozlist.html.tmpl
@@ -153,7 +153,7 @@
     <th class="field_label">URL:</th>
     <td colspan="3">
       <input name="bug_file_loc" size="60"
-             value="[% bug_file_loc FILTER html %]">
+             value="[% bug_file_loc FILTER html %]" placeholder="https://">
     </td>
   </tr>
   <tr>

--- a/extensions/BMO/template/en/default/bug/create/create-trademark.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-trademark.html.tmpl
@@ -69,7 +69,7 @@
       <td align="right"><strong>URL&nbsp;(optional):</strong></td>
       <td colspan="3">
         <input name="bug_file_loc" size="60"
-               value="[% bug_file_loc FILTER html %]">
+               value="[% bug_file_loc FILTER html %]" placeholder="https://">
       </td>
     </tr>
   </table>

--- a/extensions/BMO/template/en/default/bug/create/create-user-engagement.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-user-engagement.html.tmpl
@@ -148,7 +148,7 @@ function toggleGoalOther() {
   <div class="field_desc">
     Where would the user be sent when they click on the promotion?
   </div>
-  <input type="text" name="bug_file_loc" id="bug_file_loc" size="80">
+  <input type="text" name="bug_file_loc" id="bug_file_loc" size="80" placeholder="https://">
 </div>
 
 <div class="form_section">

--- a/extensions/BMO/template/en/default/bug/create/create-web-bounty.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-web-bounty.html.tmpl
@@ -117,7 +117,7 @@ function validateAndSubmit() {
     The full URL (hostname/subpage) where the issue exists (if the URL is especially long
     please just include it in the comments)
   </div>
-  <input type="text" name="bug_file_loc" id="bug_file_loc" size="80">
+  <input type="text" name="bug_file_loc" id="bug_file_loc" size="80" placeholder="https://">
 </div>
 
 <div class="form_section">

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -1128,6 +1128,7 @@
         field = bug_fields.bug_file_loc
         field_type = constants.FIELD_TYPE_FREETEXT
         hide_on_view = bug.bug_file_loc == ""
+        default = "https://"
         help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#bug_file_loc"
     %]
       [% INCLUDE bug_url_link %]

--- a/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
@@ -217,7 +217,9 @@ END;
 
         [% CASE constants.FIELD_TYPE_FREETEXT %]
           [%# normal input field %]
-          <input name="[% name FILTER html %]" id="[% name FILTER html %]" value="[% value FILTER html %]" [% aria_labelledby_html FILTER none +%] [% " required" IF required %]>
+          <input name="[% name FILTER html %]" id="[% name FILTER html %]" value="[% value FILTER html %]"
+                 [% IF default %] placeholder="[% default FILTER html %]"[% END %]
+                 [%+ aria_labelledby_html FILTER none +%] [% " required" IF required %]>
         [% CASE constants.FIELD_TYPE_USER %]
           [% IF action && !action.hidden %]
             <button class="field-button minor [%= action.class FILTER html IF action.class %]"

--- a/template/en/default/bug/create/create-guided.html.tmpl
+++ b/template/en/default/bug/create/create-guided.html.tmpl
@@ -233,7 +233,7 @@ function PutDescription() {
       <b>URL</b>
     </td>
     <td valign="top">
-      <input type="text" size="80" name="bug_file_loc" value="http://">
+      <input type="text" size="80" name="bug_file_loc" placeholder="https://">
       <p>
         URL that demonstrates the problem you are seeing (optional).<br>
         <b>IMPORTANT</b>: if the problem is with a broken web page, you need

--- a/template/en/default/bug/create/create.html.tmpl
+++ b/template/en/default/bug/create/create.html.tmpl
@@ -552,7 +552,7 @@ TUI_hide_default('expert_fields');
     %]
     <td colspan="3" class="field_value">
       <input name="bug_file_loc" id="bug_file_loc" class="text_input"
-             size="40" value="[% bug_file_loc FILTER html %]">
+             size="40" value="[% bug_file_loc FILTER html %]" placeholder="https://">
     </td>
   </tr>
 </tbody>

--- a/template/en/default/bug/edit.html.tmpl
+++ b/template/en/default/bug/edit.html.tmpl
@@ -627,7 +627,13 @@
         </span>
       [% END %]
       <span id="bz_url_input_area">
-        [% url_output =  INCLUDE input no_td=1 inputname => "bug_file_loc" size => "40" colspan => 2 %]
+        [% url_output = INCLUDE input
+          no_td = 1
+          colspan = 2
+          inputname = "bug_file_loc"
+          size = "40"
+          placeholder = "https://"
+        %]
         [% IF NOT bug.check_can_change_field("bug_file_loc", 0, 1)
               AND is_safe_url(bug.bug_file_loc) %]
           <a href="[% bug.bug_file_loc FILTER html %]"
@@ -1295,6 +1301,7 @@
     [% IF bug.check_can_change_field(inputname, 0, 1) %]
        <input id="[% inputname %]" name="[% inputname %]" class="text_input"
               value="[% val FILTER html %]"[% " size=\"$size\"" IF size %]
+              [% IF placeholder %] placeholder="[% placeholder FILTER html %]"[% END %]
               [% " maxlength=\"$maxlength\"" IF maxlength %]
               [% " spellcheck=\"$spellcheck\"" IF spellcheck %]>
     [% ELSE %]


### PR DESCRIPTION
Remove the default “http://“ value from the URL field. Instead, add “https://“ as the `placeholder` attribute.

## Bug

[Bug 1436619 - http:// in URL field](https://bugzilla.mozilla.org/show_bug.cgi?id=1436619)