### PR TITLE
Bug 1524158 - markdown generated by approval comment form could be improved

### DIFF
--- a/extensions/FlagTypeComment/web/js/ftc.js
+++ b/extensions/FlagTypeComment/web/js/ftc.js
@@ -210,9 +210,9 @@ Bugzilla.FlagTypeComment = class FlagTypeComment {
             }
           }
 
-          return `#### ${label}\n\n${value}`;
+          return `* **${label}**: ${value}`;
         }),
-      ].join('\n\n');
+      ].join('\n');
 
       this.add_comment(text);
       $fieldset.remove();


### PR DESCRIPTION
Using headings makes sense but in Markdown we cannot control the margin etc. so just use a list and bold text to make the comment compact. See [this screenshot](https://screenshots.firefox.com/OUJoemTLCUFMW2XX/bmo-web.vm) in action.

## Bugzilla link

[Bug 1524158 - markdown generated by approval comment form could be improved](https://bugzilla.mozilla.org/show_bug.cgi?id=1524158)