### PR TITLE
Bug 1511261 - request queue page shows 'Bugzilla::User=HASH(...)' instead of username

### DIFF
--- a/template/en/default/request/queue.html.tmpl
+++ b/template/en/default/request/queue.html.tmpl
@@ -230,7 +230,7 @@ to some group are shown by default.
   [% buglist = {} %]
 
   <h3>[% column_headers.$group_field %]:
-    [%+ (request.$group_field || "None") FILTER email FILTER html %]</h3>
+    [%+ (request.$group_field.email || request.$group_field || "None") FILTER email FILTER html %]</h3>
   <table class="requests" cellspacing="0" cellpadding="4" border="1">
     <tr>
       [% FOREACH column = display_columns %]


### PR DESCRIPTION
Show **Requester** and **Requestee** emails properly on the Request Queue page, and prevent these user objects being rendered as weird hashes.

## Bugzilla link

[Bug 1511261 - request queue page shows 'Bugzilla::User=HASH(...)' instead of username](https://bugzilla.mozilla.org/show_bug.cgi?id=1511261)