### PR TITLE
Create a role that allows Bugzilla::Object-based classes to be stored using Storable

### DIFF
--- a/Bugzilla/Role/Storable.pm
+++ b/Bugzilla/Role/Storable.pm
@@ -10,7 +10,6 @@ package Bugzilla::Role::Storable;
 use 5.10.1;
 use strict;
 use warnings;
-use Scalar::Util qw(blessed);
 use Role::Tiny;
 
 requires 'flatten_to_hash';

--- a/Bugzilla/Role/Storable.pm
+++ b/Bugzilla/Role/Storable.pm
@@ -1,0 +1,30 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::Role::Storable;
+
+use 5.10.1;
+use strict;
+use warnings;
+use Scalar::Util qw(blessed);
+use Role::Tiny;
+
+requires 'flatten_to_hash';
+
+sub STORABLE_freeze {
+  my ($self, $cloning) = @_;
+  return if $cloning;    # Regular default serialization
+  return '', $self->flatten_to_hash;
+}
+
+sub STORABLE_thaw {
+  my ($self, $cloning, $serialized, $frozen) = @_;
+  return if $cloning;
+  %$self = %$frozen;
+}
+
+1;

--- a/Bugzilla/User.pm
+++ b/Bugzilla/User.pm
@@ -129,7 +129,7 @@ use constant VALIDATOR_DEPENDENCIES => {
 
 use constant EXTRA_REQUIRED_FIELDS => qw(is_enabled);
 
-with 'Bugzilla::Elastic::Role::Object';
+with 'Bugzilla::Elastic::Role::Object', 'Bugzilla::Role::Storable';
 
 sub ES_INDEX {
     my ($class) = @_;
@@ -232,6 +232,7 @@ sub es_document {
 
     return $doc;
 }
+
 ################################################################################
 # Functions
 ################################################################################


### PR DESCRIPTION
This introduces a Role::Tiny role that uses the existing `flatten_to_hash()` method of `Bugzilla::Object` to allow Storable round-tripping.

When working on #884 it seems that the Bugzilla::User object has this CODEref in it somewhere.
This is a rather simple change that allows it to be stored and recovered.

I have another patch that isn't needed right now which is a much more efficient version of `_serialisation_keys` but it seems it isn't needed right now.