### PR TITLE
add a better flatten_to_hash method to User

### DIFF
--- a/Bugzilla/Role/FlattenToHash.pm
+++ b/Bugzilla/Role/FlattenToHash.pm
@@ -1,0 +1,42 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::Role::FlattenToHash;
+
+use 5.10.1;
+use strict;
+use warnings;
+use Role::Tiny;
+use Scalar::Util qw(blessed);
+
+requires 'DB_TABLE', '_get_db_columns';
+
+my $_error = sub { die "cannot determine attribute name from $_[0]\n" };
+
+sub _get_db_keys {
+  my ($self, $object)  = @_;
+  my $class   = blessed($self) // $self;
+  my $table   = $class->DB_TABLE;
+  my @columns = $class->_get_db_columns;
+  my $re      = qr{
+    ^\s*(?<name>\w+)\s*$
+    | ^\s*\Q$table.\E(?<name>\w+)\s*$
+    | \s+AS\s+(?<name>\w+)\s*$
+  }six;
+
+  return map { $_ =~ $re ? $+{name} : $_error->($_) } @columns;
+}
+
+sub flatten_to_hash {
+  my ($self) = @_;
+  my %hash;
+  my @keys = $self->_get_db_keys();
+  @hash{ @keys } = @$self{ @keys };
+  return \%hash;
+}
+
+1;

--- a/Bugzilla/User.pm
+++ b/Bugzilla/User.pm
@@ -33,6 +33,10 @@ use URI::QueryParam;
 use Role::Tiny::With;
 
 use base qw(Bugzilla::Object Exporter);
+
+with 'Bugzilla::Elastic::Role::Object', 'Bugzilla::Role::Storable',
+  'Bugzilla::Role::FlattenToHash';
+
 @Bugzilla::User::EXPORT = qw(is_available_username
     login_to_id user_id_to_login
     USER_MATCH_MULTIPLE USER_MATCH_FAILED USER_MATCH_SUCCESS
@@ -128,8 +132,6 @@ use constant VALIDATOR_DEPENDENCIES => {
 };
 
 use constant EXTRA_REQUIRED_FIELDS => qw(is_enabled);
-
-with 'Bugzilla::Elastic::Role::Object', 'Bugzilla::Role::Storable';
 
 sub ES_INDEX {
     my ($class) = @_;


### PR DESCRIPTION
Bugzilla::User is still not always safe for storable:

Can't use an undefined value as an ARRAY reference at
/vagrant/Bugzilla/Object.pm line 286, at
/vagrant/local/lib/perl5/TheSchwartz/Job.pm line 29.

This adds a different implementation of flatten_to_hash() that relies on the
DB_COLUMNS defined for the class (via _get_db_columns, so extensions work
correctly). The new method is `_get_db_keys` and it should always return the same result as `_serialisation_keys` except that it does not require first querying the database.
This can be tested as below (note: `Set::Object` is not currently included with BMO, but it makes the below illustration easier)

```perl
$ set(Bugzilla::User->_get_db_keys) - set(Bugzilla::User->_serialisation_keys)
Took 0.000822067260742188 seconds.

Set::Object()
```


