### PR TITLE
no bug - add pragma required to use latest sqlite version

### DIFF
--- a/Bugzilla/DB/Sqlite.pm
+++ b/Bugzilla/DB/Sqlite.pm
@@ -125,6 +125,7 @@ sub on_dbi_connected {
     # better concurrency and don't need 3.6 compatibility, then you can
     # uncomment this line.
     #journal_mode => "'WAL'",
+    legacy_alter_table => 'ON',
   );
 
   while (my ($name, $value) = each %pragmas) {


### PR DESCRIPTION
The latest sqlite is not compatible with the types of alter table statements we use, hence this pragma is required.