### PR TITLE
Bug 1402894 - Remove "Restrict this session to this IP" option from login page

### DIFF
--- a/Bugzilla/App/Plugin/Glue.pm
+++ b/Bugzilla/App/Plugin/Glue.pm
@@ -99,19 +99,13 @@ sub register {
 
       my $login_cookie = $c->cookie("Bugzilla_logincookie");
       my $user_id      = $c->cookie("Bugzilla_login");
-      my $ip_addr      = $c->tx->remote_address;
 
       return $c->bugzilla->login_redirect_if_required($type)
         unless ($login_cookie && $user_id);
 
       my $db_cookie = Bugzilla->dbh->selectrow_array(
-        q{
-                    SELECT cookie
-                      FROM logincookies
-                     WHERE cookie = ?
-                           AND userid = ?
-                           AND (restrict_ipaddr = 0 OR ipaddr = ?)
-                }, undef, ($login_cookie, $user_id, $ip_addr)
+        'SELECT cookie FROM logincookies WHERE cookie = ? AND userid = ?',
+        undef, ($login_cookie, $user_id)
       );
 
       if (defined $db_cookie && secure_compare($login_cookie, $db_cookie)) {

--- a/Bugzilla/Auth.pm
+++ b/Bugzilla/Auth.pm
@@ -93,7 +93,7 @@ sub login {
     my $cgi    = Bugzilla->cgi;
     my $uri    = URI->new($cgi->self_url);
     foreach
-      my $param (qw( Bugzilla_remember Bugzilla_restrictlogin GoAheadAndLogIn ))
+      my $param (qw( Bugzilla_remember GoAheadAndLogIn ))
     {
       $uri->query_param_delete($param);
     }
@@ -101,7 +101,6 @@ sub login {
       user          => $user,
       type          => $type,
       reason        => 'Logging in as ' . $user->identity,
-      restrictlogin => $params->{Bugzilla_restrictlogin},
       remember      => $params->{Bugzilla_remember},
       url           => $uri->as_string,
       postback =>
@@ -119,8 +118,6 @@ sub mfa_verified {
 
   my $params = Bugzilla->input_params;
   $self->{_info_getter}->{successful} = Bugzilla::Auth::Login::CGI->new();
-  $params->{Bugzilla_restrictlogin} = $event->{restrictlogin}
-    if defined $event->{restrictlogin};
   $params->{Bugzilla_remember} = $event->{remember} if defined $event->{remember};
 
   $self->_handle_login_result({user => $user}, $event->{type});

--- a/Bugzilla/Auth/Login/Cookie.pm
+++ b/Bugzilla/Auth/Login/Cookie.pm
@@ -85,23 +85,16 @@ sub get_login_info {
     ($user_id, $login_cookie) = ($token->{'user_id'}, $token->{'login_token'});
   }
 
-  my $ip_addr = remote_ip();
-
   if ($login_cookie && $user_id) {
 
     # Anything goes for these params - they're just strings which
     # we're going to verify against the db
-    trick_taint($ip_addr);
     trick_taint($login_cookie);
     detaint_natural($user_id);
 
     my $db_cookie = $dbh->selectrow_array(
-      'SELECT cookie
-                                   FROM logincookies
-                                  WHERE cookie = ?
-                                        AND userid = ?
-                                        AND (restrict_ipaddr = 0 OR ipaddr = ?)',
-      undef, ($login_cookie, $user_id, $ip_addr)
+      'SELECT cookie FROM logincookies WHERE cookie = ? AND userid = ?',
+      undef, ($login_cookie, $user_id)
     );
 
     # If the cookie is valid, return a valid username.

--- a/Bugzilla/Auth/Persist/Cookie.pm
+++ b/Bugzilla/Auth/Persist/Cookie.pm
@@ -39,13 +39,9 @@ sub persist_login {
 
   my $ip_addr = remote_ip();
   trick_taint($ip_addr);
-  my $restrict = $input_params->{Bugzilla_restrictlogin} ? 1 : 0;
 
-  $dbh->do(
-    "INSERT INTO logincookies (cookie, userid, ipaddr, lastused, restrict_ipaddr)
-              VALUES (?, ?, ?, NOW(), ?)", undef, $login_cookie, $user->id,
-    $ip_addr, $restrict
-  );
+  $dbh->do('INSERT INTO logincookies (cookie, userid, ipaddr, lastused)
+    VALUES (?, ?, ?, NOW())', undef, $login_cookie, $user->id, $ip_addr);
 
   # Issuing a new cookie is a good time to clean up the old
   # cookies.

--- a/Bugzilla/DB/Schema.pm
+++ b/Bugzilla/DB/Schema.pm
@@ -1138,7 +1138,6 @@ use constant ABSTRACT_SCHEMA => {
       ipaddr          => {TYPE => 'varchar(40)'},
       lastused        => {TYPE => 'DATETIME', NOTNULL => 1},
       id              => {TYPE => 'INTSERIAL', NOTNULL => 1, PRIMARYKEY => 1},
-      restrict_ipaddr => {TYPE => 'BOOLEAN', NOTNULL => 1, DEFAULT => 0},
     ],
     INDEXES => [
       logincookies_lastused_idx => ['lastused'],

--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -780,7 +780,8 @@ sub update_table_definitions {
 
   _add_oauth2_jwt_support();
 
-  _remove_restrict_ipaddr();
+  # Bug 1402894 - kohei.yoshino@gmail.com
+  $dbh->bz_drop_column('logincookies', 'restrict_ipaddr');
 
   ################################################################
   # New --TABLE-- changes should go *** A B O V E *** this point #
@@ -4275,13 +4276,6 @@ sub _add_oauth2_jwt_support {
   $dbh->bz_rename_column('oauth2_client_scope', 'client_id_new', 'client_id');
   $dbh->bz_alter_column('oauth2_client_scope', 'client_id',
     {TYPE => 'INT4', NOTNULL => 1});
-}
-
-sub _remove_restrict_ipaddr {
-  my $dbh = Bugzilla->dbh;
-  return unless $dbh->bz_column_info('logincookies', 'restrict_ipaddr');
-
-  $dbh->do('ALTER TABLE logincookies DROP COLUMN restrict_ipaddr');
 }
 
 1;

--- a/Bugzilla/User/Session.pm
+++ b/Bugzilla/User/Session.pm
@@ -24,7 +24,6 @@ use constant DB_COLUMNS => qw(
   lastused
   ipaddr
   id
-  restrict_ipaddr
 );
 
 use constant UPDATE_COLUMNS => qw();
@@ -46,6 +45,5 @@ sub userid          { return $_[0]->{userid} }
 sub cookie          { return $_[0]->{cookie} }
 sub lastused        { return $_[0]->{lastused} }
 sub ipaddr          { return $_[0]->{ipaddr} }
-sub restrict_ipaddr { return $_[0]->{restrict_ipaddr} }
 
 1;

--- a/Bugzilla/WebService.pm
+++ b/Bugzilla/WebService.pm
@@ -193,19 +193,15 @@ WebService method to perform a login:
 
 =item C<Bugzilla_password> (string) - That user's password.
 
-=item C<Bugzilla_restrictlogin> (boolean) - Optional. If true,
-then your login will only be valid for your IP address.
-
 =item C<Bugzilla_rememberlogin> (boolean) - Optional. If true,
 then the cookie sent back to you with the method response will
 not expire.
 
 =back
 
-The C<Bugzilla_restrictlogin> and C<Bugzilla_rememberlogin> options
-are only used when you have also specified C<Bugzilla_login> and
-C<Bugzilla_password>. This value will be deprecated in the release
-after Bugzilla 5.0 and you will be required to pass the Bugzilla_login
+The C<Bugzilla_rememberlogin> option is only used when you have also specified
+C<Bugzilla_login> and C<Bugzilla_password>. This value will be deprecated in the
+release after Bugzilla 5.0 and you will be required to pass the Bugzilla_login
 and Bugzilla_password for every call.
 
 Note that Bugzilla will return HTTP cookies along with the method

--- a/docs/en/rst/api/core/v1/general.rst
+++ b/docs/en/rst/api/core/v1/general.rst
@@ -111,12 +111,7 @@ name                    type     description
 ======================  =======  ==============================================
 **Bugzilla_login**      string   A user's login name.
 **Bugzilla_password**   string   That user's password.
-Bugzilla_restrictlogin  boolean  If true, then your login will only be
-                                 valid for your IP address.
 ======================  =======  ==============================================
-
-The ``Bugzilla_restrictlogin`` option is only used when you have also
-specified ``Bugzilla_login`` and ``Bugzilla_password``.
 
 There is also a deprecated method of authentication described below that will be
 removed in the version after Bugzilla 5.0.

--- a/docs/en/rst/api/core/v1/user.rst
+++ b/docs/en/rst/api/core/v1/user.rst
@@ -28,9 +28,6 @@ name            type     description
 ==============  =======  ========================================================
 **login**       string   The user's login name.
 **password**    string   The user's password.
-restrict_login  boolean  If set to a true value, the token returned by this
-                         method will only be valid from the IP address which
-                         called this method.
 ==============  =======  ========================================================
 
 **Response**

--- a/sanitycheck.cgi
+++ b/sanitycheck.cgi
@@ -73,7 +73,7 @@ else {
   # Only check the token if we are running this script from the
   # web browser and a parameter is passed to the script.
   # XXX - Maybe these two parameters should be deleted once logged in?
-  $cgi->delete('GoAheadAndLogIn', 'Bugzilla_restrictlogin', 'hooks_only');
+  $cgi->delete('GoAheadAndLogIn', 'hooks_only');
   if (scalar($cgi->param())) {
     my $token = $cgi->param('token');
     check_hash_token($token, ['sanitycheck']);

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -1037,7 +1037,7 @@ input.required, select.required, span.required_explanation {
     font-weight: bold;
 }
 
-#login .field-restrict, #login .field-remember {
+#login .field-remember {
     margin-left: 7em;
 }
 

--- a/skins/standard/mobile.css
+++ b/skins/standard/mobile.css
@@ -25,7 +25,7 @@ only screen and (max-device-width : 720px) {
         padding-bottom: 0px;
     }
 
-    #login .field-restrict, #login .field-remember {
+    #login .field-remember {
         margin-left: 0px;
     }
     #login .field-submit {

--- a/t/mojo-oauth2.t
+++ b/t/mojo-oauth2.t
@@ -67,7 +67,6 @@ $t->post_ok(
   '/login' => {Referer => $referer} => form => {
     Bugzilla_login         => $oauth_login,
     Bugzilla_password      => $oauth_password,
-    Bugzilla_restrictlogin => 1,
     GoAheadAndLogIn        => 1,
     client_id              => $oauth_client->{client_id},
     response_type          => 'code',

--- a/template/en/default/account/auth/login.html.tmpl
+++ b/template/en/default/account/auth/login.html.tmpl
@@ -69,15 +69,7 @@
     [% END %]
 
     [% PROCESS "global/hidden-fields.html.tmpl"
-       exclude="^Bugzilla_(login|password|restrictlogin)$" %]
-
-    <div class="field-restrict">
-      <input type="checkbox" id="Bugzilla_restrictlogin" name="Bugzilla_restrictlogin"
-             checked="checked">
-      <label for="Bugzilla_restrictlogin" class="checkbox-note">
-        Restrict this session to this IP address
-        (using this option improves security)</label>
-    </div>
+       exclude="^Bugzilla_(login|password)$" %]
 
     <div class="field-submit">
       <input type="hidden" name="Bugzilla_login_token"

--- a/template/en/default/account/prefs/sessions.html.tmpl
+++ b/template/en/default/account/prefs/sessions.html.tmpl
@@ -35,7 +35,6 @@
   <tr class="column_header">
     <th>Last used</th>
     <th>IP Address</th>
-    <th>IP Restriction</th>
     <th>Logout</th>
   </tr>
 
@@ -43,7 +42,6 @@
     <tr>
       <td>[% session.lastused FILTER time %]</td>
       <td>[% session.ipaddr OR "Unknown" FILTER html %]</td>
-      <td>[% session.restrict_ipaddr ? "Restricted" : "Unrestricted" FILTER html %]
       <td>
         [% IF session.current %]
           <b>(current)</b>


### PR DESCRIPTION
Remove the **Restrict this session to this IP address** option and relevant code since people are moving around more often, 2FA is enabled, less than 20% of users are enabling it, and no one actually wants it.

## Bugzilla link

[Bug 1402894 - Remove "Restrict this session to this IP" option from login page](https://bugzilla.mozilla.org/show_bug.cgi?id=1402894)