### PR TITLE
Bug 1529406 - Record user’s logged-in/out status and track insiders with Google Analytics

### DIFF
--- a/extensions/GoogleAnalytics/template/en/default/hook/global/header-additional_header.html.tmpl
+++ b/extensions/GoogleAnalytics/template/en/default/hook/global/header-additional_header.html.tmpl
@@ -10,6 +10,15 @@
 [% RETURN IF !Bugzilla.params.google_analytics_tracking_id || Bugzilla.cgi.http('dnt') == '1' ||
     (bug.defined && bug.groups_in.size) %]
 
-<meta name="google-analytics" content="[% Bugzilla.params.google_analytics_tracking_id FILTER html %]">
+<meta name="google-analytics" content="[% Bugzilla.params.google_analytics_tracking_id FILTER html %]" data-location="
+  [%~ urlbase FILTER html %][% template.name.replace('\.html\.tmpl$', '') FILTER html ~%]
+  " data-title="
+  [%~ IF template.name == 'pages/user_activity.html.tmpl' ~%]
+    User Activity Report
+  [%~ ELSIF template.name == 'pages/user_profile.html.tmpl' ~%]
+    User Profile
+  [%~ ELSE ~%]
+    [% title FILTER html | collapse %]
+  [%~ END ~%]">
 <script async src="https://www.google-analytics.com/analytics
   [%~ "_debug" IF Bugzilla.params.google_analytics_debug ~%].js"></script>

--- a/extensions/GoogleAnalytics/template/en/default/hook/global/header-additional_header.html.tmpl
+++ b/extensions/GoogleAnalytics/template/en/default/hook/global/header-additional_header.html.tmpl
@@ -6,19 +6,10 @@
   # defined by the Mozilla Public License, v. 2.0.
   #%]
 
-[%# Disable tracking of DNT-enabled users, security group members as well as private bugs #%]
+[%# Disable tracking of DNT-enabled users as well as private bugs #%]
 [% RETURN IF !Bugzilla.params.google_analytics_tracking_id || Bugzilla.cgi.http('dnt') == '1' ||
-    user.in_group(Param('insidergroup')) || (bug.defined && bug.groups_in.size) %]
+    (bug.defined && bug.groups_in.size) %]
 
-<meta name="google-analytics" content="[% Bugzilla.params.google_analytics_tracking_id FILTER html %]" data-location="
-  [%~ urlbase FILTER html %][% template.name.replace('\.html\.tmpl$', '') FILTER html ~%]
-  " data-title="
-  [%~ IF template.name == 'pages/user_activity.html.tmpl' ~%]
-    User Activity Report
-  [%~ ELSIF template.name == 'pages/user_profile.html.tmpl' ~%]
-    User Profile
-  [%~ ELSE ~%]
-    [% title FILTER html | collapse %]
-  [%~ END ~%]">
+<meta name="google-analytics" content="[% Bugzilla.params.google_analytics_tracking_id FILTER html %]">
 <script async src="https://www.google-analytics.com/analytics
   [%~ "_debug" IF Bugzilla.params.google_analytics_debug ~%].js"></script>

--- a/extensions/GoogleAnalytics/template/en/default/hook/global/header-start.html.tmpl
+++ b/extensions/GoogleAnalytics/template/en/default/hook/global/header-start.html.tmpl
@@ -8,9 +8,9 @@
 
 [% USE Bugzilla %]
 
-[%# Disable tracking of DNT-enabled users, security group members as well as private bugs #%]
+[%# Disable tracking of DNT-enabled users as well as private bugs #%]
 [% RETURN IF !Bugzilla.params.google_analytics_tracking_id || Bugzilla.cgi.http('dnt') == '1' ||
-    user.in_group(Param('insidergroup')) || (bug.defined && bug.groups_in.size) %]
+    (bug.defined && bug.groups_in.size) %]
 
 [% IF !javascript_urls %]
   [% javascript_urls = [] %]

--- a/extensions/GoogleAnalytics/web/js/analytics.js
+++ b/extensions/GoogleAnalytics/web/js/analytics.js
@@ -19,6 +19,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
   // Sanitize params
   params.delete('list_id');
+  params.delete('t');
   params.delete('token');
 
   // Activate Google Analytics

--- a/extensions/GoogleAnalytics/web/js/analytics.js
+++ b/extensions/GoogleAnalytics/web/js/analytics.js
@@ -5,18 +5,30 @@
  * This Source Code Form is "Incompatible With Secondary Licenses", as
  * defined by the Mozilla Public License, v. 2.0. */
 
-$(function() {
-  var meta = $('meta[name="google-analytics"]');
+window.addEventListener('DOMContentLoaded', () => {
+  'use strict';
 
-  if (meta.length) {
-    // Activate Google Analytics
-    window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-    ga('create', meta.attr('content'), 'auto');
-    ga('set', 'anonymizeIp', true);
-    ga('set', 'location', meta.data('location'));
-    ga('set', 'title', meta.data('title'));
-    ga('set', 'transport', 'beacon');
-    // Track page view
-    ga('send', 'pageview');
+  const $meta = document.querySelector('meta[name="google-analytics"]');
+
+  if (!$meta) {
+    return;
   }
-});
+
+  const url = new URL(document.location);
+  const params = url.searchParams;
+
+  // Sanitize params
+  params.delete('list_id');
+  params.delete('token');
+
+  // Activate Google Analytics
+  window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+  ga('create', $meta.content, 'auto');
+  ga('set', 'anonymizeIp', true);
+  ga('set', 'location', url);
+  ga('set', 'transport', 'beacon');
+  // Custom Dimension: logged in (true) or out (false)
+  ga('set', 'dimension1', !!BUGZILLA.user.login);
+  // Track page view
+  ga('send', 'pageview');
+}, { once: true });

--- a/extensions/GoogleAnalytics/web/js/analytics.js
+++ b/extensions/GoogleAnalytics/web/js/analytics.js
@@ -14,20 +14,14 @@ window.addEventListener('DOMContentLoaded', () => {
     return;
   }
 
-  const url = new URL(document.location);
-  const params = url.searchParams;
-
-  // Sanitize params
-  params.delete('list_id');
-  params.delete('t');
-  params.delete('token');
-
   // Activate Google Analytics
   window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
   ga('create', $meta.content, 'auto');
   ga('set', 'anonymizeIp', true);
-  ga('set', 'location', url);
   ga('set', 'transport', 'beacon');
+  // Record a crafted location (template name) and title instead of actual URL
+  ga('set', 'location', $meta.dataset.location);
+  ga('set', 'title', $meta.dataset.title);
   // Custom Dimension: logged in (true) or out (false)
   ga('set', 'dimension1', !!BUGZILLA.user.login);
   // Track page view


### PR DESCRIPTION
* <del>Start logging actual URLs instead of template names. The query params will also be logged except for sensitive tokens and user-specific bug list IDs</del>
* Start logging users’ logged-in/out status using a [custom dimention](https://support.google.com/analytics/answer/2709828)
* Start logging insiders while prevent security/private bugs being logged
* Remove jQuery dependency

## Bugzilla link

[Bug 1529406 - Record user’s logged-in/out status and track insiders with Google Analytics](https://bugzilla.mozilla.org/show_bug.cgi?id=1529406)