### PR TITLE
Bug 1522548 - Platform "From Reporter" detects macOS client as "Other"

### DIFF
--- a/Bugzilla/UserAgent.pm
+++ b/Bugzilla/UserAgent.pm
@@ -164,7 +164,7 @@ use constant OS_MAP => (
 
   # OS X 10.3 is the most likely default version of PowerPC Macs
   # OS X 10.0 is more for configurations which didn't setup 10.x versions
-  qr/\(.*Mac OS X.*\)/     => [("Mac OS X 10.3",  "Mac OS X 10.0", "Mac OS X")],
+  qr/\(.*Mac OS X.*\)/     => [("Mac OS X 10.3",  "Mac OS X 10.0", "macOS")],
   qr/\(.*Mac OS 9.*\)/     => [("Mac System 9.x", "Mac System 9.0")],
   qr/\(.*Mac OS 8\.6.*\)/  => [("Mac System 8.6", "Mac System 8.5")],
   qr/\(.*Mac OS 8\.5.*\)/  => ["Mac System 8.5"],
@@ -172,7 +172,7 @@ use constant OS_MAP => (
   qr/\(.*Mac OS 8\.0.*\)/  => ["Mac System 8.0"],
   qr/\(.*Mac OS 8[^.].*\)/ => ["Mac System 8.0"],
   qr/\(.*Mac OS 8.*\)/     => ["Mac System 8.6"],
-  qr/\(.*Darwin.*\)/       => [("Mac OS X 10.0",  "Mac OS X")],
+  qr/\(.*Darwin.*\)/       => [("Mac OS X 10.0",  "macOS")],
 
   # Silly
   qr/\(.*Mac.*PowerPC.*\)/ => ["Mac System 9.x"],

--- a/extensions/BMO/template/en/default/hook/bug/field-help-end.none.tmpl
+++ b/extensions/BMO/template/en/default/hook/bug/field-help-end.none.tmpl
@@ -81,7 +81,7 @@
        <ul>
          <li>All (happens on all operating systems; cross-platform ${terms.bug})</li>
          <li>Windows 7</li>
-         <li>Mac OS X</li>
+         <li>macOS</li>
          <li>Linux</li>
        </ul>
        Sometimes the operating system implies the platform, but not

--- a/scripts/generate_bmo_data.pl
+++ b/scripts/generate_bmo_data.pl
@@ -119,7 +119,7 @@ my @oses = (
   'Windows Vista', 'Windows 7',
   'Windows 8',     'Windows 8.1',
   'Windows 10',    'Windows Phone',
-  'Mac OS X',      'Linux',
+  'macOS',         'Linux',
   'Android',       'iOS',
   'iOS 7',         'iOS 8',
   'BSDI',          'FreeBSD',

--- a/template/en/default/bug/create/create-guided.html.tmpl
+++ b/template/en/default/bug/create/create-guided.html.tmpl
@@ -217,7 +217,7 @@ function PutDescription() {
   </tr>
 
   [% op_sys = [ "Windows 2000", "Windows XP", "Windows Vista", "Windows 7",
-                "Mac OS X", "Linux", "All", "Other" ] %]
+                "macOS", "Linux", "All", "Other" ] %]
 
   <tr>
     <td align="right" valign="top">

--- a/template/en/default/pages/bug-writing.html.tmpl
+++ b/template/en/default/pages/bug-writing.html.tmpl
@@ -76,7 +76,7 @@ no-one else appears to have reported it, then:</p>
 
     <p><b>OS:</b> On which operating system (OS) did you find
           it?
-    (e.g. Linux, Windows XP, Mac OS X.)<br>
+    (e.g. Linux, Windows XP, macOS.)<br>
     If you know the [% terms.bug %] happens on more than one type of
     operating system, choose <em>[% display_value("op_sys", "All") FILTER html %]</em>.
     If your OS isn't listed, choose <em>[% display_value("op_sys", "Other") FILTER html %]</em>.</p>
@@ -165,7 +165,7 @@ Doesn't Occur On Build 2006-08-10 on Windows XP Home (Service Pack 2)
         <li><b>Windows:</b> Note the type of the crash, and the module that the
         application crashed in (e.g. access violation in apprunner.exe).</li>
 
-        <li><b>Mac OS X:</b> Attach the "Crash Reporter" log that appears
+        <li><b>macOS:</b> Attach the "Crash Reporter" log that appears
         upon crash.
         Only include the section directly below the crashing thread, usually
         titled "Thread 0 Crashed". Please do not paste the entire log!</li>


### PR DESCRIPTION
Fix the user agent detection, and also update some documents mentioning Mac OS X.

## Bugzilla link

[Bug 1522548 - Platform "From Reporter" detects macOS client as "Other"](https://bugzilla.mozilla.org/show_bug.cgi?id=1522548)