### PR TITLE
Bug 1513087 - User preferences page is totally empty with Template v2.28

### DIFF
--- a/extensions/BugmailFilter/template/en/default/hook/account/prefs/prefs-tabs.html.tmpl
+++ b/extensions/BugmailFilter/template/en/default/hook/account/prefs/prefs-tabs.html.tmpl
@@ -6,7 +6,7 @@
   # defined by the Mozilla Public License, v. 2.0.
   #%]
 
-[% tabs = tabs.import([{
+[% CALL tabs.import([{
     name      => "bugmail_filter",
     label     => "Bugmail Filtering",
     link      => "userprefs.cgi?tab=bugmail_filter",

--- a/extensions/ComponentWatching/template/en/default/hook/account/prefs/prefs-tabs.html.tmpl
+++ b/extensions/ComponentWatching/template/en/default/hook/account/prefs/prefs-tabs.html.tmpl
@@ -6,7 +6,7 @@
   # defined by the Mozilla Public License, v. 2.0.
   #%]
 
-[% tabs = tabs.import([{
+[% CALL tabs.import([{
     name => "component_watch",
     label => "Component Watching",
     link => "userprefs.cgi?tab=component_watch",

--- a/extensions/Example/template/en/default/hook/account/prefs/prefs-tabs.html.tmpl
+++ b/extensions/Example/template/en/default/hook/account/prefs/prefs-tabs.html.tmpl
@@ -18,6 +18,6 @@
   # Contributor(s): Frédéric Buclin <LpSolit@gmail.com>
   #%]
 
-[% tabs = tabs.import([{ name => "my_tab", label => "Example Custom Preferences",
+[% CALL tabs.import([{ name => "my_tab", label => "Example Custom Preferences",
                          link => "userprefs.cgi?tab=my_tab", saveable => 1 }
                       ]) %]

--- a/extensions/RequestNagger/template/en/default/hook/account/prefs/prefs-tabs.html.tmpl
+++ b/extensions/RequestNagger/template/en/default/hook/account/prefs/prefs-tabs.html.tmpl
@@ -6,7 +6,7 @@
   # defined by the Mozilla Public License, v. 2.0.
   #%]
 
-[% tabs = tabs.import([{
+[% CALL tabs.import([{
     name => "request_nagging",
     label => "Request Reminders",
     link => "userprefs.cgi?tab=request_nagging",

--- a/extensions/SecureMail/template/en/default/hook/account/prefs/prefs-tabs.html.tmpl
+++ b/extensions/SecureMail/template/en/default/hook/account/prefs/prefs-tabs.html.tmpl
@@ -20,7 +20,7 @@
   #                 Gervase Markham <gerv@gerv.net>
   #%]
 
-[% tabs = tabs.import([{
+[% CALL tabs.import([{
     name => "securemail",
     label => "Secure Mail",
     link => "userprefs.cgi?tab=securemail",


### PR DESCRIPTION
With the latest version of template toolkit, the use preferences pages are empty.

This seems like a bug-fix upstream, rather than a regression. The reason is we're calling tabs = tabs.import() in many extensions..


It doesn't appear that hash.import() returns the hash, and this was working because the context of the template was localized.

https://metacpan.org/pod/distribution/Template-Toolkit/lib/Template/Manual/VMethods.pod#import