### PR TITLE
Bug 1511558 - Guided form's Core Component dropdown list cannot be loaded

### DIFF
--- a/extensions/GuidedBugEntry/web/js/guided.js
+++ b/extensions/GuidedBugEntry/web/js/guided.js
@@ -258,7 +258,7 @@ var product = {
         id: ++this._counter,
         params: {
           names: [productName],
-          exclude_fields: ['internals', 'milestones'],
+          exclude_fields: ['internals', 'milestones', 'components.flag_types'],
           Bugzilla_api_token : (BUGZILLA.api_token ? BUGZILLA.api_token : '')
         }
       }


### PR DESCRIPTION
Exclude the `components.flag_types` field from product API calls to improve performance.

## Bugzilla link

[Bug 1511558 - Guided form's Core Component dropdown list cannot be loaded](https://bugzilla.mozilla.org/show_bug.cgi?id=1511558)