### PR TITLE
Bug 1520856 - "Opt out of these emails" at bottom of overdue request nagging emails doesn't open desired page

### DIFF
--- a/extensions/RequestNagger/template/en/default/email/request_nagging-user.html.tmpl
+++ b/extensions/RequestNagger/template/en/default/email/request_nagging-user.html.tmpl
@@ -85,7 +85,7 @@
   <a href="[% urlbase FILTER none %]request.cgi?action=queue&amp;requestee=[% recipient.login FILTER uri %]&amp;group=type">
     See all your overdue requests
   </a><br>
-  <a href="[% urlbase FILTER none %]userprefs.cgi#request_nagging">
+  <a href="[% urlbase FILTER none %]userprefs.cgi?tab=request_nagging">
     Opt out of these emails
   </a><br>
 </div>

--- a/extensions/RequestNagger/template/en/default/email/request_nagging-user.txt.tmpl
+++ b/extensions/RequestNagger/template/en/default/email/request_nagging-user.txt.tmpl
@@ -52,7 +52,7 @@ See all your overdue requests:
   [%+ urlbase %]request.cgi?action=queue&requestee=[% recipient.login FILTER uri %]&group=type
 
 Opt out of these emails:
-  [%+ urlbase %]userprefs.cgi#request_nagging
+  [%+ urlbase %]userprefs.cgi?tab=request_nagging
 
 --
 You are receiving this mail because: you have overdue requests.


### PR DESCRIPTION
Fix the link where people can opt out of request reminders.

## Bugzilla link

[Bug 1520856 - "Opt out of these emails" at bottom of overdue request nagging emails doesn't open desired page](https://bugzilla.mozilla.org/show_bug.cgi?id=1520856)