### PR TITLE
Bug 1518266 - Font of comment emails is rendered too large since markdown has been enabled

### DIFF
--- a/extensions/BMO/template/en/default/email/bugmail.html.tmpl
+++ b/extensions/BMO/template/en/default/email/bugmail.html.tmpl
@@ -13,9 +13,6 @@
 <html>
 <head>
   <base href="[% urlbase FILTER html %]">
-  <style>
-    .comment { font-size: initial !important; }
-  </style>
 </head>
 <body style="font-family: sans-serif">
 
@@ -55,7 +52,7 @@
           [% ELSE %]
             [% comment_tag = 'pre' %]
           [% END %]
-          <[% comment_tag FILTER none %] class="comment" style="font-size: initial">[% comment.body_full({ wrap => 1 }) FILTER renderMarkdown(bug, comment) %]</[% comment_tag FILTER none %]>
+          <[% comment_tag FILTER none %] class="comment" [% IF comment_tag == 'pre' %] style="font-size: initial" [% END %]>[% comment.body_full({ wrap => 1 }) FILTER renderMarkdown(bug, comment) %]</[% comment_tag FILTER none %]>
         </div>
       [% END %]
     </div>


### PR DESCRIPTION
I verified this change looks ok in apple mail, I'll try to get it into gmail as well. Do you happen to have a working thunderbird setup?