### PR TITLE
move inline js on the buglist out to a separate file

### DIFF
--- a/js/buglist.js
+++ b/js/buglist.js
@@ -1,0 +1,23 @@
+function SetCheckboxes(value) {
+  let elements = document.querySelectorAll("input[type='checkbox'][name^='id_'")
+  for (let item of elements) {
+    item.checked = value;
+  }
+}
+
+document.addEventListener("DOMContentLoaded", function () {
+  let check_all = document.getElementById("check_all");
+  let uncheck_all = document.getElementById("uncheck_all");
+  if (check_all) {
+    check_all.addEventListener('click', event => {
+      SetCheckboxes(true);
+      event.preventDefault();
+    });
+  }
+  if (uncheck_all) {
+    uncheck_all.addEventListener('click', event => {
+      SetCheckboxes(false);
+      event.preventDefault();
+    });
+  }
+});

--- a/js/buglist.js
+++ b/js/buglist.js
@@ -1,21 +1,21 @@
 function SetCheckboxes(value) {
-  let elements = document.querySelectorAll("input[type='checkbox'][name^='id_'")
+  let elements = document.querySelectorAll("input[type='checkbox'][name^='id_'");
   for (let item of elements) {
     item.checked = value;
   }
 }
 
-document.addEventListener("DOMContentLoaded", function () {
+document.addEventListener("DOMContentLoaded", () => {
   let check_all = document.getElementById("check_all");
   let uncheck_all = document.getElementById("uncheck_all");
   if (check_all) {
-    check_all.addEventListener('click', event => {
+    check_all.addEventListener("click", event => {
       SetCheckboxes(true);
       event.preventDefault();
     });
   }
   if (uncheck_all) {
-    uncheck_all.addEventListener('click', event => {
+    uncheck_all.addEventListener("click", event => {
       SetCheckboxes(false);
       event.preventDefault();
     });

--- a/js/buglist.js
+++ b/js/buglist.js
@@ -1,5 +1,5 @@
 function SetCheckboxes(value) {
-  let elements = document.querySelectorAll("input[type='checkbox'][name^='id_'");
+  let elements = document.querySelectorAll("input[type='checkbox'][name^='id_']");
   for (let item of elements) {
     item.checked = value;
   }

--- a/template/en/default/list/edit-multiple.html.tmpl
+++ b/template/en/default/list/edit-multiple.html.tmpl
@@ -27,23 +27,8 @@
 [% dontchange = "--do_not_change--" %]
 <input type="hidden" name="dontchange" value="[% dontchange FILTER html %]">
 <input type="hidden" name="token" value="[% token FILTER html %]">
-
-<script [% script_nonce FILTER none %]>
-  function SetCheckboxes(value) {
-      var elements = document.forms.changeform.getElementsByTagName('input'),
-          numelements = elements.length,
-          item, i;
-      for (i = 0; i < numelements; i++) {
-          item = elements[i];
-          if (item.type === 'checkbox' && item.name.match(/^id_/)) {
-            item.checked = value;
-          }
-      }
-  }
-  document.write(' <input type="button" name="uncheck_all" value="Uncheck All" onclick="SetCheckboxes(false);">');
-  document.write(' <input type="button" name="check_all" value="Check All" onclick="SetCheckboxes(true);">');
-</script>
-
+<input type="button" id="uncheck_all" name="uncheck_all" value="Uncheck All">
+<input type="button" id="check_all" name="check_all" value="Check All">
 <hr>
 
 <p style="font-size:smaller">

--- a/template/en/default/list/list.html.tmpl
+++ b/template/en/default/list/list.html.tmpl
@@ -50,7 +50,7 @@
   generate_api_token = dotweak
   style = style
   atomlink = basepath _ "buglist.cgi?$urlquerypart&title=$url_filtered_title&ctype=atom"
-  javascript_urls = [ "js/util.js", "js/field.js" ]
+  javascript_urls = [ "js/util.js", "js/field.js", "js/buglist.js" ]
   style_urls = [ "skins/standard/buglist.css" ]
   doc_section = "query.html#list"
 %]


### PR DESCRIPTION
As part of the background bug editing in #884 I'm adding a checkbox that says "run edits in background". I'm adding some code to the frontend to make this obvious to the user and while I'm at it I'll need to add some new JS. Rather than add more to the html I'd like move it out.