### PR TITLE
bump version to 20190129.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20190124.1';
+our $VERSION = '20190130.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
the following changes will be pushed to bugzilla.mozilla.org:
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1511490" target="_blank">1511490</a>] BMO's oauth tokens should be use jwt</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1519782" target="_blank">1519782</a>] The OrangeFactor extension should link back to Intermittent Failure View using '&amp;tree=all'</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1523004" target="_blank">1523004</a>] Sort Phabricator revisions by numeric value instead of alphabetically</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1523172" target="_blank">1523172</a>] Advanced Search link on home page doesn’t always take me to Advanced Search</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1523365" target="_blank">1523365</a>] Ensure all requests have the HSTS header (if configured)</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1433080" target="_blank">1433080</a>] No longer show the template for tracking &amp; release notes requests</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1522731" target="_blank">1522731</a>] When you click "Update comment", the button changes size and the "Cancel" button jumps underneath your cursor, causing momentary panic that you canceled your edit</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1512815" target="_blank">1512815</a>] Optimize Bugzilla-&gt;active_custom_fields() for CPU and memory usage</li>
</ul>

