### PR TITLE
Bug 1523172 - Advanced Search link on home page doesn’t always take me to Advanced Search

### DIFF
--- a/template/en/default/index.html.tmpl
+++ b/template/en/default/index.html.tmpl
@@ -49,7 +49,7 @@
           </li>
           [% END %]
           <li id="tile-search">
-            <a href="[% basepath FILTER none %]query.cgi">
+            <a href="[% basepath FILTER none %]query.cgi?format=advanced">
               <span class="icon" aria-hidden="true"></span>
               <span class="label">Advanced Search</span>
             </a>


### PR DESCRIPTION
Specify the `format` to make sure the link will always lead to the Advanced Search page. Otherwise, you’ll be taken to your last selected or default search page, e.g. Instant Search.

## Bugzilla link

[Bug 1523172 - Advanced Search link on home page doesn’t always take me to Advanced Search](https://bugzilla.mozilla.org/show_bug.cgi?id=1523172)