### PR TITLE
Bug 1518268 - Preview cuts off bottoms of things using ```

### DIFF
--- a/template/en/default/bug/comment.html.tmpl
+++ b/template/en/default/bug/comment.html.tmpl
@@ -37,7 +37,7 @@
   <div id="comment_preview" class="bz_default_hidden bz_comment">
     <div id="comment_preview_loading" class="bz_default_hidden">Generating Preview...</div>
     <div id="comment_preview_error" class="bz_default_hidden"></div>
-    [% IF comment.is_markdown AND Param('use_markdown') %]
+    [% IF ( comment.is_markdown OR NOT comment.id ) AND Param('use_markdown') %]
       [% comment_tag = 'div' %]
     [% ELSE %]
       [% comment_tag = 'pre' %]


### PR DESCRIPTION
This fixes the bug entry form, which was using the 'pre' tag when it should use 'div'.
This works because `comment` is always defined, but sometimes it is a string and other times it is an object. calling `comment.id` is a good way to see if it is a comment object or not.