### PR TITLE
Proof of concept - rules engine extension

### DIFF
--- a/extensions/Rules/Config.pm
+++ b/extensions/Rules/Config.pm
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::Extension::Rules;
+
+use 5.10.1;
+use strict;
+
+use constant NAME => 'Rules';
+
+use constant REQUIRED_MODULES => [
+];
+
+use constant OPTIONAL_MODULES => [
+];
+
+__PACKAGE__->NAME;

--- a/extensions/Rules/Extension.pm
+++ b/extensions/Rules/Extension.pm
@@ -1,0 +1,50 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::Extension::Rules;
+
+use 5.10.1;
+use strict;
+use warnings;
+use parent qw(Bugzilla::Extension);
+
+use Mojo::Util qw(trim);
+use Bugzilla::Extension::Rules::Sandbox;
+
+our $VERSION = '0.01';
+
+my $Safe = Safe->new;
+$Safe->share_from('Bugzilla::Extension::Rules::Sandbox',
+  ['&group', '&field', '&product', '&deny']);
+$Safe->permit_only(
+  qw(
+    :base_core
+    gvsv gv gelem padsv padav padhv padany once rv2gv refgen srefgen ref
+    pushre regcmaybe regcreset regcomp subst substcont
+    )
+);
+
+
+sub bug_check_can_change_field {
+  my ($self, $args) = @_;
+
+  local $Bugzilla::Extension::Rules::Sandbox::BUG   = $args->{bug};
+  local $Bugzilla::Extension::Rules::Sandbox::FIELD = $args->{field};
+  local $Bugzilla::Extension::Rules::Sandbox::PRIV_RESULTS = $args->{priv_results};
+  $Safe->reval( Bugzilla->params->{can_change_field_rules} . "; 1" )
+  or die $@;
+}
+
+sub config_modify_panels {
+  my ($self, $args) = @_;
+
+  push @{$args->{panels}->{advanced}->{params}},
+    {name => 'can_change_field_rules', type => 'l', default => '',};
+}
+
+
+__PACKAGE__->NAME;

--- a/extensions/Rules/lib/Sandbox.pm
+++ b/extensions/Rules/lib/Sandbox.pm
@@ -1,0 +1,36 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::Extension::Rules::Sandbox;
+
+use 5.10.1;
+use strict;
+use warnings;
+use Bugzilla::Constants;
+
+our ($BUG, $FIELD, $PRIV_RESULTS);
+
+sub field {
+  my ($field) = @_;
+  return lc($FIELD) eq lc($field);
+}
+
+sub group {
+  my ($group_name) = @_;
+  return Bugzilla->user->in_group($group_name);
+}
+
+sub product {
+  my ($product_name) = @_;
+  return lc($BUG->product) eq lc($product_name);
+}
+
+sub deny {
+  push(@$PRIV_RESULTS, PRIVILEGES_REQUIRED_EMPOWERED);
+}
+
+1;

--- a/extensions/Rules/template/en/default/hook/README
+++ b/extensions/Rules/template/en/default/hook/README
@@ -1,0 +1,5 @@
+Template hooks go in this directory. Template hooks are called in normal
+ templates like [% Hook.process('some-hook') %].
+More information about them can be found in the documentation of
+Bugzilla::Extension. (Do "perldoc Bugzilla::Extension" from the main
+ directory to see that documentation.)

--- a/extensions/Rules/template/en/default/rules/README
+++ b/extensions/Rules/template/en/default/rules/README
@@ -1,0 +1,16 @@
+Normal templates go in this directory. You can load them in your
+code like this:
+
+use Bugzilla::Error;
+my $template = Bugzilla->template;
+$template->process('rules/some-template.html.tmpl')
+  or ThrowTemplateError($template->error());
+
+That would be how to load a file called some-template.html.tmpl that
+was in this directory.
+
+Note that you have to be careful that the full path of your template
+never conflicts with a template that exists in  or in
+another extension, or your template might override that template. That's why
+we created this directory called 'rules' for you, so you
+can put your templates in here to help avoid conflicts.

--- a/extensions/Rules/web/README
+++ b/extensions/Rules/web/README
@@ -1,0 +1,7 @@
+Web-accessible files, like JavaScript, CSS, and images go in this
+directory. You can reference them directly in your HTML. For example,
+if you have a file called "style.css" and your extension is called
+"Foo", you would put it in "extensions/Foo/web/style.css", and then
+you could link to it in HTML like:
+
+<link href="extensions/Foo/web/style.css" rel="stylesheet" type="text/css">


### PR DESCRIPTION
# TODO

1. Expressing rules as code is probably not ideal
2. Performance is sort of important for this.
3. This exposes a few UX issues (like when the assignee field editing is denied)

# Examples
Rules are written in a (sandboxed) subset of perl. 
![screenshot_2018-12-19 configuration advanced](https://user-images.githubusercontent.com/47717/50204308-50c75680-0332-11e9-82bf-7394adf989ac.png)

The UI is pretty much already smart enough for this, for most fields. 
Though it is a bit weird how the assigned_to field disappears.

![screenshot_2018-12-19 1 - i like cheese 1](https://user-images.githubusercontent.com/47717/50204312-5329b080-0332-11e9-8fd1-758565cdc264.png)



![screenshot_2018-12-19 1 - i like cheese](https://user-images.githubusercontent.com/47717/50204317-54f37400-0332-11e9-9eaa-e62a516b14ce.png)
