### PR TITLE
Bug 1507518 - Allow title parameter value in url to be the title of the page

### DIFF
--- a/skins/standard/buglist.css
+++ b/skins/standard/buglist.css
@@ -21,6 +21,10 @@
   text-align: center;
 }
 
+.bz_query_head h1 {
+  font-size: x-large;
+}
+
 .bz_query_timestamp {
   font-weight: bold;
 }

--- a/template/en/default/list/list.html.tmpl
+++ b/template/en/default/list/list.html.tmpl
@@ -56,6 +56,13 @@
 %]
 
 <div class="bz_query_head">
+  [% IF searchname || defaultsavename || quicksearch %]
+    <h1>[% (searchname || defaultsavename || quicksearch) FILTER html %]</h1>
+  [% ELSIF title != "$terms.Bug List" %]
+    [%# Already filtered #%]
+    <h1>[% title FILTER none %]</h1>
+  [% END %]
+
   <span class="bz_query_timestamp">
     [% currenttime FILTER time('%a %b %e %Y %T %Z') FILTER html %]<br>
   </span>


### PR DESCRIPTION
When the `buglist.cgi` URL contains the `title` param or it’s a saved search, show the title in `<h1>` on the page. Technically `<h1>` should always be there, but we can revisit later when redesigning the search results page.

![screen shot 2018-11-15 at 11 33 31](https://user-images.githubusercontent.com/2929505/48567294-b2774980-e8ca-11e8-8b9c-17a67402660e.png)

## Bugzilla link

[Bug 1507518 - Allow title parameter value in url to be the title of the page](https://bugzilla.mozilla.org/show_bug.cgi?id=1507518)