### PR TITLE
only change the line-height of paragraphs

### DIFF
--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -703,7 +703,8 @@ div.comment-text {
     font-size: 14px !important;
 }
 
-div.comment-text p {
+div.comment-text p,
+div.comment-text li {
     line-height: 21px;
     max-width: 70em;
 }

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -701,7 +701,11 @@ div.comment-text {
     padding: 0 8px 0 8px;
     font-family: inherit !important;
     font-size: 14px !important;
-    line-height: 21px !important;
+}
+
+div.comment-text p {
+    line-height: 21px;
+    max-width: 70em;
 }
 
 div.comment-text code {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1518238#c0 Looks pretty weird, we should only use the 
21px line height on paragraphs. Also, I think setting a max-width on paragraphs may make sense?