### PR TITLE
Bug 1518303 - Comments on splinter patches are misformatted with markdown styling

### DIFF
--- a/Bugzilla/Comment.pm
+++ b/Bugzilla/Comment.pm
@@ -52,6 +52,7 @@ use constant UPDATE_COLUMNS => qw(
   isprivate
   type
   extra_data
+  is_markdown
 );
 
 use constant DB_TABLE => 'longdescs';
@@ -344,6 +345,7 @@ sub body_full {
 sub set_is_private { $_[0]->set('isprivate',  $_[1]); }
 sub set_type       { $_[0]->set('type',       $_[1]); }
 sub set_extra_data { $_[0]->set('extra_data', $_[1]); }
+sub set_is_markdown { $_[0]->set('is_markdown', $_[1]); }
 
 sub add_tag {
   my ($self, $tag) = @_;

--- a/extensions/Splinter/Extension.pm
+++ b/extensions/Splinter/Extension.pm
@@ -108,6 +108,18 @@ sub page_before_template {
   }
 }
 
+sub object_end_of_create {
+  my ($self, $args) = @_;
+  my $class = $args->{class};
+
+  if ($class eq 'Bugzilla::Comment') {
+    my $comment = $args->{object};
+    if ($comment->body =~ /^Review of attachment (\d+)\s*:\n-{65}\n\n/s) {
+      $comment->set_is_markdown(0);
+      $comment->update;
+    }
+  }
+}
 
 sub bug_format_comment {
   my ($self, $args) = @_;


### PR DESCRIPTION
This matches the magic splinter header and sets the markdown flag to false if it matches. I'm not sure if it is safe to call `update()` from `object_end_of_create` though