### PR TITLE
Bug 1524158 - markdown generated by approval comment form could be improved

### DIFF
--- a/extensions/FlagTypeComment/web/js/ftc.js
+++ b/extensions/FlagTypeComment/web/js/ftc.js
@@ -178,7 +178,7 @@ Bugzilla.FlagTypeComment = class FlagTypeComment {
 
     for (const $fieldset of this.inserted_fieldsets) {
       const text = [
-        `## ${$fieldset.querySelector('h3').innerText}`,
+        `### ${$fieldset.querySelector('h3').innerText}`,
         ...[...$fieldset.querySelectorAll('tr')].map($tr => {
           const checkboxes = [...$tr.querySelectorAll('input[type="checkbox"]:checked')];
           const $radio = $tr.querySelector('input[type="radio"]:checked');
@@ -210,7 +210,7 @@ Bugzilla.FlagTypeComment = class FlagTypeComment {
             }
           }
 
-          return `### ${label}\n\n${value}`;
+          return `#### ${label}\n\n${value}`;
         }),
       ].join('\n\n');
 


### PR DESCRIPTION
Change the heading level from `<h2>` to `<h3>` and `<h3>` to `<h4>` respectively so uplift approval request comments will be a bit more readable.

## Bugzilla link

[Bug 1524158 - markdown generated by approval comment form could be improved](https://bugzilla.mozilla.org/show_bug.cgi?id=1524158)