### PR TITLE
Bug 1152434 - Remove regressing bug ID field from uplift approval request once regressed-by field is added

### DIFF
--- a/extensions/BMO/template/en/default/hook/flag/type_comment-form.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/flag/type_comment-form.html.tmpl
@@ -13,10 +13,6 @@
     </header>
     <table>
       <tr>
-        <th id="_ar_beta_i1_label">Feature/[% terms.Bug %] causing the regression</th>
-        <td><input type="text" placeholder="[% terms.Bug %] ID" aria-labelledby="_ar_beta_i1_label" data-type="b[% %]ug"></td>
-      </tr>
-      <tr>
         <th id="_ar_beta_i2_label">User impact if declined</th>
         <td><textarea aria-labelledby="_ar_beta_i2_label"></textarea></td>
       </tr>


### PR DESCRIPTION
Once the **Regressed by** field is added, the **Feature/Bug causing the regression** custom field can be removed from the uplift approval request comment. Blocked until #1067 is merged.

## Bugzilla link

[Bug 1152434 - Remove regressing bug ID field from uplift approval request once regressed-by field is added](https://bugzilla.mozilla.org/show_bug.cgi?id=1152434)