### PR TITLE
Bug 1384230 - Document flag_activity API.

### DIFF
--- a/docs/en/rst/api/core/v1/index.rst
+++ b/docs/en/rst/api/core/v1/index.rst
@@ -7,6 +7,7 @@ Core API v1
    attachment
    bug
    bug-user-last-visit
+   flag-activity
    bugzilla
    classification
    comment

--- a/extensions/Review/lib/WebService.pm
+++ b/extensions/Review/lib/WebService.pm
@@ -447,7 +447,7 @@ An object with the following fields:
 
 =item C<id> (integer)
 
-The flag type id of the flag that changed
+The id of this activity event.
 
 =item C<name> (string)
 


### PR DESCRIPTION
Also update the perldoc to fix the description of the `id`
response field.