### PR TITLE
Bug 1525808 - Remove CC changes from activity stream

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -38,11 +38,8 @@
       <li role="presentation">
         <a id="view-comments-only" role="menuitem" tabindex="-1">Comments Only</a>
       </li>
-      <li role="separator"></li>
-      <li role="presentation">
-        <a id="view-toggle-cc" role="menuitem" tabindex="-1">Show CC Changes</a>
-      </li>
       [% IF treeherder_user_ids.size %]
+        <li role="separator"></li>
         <li role="presentation">
           <a id="view-toggle-treeherder" role="menuitem" data-userids="[[% treeherder_user_ids.join(',') FILTER none %]]">Show Treeherder Comments</a>
         </li>
@@ -55,12 +52,9 @@
   PROCESS bug/time.html.tmpl;
 
   FOREACH change_set IN bug.activity_stream;
+    NEXT IF change_set.cc_only;
     extra_class = change_set.comment.collapsed ? " ca-" _ change_set.comment.author.id : "";
-    IF change_set.cc_only;
-      '<div class="change-set cc-only' _ extra_class _ '" id="' _ change_set.id _ '" style="display:none">';
-    ELSE;
-      '<div class="change-set' _ extra_class _ '" id="' _ change_set.id _ '">';
-    END;
+    '<div class="change-set' _ extra_class _ '" id="' _ change_set.id _ '">';
 
     extra_class = "";
     IF change_set.user_id == bug.assigned_to.id;
@@ -284,23 +278,16 @@
 
 [%
   BLOCK activity_body;
-    classes = "activity";
+    RETURN IF activity.cc_only && !change_set.cc_only;
     style = "";
-    IF activity.cc_only && !change_set.cc_only;
-      classes = classes _ " cc-only";
-      style = ' style="display:none"';
-    END;
     IF change_set.comment && change_set.comment.collapsed;
       style = ' style="display:none"';
     END;
-    '<div class="' _ classes _ '"' _ style _ '>';
+    '<div class="activity"' _ style _ '>';
 
     FOREACH change IN activity.changes;
-      IF change.fieldname == 'cc' && !activity.cc_only && !change_set.cc_only;
-        '<div class="change cc-only" style="display:none">';
-      ELSE;
-        '<div class="change">';
-      END;
+      NEXT IF change.fieldname == 'cc';
+      '<div class="change">';
 
       IF change.attachid;
         %]

--- a/extensions/BugModal/web/comments.js
+++ b/extensions/BugModal/web/comments.js
@@ -24,27 +24,25 @@ $(function() {
         var spinnerID = spinner.attr('id');
         var id = spinnerID.substring(spinnerID.indexOf('-') + 1);
 
-        var activitySelector = $('#view-toggle-cc').data('shown') === '1' ? '.activity' : '.activity:not(.cc-only)';
-
         // non-comment toggle
         if (spinnerID.substr(0, 1) == 'a') {
             var changeSet = spinner.parents('.change-set');
             if (forced == 'hide') {
-                changeSet.find(activitySelector).hide();
+                changeSet.find('.activity').hide();
                 changeSet.find('.gravatar').css('width', '16px').css('height', '16px');
                 $('#ar-' + id).hide();
                 update_spinner(spinner, false);
             }
             else if (forced == 'show' || forced == 'reset') {
-                changeSet.find(activitySelector).show();
+                changeSet.find('.activity').show();
                 changeSet.find('.gravatar').css('width', '32px').css('height', '32px');
                 $('#ar-' + id).show();
                 update_spinner(spinner, true);
             }
             else {
-                changeSet.find(activitySelector).slideToggle('fast', function() {
+                changeSet.find('.activity').slideToggle('fast', function() {
                     $('#ar-' + id).toggle();
-                    if (changeSet.find(activitySelector + ':visible').length) {
+                    if (changeSet.find('.activity' + ':visible').length) {
                         changeSet.find('.gravatar').css('width', '32px').css('height', '32px');
                         update_spinner(spinner, true);
                     }
@@ -77,7 +75,7 @@ $(function() {
             $('#ct-' + id).hide();
             if (BUGZILLA.user.id !== 0)
                 $('#ctag-' + id).hide();
-            $('#c' + id).find(activitySelector).hide();
+            $('#c' + id).find('.activity').hide();
             $('#c' + id).find('.comment-tags').hide();
             $('#c' + id).find('.comment-tags').hide();
             $('#c' + id).find('.gravatar').css('width', '16px').css('height', '16px');
@@ -92,7 +90,7 @@ $(function() {
             $('#ct-' + id).show();
             if (BUGZILLA.user.id !== 0)
                 $('#ctag-' + id).show();
-            $('#c' + id).find(activitySelector).show();
+            $('#c' + id).find('.activity').show();
             $('#c' + id).find('.comment-tags').show();
             $('#c' + id).find('.comment-tags').show();
             $('#c' + id).find('.gravatar').css('width', '32px').css('height', '32px');
@@ -101,7 +99,7 @@ $(function() {
         }
         else {
             $('#ct-' + id).slideToggle('fast', function() {
-                $('#c' + id).find(activitySelector).toggle();
+                $('#c' + id).find('.activity').toggle();
                 if ($('#ct-' + id + ':visible').length) {
                     $('#c' + id).find('.comment-tags').show();
                     update_spinner(realSpinner, true);
@@ -164,21 +162,6 @@ $(function() {
             $('.change-spinner:visible').each(function() {
                 toggleChange($(this), this.id.substr(0, 3) === 'cs-' ? 'show' : 'hide');
             });
-        });
-
-    $('#view-toggle-cc')
-        .click(function() {
-            var that = $(this);
-            if (that.data('shown') === '1') {
-                that.data('shown', '0');
-                that.text('Show CC Changes');
-                $('.cc-only').hide();
-            }
-            else {
-                that.data('shown', '1');
-                that.text('Hide CC Changes');
-                $('.cc-only').show();
-            }
         });
 
     $('#view-toggle-treeherder')


### PR DESCRIPTION
Remove the CC changes, which are hidden by default, and the Show CC Changes option from the modal bug page, because CC changes are not real activities.

## Bugzilla link

[Bug 1525808 - Remove CC changes from activity stream](https://bugzilla.mozilla.org/show_bug.cgi?id=1525808)