### PR TITLE
Bug 1493253 follow up - bump the version

### DIFF
--- a/extensions/BMO/web/js/firefox-crash-table.js
+++ b/extensions/BMO/web/js/firefox-crash-table.js
@@ -9,7 +9,7 @@
 window.addEventListener('DOMContentLoaded', () => {
   "use strict";
 
-  const VERSION = "0.3.1";
+  const VERSION = "0.4.0";
 
   async function fetchProductDetails() {
     const url = "https://product-details.mozilla.org/1.0/firefox_versions.json";


### PR DESCRIPTION
@calixteman asked me to bump the version of the crash table code to `0.4.0` so the queries can be distinguished from ones sent from the [original Firefox extension](https://github.com/mozilla/crash-stop-addon).