### PR TITLE
Bug 1509308 - Date for cf_last_resolved in history results should be UTC

### DIFF
--- a/Bugzilla/WebService/Server/JSONRPC.pm
+++ b/Bugzilla/WebService/Server/JSONRPC.pm
@@ -231,9 +231,9 @@ sub type {
 }
 
 sub datetime_format_outbound {
-    my $self = shift;
+    my ($self, $value) = @_;
     # YUI expects ISO8601 in UTC time; including TZ specifier
-    return $self->SUPER::datetime_format_outbound(@_) . 'Z';
+    return $value ? $self->SUPER::datetime_format_outbound($value) . 'Z' : '';
 }
 
 sub handle_login {


### PR DESCRIPTION
Return date/time (and double) values in an appropriate data type instead of string. If the value is empty, make sure an empty string will be returned. Otherwise, return a UTC date in the ISO 8601 format.

## Bugzilla link

[Bug 1509308 - Date for cf_last_resolved in history results should be UTC](https://bugzilla.mozilla.org/show_bug.cgi?id=1509308)