### PR TITLE
Bug 1518381 - lightbox is no longer used when clicking on an attachment's link in markdown comments

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -378,7 +378,7 @@ $(function() {
     }
 
     // lightboxes
-    $('.lightbox, .comment-text .lightbox + span:first-of-type a:first-of-type')
+    $('.lightbox, .comment-text .lightbox + span:first-of-type a:first-of-type, .comment-text .lightbox + p span:first-of-type a:first-of-type')
         .click(function(event) {
             if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey)
                 return;


### PR DESCRIPTION
The link to the attachment is under a paragraph tag if markdown is enabled.