### PR TITLE
Bug 1518218 - The attachment icon is misplaced

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -276,7 +276,7 @@
     [% IF comment.is_about_attachment && comment.attachment.is_image ~%]
       <a href="attachment.cgi?id=[% comment.attachment.id FILTER none %]"
         title="[% comment.attachment.description FILTER html %]"
-        class="lightbox"><img src="extensions/BugModal/web/image.png" width="16" height="16"></a>
+        class="lightbox lightbox-icon [%= "markdown" IF comment_tag == 'div' %]"><img src="extensions/BugModal/web/image.png" width="16" height="16"></a>
     [% END %]
   [% END %]
   [%~ comment.body_full FILTER renderMarkdown(bug, comment) ~%]</[% comment_tag FILTER none %]>

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -980,6 +980,10 @@ div.ui-tooltip {
     vertical-align: sub;
 }
 
+a.lightbox-icon {
+    display: none;
+}
+
 #lb_img {
     background-color: #fff;
     border: 1px solid #666;

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -980,7 +980,7 @@ div.ui-tooltip {
     vertical-align: sub;
 }
 
-a.lightbox-icon {
+a.lightbox-icon.markdown {
     display: none;
 }
 


### PR DESCRIPTION
As a quick fix, we will hide the icon until something better can be done.