### PR TITLE
Bug 1503748 - Trackpad swipe navigation and mobile horizontal scrolling broken, vertical scrolling partially broken when zoomed

### DIFF
--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -65,8 +65,7 @@
 /* fixed global header (begin) */
     @media screen and (min-width: 800px) {
         html, body {
-            overflow: hidden; /* Disable bounce effect (Safari) */
-            overscroll-behavior: none;
+            overflow-y: hidden; /* Disable bounce effect (Safari) */
             height: 100%;
         }
 
@@ -81,7 +80,6 @@
             overflow-y: scroll;
             -webkit-overflow-scrolling: touch; /* Enable momentum scrolling on iOS */
             scroll-behavior: smooth;
-            overscroll-behavior: contain;
             will-change: transform; /* Enable smooth scrolling (Safari) */
         }
     }


### PR DESCRIPTION
Fix regressions from #728 which I couldn’t find while testing.

* Trackpad swipe page navigation is no longer working due to `overscroll-behavior`
* Horizontal scrolling on a narrower screen (mobile) is no longer working due to `overflow`
* Vertical scrolling at the top and bottom of the page is no longer working when the page is zoomed due to `overscroll-behavior`