### PR TITLE
bump version to 20181129.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20181127.1';
+our $VERSION = '20181129.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
the following changes will be pushed to bugzilla.mozilla.org:
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1510427" target="_blank">1510427</a>] improve fulltext completion for real names</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1508261" target="_blank">1508261</a>] Closing DevRel sponsorship form on Bugzilla and updating Wiki page</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1508385" target="_blank">1508385</a>] Remove links to input.mozilla.org from Guided Bug Entry flow</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1510653" target="_blank">1510653</a>] API method for returning users profile information when given a valid oauth2 access token</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1510832" target="_blank">1510832</a>] Adding a trailing space to a comment causes an error</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1510109" target="_blank">1510109</a>] Implement per-product new bug comment templates</li>
</ul>