### PR TITLE
Bug 1508695 - Incorrect or missing tracking flags on search results

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -651,7 +651,7 @@ sub active_custom_fields {
         if ($can_cache) {
             request_cache->{$cache_id} = $fields;
         } else {
-            return $fields;
+            return @$fields;
         }
     }
     return @{request_cache->{$cache_id}};

--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -638,16 +638,21 @@ sub fields {
 sub active_custom_fields {
     my (undef, $params) = @_;
     my $cache_id = 'active_custom_fields';
+    my $can_cache = ! exists $params->{bug_id};
     if ($params) {
         $cache_id .= ($params->{product} ? '_p' . $params->{product}->id : '') .
                      ($params->{component} ? '_c' . $params->{component}->id : '');
         $cache_id .= ':noext' if $params->{skip_extensions};
     }
-    if (!exists request_cache->{$cache_id}) {
+    if (!$can_cache || !exists request_cache->{$cache_id}) {
         my $fields = Bugzilla::Field->match({ custom => 1, obsolete => 0, skip_extensions => 1 });
         Bugzilla::Hook::process('active_custom_fields',
                                 { fields => \$fields, params => $params });
-        request_cache->{$cache_id} = $fields;
+        if ($can_cache) {
+            request_cache->{$cache_id} = $fields;
+        } else {
+            return $fields;
+        }
     }
     return @{request_cache->{$cache_id}};
 }


### PR DESCRIPTION
Note that passing bug_id to active_custom_flags() means you can get inactive flags.

call list:
* Bugzilla->active_custom_flags
* Bugzilla::Extension::TrackingFlags::active_custom_flags
* Bugzilla::Extension::TrackingFlags::Flag::match
* Bugzilla::Extension::TrackingFlags::Flag::preload_all_the_things


```perl
# Preload bug values if a bug_id is passed
    if ($params && exists $params->{'bug_id'} && $params->{'bug_id'}) {
        # We don't want to use @flag_ids here as we want all flags attached to this bug
        # even if they are inactive.
```