### PR TITLE
Bug 1509122 - Need additional space between status icon and status text in the revision panel in show_bug

### DIFF
--- a/extensions/PhabBugz/web/style/phabricator.css
+++ b/extensions/PhabBugz/web/style/phabricator.css
@@ -71,6 +71,7 @@ span[class^="review-status-icon-"]::before
     display: inline-block;
     font-variant: normal;
     text-rendering: auto;
+    margin: -2px 4px -2px 0;
     font-family: FontAwesome-DifferentialStatus;
 }
 


### PR DESCRIPTION
Lifted from Phabricator CSS