### PR TITLE
Bug 1351116 followup - Don't match regular links

### DIFF
--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -724,7 +724,7 @@ sub bug_format_comment {
 
     # link github pull requests and issues
     push (@$regexes, {
-        match => qr/\b([A-Za-z0-9_\.-]+)\/([A-Za-z0-9_\.-]+)\#([0-9]+)\b/,
+        match => qr/(?!\w+\/)([\w\.-]+)\/([\w\.-]+)\#(\d+)\b/,
         replace => sub {
             my $args = shift;
             my $owner = html_quote($args->{matches}->[0]);


### PR DESCRIPTION
The regex in #897 matches not only GitHub issues/PRs but also regular links with a fragment, Searchfox URLs in particular. This modified and simplified regex checks if there's no slash before the string to exclude those links.