### PR TITLE
Bug 1505831 - Add nick field to all user objects including *_detail returned by /rest/bug

### DIFF
--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -1541,6 +1541,7 @@ sub _user_to_hash {
     my $item = filter $filters, {
         id        => $self->type('int', $user->id),
         real_name => $self->type('string', $user->name),
+        nick      => $self->type('string', $user->nick),
         name      => $self->type('email', $user->login),
         email     => $self->type('email', $user->email),
     }, $types, $prefix;
@@ -2826,6 +2827,11 @@ C<int> The user id for this user.
 =item C<real_name>
 
 C<string> The 'real' name for this user, if any.
+
+=item C<nick>
+
+C<string> The user's nickname. Currently this is extracted from the real_name,
+name or email field.
 
 =item C<name>
 

--- a/Bugzilla/WebService/Group.pm
+++ b/Bugzilla/WebService/Group.pm
@@ -210,6 +210,7 @@ sub _get_group_membership {
         map {{
             id                => $self->type('int', $_->id),
             real_name         => $self->type('string', $_->name),
+            nick              => $self->type('string', $_->nick),
             name              => $self->type('string', $_->login),
             email             => $self->type('string', $_->email),
             can_login         => $self->type('boolean', $_->is_enabled),
@@ -546,6 +547,11 @@ C<int> The id of the user.
 =item real_name
 
 C<string> The actual name of the user.
+
+=item nick
+
+C<string> The user's nickname. Currently this is extracted from the real_name,
+name or email field.
 
 =item email
 

--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -192,6 +192,7 @@ sub suggest {
         {
             id        => $self->type(int    => $_->{id}),
             real_name => $self->type(string => $_->{real_name}),
+            nick      => $self->type(string => $_->{nick}),
             name      => $self->type(email  => $_->{name}),
         }
     } @$results;
@@ -240,6 +241,7 @@ sub get {
         @users = map { filter $params, {
                      id        => $self->type('int', $_->id),
                      real_name => $self->type('string', $_->name),
+                     nick      => $self->type('string', $_->nick),
                      name      => $self->type('email', $_->login),
                  } } @$in_group;
 
@@ -290,6 +292,7 @@ sub get {
         my $user_info = filter $params, {
             id        => $self->type('int', $user->id),
             real_name => $self->type('string', $user->name),
+            nick      => $self->type('string', $user->nick),
             name      => $self->type('email', $user->login),
             email     => $self->type('email', $user->email),
             can_login => $self->type('boolean', $user->is_enabled ? 1 : 0),
@@ -496,6 +499,7 @@ sub whoami {
         {
             id         => $self->type( 'int',     $user->id ),
             real_name  => $self->type( 'string',  $user->name ),
+            nick       => $self->type( 'string',  $user->nick ),
             name       => $self->type( 'email',   $user->login ),
             mfa_status => $self->type( 'boolean', !!$user->mfa ),
         }
@@ -1026,6 +1030,11 @@ Even if the user's login name changes, this will not change.
 
 C<string> The actual name of the user. May be blank.
 
+=item nick
+
+C<string> The user's nickname. Currently this is extracted from the real_name,
+name or email field.
+
 =item email
 
 C<string> The email address of the user.
@@ -1100,10 +1109,10 @@ name of each saved search.
 =back
 
 B<Note>: If you are not logged in to Bugzilla when you call this function, you
-will only be returned the C<id>, C<name>, and C<real_name> items. If you are
-logged in and not in editusers group, you will only be returned the C<id>, C<name>,
-C<real_name>, C<email>, and C<can_login> items. The groups returned are filtered
-based on your permission to bless each group.
+will only be returned the C<id>, C<name>, C<real_name> and C<nick> items. If you
+are logged in and not in editusers group, you will only be returned the C<id>,
+C<name>, C<real_name>, C<nick>, C<email> and C<can_login> items. The groups
+returned are filtered based on your permission to bless each group.
 
 =back
 
@@ -1151,6 +1160,8 @@ for C<match> has changed to only returning enabled accounts.
 =item Error 804 has been added in Bugzilla 4.0.9 and 4.2.4. It's now
 illegal to pass a group name you don't belong to.
 
+=item C<nick> Added in Bugzilla B<6.0>.
+
 =back
 
 =item REST API call added in Bugzilla B<5.0>.
@@ -1183,6 +1194,11 @@ Even if the user's login name changes, this will not change.
 =item real_name
 
 C<string> The actual name of the user. May be blank.
+
+=item nick
+
+C<string> The user's nickname. Currently this is extracted from the real_name,
+name or email field.
 
 =item name
 

--- a/docs/en/rst/api/core/v1/bug.rst
+++ b/docs/en/rst/api/core/v1/bug.rst
@@ -45,6 +45,7 @@ name              type   description
          "assigned_to_detail": {
            "id": 2,
            "real_name": "Test User",
+           "nick": "user",
            "name": "user@bugzilla.org",
            "email": "user@bugzilla.org"
          },
@@ -75,6 +76,7 @@ name              type   description
            {
              "id": 786,
              "real_name": "Foo Bar",
+             "nick": "foo",
              "name": "foo@bar.com",
              "email": "foo@bar.com"
            },
@@ -112,6 +114,7 @@ name              type   description
          "creator_detail": {
            "id": 28,
            "real_name": "hello",
+           "nick": "namachi",
            "name": "user@bugzilla.org",
            "email": "namachi@netscape.com"
          },
@@ -254,6 +257,8 @@ name       type    description
 =========  ======  ==============================================================
 id         int     The user ID for this user.
 real_name  string  The 'real' name for this user, if any.
+nick       string  The user's nickname. Currently this is extracted from the
+                   real_name, name or email field.
 name       string  The user's Bugzilla login.
 email      string  The user's email address. Currently this is the same value as
                    the name.

--- a/docs/en/rst/api/core/v1/flag-activity.rst
+++ b/docs/en/rst/api/core/v1/flag-activity.rst
@@ -83,11 +83,13 @@ For example, to get the first 100 flag-activity entries that occurred on or afte
        "requestee": {
          "id": 123,
          "name": "user@mozilla.com",
+         "nick": "user",
          "real_name": "J. Random User"
        },
        "setter": {
          "id": 123,
          "name": "user@mozilla.com",
+         "nick": "user",
          "real_name": "J. Random User"
        },
        "status": "?",
@@ -127,6 +129,8 @@ name       type    description
 id         int     The unique ID of the user.
 name       string  The login of the user (typically an email address).
 real_name  string  The real name of the user, if set.
+nick       string  The user's nickname. Currently this is extracted
+                   the real_name, name or email field.
 =========  ======  ====================================================
 
 The type object has the following fields:

--- a/docs/en/rst/api/core/v1/group.rst
+++ b/docs/en/rst/api/core/v1/group.rst
@@ -223,6 +223,7 @@ membership  boolean  Set to 1 then a list of members of the passed groups names
          "membership": [
            {
              "real_name": "Bugzilla User",
+             "nick": "user",
              "can_login": true,
              "name": "user@bugzilla.org",
              "login_denied_text": "",
@@ -280,6 +281,8 @@ name           type     description
 =============  =======  =========================================================
 id             int      The ID of the user.
 real_name      string   The actual name of the user.
+nick           string   The user's nickname. Currently this is extracted from
+                        the real_name, name or email field.
 email          string   The email address of the user.
 name           string   The login name of the user. Note that in some situations
                         this is different than their email.

--- a/docs/en/rst/api/core/v1/user.rst
+++ b/docs/en/rst/api/core/v1/user.rst
@@ -352,6 +352,8 @@ id                 int      The unique integer ID that Bugzilla uses to represen
                             this user. Even if the user's login name changes,
                             this will not change.
 real_name          string   The actual name of the user. May be blank.
+nick               string   The user's nickname. Currently this is extracted from
+                            the real_name, name or email field.
 email              string   The email address of the user.
 name               string   The login name of the user. Note that in some
                             situations this is different than their email.
@@ -398,11 +400,11 @@ query  string  The CGI parameters for the saved report.
 =====  ======  ==================================================================
 
 If you are not authenticated when you call this function, you will only be
-returned the ``id``, ``name``, and ``real_name`` items. If you are authenticated
-and not in 'editusers' group, you will only be returned the ``id``, ``name``,
-``real_name``, ``email``, ``can_login``, and ``groups`` items. The groups
-returned are filtered based on your permission to bless each group. The
-``saved_searches`` and ``saved_reports`` items are only returned if you are
+returned the ``id``, ``name``, ``real_name`` and ``nick`` items. If you are
+authenticated and not in 'editusers' group, you will only be returned the ``id``,
+``name``, ``real_name``, ``nick``, ``email``, ``can_login`` and ``groups`` items.
+The groups returned are filtered based on your permission to bless each group.
+The ``saved_searches`` and ``saved_reports`` items are only returned if you are
 querying your own account, even if you are in the editusers group.
 
 **Errors**
@@ -445,6 +447,7 @@ logged in user.
      "id" : "1234",
      "name" : "user@bugzulla.org",
      "real_name" : "Test User",
+     "nick" : "user"
    }
 
 ========== ======  =====================================================
@@ -454,5 +457,7 @@ id         int     The unique integer ID that Bugzilla uses to represent
                    this user. Even if the user's login name changes,
                    this will not change.
 real_name  string  The actual name of the user. May be blank.
+nick       string  The user's nickname. Currently this is extracted from
+                   the real_name, name or email field.
 name       string  string  The login name of the user.
 ========== ======  =====================================================

--- a/extensions/Review/lib/WebService.pm
+++ b/extensions/Review/lib/WebService.pm
@@ -71,6 +71,7 @@ sub suggestions {
             id    => $self->type('int', $reviewer->id),
             email => $self->type('email', $reviewer->login),
             name  => $self->type('string', $reviewer->name),
+            nick  => $self->type('string', $reviewer->nick),
             review_count => $self->type('int', $reviewer->review_count),
         };
     }
@@ -289,6 +290,7 @@ sub _user_to_hash {
     return {
         id        => $self->type('int',    $user->id),
         real_name => $self->type('string', $user->name),
+        nick      => $self->type('string', $user->nick),
         name      => $self->type('email',  $user->login),
     };
 }
@@ -488,6 +490,11 @@ The id of the bugzilla user. A unique integer value.
 =item C<real_name> (string)
 
 The real name of the bugzilla user.
+
+=item C<nick> (string)
+
+The user's nickname. Currently this is extracted from the real_name, name or
+email field.
 
 =item C<name> (string)
 

--- a/qa/t/webservice_user_get.t
+++ b/qa/t/webservice_user_get.t
@@ -141,8 +141,8 @@ sub post_success {
     }
     else {
         my @item_keys = sort keys %$item;
-        is_deeply(\@item_keys, ['id', 'name', 'real_name'],
-            'Only id, name, and real_name are returned to logged-out users');
+        is_deeply(\@item_keys, ['id', 'name', 'real_name', 'nick'],
+            'Only id, name, real_name and nick are returned to logged-out users');
         return;
     }
 

--- a/qa/t/webservice_user_get.t
+++ b/qa/t/webservice_user_get.t
@@ -141,8 +141,8 @@ sub post_success {
     }
     else {
         my @item_keys = sort keys %$item;
-        is_deeply(\@item_keys, ['id', 'name', 'real_name', 'nick'],
-            'Only id, name, real_name and nick are returned to logged-out users');
+        is_deeply(\@item_keys, ['id', 'name', 'nick', 'real_name'],
+            'Only id, name, nick and real_name are returned to logged-out users');
         return;
     }
 
@@ -198,14 +198,14 @@ foreach my $rpc (@clients) {
     my $exclude_none = $rpc->bz_call_success('User.get', {
         names => [$get_user], exclude_fields => ['asdfasdfsdf'],
     }, 'User.get excluding only invalid fields');
-    is(scalar keys %{ $exclude_none->result->{users}->[0] }, 3,
+    is(scalar keys %{ $exclude_none->result->{users}->[0] }, 4,
        'All fields returned for user');
 
     my $exclude_one = $rpc->bz_call_success('User.get', {
         names => [$get_user], exclude_fields => ['id'],
     }, 'User.get excluding id');
-    is(scalar keys %{ $exclude_one->result->{users}->[0] }, 2,
-       'Only two fields returned for user');
+    is(scalar keys %{ $exclude_one->result->{users}->[0] }, 3,
+       'Only three fields returned for user');
 
     my $override = $rpc->bz_call_success('User.get', {
         names => [$get_user], include_fields => ['id', 'name'],


### PR DESCRIPTION
Expose the internal `nick` field to user objects returned by various API methods, `/rest/bug` and `/rest/user` in particular.

## Bug

[Bug 1505831 - Add nick field to all user objects including *_detail returned by /rest/bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1505831)