### PR TITLE
Bug 1523317 - Exclude Graveyard products from QuickSearch results

### DIFF
--- a/Bugzilla/Hook.pm
+++ b/Bugzilla/Hook.pm
@@ -1417,6 +1417,27 @@ want it to map to. You can modify existing mappings or add new ones.
 
 =back
 
+=head2 quicksearch_run
+
+This hook allows you to alter the QuickSearch params, so you can, for example,
+include specific bug status or exclude specific products in search results
+by default.
+
+Params:
+
+=over
+
+=item C<cgi> - The current C<cgi> object. The search params can be altered
+using C<< $cgi->param(field, value) >>.
+
+=item C<bug_status_set> - A boolean indicating whether the status and/or
+resolution is specified in the search query entered by user.
+
+=item C<bug_product_set> - A boolean indicating whether the classification,
+product and/or component is specified in the search query entered by user.
+
+=back
+
 =head2 sanitycheck_check
 
 This hook allows for extra sanity checks to be added, for use by

--- a/Bugzilla/Hook.pm
+++ b/Bugzilla/Hook.pm
@@ -1438,6 +1438,20 @@ product and/or component is specified in the search query entered by user.
 
 =back
 
+=head2 quicksearch_test
+
+This hook allows you to alter the QuickSearch params in the test. This has to
+correspond with the C<quicksearch_run> hook described above.
+
+Params:
+
+=over
+
+=item C<opt> - A hash of the test options containing C<params>, which has to be
+altered in the same way as C<quicksearch_run>.
+
+=back
+
 =head2 sanitycheck_check
 
 This hook allows for extra sanity checks to be added, for use by

--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -873,6 +873,18 @@ sub quicksearch_map {
   }
 }
 
+sub quicksearch_run {
+  my ($self, $args) = @_;
+  my ($cgi, $bug_product_set) = @$args{qw(cgi bug_product_set)};
+
+  # Exclude Graveyard products by default
+  unless ($bug_product_set) {
+    $cgi->param("f1", 'classification');
+    $cgi->param("o1", 'notequals');
+    $cgi->param("v1", 'Graveyard');
+  }
+}
+
 sub object_columns {
   my ($self, $args) = @_;
   return unless $args->{class}->isa('Bugzilla::Product');

--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -889,9 +889,9 @@ sub quicksearch_test {
   my ($self, $args) = @_;
   my $opt = $args->{'opt'};
 
-  $opt{params}->{'f1'} = 'classification';
-  $opt{params}->{'o1'} = 'notequals';
-  $opt{params}->{'v1'} = 'Graveyard';
+  $opt->{params}->{'f1'} = 'classification';
+  $opt->{params}->{'o1'} = 'notequals';
+  $opt->{params}->{'v1'} = 'Graveyard';
 }
 
 sub object_columns {

--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -879,10 +879,19 @@ sub quicksearch_run {
 
   # Exclude Graveyard products by default
   unless ($bug_product_set) {
-    $cgi->param("f1", 'classification');
-    $cgi->param("o1", 'notequals');
-    $cgi->param("v1", 'Graveyard');
+    $cgi->param('f1', 'classification');
+    $cgi->param('o1', 'notequals');
+    $cgi->param('v1', 'Graveyard');
   }
+}
+
+sub quicksearch_test {
+  my ($self, $args) = @_;
+  my $opt = $args->{'opt'};
+
+  $opt{params}->{'f1'} = 'classification';
+  $opt{params}->{'o1'} = 'notequals';
+  $opt{params}->{'v1'} = 'Graveyard';
 }
 
 sub object_columns {

--- a/extensions/TrackingFlags/Extension.pm
+++ b/extensions/TrackingFlags/Extension.pm
@@ -353,7 +353,7 @@ sub buglist_column_joins {
 
   # if there are elements in the tracking_flags array, then they have been
   # removed from the query, so we mustn't generate joins
-  return if scalar @{$args->{search}->{tracking_flags}};
+  return if scalar @{$args->{search}->{tracking_flags} || []};
 
   my $column_joins   = $args->{'column_joins'};
   my @tracking_flags = Bugzilla::Extension::TrackingFlags::Flag->get_all;

--- a/t/quicksearch.t
+++ b/t/quicksearch.t
@@ -13,6 +13,7 @@ use Bugzilla::Test::MockDB;
 use Bugzilla::Test::MockParams (password_complexity => 'no_constraints');
 use Bugzilla;
 use Bugzilla::Constants;
+use Bugzilla::Hook;
 BEGIN { Bugzilla->extensions }
 use Test2::V0;
 use Test2::Tools::Mock qw(mock mock_accessor);
@@ -121,6 +122,10 @@ sub test_quicksearch {
       $vars->{$key} = [sort @{$vars->{$key} // []}];
     }
   }
+
+  # Provide a hook to allow modifying the params. This has to correspond with
+  # the `quicksearch_run` hook
+  Bugzilla::Hook::process('quicksearch_test', { 'opt' => $opt };
 
   is($vars, $opt{params}, "test params: $opt{input}");
   if (my $sql = $opt{sql_like}) {

--- a/t/quicksearch.t
+++ b/t/quicksearch.t
@@ -125,7 +125,7 @@ sub test_quicksearch {
 
   # Provide a hook to allow modifying the params. This has to correspond with
   # the `quicksearch_run` hook
-  Bugzilla::Hook::process('quicksearch_test', { 'opt' => \%opt };
+  Bugzilla::Hook::process('quicksearch_test', { 'opt' => \%opt });
 
   is($vars, $opt{params}, "test params: $opt{input}");
   if (my $sql = $opt{sql_like}) {

--- a/t/quicksearch.t
+++ b/t/quicksearch.t
@@ -125,7 +125,7 @@ sub test_quicksearch {
 
   # Provide a hook to allow modifying the params. This has to correspond with
   # the `quicksearch_run` hook
-  Bugzilla::Hook::process('quicksearch_test', { 'opt' => $opt };
+  Bugzilla::Hook::process('quicksearch_test', { 'opt' => \%opt };
 
   is($vars, $opt{params}, "test params: $opt{input}");
   if (my $sql = $opt{sql_like}) {


### PR DESCRIPTION
Exclude Graveyard products when no classification, product or component is specified in search terms, just like we are only searching open bugs by default. Given that there are several QuickSearch forms on the site, this will be done server side, in the BMO extension.

## Bugzilla link

[Bug 1523317 - Exclude Graveyard products from QuickSearch results](https://bugzilla.mozilla.org/show_bug.cgi?id=1523317)