### PR TITLE
cleanup oauth2 code and make a better mechanism for splitting routes out from the application class

### DIFF
--- a/Bugzilla/Quantum.pm
+++ b/Bugzilla/Quantum.pm
@@ -21,7 +21,7 @@ use Bugzilla::Extension             ();
 use Bugzilla::Install::Requirements ();
 use Bugzilla::Logging;
 use Bugzilla::Quantum::CGI;
-use Bugzilla::Quantum::OAuth2 qw(oauth2);
+use Bugzilla::Quantum::OAuth2::Clients;
 use Bugzilla::Quantum::SES;
 use Bugzilla::Quantum::Home;
 use Bugzilla::Quantum::API;
@@ -47,9 +47,7 @@ sub startup {
     unless $ENV{BUGZILLA_DISABLE_SIZELIMIT};
   $self->plugin('ForwardedFor') if Bugzilla->has_feature('better_xff');
   $self->plugin('Bugzilla::Quantum::Plugin::Helpers');
-
-  # OAuth2 Support
-  oauth2($self);
+  $self->plugin('Bugzilla::Quantum::Plugin::OAuth2');
 
   # hypnotoad is weird and doesn't look for MOJO_LISTEN itself.
   $self->config(
@@ -103,7 +101,7 @@ sub setup_routes {
   my ($self) = @_;
 
   my $r = $self->routes;
-  Bugzilla::Quantum::CGI->load_all($r);
+  Bugzilla::Quantum::CGI->setup_routes($r);
   Bugzilla::Quantum::CGI->load_one('bzapi_cgi',
     'extensions/BzAPI/bin/rest.cgi');
 
@@ -140,17 +138,9 @@ sub setup_routes {
   $r->any('/login')->to('CGI#index_cgi' => {'GoAheadAndLogIn' => '1'});
   $r->any('/:new_bug' => [new_bug => qr{new[-_]bug}])->to('CGI#new_bug_cgi');
 
-  $r->get('/api/user/profile')->to('API#user_profile');
-
-  my $ses_auth = $r->under(
-    '/ses' => sub {
-      my ($c) = @_;
-      my $lc = Bugzilla->localconfig;
-
-      return $c->basic_auth('SES', $lc->{ses_username}, $lc->{ses_password});
-    }
-  );
-  $ses_auth->any('/index.cgi')->to('SES#main');
+  Bugzilla::Quantum::API->setup_routes($r);
+  Bugzilla::Quantum::SES->setup_routes($r);
+  Bugzilla::Quantum::OAuth2::Clients->setup_routes($r);
 }
 
 1;

--- a/Bugzilla/Quantum/API.pm
+++ b/Bugzilla/Quantum/API.pm
@@ -9,6 +9,11 @@ package Bugzilla::Quantum::API;
 use 5.10.1;
 use Mojo::Base qw( Mojolicious::Controller );
 
+sub setup_routes {
+  my ($class, $r) = @_;
+  $r->get('/api/user/profile')->to('API#user_profile');
+}
+
 sub user_profile {
   my ($self) = @_;
 

--- a/Bugzilla/Quantum/CGI.pm
+++ b/Bugzilla/Quantum/CGI.pm
@@ -23,7 +23,7 @@ use Bugzilla::Constants qw(bz_locations USAGE_MODE_BROWSER);
 our $C;
 my %SEEN;
 
-sub load_all {
+sub setup_routes {
   my ($class, $r) = @_;
 
   foreach my $file (glob '*.cgi') {

--- a/Bugzilla/Quantum/Plugin/OAuth2.pm
+++ b/Bugzilla/Quantum/Plugin/OAuth2.pm
@@ -5,59 +5,28 @@
 # This Source Code Form is "Incompatible With Secondary Licenses", as
 # defined by the Mozilla Public License, v. 2.0.
 
-package Bugzilla::Quantum::OAuth2;
-
+package Bugzilla::Quantum::Plugin::OAuth2;
 use 5.10.1;
-use strict;
-use warnings;
+use Mojo::Base 'Mojolicious::Plugin::OAuth2::Server';
 
-use Bugzilla;
 use Bugzilla::Constants;
 use Bugzilla::Error;
 use Bugzilla::Logging;
 use Bugzilla::Util;
 use Bugzilla::Token;
-
 use DateTime;
-
 use Mojo::Util qw(secure_compare);
 
-use base qw(Exporter);
-our @EXPORT_OK = qw(oauth2);
+sub register {
+  my ($self, $app, $conf) = @_;
 
-sub oauth2 {
-  my ($self) = @_;
-
-  $self->plugin(
-    'OAuth2::Server' => {
-      login_resource_owner      => \&_resource_owner_logged_in,
-      confirm_by_resource_owner => \&_resource_owner_confirm_scopes,
-      verify_client             => \&_verify_client,
-      store_auth_code           => \&_store_auth_code,
-      verify_auth_code          => \&_verify_auth_code,
-      store_access_token        => \&_store_access_token,
-      verify_access_token       => \&_verify_access_token,
-    }
-  );
-
-  # Manage the client list
-  my $r            = $self->routes;
-  my $client_route = $r->under(
-    '/admin/oauth' => sub {
-      my ($c) = @_;
-      my $user = $c->bugzilla->login(LOGIN_REQUIRED) || return undef;
-      $user->in_group('admin')
-        || ThrowUserError('auth_failure',
-        {group => 'admin', action => 'edit', object => 'oauth_clients'});
-      return 1;
-    }
-  );
-  $client_route->any('/list')->to('OAuth2::Clients#list')->name('list_clients');
-  $client_route->any('/create')->to('OAuth2::Clients#create')
-    ->name('create_client');
-  $client_route->any('/delete')->to('OAuth2::Clients#delete')
-    ->name('delete_client');
-  $client_route->any('/edit')->to('OAuth2::Clients#edit')->name('edit_client');
+  $conf->{login_resource_owner}     = \&_resource_owner_logged_in;
+  $conf->{confirm_by_resource_owner}= \&_resource_owner_confirm_scopes;
+  $conf->{verify_client}            = \&_verify_client;
+  $conf->{store_auth_code}          = \&_store_auth_code;
+  $conf->{verify_auth_code}         = \&_verify_auth_code;
+  $conf->{store_access_token}       = \&_store_access_token;
+  $conf->{verify_access_token}      = \&_verify_access_token;
 
   $self->helper(
     'bugzilla.oauth' => sub {
@@ -75,7 +44,7 @@ sub oauth2 {
     }
   );
 
-  return 1;
+  return $self->SUPER::register($app, $conf);
 }
 
 sub _resource_owner_logged_in {

--- a/Bugzilla/Quantum/Plugin/OAuth2.pm
+++ b/Bugzilla/Quantum/Plugin/OAuth2.pm
@@ -28,7 +28,7 @@ sub register {
   $conf->{store_access_token}       = \&_store_access_token;
   $conf->{verify_access_token}      = \&_verify_access_token;
 
-  $self->helper(
+  $app->helper(
     'bugzilla.oauth' => sub {
         my ($c, @scopes) = @_;
 

--- a/Bugzilla/Quantum/SES.pm
+++ b/Bugzilla/Quantum/SES.pm
@@ -74,6 +74,20 @@ declare Notification,
   slurpy Any,
   ];
 
+sub setup_routes {
+  my ($class, $r) = @_;
+
+  my $ses_auth = $r->under(
+    '/ses' => sub {
+      my ($c) = @_;
+      my $lc = Bugzilla->localconfig;
+
+      return $c->basic_auth('SES', $lc->{ses_username}, $lc->{ses_password});
+    }
+  );
+  $ses_auth->any('/index.cgi')->to('SES#main');
+}
+
 sub main {
   my ($self) = @_;
   try {


### PR DESCRIPTION
I think this is a more sensible way of handling routes. 

The convention is that each controller can have a setup_routes() class method, which is passed in the routes object. Note this is something like what CGI->load_all() was doing, so I renamed load_all() to setup_routes.

Additionally, we subclass the oauth plugin to provide our defaults.