### PR TITLE
Bug 1510832 - Adding a trailing space to a comment causes an error

### DIFF
--- a/extensions/EditComments/web/js/inline-editor.js
+++ b/extensions/EditComments/web/js/inline-editor.js
@@ -50,7 +50,8 @@ Bugzilla.InlineCommentEditor = class InlineCommentEditor {
   }
 
   /**
-   * Check if the comment is edited.
+   * Check if the comment is edited. Ignore leading/trailing white space(s) and/or additional empty line(s) when
+   * comparing the changes.
    * @private
    * @readonly
    * @type {Boolean}

--- a/extensions/EditComments/web/js/inline-editor.js
+++ b/extensions/EditComments/web/js/inline-editor.js
@@ -56,7 +56,7 @@ Bugzilla.InlineCommentEditor = class InlineCommentEditor {
    * @type {Boolean}
    */
   get edited() {
-    return this.$textarea.value !== this.raw_comment;
+    return this.$textarea.value.trim() !== this.raw_comment.trim();
   }
 
   /**


### PR DESCRIPTION
Ignore trailing space(s) or additional empty line(s) when checking if the comment is edited. This have to be caught client-side even though I’ve added a server-side check just in case. With this fix, those changes won’t enable the Update Comment (Save) button.