### PR TITLE
Bug 1524175 - Redirect to show_bug.cgi after creating or updating an attachment

### DIFF
--- a/attachment.cgi
+++ b/attachment.cgi
@@ -653,31 +653,26 @@ sub insert {
 
   $dbh->bz_commit_transaction;
 
-  # Define the variables and functions that will be passed to the UI template.
-  $vars->{'attachment'} = $attachment;
-
-  # We cannot reuse the $bug object as delta_ts has eventually been updated
-  # since the object was created.
-  $vars->{'bugs'}              = [new Bugzilla::Bug($bugid)];
-  $vars->{'header_done'}       = 1;
-  $vars->{'contenttypemethod'} = $cgi->param('contenttypemethod');
-
+  # Persist details of what changed and redirect to show_bug page.
   my $recipients = {'changer' => $user, 'owner' => $owner};
-  $vars->{'sent_bugmail'} = Bugzilla::BugMail::Send($bugid, $recipients);
+  my $sent_bugmail = Bugzilla::BugMail::Send($bugid, $recipients);
+  my $content_type_method = $cgi->param('contenttypemethod');
 
-  # BMO: add show_bug_format hook for experimental UI work
-  my $show_bug_format = {};
-  Bugzilla::Hook::process('show_bug_format', $show_bug_format);
+  my $last_sent_attachment_change = {
+    attachment => {
+      id => $attachment->id,
+      bug_id => $attachment->bug_id,
+      contenttype => $attachment->contenttype,
+      description => $attachment->description,
+    },
+    type => 'created',
+    recipient_count => scalar @{$sent_bugmail->{sent}},
+    content_type_method => $content_type_method,
+  };
+  $Bugzilla::App::CGI::C->flash(last_sent_attachment_changes => [$last_sent_attachment_change]);
 
-  if ($show_bug_format->{format} eq 'modal') {
-    $C->content_security_policy(SHOW_BUG_MODAL_CSP($bugid));
-  }
-
-  print $cgi->header();
-
-  # Generate and return the UI (HTML page) from the appropriate template.
-  $template->process("attachment/created.html.tmpl", $vars)
-    || ThrowTemplateError($template->error());
+  my $redirect_url = $Bugzilla::App::CGI::C->url_for('show_bugcgi')->query(id => $bugid);
+  $Bugzilla::App::CGI::C->redirect_to($redirect_url);
 }
 
 # Displays a form for editing attachment properties.
@@ -840,26 +835,23 @@ sub update {
   # Commit the transaction now that we are finished updating the database.
   $dbh->bz_commit_transaction();
 
-  # Define the variables and functions that will be passed to the UI template.
-  $vars->{'attachment'}  = $attachment;
-  $vars->{'bugs'}        = [$bug];
-  $vars->{'header_done'} = 1;
-  $vars->{'sent_bugmail'}
-    = Bugzilla::BugMail::Send($bug->id, {'changer' => $user});
+  # Persist details of what changed and redirect to show_bug page.
+  my $sent_bugmail = Bugzilla::BugMail::Send($bug->id, {'changer' => $user});
 
-  # BMO: add show_bug_format hook for experimental UI work
-  my $show_bug_format = {};
-  Bugzilla::Hook::process('show_bug_format', $show_bug_format);
+  my $last_sent_attachment_change = {
+    attachment => {
+      id => $attachment->id,
+      bug_id => $attachment->bug_id,
+      contenttype => $attachment->contenttype,
+      description => $attachment->description,
+    },
+    type => 'updated',
+    recipient_count => scalar @{$sent_bugmail->{sent}},
+  };
+  $Bugzilla::App::CGI::C->flash(last_sent_attachment_changes => [$last_sent_attachment_change]);
 
-  if ($show_bug_format->{format} eq 'modal') {
-    $C->content_security_policy(SHOW_BUG_MODAL_CSP($bug->id));
-  }
-
-  print $cgi->header();
-
-  # Generate and return the UI (HTML page) from the appropriate template.
-  $template->process("attachment/updated.html.tmpl", $vars)
-    || ThrowTemplateError($template->error());
+  my $redirect_url = $Bugzilla::App::CGI::C->url_for('show_bugcgi')->query(id => $bug->id);
+  $Bugzilla::App::CGI::C->redirect_to($redirect_url);
 }
 
 # Only administrators can delete attachments.
