### PR TITLE
Bug 1522601 - Uplift request question and answer don't show up as comments

### DIFF
--- a/extensions/FlagTypeComment/web/js/ftc.js
+++ b/extensions/FlagTypeComment/web/js/ftc.js
@@ -169,9 +169,11 @@ Bugzilla.FlagTypeComment = class FlagTypeComment {
    * @returns {Boolean} Always `true` to allow submitting the form.
    */
   form_onsubmit() {
-    if (this.inserted_fieldsets.length) {
-      // Enable Markdown
-      this.$comment.form.querySelector('[name="markdown_off"]').remove();
+    const $markdown_off = this.$comment.form.querySelector('input[name="markdown_off"]');
+
+    // Enable Markdown for any regular patches. Phabricator requests don't come with this hidden `<input>`
+    if (this.inserted_fieldsets.length && $markdown_off) {
+      $markdown_off.remove();
     }
 
     for (const $fieldset of this.inserted_fieldsets) {


### PR DESCRIPTION
Fix the uplift request form doesn't work with Phabricator requests due to the Markdown syntax support added in #1055. Phabricator request attachments don't come with `<input name="markdown_off">` so trying to remove it will be a `SyntaxError`, leading to an empty comment.

## Bugzilla link

[Bug 1522601 - Uplift request question and answer don't show up as comments](https://bugzilla.mozilla.org/show_bug.cgi?id=1522601)