### PR TITLE
Bug 1517606 - Prevent infinite loops by making workers die after 5 minutes

### DIFF
--- a/Bugzilla/JobQueue.pm
+++ b/Bugzilla/JobQueue.pm
@@ -130,7 +130,11 @@ sub work {
     first_interval => 0,
     interval       => $delay,
     reschedule     => 'drift',
-    on_tick        => sub { $self->work_once }
+    on_tick        => sub {
+      alarm(60 * 5);
+      $self->work_once
+      alarm(0);
+    }
   );
   DEBUG("working every $delay seconds");
   $loop->add($timer);

--- a/Bugzilla/JobQueue.pm
+++ b/Bugzilla/JobQueue.pm
@@ -132,7 +132,7 @@ sub work {
     reschedule     => 'drift',
     on_tick        => sub {
       alarm(60 * 5);
-      $self->work_once
+      $self->work_once;
       alarm(0);
     }
   );

--- a/jobqueue-worker.pl
+++ b/jobqueue-worker.pl
@@ -18,7 +18,6 @@ BEGIN {
   my $dir = rel2abs(dirname(__FILE__));
   lib->import($dir, catdir($dir, 'lib'), catdir($dir, qw(local lib perl5)));
   chdir $dir or die "chdir $dir failed: $!";
-
 }
 
 use Bugzilla::JobQueue::Worker;


### PR DESCRIPTION
Inside the 'tick' function for the worker processes, we set an alarm() for five minutes. That should be long enough -- and importantly after five minutes another worker may pick up the same job. In the case of a job triggering an infinite loop, only a max of one worker will be out of commission for that time.