### PR TITLE
Bug 324535 - Allow the use of relative dates in charts

### DIFF
--- a/Bugzilla/Chart.pm
+++ b/Bugzilla/Chart.pm
@@ -19,6 +19,7 @@ use warnings;
 
 use Bugzilla::Error;
 use Bugzilla::Util;
+use Bugzilla::Util::DateTime;
 use Bugzilla::Series;
 
 use Date::Format;
@@ -87,7 +88,7 @@ sub init {
     # Make sure the dates are ones we are able to interpret
     foreach my $date ('datefrom', 'dateto') {
         if ($self->{$date}) {
-            $self->{$date} = str2time($self->{$date})
+            $self->{$date} = parse_date($self->{$date})
               || ThrowUserError("illegal_date", { date => $self->{$date}});
         }
     }

--- a/Bugzilla/Util/DateTime.pm
+++ b/Bugzilla/Util/DateTime.pm
@@ -5,7 +5,7 @@
 # This Source Code Form is "Incompatible With Secondary Licenses", as
 # defined by the Mozilla Public License, v. 2.0.
 
-package Bugzilla::Extension::BMO::Util;
+package Bugzilla::Util::DateTime;
 
 use 5.10.1;
 use strict;
@@ -20,8 +20,7 @@ use base qw(Exporter);
 
 our @EXPORT = qw( string_to_datetime
                   time_to_datetime
-                  parse_date
-                  is_active_status_field );
+                  parse_date );
 
 sub string_to_datetime {
     my $input = shift;
@@ -73,20 +72,6 @@ sub parse_date {
         return undef;
     }
     return str2time($str);
-}
-
-sub is_active_status_field {
-    my ($field) = @_;
-
-    if ($field->type == FIELD_TYPE_EXTENSION
-        && $field->isa('Bugzilla::Extension::TrackingFlags::Flag')
-        && $field->flag_type eq 'tracking'
-        && $field->name =~ /_status_/
-    ) {
-        return $field->is_active;
-    }
-
-    return 0;
 }
 
 1;

--- a/extensions/BMO/lib/Reports/UserActivity.pm
+++ b/extensions/BMO/lib/Reports/UserActivity.pm
@@ -12,9 +12,9 @@ use strict;
 use warnings;
 
 use Bugzilla::Error;
-use Bugzilla::Extension::BMO::Util;
 use Bugzilla::User;
 use Bugzilla::Util qw(trim);
+use Bugzilla::Util::DateTime;
 use DateTime;
 
 sub report {


### PR DESCRIPTION
Move `Bugzilla::Extension::BMO::Util` to `Bugzilla::Util::DateTime` and use the `parse_date` method for the charts. In the future, the other date-related methods in `Bugzilla::Util` could also be moved to `Bugzilla::Util::DateTime`.

## Bugzilla link

[Bug 324535 - Allow the use of relative dates in charts](https://bugzilla.mozilla.org/show_bug.cgi?id=324535)