### PR TITLE
Bug 1517429 - Search: Filter out by default Product containing "Graveyard"

### DIFF
--- a/extensions/BMO/template/en/default/hook/global/header-start.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/global/header-start.html.tmpl
@@ -14,6 +14,10 @@
   [% javascript_urls.push('extensions/BMO/web/js/sorttable.js') %]
 [% END %]
 
+[% IF template.name == 'search/search-advanced.html.tmpl' %]
+  [% javascript_urls.push('extensions/BMO/web/js/advanced-search.js') %]
+[% END %]
+
 [% IF !bodyclasses %]
   [% bodyclasses = [] %]
 [% END %]

--- a/extensions/BMO/web/js/advanced-search.js
+++ b/extensions/BMO/web/js/advanced-search.js
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This Source Code Form is "Incompatible With Secondary Licenses", as
+ * defined by the Mozilla Public License, v. 2.0. */
+
+/**
+ * Reference or define the Bugzilla app namespace.
+ * @namespace
+ */
+var Bugzilla = Bugzilla || {}; // eslint-disable-line no-var
+
+/**
+ * Implement Advanced Search page features.
+ */
+Bugzilla.AdvancedSearch = class AdvancedSearch {
+  /**
+   * Initialize a new AdvancedSearch instance.
+   */
+  constructor() {
+    this.params = (new URL(document.location)).searchParams;
+    this.$classifications = document.querySelector('#classification');
+
+    this.hide_graveyard();
+  }
+
+  /**
+   * Hide Graveyard products by selecting classifications other than Graveyard.
+   */
+  hide_graveyard() {
+    // Give up if URL params contain certain fields
+    if (this.params.has('classification') || this.params.has('product') || this.params.has('component')) {
+      return;
+    }
+
+    // Select non-Graveyard classifications
+    for (const $option of this.$classifications.options) {
+      $option.selected = $option.value !== 'Graveyard';
+    }
+
+    // Fire an event to update the Product and Component lists
+    this.$classifications.dispatchEvent(new Event('change'));
+  }
+};
+
+window.addEventListener('DOMContentLoaded', () => new Bugzilla.AdvancedSearch(), { once: true });


### PR DESCRIPTION
Hide Graveyard products by selecting classifications other than Graveyard. As you can see, this is done with JavaScript when the Advanced Search page is loaded.

## Bugzilla link

[Bug 1517429 - Search: Filter out by default Product containing "Graveyard"](https://bugzilla.mozilla.org/show_bug.cgi?id=1517429)