### PR TITLE
Bug 1391439 - Add ability to capture and attach a screenshot through the Bugzilla UI

### DIFF
--- a/js/attachment.js
+++ b/js/attachment.js
@@ -597,7 +597,7 @@ Bugzilla.AttachmentForm = class AttachmentForm {
     const [date, time] = (new Date().toISOString()).match(/^(.+)T(.+)\./).splice(1);
 
     // Process as a PNG file
-    this.process_file(new File([blob], `Screenshot on ${date} at ${time}`, { type: 'image/png' }));
+    this.process_file(new File([blob], `Screenshot on ${date} at ${time}.png`, { type: 'image/png' }));
     this.update_ispatch(false, true);
 
     // Clean up

--- a/js/attachment.js
+++ b/js/attachment.js
@@ -568,7 +568,7 @@ Bugzilla.AttachmentForm = class AttachmentForm {
    * Capture API is supported, then attach it as a PNG image.
    * @see https://developer.mozilla.org/en-US/docs/Web/API/Screen_Capture_API
    */
-  async capture_onclick() {
+  capture_onclick() { (async () => {
     if (typeof navigator.mediaDevices.getDisplayMedia !== 'function') {
       alert('This function requires the latest browser such as Firefox 66 or Chrome 72.');
       return;
@@ -605,7 +605,7 @@ Bugzilla.AttachmentForm = class AttachmentForm {
     $video.pause();
     $video.srcObject.getTracks().forEach(track => track.stop());
     $video.srcObject = null;
-  }
+  })(); }
 
   /**
    * Called whenever the content of the textarea is updated. Update the Content Type, `required` property, etc.

--- a/js/attachment.js
+++ b/js/attachment.js
@@ -564,9 +564,9 @@ Bugzilla.AttachmentForm = class AttachmentForm {
   }
 
   /**
-   * Called whenever the Take a Screenshot button is clicked. Capture a screen, window or browser tab if possible, and
-   * attach it as a image.
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/Screen_Capture_API/Using_Screen_Capture
+   * Called whenever the Take a Screenshot button is clicked. Capture a screen, window or browser tab if the Screen
+   * Capture API is supported, then attach it as a PNG image.
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/Screen_Capture_API
    */
   async capture_onclick() {
     if (typeof navigator.mediaDevices.getDisplayMedia !== 'function') {

--- a/js/attachment.js
+++ b/js/attachment.js
@@ -570,7 +570,7 @@ Bugzilla.AttachmentForm = class AttachmentForm {
    */
   async capture_onclick() {
     if (typeof navigator.mediaDevices.getDisplayMedia !== 'function') {
-      alert('This function requires the latest browser including Firefox 66 and Chrome 72.');
+      alert('This function requires the latest browser such as Firefox 66 or Chrome 72.');
       return;
     }
 

--- a/js/attachment.js
+++ b/js/attachment.js
@@ -570,7 +570,7 @@ Bugzilla.AttachmentForm = class AttachmentForm {
    */
   capture_onclick() {
     if (typeof navigator.mediaDevices.getDisplayMedia !== 'function') {
-      alert('This function requires the latest browser such as Firefox 66 or Chrome 72.');
+      alert('This function requires the most recent browser version such as Firefox 66 or Chrome 72.');
       return;
     }
 

--- a/js/attachment.js
+++ b/js/attachment.js
@@ -593,11 +593,12 @@ Bugzilla.AttachmentForm = class AttachmentForm {
     // Draw a video frame on `<canvas>`
     $canvas.getContext('2d').drawImage($video, 0, 0, width, height);
 
+    // Convert to a PNG image
     const blob = await new Promise(resolve => $canvas.toBlob(blob => resolve(blob)));
-    const [date, time] = (new Date().toISOString()).match(/^(.+)T(.+)\./).splice(1);
+    const [date, time] = (new Date()).toISOString().match(/^(.+)T(.+)\./).splice(1);
+    const file = new File([blob], `Screenshot on ${date} at ${time}.png`, { type: 'image/png' });
 
-    // Process as a PNG file
-    this.process_file(new File([blob], `Screenshot on ${date} at ${time}.png`, { type: 'image/png' }));
+    this.process_file(file);
     this.update_ispatch(false, true);
 
     // Clean up

--- a/template/en/default/attachment/createformcontents.html.tmpl
+++ b/template/en/default/attachment/createformcontents.html.tmpl
@@ -30,8 +30,11 @@
     <section id="att-dropbox">
       <header>
         <span class="icon" aria-hidden="true"></span>
-        <span><label id="att-browse-label" tabindex="0" role="button">Browse a file</label>,
-          drag &amp; drop it, or paste text/link/image below.</span>
+        <span>
+          <label id="att-browse-label" tabindex="0" role="button">Browse a file</label>,
+          drag &amp; drop it, paste text/link/image below, or
+          <label id="att-capture-label" tabindex="0" role="button">take a screenshot</label>.
+        </span>
       </header>
       <div>
         <textarea hidden id="att-data" name="data_base64"


### PR DESCRIPTION
Use the latest [Screen Capture API](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Capture_API/Using_Screen_Capture) currently available in Firefox Nightly/Beta and Chrome to let users take a screenshot directly from the browser. Wow, we don’t need Java nor Flash! 🎉

Note: this API requires HTTPS 🔒 which means the local server must have a TLS certificate to test the functionality. I don’t know how to do it with Vagrant so I’m using the [Apache reverse proxy](https://httpd.apache.org/docs/2.4/howto/reverse_proxy.html) instead.

## Bugzilla link

[Bug 1391439 - Add ability to capture and attach a screenshot through the Bugzilla UI](https://bugzilla.mozilla.org/show_bug.cgi?id=1391439)