### PR TITLE
Bug 1520582 - Block ips of users that get too many page errors

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -769,7 +769,8 @@ sub elastic {
 }
 
 sub check_rate_limit {
-  my ($class, $name, $ip) = @_;
+  my ($class, $name, $ip, $throw_error) = @_;
+  $throw_error //= sub { ThrowUserError("rate_limit") };
   my $params = Bugzilla->params;
   if ($params->{rate_limit_active}) {
     my $rules = decode_json($params->{rate_limit_rules});
@@ -789,7 +790,7 @@ sub check_rate_limit {
         "[rate_limit] action=$action, ip=$ip, limit=$limit, name=$name");
       if ($action eq 'block') {
         $Bugzilla::App::CGI::C->block_ip($ip);
-        ThrowUserError("rate_limit");
+        $throw_error->();
       }
     }
   }

--- a/Bugzilla/Config/Admin.pm
+++ b/Bugzilla/Config/Admin.pm
@@ -58,6 +58,7 @@ sub default_rate_limit_rules {
     github          => [10, 60],
     get_attachments => [75, 60],
     get_comments    => [75, 60],
+    webpage_errors  => [10, 120],
   });
 }
 
@@ -75,6 +76,7 @@ sub check_rate_limit_rules {
   my @required = qw(
     show_bug github get_bug
     get_attachments get_comments
+    webpage_errors
   );
   foreach my $required (@required) {
     return "missing $required" unless exists $val->{$required};
@@ -89,6 +91,7 @@ sub update_rate_limit_rules {
   $val->{github}          = [10, 60];
   $val->{get_attachments} = [75, 60];
   $val->{get_comments}    = [75, 60];
+  $val->{webpage_errors}  = [10, 120];
   return encode_json($val);
 }
 

--- a/Bugzilla/Config/Admin.pm
+++ b/Bugzilla/Config/Admin.pm
@@ -58,7 +58,7 @@ sub default_rate_limit_rules {
     github          => [10, 60],
     get_attachments => [75, 60],
     get_comments    => [75, 60],
-    webpage_errors  => [10, 120],
+    webpage_errors  => [75, 60],
   });
 }
 
@@ -91,7 +91,7 @@ sub update_rate_limit_rules {
   $val->{github}          = [10, 60];
   $val->{get_attachments} = [75, 60];
   $val->{get_comments}    = [75, 60];
-  $val->{webpage_errors}  = [10, 120];
+  $val->{webpage_errors}  = [75, 60];
   return encode_json($val);
 }
 

--- a/Bugzilla/Error.pm
+++ b/Bugzilla/Error.pm
@@ -86,6 +86,7 @@ sub _throw_error {
   }
 
   if (Bugzilla->error_mode == ERROR_MODE_WEBPAGE) {
+    Bugzilla->check_rate_limit("webpage_errors", remote_ip(), sub { $vars->{rate_limit_error} = 1 });
     my $cgi = Bugzilla->cgi;
     $cgi->close_standby_message('text/html', 'inline', 'error', 'html');
     $template->process($name, $vars) || ThrowTemplateError($template->error());

--- a/template/en/default/global/code-error.html.tmpl
+++ b/template/en/default/global/code-error.html.tmpl
@@ -545,6 +545,7 @@
 
 <p class="throw_error">
   [% error_message FILTER none %]
+  [% IF rate_limit_error %] (rate limit exceeded) [% END %]
 </p>
 
 [% IF variables %]

--- a/template/en/default/global/user-error.html.tmpl
+++ b/template/en/default/global/user-error.html.tmpl
@@ -2012,6 +2012,7 @@
   <tr>
     <td id="error_msg" class="throw_error">
       [% error_message FILTER none %]
+      [% IF rate_limit_error %] (rate limit exceeded) [% END %]
     </td>
   </tr>
 </table>


### PR DESCRIPTION
This PR hooks into both the UserError and CodeError calls. If the error is happening in 'webpage' mode, we check a rate limit. If the rate limit is exceeded, we set a template var (so the template can indicate a rate limit was exceeded) and block as normal.

The default is generous, we can experiment in prod.