### PR TITLE
Bug 1521653 - Cannot edit comments after creating or updating an attachment

### DIFF
--- a/extensions/EditComments/template/en/default/hook/global/header-start.html.tmpl
+++ b/extensions/EditComments/template/en/default/hook/global/header-start.html.tmpl
@@ -7,9 +7,7 @@
   #%]
 
 [%
-  RETURN UNLESS template.name == 'bug/show-modal.html.tmpl'
-    || template.name == 'bug/create/created.html.tmpl'
-    || template.name == 'bug/process/results.html.tmpl';
+  RETURN UNLESS bug.defined;
   RETURN UNLESS user.is_insider
     || Param('edit_comments_group') && user.in_group(Param('edit_comments_group'));
 


### PR DESCRIPTION
Simply check if `bug` is defined. Tested with several scenarios we have encountered the issue: create a bug, update a bug, view a bug, create an attachment, and update an attachment. The only downside I could find is that the strings will also be included in the legacy bug page where comments are not editable, but given the modal bug page is default, that case can be ignored.

## Bugzilla link

[Bug 1521653 - Cannot edit comments after creating or updating an attachment](https://bugzilla.mozilla.org/show_bug.cgi?id=1521653)