@@ -914,24 +906,23 @@ sub delete_attachment {
     # Insert the comment.
     $bug->update();
 
-    # Required to display the bug the deleted attachment belongs to.
-    $vars->{'bugs'}        = [$bug];
-    $vars->{'header_done'} = 1;
+    # Persist details of what changed and redirect to show_bug page.
+    my $sent_bugmail = Bugzilla::BugMail::Send($bug->id, {'changer' => $user});
 
-    $vars->{'sent_bugmail'}
-      = Bugzilla::BugMail::Send($bug->id, {'changer' => $user});
+    my $last_sent_attachment_change = {
+      attachment => {
+        id => $attachment->id,
+        bug_id => $attachment->bug_id,
+        contenttype => $attachment->contenttype,
+        description => $attachment->description,
+      },
+      type => 'deleted',
+      recipient_count => scalar @{$sent_bugmail->{sent}},
+    };
+    $Bugzilla::App::CGI::C->flash(last_sent_attachment_changes => [$last_sent_attachment_change]);
 
-    # BMO: add show_bug_format hook for experimental UI work
-    my $show_bug_format = {};
-    Bugzilla::Hook::process('show_bug_format', $show_bug_format);
-
-    if ($show_bug_format->{format} eq 'modal') {
-      $C->content_security_policy(SHOW_BUG_MODAL_CSP($bug->id));
-    }
-
-    print $cgi->header();
-    $template->process("attachment/updated.html.tmpl", $vars)
-      || ThrowTemplateError($template->error());
+    my $redirect_url = $Bugzilla::App::CGI::C->url_for('show_bugcgi')->query(id => $bug->id);
+    $Bugzilla::App::CGI::C->redirect_to($redirect_url);
   }
   else {
     # Create a token.

--- a/extensions/BugModal/template/en/default/bug/show-modal.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug/show-modal.html.tmpl
@@ -13,13 +13,23 @@
   [% header_done = 1 %]
 [% END %]
 
-[%# Displays changes to bugs that happened in the last request #%]
+[%# Display changes to bugs that happened in the last request #%]
 [% sentmail = c.flash("last_sent_changes") %]
 [% FOREACH item = sentmail %]
   [% INCLUDE bug/process/results.html.tmpl
      id = item.id
      type = item.type
      recipient_count = item.recipient_count
+   %]
+[% END %]
+
+[% sentattachmentmail = c.flash("last_sent_attachment_changes") %]
+[% FOREACH item = sentattachmentmail %]
+  [% INCLUDE "bug/process/attachment-results.html.tmpl"
+     attachment = item.attachment
+     type = item.type
+     recipient_count = item.recipient_count
+     content_type_method = item.content_type_method
    %]
 [% END %]
 

--- a/template/en/default/bug/process/attachment-results.html.tmpl
+++ b/template/en/default/bug/process/attachment-results.html.tmpl
@@ -1,0 +1,68 @@
+[%# The contents of this file are subject to the Mozilla Public
+  # License Version 1.1 (the "License"); you may not use this file
+  # except in compliance with the License. You may obtain a copy of
+  # the License at http://www.mozilla.org/MPL/
+  #
+  # Software distributed under the License is distributed on an "AS
+  # IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+  # implied. See the License for the specific language governing
+  # rights and limitations under the License.
+  #
+  # The Original Code is the Bugzilla Bug Tracking System.
+  #
+  # The Initial Developer of the Original Code is Netscape Communications
+  # Corporation. Portions created by Netscape are
+  # Copyright (C) 1998 Netscape Communications Corporation. All
+  # Rights Reserved.
+  #
+  # Contributor(s): Israel Madueme <imadueme@mozilla.org>
+  #%]
+
+[%# INTERFACE:
+  # attachment: Actual attachment object or dictionary containing all of the following properties:
+  #     {id, bug_id, contenttype, description}
+  # type: string; the type of change/check that was made. Should be one of:
+  #     (created, updated, deleted)
+  # recipient_count: string; The number of people that were emailed.
+  # content_type_method: string; How the content type method was determined; one of:
+  #     ('autodetect', 'manual')
+  #%]
+
+[% PROCESS global/variables.none.tmpl %]
+
+<dl>
+  <dt>
+    [% IF type == 'created' %]
+        <a title="[% attachment.description FILTER html %]"
+           href="[% basepath FILTER none %]attachment.cgi?id=[% attachment.id FILTER none %]&amp;action=edit">Attachment #[% attachment.id FILTER none %]</a>
+        to [% "$terms.bug $attachment.bug_id" FILTER bug_link(attachment.bug_id) FILTER none %] created
+    [% ELSE %]
+        Changes to
+        <a title="[% attachment.description FILTER html %]"
+           href="[% basepath FILTER none %]attachment.cgi?id=[% attachment.id FILTER none %]&amp;action=edit">attachment [% attachment.id FILTER none %]</a>
+        of [% "$terms.bug $attachment.bug_id" FILTER bug_link(attachment.bug_id) FILTER none %] submitted
+    [% END %]
+  </dt>
+  <dd>
+    [% INCLUDE "bug/process/bugmail.html.tmpl"
+        mailing_bugid = attachment.bug_id
+        recipient_count = recipient_count
+    %]
+    [% IF content_type_method == 'autodetect' %]
+      <p>
+        <b>Note:</b> [% terms.Bugzilla %] automatically detected the content type
+        <em>[% attachment.contenttype FILTER html %]</em> for this attachment.  If this is
+        incorrect, correct the value by editing the attachment's
+        <a href="[% basepath FILTER none %]attachment.cgi?id=[% attachment.id FILTER none %]&amp;action=edit">details</a>.
+      </p>
+    [% END %]
+
+    [%# Links to more information about the changed bug. %]
+    [% Hook.process("links") %]
+  </dd>
+</dl>
+
+<p>
+<a href="[% basepath FILTER none %]attachment.cgi?bugid=[% attachment.bug_id FILTER none %]&amp;action=enter">Create
+ Another Attachment to [% terms.Bug %] [%+ attachment.bug_id FILTER none %]</a>
+</p>

--- a/template/en/default/bug/show.html.tmpl
+++ b/template/en/default/bug/show.html.tmpl
@@ -32,13 +32,23 @@
   [% header_done = 1 %]
 [% END %]
 
-[%# Displays changes to bugs that happened in the last request #%]
+[%# Display changes to bugs that happened in the last request #%]
 [% sentmail = c.flash("last_sent_changes") %]
 [% FOREACH item = sentmail %]
   [% INCLUDE bug/process/results.html.tmpl
      id = item.id
      type = item.type
      recipient_count = item.recipient_count
+   %]
+[% END %]
+
+[% sentattachmentmail = c.flash("last_sent_attachment_changes") %]
+[% FOREACH item = sentattachmentmail %]
+  [% INCLUDE "bug/process/attachment-results.html.tmpl"
+     attachment = item.attachment
+     type = item.type
+     sent_bugmail = item.sent_bugmail
+     content_type_method = item.content_type_method
    %]
 [% END %]
 


### PR DESCRIPTION
- Includes changes from https://github.com/mozilla-bteam/bmo/pull/1068 until that gets merged.
- This PR depends on #1065 being merged.
- As the title suggests this causes BMO to redirect when attachments are created/updated/deleted. This lets us have 1 point (show_bug.cgi) that actually renders the show bug page.
- This works for the bug modal UI and the old UI.
-  ~~TODO: Determine how to handle large recipient lists which won't fit in flash storage.~~ Solved by just listing how many people were emailed.