### PR TITLE
remove index.html stuff

### DIFF
--- a/google1498b17dba53f45e.html
+++ b/google1498b17dba53f45e.html
@@ -1,1 +1,0 @@
-google-site-verification: google1498b17dba53f45e.html


### PR DESCRIPTION
index.html is never used, so we should remove that option.
This also removes the useless google verification html file too.