### PR TITLE
Bug 1508903 - internal error on requests.cgi:  Bad argument param sent to Bugzilla::User::new function.

### DIFF
--- a/request.cgi
+++ b/request.cgi
@@ -289,7 +289,7 @@ sub queue {
           'attach_id'       => $data->[7] ,
           'attach_summary'  => $data->[8] ,
           'requester'       => Bugzilla::User->new({ name => $data->[10], cache => 1 }) ,
-          'requestee'       => Bugzilla::User->new({ name => $data->[12], cache => 1 }) ,
+          'requestee'       => $data->[12] ? Bugzilla::User->new({ name => $data->[12], cache => 1 }) : undef ,
           'restricted'      => $data->[13] ? 1 : 0,
           'created'         => $data->[14],
           'attach_mimetype' => $data->[15],

--- a/template/en/default/request/queue.csv.tmpl
+++ b/template/en/default/request/queue.csv.tmpl
@@ -35,7 +35,7 @@ No requests.
     [% FOREACH column = display_columns %]
       [% IF column == 'created' %]
         [% request.$column FILTER time FILTER csv %]
-      [% ELSIF column.match('^requeste') %]
+      [% ELSIF column.match('^requeste') && request.$column %]
         [% IF request.$column.name %]
           [% request.$column.name _ ' <' _ request.$column.email _ '>' FILTER email FILTER csv %]
         [% ELSE %]

--- a/template/en/default/request/queue.html.tmpl
+++ b/template/en/default/request/queue.html.tmpl
@@ -265,9 +265,7 @@ to some group are shown by default.
 [% END %]
 
 [% BLOCK display_requestee %]
-  [% IF !request.requestee %]
-    [% RETURN %]
-  [% END %]
+  [% RETURN IF !request.requestee %]
   [% IF request.requestee.name %]
     [% request.requestee.name _ ' <' _ request.requestee.email _ '>' FILTER email FILTER html %]
   [% ELSE %]

--- a/template/en/default/request/queue.html.tmpl
+++ b/template/en/default/request/queue.html.tmpl
@@ -265,6 +265,9 @@ to some group are shown by default.
 [% END %]
 
 [% BLOCK display_requestee %]
+  [% IF !request.requestee %]
+    [% RETURN %]
+  [% END %]
   [% IF request.requestee.name %]
     [% request.requestee.name _ ' <' _ request.requestee.email _ '>' FILTER email FILTER html %]
   [% ELSE %]

--- a/template/en/default/request/queue.json.tmpl
+++ b/template/en/default/request/queue.json.tmpl
@@ -22,10 +22,10 @@ foreach my $request (@$requests) {
             $val = $time_filter->( $request->{$column} );
         }
         elsif ( $column =~ /^requeste/ ) {
-            $val = {
+            $val = $request->{$column} ? {
                 nick => $request->{$column}->nick,
                 gravatar => $request->{$column}->gravatar,
-            };
+            } : undef;
         }
         elsif ( $column =~ /_id$/ ) {
             $val = $request->{$column} ? 0 + $request->{$column} : undef;


### PR DESCRIPTION
Fix a regression from #691. The requestee of a flag can be undefined if it's not specifically requestable. This PR prevents `Bugzilla::User::new` being called in such cases, and make the requestee column empty in HTML/CSV and `null` in JSON. 