### PR TITLE
Bug 1502500 - Adding the qe-verify flag as an editable field when using Bugzilla's "Change Several Bugs at Once" option

### DIFF
--- a/buglist.cgi
+++ b/buglist.cgi
@@ -1080,6 +1080,9 @@ if ($dotweak && scalar @bugs) {
         = [map($_->name, grep($_->is_active, @{$one_product->milestones}))];
     }
   }
+
+  # Allow to edit flags as well
+  $vars->{'flag_types'} = Bugzilla::FlagType::match({target_type => 'bug'});
 }
 
 # If we're editing a stored query, use the existing query name as default for

--- a/process_bug.cgi
+++ b/process_bug.cgi
@@ -401,8 +401,7 @@ foreach my $b (@bug_objects) {
 # allow them to be set using set_all.
 foreach my $bug (@bug_objects) {
   my ($flags, $new_flags)
-    = Bugzilla::Flag->extract_flags_from_cgi($bug, undef, $vars,
-    SKIP_REQUESTEE_ON_ERROR);
+    = Bugzilla::Flag->extract_flags_from_cgi($bug, undef, $vars);
   $bug->set_flags($flags, $new_flags);
 }
 

--- a/process_bug.cgi
+++ b/process_bug.cgi
@@ -396,14 +396,14 @@ foreach my $b (@bug_objects) {
   }
 }
 
-if (defined $cgi->param('id')) {
-
-  # Flags should be set AFTER the bug has been moved into another
-  # product/component. The structure of flags code doesn't currently
-  # allow them to be set using set_all.
+# Flags should be set AFTER the bug has been moved into another
+# product/component. The structure of flags code doesn't currently
+# allow them to be set using set_all.
+foreach my $bug (@bug_objects) {
   my ($flags, $new_flags)
-    = Bugzilla::Flag->extract_flags_from_cgi($first_bug, undef, $vars);
-  $first_bug->set_flags($flags, $new_flags);
+    = Bugzilla::Flag->extract_flags_from_cgi($bug, undef, $vars,
+    SKIP_REQUESTEE_ON_ERROR);
+  $bug->set_flags($flags, $new_flags);
 }
 
 ##############################

--- a/template/en/default/flag/list.html.tmpl
+++ b/template/en/default/flag/list.html.tmpl
@@ -133,6 +133,9 @@
                 class="flag_select flag_type-[% type.id %]"
                 data-id="[% type.id %]" data-name="[% type.name FILTER html FILTER no_break %]"
                 [% IF !can_edit_flag %] disabled="disabled"[% END %]>
+        [% IF dontchange %]
+          <option value="[% dontchange FILTER html %]" selected>[% dontchange FILTER html %]</option>
+        [% END %]
         [%# Only display statuses the user is allowed to set. %]
         [% IF !flag
               || (can_edit_flag && user.can_unset_flag(type, flag.status) && user.can_request_flag(type))

--- a/template/en/default/list/edit-multiple.html.tmpl
+++ b/template/en/default/list/edit-multiple.html.tmpl
@@ -290,6 +290,8 @@
 
 </table>
 
+[% PROCESS "flag/list.html.tmpl" any_flags_requesteeble = 1 %]
+
 <b><label for="comment">Additional Comments:</label></b>
 [% IF user.is_insider %]
   <input type="checkbox" name="comment_is_private" value="1"


### PR DESCRIPTION
Allow to bulk-edit bug flags on the **Change Several Bugs at Once** page.

## Bugzilla link

[Bug 1502500 - Adding the qe-verify flag as an editable field when using Bugzilla's "Change Several Bugs at Once" option](https://bugzilla.mozilla.org/show_bug.cgi?id=1502500)