### PR TITLE
bump version to 20181212.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20181207.1';
+our $VERSION = '20181212.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
the following changes will be pushed to bugzilla.mozilla.org:
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1513087" target="_blank">1513087</a>] User preferences page is totally empty with Template v2.28</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1456878" target="_blank">1456878</a>] Support markdown comments</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1510109" target="_blank">1510109</a>] Implement per-product new bug comment templates</li>
</ul>