### PR TITLE
Bug 1507867 - splinter review links in emails are missing host/scheme, rendering them unusable

### DIFF
--- a/extensions/Splinter/Extension.pm
+++ b/extensions/Splinter/Extension.pm
@@ -33,8 +33,8 @@ BEGIN {
 }
 
 sub _get_review_url {
-    my ($class, $bug_id, $attach_id) = @_;
-    return get_review_url(Bugzilla::Bug->check({ id => $bug_id, cache => 1 }), $attach_id);
+    my ($class, $bug_id, $attach_id, $use_abs_url) = @_;
+    return get_review_url(Bugzilla::Bug->check({ id => $bug_id, cache => 1 }), $attach_id, $use_abs_url);
 }
 
 sub page_before_template {

--- a/extensions/Splinter/lib/Util.pm
+++ b/extensions/Splinter/lib/Util.pm
@@ -86,17 +86,18 @@ sub attachment_id_is_patch {
 }
 
 sub get_review_base {
+    my $use_abs_url = shift // 0;
     my $base = Bugzilla->params->{'splinter_base'};
     $base =~ s!/$!!;
-    my $basepath = Bugzilla->localconfig->{basepath};
+    my $basepath = Bugzilla->localconfig->{$use_abs_url ? 'urlbase' : 'basepath'};
     $basepath =~ s!/$!! if $base =~ "^/";
     $base = $basepath . $base;
     return $base;
 }
 
 sub get_review_url {
-    my ($bug, $attach_id) = @_;
-    my $base = get_review_base();
+    my ($bug, $attach_id, $use_abs_url) = @_;
+    my $base = get_review_base($use_abs_url);
     my $bug_id = $bug->id;
     return $base . ($base =~ /\?/ ? '&' : '?') . "bug=$bug_id&attachment=$attach_id";
 }

--- a/extensions/Splinter/template/en/default/hook/request/email-after_summary.txt.tmpl
+++ b/extensions/Splinter/template/en/default/hook/request/email-after_summary.txt.tmpl
@@ -4,6 +4,6 @@
       && attachment && attachment.ispatch %]
 
 Review
-[%+ Bugzilla.splinter_review_url(bug.bug_id, attachment.id) FILTER none %]
+[%+ Bugzilla.splinter_review_url(bug.bug_id, attachment.id, 1) FILTER none %]
 [%- END %]
 


### PR DESCRIPTION
Use an absolute/complete URL for a Splinter review link in plaintext emails. In HTML, there is `<base href>` so a relative URL should work. Tested locally with [actual emails](https://github.com/mozilla-bteam/bmo#testing-emails).

## Bugzilla link

[Bug 1507867 - splinter review links in emails are missing host/scheme, rendering them unusable](https://bugzilla.mozilla.org/show_bug.cgi?id=1507867)