### PR TITLE
improve fulltext completion for real names

### DIFF
--- a/Bugzilla/DB/Mysql.pm
+++ b/Bugzilla/DB/Mysql.pm
@@ -32,7 +32,7 @@ use Bugzilla::Util;
 use Bugzilla::Error;
 use Bugzilla::DB::Schema::Mysql;
 
-use List::Util qw(max any);
+use List::Util qw(max any all);
 use Text::ParseWords;
 use Carp;
 
@@ -236,13 +236,17 @@ sub sql_group_by {
 
 sub sql_prefix_match_fulltext {
   my ($self, $column, $prefix) = @_;
-  my @words = map { "+$_" } split(/\s+/, $prefix);
-  $words[-1] .= '*';
-  return sprintf(
-    'MATCH(%s) AGAINST (%s IN BOOLEAN MODE)',
-    $column,
-    $self->quote(join(' ', @words))
-  );
+  my @words = split(/\s+/, $prefix);
+  if (all { /^\w+$/ } @words) {
+      $words[-1] .= '*';
+      return sprintf(
+          'MATCH(%s) AGAINST (%s IN BOOLEAN MODE)',
+          $column,
+          $self->quote(join(' ', map { "+$_" } @words))
+      );
+  } else {
+      return sprintf('MATCH(%s) AGAINST (%s)', $column, $self->quote($prefix));
+  }
 }
 
 sub bz_explain {

--- a/Bugzilla/DB/Mysql.pm
+++ b/Bugzilla/DB/Mysql.pm
@@ -234,6 +234,17 @@ sub sql_group_by {
     return "GROUP BY $needed_columns";
 }
 
+sub sql_prefix_match_fulltext {
+  my ($self, $column, $prefix) = @_;
+  my @words = map { "+$_" } split(/\s+/, $prefix);
+  $words[-1] .= '*';
+  return sprintf(
+    'MATCH(%s) AGAINST (%s IN BOOLEAN MODE)',
+    $column,
+    $self->quote(join(' ', @words))
+  );
+}
+
 sub bz_explain {
     my ($self, $sql) = @_;
     my $sth  = $self->prepare("EXPLAIN $sql");

--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -167,13 +167,13 @@ sub suggest {
     }
     else {
         if ($have_mysql && ( $s =~ /[[:space:]]/ || $s =~ /[^[:ascii:]]/ ) ) {
-            my $match = sprintf 'MATCH(realname) AGAINST (%s) ', $dbh->quote($s);
+            my $match = $dbh->sql_prefix_match_fulltext('realname', $s);
             push @select, "$match AS relevance";
             $order = 'relevance DESC';
             $where = $match;
         }
         elsif ($have_mysql && $s =~ /^[[:upper:]]/) {
-            my $match = sprintf 'MATCH(realname) AGAINST (%s) ', $dbh->quote($s);
+            my $match = $dbh->sql_prefix_match_fulltext('realname', $s);
             $where = join ' OR ',
                 $match,
                 $dbh->sql_prefix_match( nickname => $s ),


### PR DESCRIPTION
This patch improves the behavior of fulltext searches for real names.
For instance, 'Israel Mad' actually finds @purelogiq now (it turns into
```sql
SELECT login_name FROM  profiles where MATCH(realname) AGAINST ('+Israel +Mad*' IN BOOLEAN MODE)  LIMIT 25
```

The trick is to the use [Boolean Mode](https://dev.mysql.com/doc/refman/5.5/en/fulltext-boolean.html), so each word is prefixed with a `+`, and the final word ends with `*`.
