### PR TITLE
Bug 1510109 - Implement per-product new bug comment templates

### DIFF
--- a/Bugzilla/Product.pm
+++ b/Bugzilla/Product.pm
@@ -55,6 +55,7 @@ use constant UPDATE_COLUMNS => qw(
   defaultmilestone
   isactive
   allows_unconfirmed
+  bug_description_template
 );
 
 use constant VALIDATORS => {
@@ -521,6 +522,7 @@ sub set_description        { $_[0]->set('description',        $_[1]); }
 sub set_default_milestone  { $_[0]->set('defaultmilestone',   $_[1]); }
 sub set_is_active          { $_[0]->set('isactive',           $_[1]); }
 sub set_allows_unconfirmed { $_[0]->set('allows_unconfirmed', $_[1]); }
+sub set_bug_description_template { $_[0]->set('bug_description_template', $_[1]); }
 
 sub set_group_controls {
   my ($self, $group, $settings) = @_;
@@ -901,6 +903,17 @@ sub is_active          { return $_[0]->{'isactive'}; }
 sub default_milestone  { return $_[0]->{'defaultmilestone'}; }
 sub classification_id  { return $_[0]->{'classification_id'}; }
 
+# Lazy-load the bug_description_template column
+sub bug_description_template {
+  my $self = shift;
+  if (!exists $self->{'bug_description_template'}) {
+    $self->{'bug_description_template'} = Bugzilla->dbh->selectrow_array(
+      'SELECT bug_description_template FROM products WHERE id = ?',
+      undef, $self->id);
+  }
+  return $self->{'bug_description_template'};
+}
+
 ###############################
 ####      Subroutines    ######
 ###############################
@@ -953,6 +966,7 @@ Bugzilla::Product - Bugzilla product class.
     my $defaultmilestone = $product->default_milestone;
     my $classificationid = $product->classification_id;
     my $allows_unconfirmed = $product->allows_unconfirmed;
+    my $bug_description_template = $product->bug_description_template;
 
 =head1 DESCRIPTION
 

--- a/editproducts.cgi
+++ b/editproducts.cgi
@@ -165,6 +165,7 @@ if ($action eq 'new') {
     isactive           => scalar $cgi->param('is_active'),
     create_series      => scalar $cgi->param('createseries'),
     allows_unconfirmed => scalar $cgi->param('allows_unconfirmed'),
+    bug_description_template => scalar $cgi->param('bug_description_template'),
   );
   my $product = Bugzilla::Product->create(\%create_params);
 
@@ -283,6 +284,7 @@ if ($action eq 'update') {
     is_active          => scalar $cgi->param('is_active'),
     allows_unconfirmed => scalar $cgi->param('allows_unconfirmed'),
     default_milestone  => scalar $cgi->param('defaultmilestone'),
+    bug_description_template => scalar $cgi->param('bug_description_template'),
   });
 
   my $changes = $product->update();

--- a/enter_bug.cgi
+++ b/enter_bug.cgi
@@ -335,7 +335,7 @@ else {
 
   $vars->{'cc'} = join(', ', $cgi->param('cc'));
 
-  $vars->{'comment'}            = formvalue('comment');
+  $vars->{'comment'}            = formvalue('comment', $product->bug_description_template);
   $vars->{'comment_is_private'} = formvalue('comment_is_private');
 
   # BMO Add support for mentors

--- a/template/en/default/admin/products/edit-common.html.tmpl
+++ b/template/en/default/admin/products/edit-common.html.tmpl
@@ -42,6 +42,12 @@
         [% product.description FILTER html %]</textarea>
   </td>
 </tr>
+<tr>
+  <th align="right">New [% terms.bug %] comment template:</th>
+  <td><textarea rows="8" cols="64" wrap="virtual" name="bug_description_template">
+        [% product.bug_description_template FILTER html %]</textarea>
+  </td>
+</tr>
 
 [% IF Param('usetargetmilestone') -%]
   <tr>


### PR DESCRIPTION
* Allow Bugzilla admins to define a per-product new bug comment template on the Edit Product page. [Screenshot](https://screenshots.firefox.com/8EvjYUvtfAdZucfm/bmo-web.vm)
* Prefill the comment box on the New Bug page with the per-product template if defined.

## Bugzilla link

[Bug 1510109 - Implement per-product new bug comment templates](https://bugzilla.mozilla.org/show_bug.cgi?id=1510109)