### PR TITLE
Bug 1505762 - count_only=1 results in error with REST API

### DIFF
--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -632,7 +632,7 @@ sub search {
             return $data;
         }
         else {
-            return { bug_count => $self->type('int', scalar @$data) };
+            return { bug_count => $self->type('int', $data) };
         }
     }
 


### PR DESCRIPTION
Fix a regression from #872. Looks like my first attempt was right, and I didn’t test the updated code 😓 When `count_only=1`, the `$data` will be an integer so it can be used as-is.

## Bug

[Bug 1505762 - count_only=1 results in error with REST API](https://bugzilla.mozilla.org/show_bug.cgi?id=1505762)