### PR TITLE
Bug 1510109 - Implement per-product new bug comment templates (schema change only)

### DIFF
--- a/Bugzilla/DB/Schema.pm
+++ b/Bugzilla/DB/Schema.pm
@@ -1418,6 +1418,7 @@ use constant ABSTRACT_SCHEMA => {
                                   NOTNULL => 1, DEFAULT => "'---'"},
             allows_unconfirmed => {TYPE => 'BOOLEAN', NOTNULL => 1,
                                    DEFAULT => 'TRUE'},
+            bug_description_template => {TYPE => 'MEDIUMTEXT'},
         ],
         INDEXES => [
             products_name_idx   => {FIELDS => ['name'],

--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -778,6 +778,9 @@ sub update_table_definitions {
     # Bug 1354589 - dkl@mozilla.com
     _populate_oauth2_scopes();
 
+    # Bug 1510109 - kohei.yoshino@gmail.com
+    $dbh->bz_add_column('products', 'bug_description_template', {TYPE => 'MEDIUMTEXT'});
+
     ################################################################
     # New --TABLE-- changes should go *** A B O V E *** this point #
     ################################################################


### PR DESCRIPTION
Split from #942. Add the `bug_description_template` column to the `products` table in preparation for the feature addition.

## Bugzilla link

[Bug 1510109 - Implement per-product new bug comment templates](https://bugzilla.mozilla.org/show_bug.cgi?id=1510109)