### PR TITLE
make user suggest faster by doing less work

### DIFF
--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -197,8 +197,10 @@ sub suggest {
         }
     } @$results;
 
-    Bugzilla::Hook::process('webservice_user_suggest',
-        { webservice => $self, params => $params, users => \@users });
+    unless ($params->{fast_mode}) {
+      Bugzilla::Hook::process('webservice_user_suggest',
+          { webservice => $self, params => $params, users => \@users });
+    }
 
     return { users => \@users };
 }

--- a/js/field.js
+++ b/js/field.js
@@ -718,6 +718,7 @@ $(function() {
         serviceUrl: `${BUGZILLA.config.basepath}rest/user/suggest`,
         params: {
             Bugzilla_api_token: BUGZILLA.api_token,
+            fast_mode: 1
         },
         paramName: 'match',
         deferRequestBy: 250,


### PR DESCRIPTION
I don't think we need to load the request info for every user suggestion,
so this adds a fast_mode option that avoids calling the hook.