### PR TITLE
bump version to 20190116.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20190115.1';
+our $VERSION = '20190116.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
the following changes will be pushed to bugzilla.mozilla.org:
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1518522" target="_blank">1518522</a>] phabbugz comments in bugs need to set is_markdown to true</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1493253" target="_blank">1493253</a>] Embed crash count table to bug pages</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1518264" target="_blank">1518264</a>] New non-monospace comments styled with way too small a font size</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1500441" target="_blank">1500441</a>] Make site-wide announcement dismissable</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1519240" target="_blank">1519240</a>] Markdown comments ruin links wrapped in &lt;&gt;</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1519157" target="_blank">1519157</a>] Linkification is disabled on &lt;h1&gt;, &lt;h2&gt; etc.</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1518328" target="_blank">1518328</a>] The edit comment feature should have a preview mode as well</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1510996" target="_blank">1510996</a>] Abandoned phabricator revisions should be hidden by default</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1518967" target="_blank">1518967</a>] Edit attachment as comment does markdown, which is very unexpected</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1519659" target="_blank">1519659</a>] Need to reload the page before being able to edit</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1520221" target="_blank">1520221</a>] Avoid wrapping markdown comments</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1519564" target="_blank">1519564</a>] Add a mechanism for disabling all special markdown syntax</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1520495" target="_blank">1520495</a>] Crash count table does not detect uplift links in Markdown comments</li>
</ul>
