### PR TITLE
Bug 1523365 - Ensure all requests have the HSTS header (if configured)

### DIFF
--- a/Bugzilla/App.pm
+++ b/Bugzilla/App.pm
@@ -127,7 +127,7 @@ sub startup {
   }
   $self->hook(after_dispatch => sub {
     my ($c) = @_;
-    if ($self->req->is_secure
+    if ($c->req->is_secure
       && ! $c->res->headers->strict_transport_security
       && Bugzilla->params->{'strict_transport_security'} ne 'off')
     {

--- a/Bugzilla/App.pm
+++ b/Bugzilla/App.pm
@@ -17,7 +17,7 @@ use FileHandle;    # this is for compat back to 5.10
 use Bugzilla          ();
 use Bugzilla::BugMail ();
 use Bugzilla::CGI     ();
-use Bugzilla::Constants qw(bz_locations);
+use Bugzilla::Constants qw(bz_locations MAX_STS_AGE);
 use Bugzilla::Extension             ();
 use Bugzilla::Install::Requirements ();
 use Bugzilla::Logging;

--- a/Bugzilla/App.pm
+++ b/Bugzilla/App.pm
@@ -122,6 +122,16 @@ sub startup {
         else {
           $c->res->headers->cache_control('public, max-age=31536000, immutable');
         }
+        if ($self->https
+          && not $c->res->headers->strict_transport_security
+          && Bugzilla->params->{'strict_transport_security'} ne 'off')
+        {
+          my $sts_opts = 'max-age=' . MAX_STS_AGE;
+          if (Bugzilla->params->{'strict_transport_security'} eq 'include_subdomains') {
+            $sts_opts .= '; includeSubDomains';
+          }
+          $c->res->headers->strict_transport_security($sts_opts);
+        }
       }
     );
   }


### PR DESCRIPTION
The STS header is set on 200's but not on other response codes such as 404s.
The intention is for this to fix that, but I've not been able to test this change.
I've got BMO to run using docker-compose but for some reason that doesnt appear to pick up any of my changes, even when I change other parts of the code that should be much more visible :/
Will happily test if someone can explain to me how I can get my local changes reflected in the docker images.
The conditions were ripped off from https://github.com/mozilla-bteam/bmo/blob/master/Bugzilla/CGI.pm#L593-L602

