### PR TITLE
Bug 1499697 - Update triage owner list to include all Firefox-related major products and stop saying __Any__

### DIFF
--- a/extensions/BMO/lib/Reports/Triage.pm
+++ b/extensions/BMO/lib/Reports/Triage.pm
@@ -27,10 +27,14 @@ use constant MAX_NUMBER_BUGS => 4000;
 
 use constant DEFAULT_OWNER_PRODUCTS => (
     'Core',
+    'DevTools',
+    'External Software Affecting Firefox',
     'Firefox',
     'Firefox for Android',
-    'Firefox for iOS',
+    'Firefox Build System',
+    'Testing',
     'Toolkit',
+    'WebExtensions',
 );
 
 sub unconfirmed {

--- a/extensions/BMO/template/en/default/pages/triage_owners.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/triage_owners.html.tmpl
@@ -46,7 +46,7 @@
     <th>Product:</th>
     <td>
       <select name="product" id="product">
-        <option value="">__Any__</option>
+        <option value="">Firefox-related major products</option>
         [% FOREACH p = user.get_selectable_products %]
           <option value="[% p.name FILTER html %]"
             [% " selected" IF product == p.name %]>


### PR DESCRIPTION
* Update the default product list for the [Triage Owners](https://bugzilla.mozilla.org/page.cgi?id=triage_owners.html) page
* Use a proper label for the default list instead of confusing `__Any__`

## Bugzilla link

[Bug 1499697 - Update triage owner list to include all Firefox-related major products and stop saying `__Any__`](https://bugzilla.mozilla.org/show_bug.cgi?id=1499697)