### PR TITLE
Bug 1512424 - Comment Reply button is not working properly on Chrome

### DIFF
--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -638,6 +638,10 @@ h3.change-name {
     color: #555;
 }
 
+.comment-actions button.iconic .icon {
+  pointer-events: none;
+}
+
 .comment-actions button.iconic .icon::before {
     font-family: 'Material Icons';
     font-size: 16px;


### PR DESCRIPTION
Fix a regression from #736 where I changed the design of comment action buttons from text to icons. The icon itself should not be clickable, otherwise the click event target will be wrong.

## Bugzilla link

[Bug 1512424 - Comment Reply button is not working properly on Chrome](https://bugzilla.mozilla.org/show_bug.cgi?id=1512424)