### PR TITLE
Bug 1512815 - Skip preloading tracking flags in the Bug API

### DIFF
--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -352,7 +352,7 @@ sub SPECIAL_PARSING {
     # BMO - add ability to use pronoun for triage owners
     triage_owner => \&_triage_owner_pronoun,
   };
-  foreach my $field (Bugzilla->active_custom_fields) {
+  foreach my $field (Bugzilla->active_custom_fields({skip_extensions => 1})) {
     if ($field->type == FIELD_TYPE_DATETIME) {
       $map->{$field->name} = \&_datetime_translate;
     }

--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -55,7 +55,7 @@ sub DATE_FIELDS {
   };
 
   # Add date related custom fields
-  foreach my $field (Bugzilla->active_custom_fields) {
+  foreach my $field (Bugzilla->active_custom_fields({skip_extensions => 1})) {
     next
       unless ($field->type == FIELD_TYPE_DATETIME
       || $field->type == FIELD_TYPE_DATE);
@@ -536,6 +536,7 @@ sub search {
   my $user = Bugzilla->user;
   my $dbh  = Bugzilla->dbh;
 
+  local $Bugzilla::Extension::TrackingFlags::Flag::SKIP_PRELOAD = 1;
   Bugzilla->switch_to_shadow_db();
 
   my $match_params = dclone($params);

--- a/extensions/TrackingFlags/lib/Flag.pm
+++ b/extensions/TrackingFlags/lib/Flag.pm
@@ -23,6 +23,8 @@ use Bugzilla::Extension::TrackingFlags::Flag::Bug;
 use Bugzilla::Extension::TrackingFlags::Flag::Value;
 use Bugzilla::Extension::TrackingFlags::Flag::Visibility;
 
+our $SKIP_PRELOAD = 0;
+
 ###############################
 ####    Initialization     ####
 ###############################
@@ -210,7 +212,7 @@ sub match {
   my $is_active_filter = delete $params->{is_active};
 
   my $flags = $class->SUPER::match($params);
-  preload_all_the_things($flags, {bug_id => $bug_id});
+  preload_all_the_things($flags, {bug_id => $bug_id}) unless $SKIP_PRELOAD;
 
   if ($is_active_filter) {
     $flags = [grep { $_->is_active || exists $_->{bug_flag} } @$flags];
@@ -223,7 +225,7 @@ sub get_all {
   my $cache = Bugzilla->request_cache;
   if (!exists $cache->{'tracking_flags'}) {
     my @tracking_flags = $self->SUPER::get_all(@_);
-    preload_all_the_things(\@tracking_flags);
+    preload_all_the_things(\@tracking_flags) unless $SKIP_PRELOAD;
     my %tracking_flags_hash = map { $_->flag_id => $_ } @tracking_flags;
     $cache->{'tracking_flags'} = \%tracking_flags_hash;
   }


### PR DESCRIPTION
Two fixes here:

1. In cases where tracking flags are obviously not needed, we pass `skip_extensions`
2.  per @dklawren suggestion, in search we set a var to disable preloading