### PR TITLE
Bug 179115 - changes to Cc: list should not update bug's last changed date

### DIFF
--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -1354,8 +1354,11 @@ sub update {
     }
   );
 
-  # If any change occurred, refresh the timestamp of the bug.
-  if ( scalar(keys %$changes)
+  # If any change other than CC additions/removals occurred, refresh the
+  # timestamp of the bug.
+  my $changes_size = scalar(keys %$changes);
+  if ( $changes_size > 1
+    || $changes_size == 1 && !defined $changes->{'cc'}
     || $self->{added_comments}
     || $self->{comment_isprivate})
   {


### PR DESCRIPTION
Stop updating the last modified date = `delta_ts` field when only CC is changed. This makes triagers’ life much easier and helps people focus on real contributions.

## Bugzilla link

[Bug 179115 - changes to Cc: list should not update bug’s last changed date](https://bugzilla.mozilla.org/show_bug.cgi?id=179115)