### PR TITLE
Bug 1493253 follow up - Set CSP for crash table iframe

### DIFF
--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -39,7 +39,10 @@ sub DEFAULT_CSP {
     default_src => ['self'],
     script_src =>
       ['self', 'nonce', 'unsafe-inline', 'https://www.google-analytics.com'],
-    frame_src   => ['none',],
+    frame_src   => [
+      # This is for extensions/BMO/web/js/firefox-crash-table.js
+      'https://crash-stop-addon.herokuapp.com',
+    ],
     worker_src  => ['none',],
     img_src     => ['self', 'blob:', 'https://secure.gravatar.com'],
     style_src   => ['self', 'unsafe-inline'],
@@ -98,7 +101,12 @@ sub SHOW_BUG_MODAL_CSP {
       # This is from extensions/OrangeFactor/web/js/orange_factor.js
       'https://treeherder.mozilla.org/api/failurecount/',
     ],
-    frame_src  => ['self',],
+    frame_src  => [
+      'self',
+
+      # This is for extensions/BMO/web/js/firefox-crash-table.js
+      'https://crash-stop-addon.herokuapp.com',
+    ],
     worker_src => ['none',],
   );
   if (use_attachbase() && $bug_id) {


### PR DESCRIPTION
I thought the crash data table was being displayed when it was deployed on the dev server, but it’s not working on the staging server now. The `frame-src` CSP is required to show the `<iframe>` properly.

Note: since the table is needed for modal *and* legacy bug pages, both `SHOW_BUG_MODAL_CSP` and `DEFAULT_CSP` have to be updated.