### PR TITLE
bump version to 20181108.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20181106.1';
+our $VERSION = '20181108.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
the following changes will be pushed to bugzilla.mozilla.org:
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1436619" target="_blank">1436619</a>] http:// in URL field</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1505762" target="_blank">1505762</a>] count_only=1 results in error with REST API</li>
</ul>

