### PR TITLE
Bug 1514765 - fix new bug comment preview

### DIFF
--- a/template/en/default/bug/comment.html.tmpl
+++ b/template/en/default/bug/comment.html.tmpl
@@ -37,7 +37,12 @@
   <div id="comment_preview" class="bz_default_hidden bz_comment">
     <div id="comment_preview_loading" class="bz_default_hidden">Generating Preview...</div>
     <div id="comment_preview_error" class="bz_default_hidden"></div>
-    <div id="comment_preview_text" class="bz_comment_text"></div>
+    [% IF comment.is_markdown AND Param('use_markdown') %]
+      [% comment_tag = 'div' %]
+    [% ELSE %]
+      [% comment_tag = 'pre' %]
+    [% END %]
+    <[% comment_tag FILTER none %] id="comment_preview_text" class="bz_comment_text"></[% comment_tag FILTER none %]>
   </div>
 [% END %]
 


### PR DESCRIPTION
We forgot to correctly switch between a div and pre tag on the new
bug comment preview, based on whether markdown is enabled or not.
This was causing plaintext comments to lose their formatting (only when previewed).