### PR TITLE
bump version to 20190108.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20181213.1';
+our $VERSION = '20190108.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
the following changes will be pushed to bugzilla.mozilla.org:
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1514765" target="_blank">1514765</a>] New bug comment preview broken when use_markdown is disabled</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1515144" target="_blank">1515144</a>] Prevent Google Analytics script from being loaded when DNT:1 so that Tracking Protection doesn't have to block it</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1515405" target="_blank">1515405</a>] Add rate limiting for comments and attachment accesses</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1514848" target="_blank">1514848</a>] Add utility to revoke API keys</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1506725" target="_blank">1506725</a>] Update form.doc to direct reporters to GitHub</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1493253" target="_blank">1493253</a>] Embed crash count table to bug pages</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1514446" target="_blank">1514446</a>] Disabled users don't have 'strikethrough' in group owners report</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1508389" target="_blank">1508389</a>] Change links for WebCompat reporting</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1516021" target="_blank">1516021</a>] Rename all references in the code and file tree from Quantum to App</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1514411" target="_blank">1514411</a>] NSS, DevTools and other products don't have "Has STR" and "Has Regression Range" fields</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1516188" target="_blank">1516188</a>] Alignment of "Bugs Filed" section in profile page is not same as of rest of rows below it.</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1517606" target="_blank">1517606</a>] Infinite loop in Bugzilla::Extension::BMO::_inject_headers_into_body()</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1518381" target="_blank">1518381</a>] lightbox is no longer used when clicking on an attachment's link in markdown comments</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1512526" target="_blank">1512526</a>] Revisions table: mouse over anywhere in the reviewer name should pop up the review status</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1509122" target="_blank">1509122</a>] Need additional space between status icon and status text in the revision panel in show_bug</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1518264" target="_blank">1518264</a>] New non-monospace comments styled with way too small a font size</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1518380" target="_blank">1518380</a>] reduce the margins of blockquotes in html comments</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1518350" target="_blank">1518350</a>] Allow literal html tags to stand for themselves</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1518303" target="_blank">1518303</a>] Comments on splinter patches are misformatted with markdown styling</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1518218" target="_blank">1518218</a>] The attachment icon is misplaced</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1518268" target="_blank">1518268</a>] Preview cuts off bottoms of things using ```</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1518266" target="_blank">1518266</a>] Font of comment emails is rendered too large since markdown has been enabled</li>
</ul>