### PR TITLE
Bug 1351116 - github issue links are not expanded in parentheses

### DIFF
--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -724,13 +724,13 @@ sub bug_format_comment {
 
     # link github pull requests and issues
     push (@$regexes, {
-        match => qr/(\s)([A-Za-z0-9_\.-]+)\/([A-Za-z0-9_\.-]+)\#([0-9]+)\b/,
+        match => qr/\b([A-Za-z0-9_\.-]+)\/([A-Za-z0-9_\.-]+)\#([0-9]+)\b/,
         replace => sub {
             my $args = shift;
-            my $owner = html_quote($args->{matches}->[1]);
-            my $repo = html_quote($args->{matches}->[2]);
-            my $number = html_quote($args->{matches}->[3]);
-            return qq# <a href="https://github.com/$owner/$repo/issues/$number">$owner/$repo\#$number</a>#;
+            my $owner = html_quote($args->{matches}->[0]);
+            my $repo = html_quote($args->{matches}->[1]);
+            my $number = html_quote($args->{matches}->[2]);
+            return qq#<a href="https://github.com/$owner/$repo/issues/$number">$owner/$repo\#$number</a>#;
         }
     });
 


### PR DESCRIPTION
The original PR #26 requires a space before a PR/issue notation but it doesn’t work when it’s in parentheses or at the beginning of line. Just use `\b` instead.

## Bugzilla link

[Bug 1351116 - github issue links are not expanded in parentheses](https://bugzilla.mozilla.org/show_bug.cgi?id=1351116)