### PR TITLE
Bug 1532406 - Removed useless trick_taint() and untaint() calls

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -602,9 +602,6 @@ sub log_user_request {
     $user_id, remote_ip(), $user_agent, $request_url, $method,
     $bug_id,  $attach_id,  $action,     $server
   );
-  foreach my $param (@params) {
-    trick_taint($param) if defined $param;
-  }
 
   eval {
     local request_cache->{dbh};

--- a/Bugzilla/App/CGI.pm
+++ b/Bugzilla/App/CGI.pm
@@ -10,7 +10,6 @@ use Mojo::Base 'Mojolicious::Controller';
 
 use CGI::Compile;
 use Try::Tiny;
-use Taint::Util qw(untaint);
 use Sys::Hostname;
 use Sub::Quote 2.005000;
 use Sub::Name;
@@ -52,7 +51,6 @@ sub load_one {
   my $package = __PACKAGE__ . "::$name", my $inner_name = "_$name";
   my $content = path(bz_locations->{cgi_path}, $file)->slurp;
   $content = "package $package; $content";
-  untaint($content);
   my %options = (package => $package, file => $file, line => 1, no_defer => 1,);
   die "Tried to load $file more than once" if $SEEN{$file}++;
   my $inner = quote_sub $inner_name, $content, {}, \%options;

--- a/Bugzilla/Attachment.pm
+++ b/Bugzilla/Attachment.pm
@@ -442,7 +442,6 @@ sub _check_content_type {
   {
     ThrowUserError("invalid_content_type", {contenttype => $content_type});
   }
-  trick_taint($content_type);
 
   return $content_type;
 }
@@ -498,7 +497,6 @@ sub _check_filename {
   # Truncate the filename to 100 characters, counting from the end of the
   # string to make sure we keep the filename extension.
   $filename = substr($filename, -100, 100);
-  trick_taint($filename);
 
   return $filename;
 }

--- a/Bugzilla/Attachment/Database.pm
+++ b/Bugzilla/Attachment/Database.pm
@@ -11,8 +11,6 @@ use 5.10.1;
 use strict;
 use warnings;
 
-use Bugzilla::Util qw(trick_taint);
-
 sub new {
   return bless({}, shift);
 }
@@ -22,7 +20,6 @@ sub store {
   my $dbh = Bugzilla->dbh;
   my $sth = $dbh->prepare(
     "INSERT INTO attach_data (id, thedata) VALUES ($attach_id, ?)");
-  trick_taint($data);
   $sth->bind_param(1, $data, $dbh->BLOB_TYPE);
   $sth->execute();
 }

--- a/Bugzilla/Auth/Login/Cookie.pm
+++ b/Bugzilla/Auth/Login/Cookie.pm
@@ -51,7 +51,6 @@ sub get_login_info {
       @{$cgi->{'Bugzilla_cookie_list'}};
       $user_id = $cookie->value if $cookie;
     }
-    trick_taint($login_cookie) if $login_cookie;
     $self->cookie($login_cookie);
 
     # If the call is for a web service, and an api token is provided, check
@@ -89,7 +88,6 @@ sub get_login_info {
 
     # Anything goes for these params - they're just strings which
     # we're going to verify against the db
-    trick_taint($login_cookie);
     detaint_natural($user_id);
 
     my $db_cookie = $dbh->selectrow_array(

--- a/Bugzilla/Auth/Persist/Cookie.pm
+++ b/Bugzilla/Auth/Persist/Cookie.pm
@@ -38,7 +38,6 @@ sub persist_login {
     = Bugzilla::Token::GenerateUniqueToken('logincookies', 'cookie');
 
   my $ip_addr = remote_ip();
-  trick_taint($ip_addr);
 
   $dbh->do('INSERT INTO logincookies (cookie, userid, ipaddr, lastused)
     VALUES (?, ?, ?, NOW())', undef, $login_cookie, $user->id, $ip_addr);
@@ -144,7 +143,6 @@ sub logout {
   # logged in and got the same cookie, we could be logging the other
   # user out here. Yes, this is very very very unlikely, but why take
   # chances? - bbaetz
-  map { trick_taint($_) } @login_cookies;
   @login_cookies = map { $dbh->quote($_) } @login_cookies;
   if ($type == LOGOUT_KEEP_CURRENT) {
     $dbh->do(

--- a/Bugzilla/Auth/Verify.pm
+++ b/Bugzilla/Auth/Verify.pm
@@ -47,7 +47,6 @@ sub create_or_update_user {
     my $username_user_id = login_to_id($username || '');
     my $extern_user_id;
     if ($extern_id) {
-      trick_taint($extern_id);
       $extern_user_id = $dbh->selectrow_array(
         'SELECT userid
                  FROM profiles WHERE extern_id = ?', undef, $extern_id
@@ -81,8 +80,6 @@ sub create_or_update_user {
 
       # external authentication
       # systems might follow different standards than ours. So in this
-      # place here, we call trick_taint without checks.
-      trick_taint($password);
 
       # XXX Theoretically this could fail with an error, but the fix for
       # that is too involved to be done right now.
@@ -133,7 +130,6 @@ sub create_or_update_user {
 
     # $real_name is more than likely tainted, but we only use it
     # in a placeholder and we never use it after this.
-    trick_taint($real_name);
     $user->set_name($real_name);
     $user_updated = 1;
   }

--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -2368,7 +2368,6 @@ sub _check_tag_name {
   $tag = clean_text($tag);
   $tag || ThrowUserError('no_tag_to_edit');
   ThrowUserError('tag_name_too_long') if length($tag) > MAX_LEN_QUERY_NAME;
-  trick_taint($tag);
 
   # Tags are all lowercase.
   return lc($tag);
@@ -3451,7 +3450,6 @@ sub add_see_also {
 
   my $field_values = $class->run_create_validators($params);
   my $value        = $field_values->{value}->as_string;
-  trick_taint($value);
   $field_values->{value} = $value;
 
   # We only add the new URI if it hasn't been added yet. URIs are
@@ -4345,7 +4343,6 @@ sub bug_alias_to_id {
   my ($alias) = @_;
   return undef unless Bugzilla->params->{"usebugaliases"};
   my $dbh = Bugzilla->dbh;
-  trick_taint($alias);
   return $dbh->selectrow_array("SELECT bug_id FROM bugs WHERE alias = ?",
     undef, $alias);
 }
@@ -4445,7 +4442,6 @@ sub GetBugActivity {
   # Only consider changes since $starttime, if given.
   my $datepart = "";
   if (defined $starttime) {
-    trick_taint($starttime);
     push(@args, $starttime);
     $datepart = "AND bug_when > ?";
   }
@@ -4674,8 +4670,6 @@ sub LogActivityEntry {
     else {
       $added = "";      # no more entries
     }
-    trick_taint($addstr);
-    trick_taint($removestr);
     my $fieldid = get_field_id($col);
     $dbh->do(
       "INSERT INTO bugs_activity

--- a/Bugzilla/Comment.pm
+++ b/Bugzilla/Comment.pm
@@ -172,7 +172,6 @@ sub update {
           $weighted->update();
         }
       }
-      trick_taint($tag);
       $sth_delete->execute($self->id, $tag);
       $sth_activity->execute($self->bug_id, $self->id, Bugzilla->user->id, $when, '',
         $tag);
@@ -187,7 +186,6 @@ sub update {
       else {
         Bugzilla::Comment::TagWeights->create({tag => $tag, weight => 1});
       }
-      trick_taint($tag);
       $sth_insert->execute($self->id, $tag);
       $sth_activity->execute($self->bug_id, $self->id, Bugzilla->user->id, $when,
         $tag, '');

--- a/Bugzilla/DB.pm
+++ b/Bugzilla/DB.pm
@@ -118,7 +118,6 @@ use constant INDEX_DROPS_REQUIRE_FK_DROPS => 1;
 sub quote {
   my $self   = shift;
   my $retval = $self->dbh->quote(@_);
-  trick_taint($retval) if defined $retval;
   return $retval;
 }
 
@@ -473,9 +472,6 @@ sub sql_fulltext_search {
   # surround the words with wildcards and SQL quotes so we can use them
   # in LIKE search clauses
   @words = map($self->quote("\%$_\%"), @words);
-
-  # untaint words, since they are safe to use now that we've quoted them
-  trick_taint($_) foreach @words;
 
   # turn the words into a set of LIKE search clauses
   @words = map("LOWER($column) LIKE $_", @words);

--- a/Bugzilla/DB/Mysql.pm
+++ b/Bugzilla/DB/Mysql.pm
@@ -181,9 +181,6 @@ sub sql_fulltext_search {
   # quote the text for use in the MATCH AGAINST expression
   $text = $self->quote($text);
 
-  # untaint the text, since it's safe to use now that we've quoted it
-  trick_taint($text);
-
   return "MATCH($column) AGAINST($text $mode)";
 }
 

--- a/Bugzilla/DB/Oracle.pm
+++ b/Bugzilla/DB/Oracle.pm
@@ -170,7 +170,6 @@ sub sql_from_days {
 sub sql_fulltext_search {
   my ($self, $column, $text) = @_;
   $text = $self->quote($text);
-  trick_taint($text);
   $fulltext_label++;
   return "CONTAINS($column,$text,$fulltext_label) > 0", "SCORE($fulltext_label)";
 }

--- a/Bugzilla/Elastic.pm
+++ b/Bugzilla/Elastic.pm
@@ -9,7 +9,6 @@ use 5.10.1;
 use Moo;
 
 use Bugzilla::Elastic::Search;
-use Bugzilla::Util qw(trick_taint);
 
 with 'Bugzilla::Elastic::Role::HasClient';
 

--- a/Bugzilla/Elastic/Search.pm
+++ b/Bugzilla/Elastic/Search.pm
@@ -10,7 +10,6 @@ use 5.10.1;
 use Moo;
 use Bugzilla::Search;
 use Bugzilla::Search::Quicksearch;
-use Bugzilla::Util qw(trick_taint);
 use namespace::clean;
 
 use Bugzilla::Elastic::Search::FakeCGI;
@@ -104,9 +103,7 @@ sub data {
     $source->{relevance} = $hit->{_score};
     foreach my $val (values %$source) {
       next unless defined $val;
-      trick_taint($val);
     }
-    trick_taint($hit->{_id});
     if ($source) {
       $hits{$hit->{_id}} = [@$source{@fields}];
     }

--- a/Bugzilla/Extension.pm
+++ b/Bugzilla/Extension.pm
@@ -17,7 +17,6 @@ use Bugzilla::Install::Util qw( extension_code_files );
 
 use File::Basename;
 use File::Spec;
-use Taint::Util qw(untaint);
 
 BEGIN { push @INC, \&INC_HOOK }
 
@@ -35,7 +34,6 @@ sub INC_HOOK {
       = Cwd::realpath(File::Spec->catpath($vol, File::Spec->catdir(@dirs), $file));
 
     my $first = 1;
-    untaint($real_file);
     $INC{$fake_file} = $real_file;
     my $found = open my $fh, '<', $real_file;
     unless ($found) {
@@ -48,7 +46,6 @@ sub INC_HOOK {
       if (!$first) {
         return 0 if eof $fh;
         $_ = readline $fh or return 0;
-        untaint($_);
         return 1;
       }
       else {

--- a/Bugzilla/Field.pm
+++ b/Bugzilla/Field.pm
@@ -1466,7 +1466,6 @@ sub check_field {
     or !grep { $_ eq $value } @$legalsRef)
   {
     return 0 if $no_warn;    # We don't want an error to be thrown; return.
-    trick_taint($name);
 
     my $field = new Bugzilla::Field({name => $name});
     my $field_desc = $field ? $field->description : $name;
@@ -1497,7 +1496,6 @@ sub get_field_id {
   my ($name) = @_;
   my $dbh = Bugzilla->dbh;
 
-  trick_taint($name);
   my $id = $dbh->selectrow_array(
     'SELECT id FROM fielddefs
                                     WHERE name = ?', undef, $name

--- a/Bugzilla/Flag.pm
+++ b/Bugzilla/Flag.pm
@@ -970,7 +970,6 @@ sub extract_flags_from_cgi {
     next if (!$flag_type->is_multiplicable && $has_flags);
 
     my $status = $cgi->param("flag_type-$type_id");
-    trick_taint($status);
 
     my @logins = $cgi->param("requestee_type-$type_id");
     if ($status eq "?" && scalar(@logins)) {

--- a/Bugzilla/FlagType.pm
+++ b/Bugzilla/FlagType.pm
@@ -345,7 +345,6 @@ sub _check_group {
   my ($invocant, $group) = @_;
   return unless $group;
 
-  trick_taint($group);
   $group = Bugzilla::Group->check($group);
   return $group->id;
 }
@@ -682,7 +681,6 @@ sub sqlify_criteria {
 
   if ($criteria->{name}) {
     my $name = $dbh->quote($criteria->{name});
-    trick_taint($name);    # Detaint data as we have quoted it.
     push(@criteria, "flagtypes.name = $name");
   }
   if ($criteria->{target_type}) {

--- a/Bugzilla/Install/Localconfig.pm
+++ b/Bugzilla/Install/Localconfig.pm
@@ -31,7 +31,6 @@ use List::Util qw(first);
 use Tie::Hash::NamedCapture;
 use Safe;
 use Term::ANSIColor;
-use Taint::Util qw(untaint);
 use Sys::Hostname qw(hostname);
 
 use parent qw(Exporter);
@@ -124,17 +123,14 @@ sub _read_localconfig_from_env {
       foreach my $override (PARAM_OVERRIDE) {
         my $o_key = ENV_PREFIX . $override;
         $localconfig{param_override}{$override} = $ENV{$o_key};
-        untaint($localconfig{param_override}{$override});
       }
     }
     elsif (exists $ENV{$key}) {
       $localconfig{$name} = $ENV{$key};
-      untaint($localconfig{$name});
     }
     else {
       my $default = $var->{default};
       $localconfig{$name} = ref($default) eq 'CODE' ? $default->() : $default;
-      untaint($localconfig{$name});
     }
   }
 

--- a/Bugzilla/Install/Util.pm
+++ b/Bugzilla/Install/Util.pm
@@ -137,7 +137,6 @@ sub extension_code_files {
     # We know that these paths are safe, because they came from
     # extensionsdir and we checked them specifically for their format.
     # Also, the only thing we ever do with them is pass them to "require".
-    trick_taint($_) foreach @load_files;
     push(@files, \@load_files);
   }
 
@@ -308,7 +307,6 @@ sub _template_lang_directories {
     foreach my $dir (@add) {
       my $full_dir = "$templatedir/$lang/$dir";
       if (-d $full_dir) {
-        trick_taint($full_dir);
         push(@result, $full_dir);
       }
     }
@@ -592,14 +590,6 @@ use constant _cache => {};
 ###############################
 # Copied from Bugzilla::Util #
 ##############################
-
-sub trick_taint {
-  require Carp;
-  Carp::confess("Undef to trick_taint") unless defined $_[0];
-  my $match = $_[0] =~ /^(.*)$/s;
-  $_[0] = $match ? $1 : undef;
-  return (defined($_[0]));
-}
 
 sub trim {
   my ($str) = @_;

--- a/Bugzilla/Logging.pm
+++ b/Bugzilla/Logging.pm
@@ -15,13 +15,11 @@ use Log::Log4perl::MDC;
 use File::Spec::Functions qw(rel2abs catfile);
 use Bugzilla::Constants qw(bz_locations);
 use English qw(-no_match_vars $PROGRAM_NAME);
-use Taint::Util qw(untaint);
 
 sub logfile {
   my ($class, $name) = @_;
 
   my $file = rel2abs(catfile(bz_locations->{logsdir}, $name));
-  untaint($file);
   return $file;
 }
 

--- a/Bugzilla/MFA.pm
+++ b/Bugzilla/MFA.pm
@@ -14,7 +14,6 @@ use warnings;
 use Bugzilla::RNG qw( irand );
 use Bugzilla::Token
   qw( issue_short_lived_session_token set_token_extra_data get_token_extra_data delete_token );
-use Bugzilla::Util qw( trick_taint );
 
 sub new {
   my ($class, $user) = @_;
@@ -140,7 +139,6 @@ sub generate_recovery_codes {
 
 sub property_get {
   my ($self, $name) = @_;
-  trick_taint($name);
   return
     scalar Bugzilla->dbh->selectrow_array(
     "SELECT value FROM profile_mfa WHERE user_id = ? AND name = ?",
@@ -149,8 +147,6 @@ sub property_get {
 
 sub property_set {
   my ($self, $name, $value) = @_;
-  trick_taint($name);
-  trick_taint($value);
   Bugzilla->dbh->do(
     "INSERT INTO profile_mfa (user_id, name, value) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE value = ?",
     undef, $self->{user}->id, $name, $value, $value
@@ -159,7 +155,6 @@ sub property_set {
 
 sub property_delete {
   my ($self, $name) = @_;
-  trick_taint($name);
   Bugzilla->dbh->do("DELETE FROM profile_mfa WHERE user_id = ? AND name = ?",
     undef, $self->{user}->id, $name);
 }

--- a/Bugzilla/Memcached.pm
+++ b/Bugzilla/Memcached.pm
@@ -16,7 +16,7 @@ use Log::Log4perl qw(:easy);
 use Bugzilla::Error;
 use Scalar::Util qw(blessed);
 use List::Util qw(sum);
-use Bugzilla::Util qw(trick_taint trim);
+use Bugzilla::Util qw(trim);
 use URI::Escape;
 use Encode;
 use Sys::Syslog qw(:DEFAULT);
@@ -346,7 +346,6 @@ sub _bloomfilter_prefix {
 sub _encode_key {
   my ($self, $key) = @_;
   $key = $self->_global_prefix . '.' . uri_escape_utf8($key);
-  trick_taint($key) if defined $key;
   return length($self->{namespace} . $key) > MAX_KEY_LENGTH ? undef : $key;
 }
 

--- a/Bugzilla/Object.pm
+++ b/Bugzilla/Object.pm
@@ -161,7 +161,6 @@ sub _load_from_db {
       push(@values, @{$param->{'values'}});
     }
 
-    map { trick_taint($_) } @values;
     $object_data
       = $dbh->selectrow_hashref("SELECT $columns FROM $table WHERE $condition",
       undef, @values);
@@ -425,7 +424,6 @@ sub _do_list_select {
     # for the caller. So we copy the array. It's safe to untaint because
     # they're only used in placeholders here.
     my @untainted = @{$values || []};
-    trick_taint($_) foreach @untainted;
     $objects = $dbh->selectall_arrayref($sql, {Slice => {}}, @untainted);
     $class->_serialisation_keys($objects->[0]) if @$objects;
   }
@@ -474,7 +472,6 @@ sub set {
   if (exists $validators{$field}) {
     my $validator = $validators{$field};
     $value = $self->$validator($value, $field);
-    trick_taint($value) if (defined $value && !ref($value));
 
     if ($self->can('_set_global_validator')) {
       $self->_set_global_validator($value, $field);
@@ -552,7 +549,6 @@ sub update {
       next;
     }
 
-    trick_taint($new) if defined $new;
     push(@values,         $new);
     push(@update_columns, $column);
 
@@ -731,7 +727,6 @@ sub run_create_validators {
 
     # We want people to be able to explicitly set fields to NULL,
     # and that means they can be set to undef.
-    trick_taint($value) if defined $value && !ref($value);
     $field_values{$field} = $value;
   }
 

--- a/Bugzilla/PatchReader/AddCVSContext.pm
+++ b/Bugzilla/PatchReader/AddCVSContext.pm
@@ -34,11 +34,9 @@ sub my_rmtree {
       $this->my_rmtree($file);
     }
     else {
-      trick_taint($file);
       unlink $file;
     }
   }
-  trick_taint($dir);
   rmdir $dir;
 }
 
@@ -215,7 +213,6 @@ sub push_context_lines {
     open(my $fh, '<', $this->{FILENAME}) or die "Could not open $this->{FILENAME}";
     $this->{FILE}           = $fh;
     $this->{NEXT_FILE_LINE} = 1;
-    trick_taint($olddir);    # $olddir comes from getcwd()
     chdir($olddir) or die "Could not cd back to $olddir";
   }
 
@@ -240,10 +237,5 @@ sub push_context_lines {
   $this->{SECTION_END} = $i - 1;
 }
 
-sub trick_taint {
-  $_[0] =~ /^(.*)$/s;
-  $_[0] = $1;
-  return (defined($_[0]));
-}
 
 1;

--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -1884,7 +1884,6 @@ sub _handle_chart {
 
   $self->_chart_fields->{$field}
     or ThrowCodeError("invalid_field_name", {field => $field});
-  trick_taint($field);
 
   # This is the field as you'd reference it in a SQL statement.
   my $full_field = $field =~ /\./ ? $field : "bugs.$field";
@@ -2091,7 +2090,6 @@ sub _quote_unless_numeric {
   my $is_numeric       = $numeric_operator && $numeric_field && $numeric_value;
   if ($is_numeric) {
     my $quoted = $value;
-    trick_taint($quoted);
     return $quoted;
   }
   return Bugzilla->dbh->quote($value);

--- a/Bugzilla/Search/Clause.pm
+++ b/Bugzilla/Search/Clause.pm
@@ -13,7 +13,6 @@ use warnings;
 
 use Bugzilla::Error;
 use Bugzilla::Search::Condition qw(condition);
-use Bugzilla::Util qw(trick_taint);
 
 sub new {
   my ($class, $joiner) = @_;
@@ -21,8 +20,6 @@ sub new {
     ThrowCodeError('search_invalid_joiner', {joiner => $joiner});
   }
 
-  # This will go into SQL directly so needs to be untainted.
-  trick_taint($joiner) if $joiner;
   bless {joiner => $joiner || 'AND'}, $class;
 }
 

--- a/Bugzilla/Search/ClauseGroup.pm
+++ b/Bugzilla/Search/ClauseGroup.pm
@@ -15,7 +15,6 @@ use base qw(Bugzilla::Search::Clause);
 
 use Bugzilla::Error;
 use Bugzilla::Search::Condition qw(condition);
-use Bugzilla::Util qw(trick_taint);
 use List::MoreUtils qw(uniq);
 
 use constant UNSUPPORTED_FIELDS => qw(

--- a/Bugzilla/Series.pm
+++ b/Bugzilla/Series.pm
@@ -159,7 +159,6 @@ sub initFromCGI {
     "subcategory", "name",  "frequency", "public",
     "query_format"
   );
-  trick_taint($self->{'query'});
 
   $self->{'public'} = $cgi->param('public') ? 1 : 0;
 
@@ -239,7 +238,6 @@ sub existsInDatabase {
   my $category_id    = getCategoryID($self->{'category'});
   my $subcategory_id = getCategoryID($self->{'subcategory'});
 
-  trick_taint($self->{'name'});
   my $series_id
     = $dbh->selectrow_array("SELECT series_id "
       . "FROM series WHERE category = $category_id "
@@ -257,9 +255,6 @@ sub getCategoryID {
 
   # This seems for the best idiom for "Do A. Then maybe do B and A again."
   while (1) {
-
-    # We are quoting this to put it in the DB, so we can remove taint
-    trick_taint($category);
 
     $category_id
       = $dbh->selectrow_array("SELECT id "

--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -101,8 +101,6 @@ sub get_format {
   # Security - allow letters and a hyphen only
   $ctype =~ s/[^a-zA-Z\-]//g;
   $format =~ s/[^a-zA-Z\-]//g;
-  trick_taint($ctype);
-  trick_taint($format);
 
   $template .= ($format ? "-$format" : "");
   $template .= ".$ctype.tmpl";

--- a/Bugzilla/Template/PreloadProvider.pm
+++ b/Bugzilla/Template/PreloadProvider.pm
@@ -21,8 +21,6 @@ use Template::Constants qw( STATUS_ERROR );
 use Template::Document;
 use Template::Config;
 
-use Bugzilla::Util qw(trick_taint);
-
 sub _init {
   my $self = shift;
   $self->SUPER::_init(@_);
@@ -41,7 +39,6 @@ sub _init {
         unless ($search->{$key}) {
           $search->{$key} = $name;
         }
-        trick_taint($name);
         my $data = {
           path => $name,
           name => $key,
@@ -52,7 +49,6 @@ sub _init {
           },
           time => (stat($name))[9],
         };
-        trick_taint($data->{text}) if $data->{text};
         $cache->{$name} = $self->_bz_compile($data) or die "compile error: $name";
       }
     };

--- a/Bugzilla/Token.pm
+++ b/Bugzilla/Token.pm
@@ -370,7 +370,6 @@ sub Cancel {
   $vars ||= {};
 
   # Get information about the token being canceled.
-  trick_taint($token);
   my ($db_token, $issuedate, $tokentype, $eventdata, $userid)
     = $dbh->selectrow_array(
     'SELECT token, '
@@ -451,7 +450,6 @@ sub GetTokenData {
 
   return unless defined $token;
   $token = clean_text($token);
-  trick_taint($token);
 
   my @token_data = $dbh->selectrow_array(
         "SELECT token, userid, "
@@ -475,7 +473,6 @@ sub delete_token {
   my $dbh = Bugzilla->dbh;
 
   return unless defined $token;
-  trick_taint($token);
 
   $dbh->do("DELETE FROM tokens WHERE token = ?", undef, $token);
 }
@@ -543,7 +540,6 @@ sub set_token_extra_data {
 
 sub get_token_extra_data {
   my ($token) = @_;
-  trick_taint($token);
   my ($data)
     = Bugzilla->dbh->selectrow_array(
     "SELECT extra_data FROM token_data WHERE token = ?",
@@ -565,8 +561,6 @@ sub _create_token {
   my $dbh = Bugzilla->dbh;
 
   detaint_natural($userid) if defined $userid;
-  trick_taint($tokentype);
-  trick_taint($eventdata);
 
   my $is_shadow = Bugzilla->is_shadow_db;
   $dbh = Bugzilla->switch_to_main_db() if $is_shadow;

--- a/Bugzilla/User/Setting.pm
+++ b/Bugzilla/User/Setting.pm
@@ -23,7 +23,7 @@ use base qw(Exporter);
 );
 
 use Bugzilla::Error;
-use Bugzilla::Util qw(trick_taint get_text);
+use Bugzilla::Util qw(get_text);
 use Module::Runtime qw(require_module);
 
 ###############################
@@ -286,7 +286,7 @@ sub validate_value {
   my $self = shift;
 
   if (grep(/^$_[0]$/, @{$self->legal_values()})) {
-    trick_taint($_[0]);
+    # do nothing
   }
   else {
     ThrowCodeError('setting_value_invalid',

--- a/Bugzilla/Util.pm
+++ b/Bugzilla/Util.pm
@@ -12,7 +12,7 @@ use strict;
 use warnings;
 
 use base qw(Exporter);
-@Bugzilla::Util::EXPORT = qw(trick_taint detaint_natural
+@Bugzilla::Util::EXPORT = qw(detaint_natural
   detaint_signed
   with_writable_database with_readonly_database
   html_quote url_quote xml_quote
@@ -73,12 +73,6 @@ sub with_readonly_database(&) {
   local Bugzilla->request_cache->{error_mode} = ERROR_MODE_DIE;
   Bugzilla->switch_to_shadow_db();
   $code->();
-}
-
-sub trick_taint {
-  untaint($_[0]);
-
-  return defined $_[0];
 }
 
 sub detaint_natural {
@@ -993,7 +987,6 @@ Bugzilla::Util - Generic utility functions for bugzilla
   use Bugzilla::Util;
 
   # Functions for dealing with variable tainting
-  trick_taint($var);
   detaint_natural($var);
   detaint_signed($var);
 
@@ -1055,17 +1048,6 @@ Several functions are available to deal with tainted variables. B<Use these
 with care> to avoid security holes.
 
 =over 4
-
-=item C<trick_taint($val)>
-
-Tricks perl into untainting a particular variable.
-
-Use trick_taint() when you know that there is no way that the data
-in a scalar can be tainted, but taint mode still bails on it.
-
-B<WARNING!! Using this routine on data that really could be tainted defeats
-the purpose of taint mode.  It should only be used on variables that have been
-sanity checked in some way and have been determined to be OK.>
 
 =item C<detaint_natural($num)>
 

--- a/Bugzilla/Util.pm
+++ b/Bugzilla/Util.pm
@@ -45,7 +45,6 @@ use English qw(-no_match_vars $EGID);
 use List::MoreUtils qw(any none);
 use POSIX qw(floor ceil);
 use Scalar::Util qw(tainted blessed);
-use Taint::Util qw(untaint);
 use Text::Wrap;
 use Try::Tiny;
 
@@ -418,9 +417,6 @@ sub is_ipv6 {
 
   my $ipv6 = join(':', @chunks);
 
-  # The IP address is valid and can now be detainted.
-  untaint($ipv6);
-
   # Need to handle the exception of trailing :: being valid.
   return "${ipv6}::" if $ip =~ /::$/;
   return $ipv6;
@@ -716,12 +712,6 @@ sub bz_crypt {
 
     # Crypt the password.
     $crypted_password = crypt($password, $salt);
-
-    # HACK: Perl has bug where returned crypted password is considered
-    # tainted. See http://rt.perl.org/rt3/Public/Bug/Display.html?id=59998
-    unless (tainted($password) || tainted($salt)) {
-      untaint($crypted_password);
-    }
   }
   else {
     my $hasher = Digest->new($algorithm);
@@ -765,8 +755,6 @@ sub validate_email_syntax {
     && $email =~ /^$addr_spec$/
     && length($email) <= 127)
   {
-    # We assume these checks to suffice to consider the address untainted.
-    untaint($_[0]);
     return 1;
   }
   return 0;

--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -23,7 +23,7 @@ use Bugzilla::WebService::Util
   qw(extract_flags filter filter_wants validate translate);
 use Bugzilla::Bug;
 use Bugzilla::BugMail;
-use Bugzilla::Util qw(trick_taint trim detaint_natural remote_ip);
+use Bugzilla::Util qw(trim detaint_natural remote_ip);
 use Bugzilla::Version;
 use Bugzilla::Milestone;
 use Bugzilla::Status;
@@ -898,7 +898,6 @@ sub legal_values {
   if (grep($_->name eq $field, @global_selects)) {
 
     # The field is a valid one.
-    trick_taint($field);
     $values = get_legal_field_values($field);
   }
   elsif (grep($_ eq $field, PRODUCT_SPECIFIC_FIELDS)) {

--- a/Bugzilla/WebService/Elastic.pm
+++ b/Bugzilla/WebService/Elastic.pm
@@ -28,7 +28,7 @@ use Bugzilla;
 use Bugzilla::Constants;
 use Bugzilla::Error;
 use Bugzilla::WebService::Util qw(validate);
-use Bugzilla::Util qw(trim detaint_natural trick_taint);
+use Bugzilla::Util qw(trim detaint_natural );
 
 use constant READ_ONLY      => qw( suggest_users );
 use constant PUBLIC_METHODS => qw( suggest_users );
@@ -44,7 +44,6 @@ sub suggest_users {
 
   ThrowUserError('user_access_by_match_denied') unless Bugzilla->user->id;
 
-  trick_taint($params->{match});
   my $results = Bugzilla->elastic->suggest_users($params->{match} . "");
   my @users = map { {
     real_name => $self->type(string => $_->{real_name}),

--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -24,7 +24,6 @@ use Bugzilla::WebService::Util qw(filter filter_wants validate
 use Bugzilla::Hook;
 
 use List::Util qw(first);
-use Taint::Util qw(untaint);
 
 # Don't need auth to login
 use constant LOGIN_EXEMPT => {login => 1, offer_account_by_email => 1,};
@@ -140,7 +139,6 @@ sub suggest {
 
   ThrowUserError('user_access_by_match_denied') unless Bugzilla->user->id;
 
-  untaint($params->{match});
   my $s = $params->{match};
   trim($s);
   return {users => []} if length($s) < 3;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -89,7 +89,6 @@ my %requires = (
   'Scope::Guard'                        => '0.21',
   'Sereal'                              => '4.004',
   'Sub::Quote'                          => '2.005000',
-  'Taint::Util'                         => '0.08',
   'Template'                            => '2.24',
   'Text::CSV_XS'                        => '1.26',
   'Throwable'                           => '0.200013',

--- a/auth.cgi
+++ b/auth.cgi
@@ -16,7 +16,6 @@ use Bugzilla;
 use Bugzilla::Constants;
 use Bugzilla::Error;
 use Bugzilla::Hook;
-use Bugzilla::Util qw(trick_taint);
 use Bugzilla::Token qw(issue_auth_delegation_token check_auth_delegation_token);
 use Bugzilla::Mailer qw(MessageToMTA);
 
@@ -38,9 +37,6 @@ my $callback = $cgi->param('callback')
   or ThrowUserError("auth_delegation_missing_callback");
 my $description = $cgi->param('description')
   or ThrowUserError("auth_delegation_missing_description");
-
-trick_taint($callback);
-trick_taint($description);
 
 ThrowUserError("auth_delegation_invalid_description")
   unless $description =~ /^[\w\s]{3,255}$/;
@@ -76,7 +72,6 @@ if ($confirmed || $skip_confirmation) {
   my $token = $cgi->param('token');
   unless ($skip_confirmation) {
     ThrowUserError("auth_delegation_missing_token") unless $token;
-    trick_taint($token);
 
     unless (check_auth_delegation_token($token, $callback)) {
       ThrowUserError('auth_delegation_invalid_token',

--- a/buglist.cgi
+++ b/buglist.cgi
@@ -350,11 +350,10 @@ if ($cmdtype eq "dorem") {
   elsif ($remaction eq "forget") {
     $user = Bugzilla->login(LOGIN_REQUIRED);
 
-    # Copy the name into a variable, so that we can trick_taint it for
+    # Copy the name into a variable for
     # the DB. We know it's safe, because we're using placeholders in
     # the SQL, and the SQL is only a DELETE.
     my $qname = $cgi->param('namedcmd');
-    trick_taint($qname);
 
     # Do not forget the saved search if it is being used in a whine
     my $whines_in_use = $dbh->selectcol_arrayref(
@@ -547,8 +546,8 @@ else {
 
 # Weed out columns that don't actually exist to prevent the user
 # from hacking their column list cookie to grab data to which they
-# should not have access.  Detaint the data along the way.
-@displaycolumns = grep($columns->{$_} && trick_taint($_), @displaycolumns);
+# should not have access.
+@displaycolumns = grep { $columns->{$_} } @displaycolumns);
 
 # Remove the "ID" column from the list because bug IDs are always displayed
 # and are hard-coded into the display templates.

--- a/buglist.cgi
+++ b/buglist.cgi
@@ -547,7 +547,7 @@ else {
 # Weed out columns that don't actually exist to prevent the user
 # from hacking their column list cookie to grab data to which they
 # should not have access.
-@displaycolumns = grep { $columns->{$_} } @displaycolumns);
+@displaycolumns = grep { $columns->{$_} } @displaycolumns;
 
 # Remove the "ID" column from the list because bug IDs are always displayed
 # and are hard-coded into the display templates.

--- a/editclassifications.cgi
+++ b/editclassifications.cgi
@@ -201,7 +201,6 @@ if ($action eq 'reclassify') {
     check_token_data($token, 'reclassify_classifications');
     if (defined $cgi->param('prodlist')) {
       foreach my $prod ($cgi->param("prodlist")) {
-        trick_taint($prod);
         $sth->execute($classification->id, $prod);
         push @names, $prod;
       }
@@ -212,7 +211,6 @@ if ($action eq 'reclassify') {
     check_token_data($token, 'reclassify_classifications');
     if (defined $cgi->param('myprodlist')) {
       foreach my $prod ($cgi->param("myprodlist")) {
-        trick_taint($prod);
         $sth->execute(1, $prod);
         push @names, $prod;
       }

--- a/editgroups.cgi
+++ b/editgroups.cgi
@@ -66,7 +66,6 @@ sub CheckGroupID {
 sub CheckGroupRegexp {
   my ($regexp) = @_;
   $regexp = trim($regexp || '');
-  trick_taint($regexp);
   ThrowUserError("invalid_regexp") unless (eval {qr/$regexp/});
   return $regexp;
 }

--- a/editusers.cgi
+++ b/editusers.cgi
@@ -151,10 +151,6 @@ elsif ($action eq 'list') {
         $matchstr = '' unless defined $matchstr;
       }
 
-      # We can trick_taint because we use the value in a SELECT only,
-      # using a placeholder.
-      trick_taint($matchstr);
-
       if ($matchtype eq 'regexp') {
         $query .= $dbh->sql_regexp($expr, '?', 0, $dbh->quote($matchstr));
       }

--- a/editwhines.cgi
+++ b/editwhines.cgi
@@ -127,9 +127,6 @@ if ($cgi->param('update')) {
         my $body    = ($cgi->param("event_${eventid}_body")    or '');
         my $mailifnobugs = $cgi->param("event_${eventid}_mailifnobugs") ? 1 : 0;
 
-        trick_taint($subject) if $subject;
-        trick_taint($body)    if $body;
-
         if ( ($subject ne $events->{$eventid}->subject)
           || ($mailifnobugs != $events->{$eventid}->mail_if_no_bugs)
           || ($body ne $events->{$eventid}->body))
@@ -224,7 +221,6 @@ if ($cgi->param('update')) {
             elsif ($mailto_type == MAILTO_GROUP) {
 
               # The group name is used in a placeholder.
-              trick_taint($mailto);
               $mailto_id = Bugzilla::Group::ValidateGroupName($mailto, ($user))
                 || ThrowUserError('invalid_group_name', {name => $mailto});
             }
@@ -242,10 +238,6 @@ if ($cgi->param('update')) {
             || ($o_mailto ne $mailto)
             || ($o_mailto_type != $mailto_type))
           {
-
-            trick_taint($day);
-            trick_taint($time);
-
             # the schedule table must be locked
             $sth
               = $dbh->prepare("UPDATE whine_schedules "
@@ -296,8 +288,6 @@ if ($cgi->param('update')) {
           {
 
             detaint_natural($sort);
-            trick_taint($queryname);
-            trick_taint($title);
 
             $sth
               = $dbh->prepare("UPDATE whine_queries "

--- a/extensions/AntiSpam/Extension.pm
+++ b/extensions/AntiSpam/Extension.pm
@@ -15,7 +15,7 @@ use base qw(Bugzilla::Extension);
 
 use Bugzilla::Error;
 use Bugzilla::Group;
-use Bugzilla::Util qw(remote_ip trick_taint);
+use Bugzilla::Util qw(remote_ip);
 use Email::Address;
 use Socket;
 
@@ -101,7 +101,6 @@ sub _domain_blocking {
 sub _ip_blocking {
   my ($self, $login) = @_;
   my $ip = remote_ip();
-  trick_taint($ip);
   my $blocked
     = Bugzilla->dbh->selectrow_array(
     "SELECT 1 FROM antispam_ip_blocklist WHERE ip_address=?",
@@ -192,7 +191,6 @@ sub comment_after_add_tag {
   return if $author->comment_count < $count;
 
   # get user's comments
-  trick_taint($tag);
   my $comments = Bugzilla->dbh->selectall_arrayref("
         SELECT longdescs.comment_id,longdescs_tags.id
           FROM longdescs

--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -1130,7 +1130,6 @@ sub bug_end_of_create {
 
   # store user-agent
   if (my $ua = Bugzilla->cgi->user_agent) {
-    trick_taint($ua);
     Bugzilla->dbh->do(
       "INSERT INTO bug_user_agent (bug_id, user_agent) VALUES (?, ?)",
       undef, $bug->id, $ua);
@@ -2438,7 +2437,6 @@ sub query_database {
     }
 
     check_hash_token($input->{token}, ['query_database']);
-    trick_taint($query);
     $vars->{executed} = 1;
 
     # add limit if missing

--- a/extensions/BMO/lib/Reports/ReleaseTracking.pm
+++ b/extensions/BMO/lib/Reports/ReleaseTracking.pm
@@ -15,7 +15,7 @@ use Bugzilla::Constants;
 use Bugzilla::Error;
 use Bugzilla::Field;
 use Bugzilla::FlagType;
-use Bugzilla::Util qw(trick_taint validate_date);
+use Bugzilla::Util qw(validate_date);
 use JSON qw(-convert_blessed_universally);
 use List::MoreUtils qw(uniq);
 
@@ -340,7 +340,6 @@ sub _parse_query {
   my $flag_name = shift @query;
   @{Bugzilla::FlagType::match({name => $flag_name, is_active => 1})}
     or ThrowUserError('report_invalid_parameter', {name => 'flag_name'});
-  trick_taint($flag_name);
   $query->{flag_name} = $flag_name;
 
   # flag_status

--- a/extensions/BMO/lib/WebService.pm
+++ b/extensions/BMO/lib/WebService.pm
@@ -27,7 +27,7 @@ use base qw(Bugzilla::WebService);
 
 use Bugzilla::Constants;
 use Bugzilla::Error;
-use Bugzilla::Util qw(detaint_natural trick_taint);
+use Bugzilla::Util qw(detaint_natural);
 use Bugzilla::WebService::Util qw(validate);
 use Bugzilla::Field;
 

--- a/extensions/BugModal/Extension.pm
+++ b/extensions/BugModal/Extension.pm
@@ -18,7 +18,7 @@ use Bugzilla::Extension::BugModal::MonkeyPatches;
 use Bugzilla::Extension::BugModal::Util qw(date_str_to_time);
 use Bugzilla::Constants;
 use Bugzilla::User::Setting;
-use Bugzilla::Util qw(trick_taint datetime_from html_quote time_ago);
+use Bugzilla::Util qw(datetime_from html_quote time_ago);
 use List::MoreUtils qw(any);
 use Template::Stash;
 use JSON::XS qw(encode_json);

--- a/extensions/BugModal/lib/WebService.pm
+++ b/extensions/BugModal/lib/WebService.pm
@@ -22,7 +22,6 @@ use Bugzilla::Milestone;
 use Bugzilla::Product;
 use Bugzilla::Version;
 use List::MoreUtils qw(any first_value);
-use Taint::Util qw(untaint);
 
 # these methods are much lighter than our public API calls
 
@@ -95,7 +94,6 @@ sub initial_field_values {
 sub product_info {
   my ($self, $params) = @_;
   if (!ref $params->{product_name}) {
-    untaint($params->{product_name});
   }
   else {
     ThrowCodeError('params_required',

--- a/extensions/BzAPI/Extension.pm
+++ b/extensions/BzAPI/Extension.pm
@@ -17,7 +17,7 @@ use Bugzilla::Extension::BzAPI::Constants;
 use Bugzilla::Extension::BzAPI::Util qw(fix_credentials filter_wants_nocache);
 
 use Bugzilla::Error;
-use Bugzilla::Util qw(trick_taint datetime_from);
+use Bugzilla::Util qw(datetime_from);
 use Bugzilla::Constants;
 use Bugzilla::Install::Filesystem;
 use Bugzilla::WebService::Constants;
@@ -269,7 +269,6 @@ sub _preload_handlers {
     my $all_handlers = {};
     foreach my $module (_resource_modules()) {
       my $resource_class = "Bugzilla::Extension::BzAPI::Resources::$module";
-      trick_taint($resource_class);
       eval { require_module($resource_class) };
       next if ($@ || !$resource_class->can('rest_handlers'));
       my $handlers = $resource_class->rest_handlers;

--- a/extensions/BzAPI/lib/Resources/Bug.pm
+++ b/extensions/BzAPI/lib/Resources/Bug.pm
@@ -14,7 +14,7 @@ use warnings;
 use Bugzilla::Bug;
 use Bugzilla::Error;
 use Bugzilla::Token qw(issue_hash_token);
-use Bugzilla::Util qw(trick_taint diff_arrays);
+use Bugzilla::Util qw(diff_arrays);
 use Bugzilla::WebService::Constants;
 
 use Bugzilla::Extension::BzAPI::Util;
@@ -145,13 +145,13 @@ sub get_bug_count_resource {
 
   # Validate the values in the axis fields or throw an error.
   !$row_field
-    || ($valid_columns->{$row_field} && trick_taint($row_field))
+    || $valid_columns->{$row_field}
     || ThrowCodeError("report_axis_invalid", {fld => "x", val => $row_field});
   !$col_field
-    || ($valid_columns->{$col_field} && trick_taint($col_field))
+    || $valid_columns->{$col_field}
     || ThrowCodeError("report_axis_invalid", {fld => "y", val => $col_field});
   !$tbl_field
-    || ($valid_columns->{$tbl_field} && trick_taint($tbl_field))
+    || $valid_columns->{$tbl_field}
     || ThrowCodeError("report_axis_invalid", {fld => "z", val => $tbl_field});
 
   my @axis_fields = grep {$_} ($row_field, $col_field, $tbl_field);

--- a/extensions/ComponentWatching/Extension.pm
+++ b/extensions/ComponentWatching/Extension.pm
@@ -18,7 +18,7 @@ use Bugzilla::Error;
 use Bugzilla::Group;
 use Bugzilla::User;
 use Bugzilla::User::Setting;
-use Bugzilla::Util qw(detaint_natural trim trick_taint);
+use Bugzilla::Util qw(detaint_natural trim);
 
 our $VERSION = '2';
 
@@ -571,7 +571,6 @@ sub _addPrefixWatch {
   my ($user, $product, $prefix) = @_;
   my $dbh = Bugzilla->dbh;
 
-  trick_taint($prefix);
   my $sth = $dbh->prepare("
         SELECT 1
           FROM component_watch

--- a/extensions/EditComments/Extension.pm
+++ b/extensions/EditComments/Extension.pm
@@ -243,7 +243,6 @@ sub bug_end_of_update {
         && defined $params->{"edit_comment_checkbox_$comment_id"}
         && $params->{"edit_comment_checkbox_$comment_id"} == 'on') ? 1 : 0;
 
-    trick_taint($new_comment);
     $dbh->do(
       "UPDATE longdescs SET thetext = ?, edit_count = edit_count + 1
                   WHERE comment_id = ?", undef, $new_comment, $comment_id

--- a/extensions/EditComments/lib/WebService.pm
+++ b/extensions/EditComments/lib/WebService.pm
@@ -18,7 +18,7 @@ use Bugzilla::Comment;
 use Bugzilla::Constants;
 use Bugzilla::Error;
 use Bugzilla::Template;
-use Bugzilla::Util qw(trick_taint trim);
+use Bugzilla::Util qw(trim);
 use Bugzilla::WebService::Util qw(validate);
 
 use constant PUBLIC_METHODS => qw(
@@ -124,7 +124,6 @@ sub update_comment {
       && $params->{is_hidden} == 1) ? 1 : 0;
 
   # Update the `longdescs` (comments) table
-  trick_taint($new_comment);
   $dbh->do(
     'UPDATE longdescs SET thetext = ?, edit_count = edit_count + 1 WHERE comment_id = ?',
     undef, $new_comment, $comment_id

--- a/extensions/EditTable/Extension.pm
+++ b/extensions/EditTable/Extension.pm
@@ -25,7 +25,6 @@ use base qw(Bugzilla::Extension);
 use Bugzilla::Error;
 use Bugzilla::Hook;
 use Bugzilla::Token;
-use Bugzilla::Util qw(trick_taint);
 use JSON;
 use Storable qw(dclone);
 
@@ -68,7 +67,6 @@ sub page_before_template {
   my $id_field = $table->{id_field};
   my $order_by = $table->{order_by} || $id_field;
   my $group    = $table->{group} || 'admin';
-  trick_taint($table_name);
 
   Bugzilla->user->in_group($group)
     || ThrowUserError('auth_failure',
@@ -94,7 +92,6 @@ sub page_before_template {
       $dbh->bz_start_transaction;
 
       foreach my $row (@$data) {
-        map { trick_taint($_) } @$row;
         if ($row->[0] eq '-') {
 
           # add

--- a/extensions/Ember/lib/WebService.pm
+++ b/extensions/Ember/lib/WebService.pm
@@ -21,7 +21,6 @@ use Bugzilla::Product;
 use Bugzilla::Constants;
 use Bugzilla::Error;
 use Bugzilla::Field;
-use Bugzilla::Util qw(trick_taint);
 
 use Bugzilla::Extension::Ember::FakeBug;
 
@@ -144,7 +143,6 @@ sub show {
   # Only return changes since last_updated if provided
   my $last_updated = delete $params->{last_updated};
   if ($last_updated) {
-    trick_taint($last_updated);
 
     my $updated_fields = $dbh->selectcol_arrayref(
       'SELECT fieldid FROM bugs_activity
@@ -244,7 +242,6 @@ sub bug {
   # Only return changes since last_updated if provided
   my $last_updated = delete $params->{last_updated};
   if ($last_updated) {
-    trick_taint($last_updated);
     my $updated_fields = $dbh->selectcol_arrayref(
       'SELECT fielddefs.name
                                                          FROM fielddefs INNER JOIN bugs_activity

--- a/extensions/FlagTypeComment/Extension.pm
+++ b/extensions/FlagTypeComment/Extension.pm
@@ -29,7 +29,6 @@ use base qw(Bugzilla::Extension);
 use Bugzilla::Extension::FlagTypeComment::Constants;
 
 use Bugzilla::FlagType;
-use Bugzilla::Util qw(trick_taint);
 use Scalar::Util qw(blessed);
 
 our $VERSION = '1';
@@ -84,7 +83,6 @@ sub _set_ftc_states {
     }
     else {
       ($target_type, $id) = ($type->{target_type}, $type->{id});
-      trick_taint($id) if $id;
     }
     if ($target_type eq 'bug') {
       return unless FLAGTYPE_COMMENT_BUG_FLAGS;
@@ -167,7 +165,6 @@ sub _set_flagtypes {
     my $text
       = $input->{"ftc_${flagtype_id}_$state"} || $input->{"ftc_new_$state"} || '';
     $text =~ s/\r\n/\n/g;
-    trick_taint($text);
 
     if ($text ne '') {
       if ($dbh->selectrow_array(

--- a/extensions/GitHubAuth/Extension.pm
+++ b/extensions/GitHubAuth/Extension.pm
@@ -16,7 +16,6 @@ use parent qw(Bugzilla::Extension);
 use Bugzilla::Extension::GitHubAuth::Client;
 
 use Bugzilla::Error;
-use Bugzilla::Util qw(trick_taint);
 use List::Util qw(first);
 use URI;
 use URI::QueryParam;

--- a/extensions/GitHubAuth/lib/Login.pm
+++ b/extensions/GitHubAuth/lib/Login.pm
@@ -17,7 +17,7 @@ use fields qw(github_failure);
 use Scalar::Util qw(blessed);
 
 use Bugzilla::Constants qw(AUTH_NODATA AUTH_ERROR USAGE_MODE_BROWSER);
-use Bugzilla::Util qw(trick_taint generate_random_password);
+use Bugzilla::Util qw(generate_random_password);
 use Bugzilla::Token qw(issue_short_lived_session_token set_token_extra_data);
 use List::MoreUtils qw(any);
 use Bugzilla::Extension::GitHubAuth::Client;
@@ -76,8 +76,6 @@ sub _get_login_info_from_github {
   my $code     = $cgi->param('code');
 
   return {failure => AUTH_ERROR, error => 'github_missing_code'} unless $code;
-
-  trick_taint($code);
 
   my $client = Bugzilla::Extension::GitHubAuth::Client->new;
 
@@ -165,7 +163,6 @@ sub _get_login_info_from_email {
     user_error => 'github_invalid_email',
     details    => {email => ''}
     };
-  trick_taint($email);
 
   unless (any { $_ eq $email } @{Bugzilla->request_cache->{github_emails}}) {
     return {

--- a/extensions/MyDashboard/lib/WebService.pm
+++ b/extensions/MyDashboard/lib/WebService.pm
@@ -14,7 +14,7 @@ use base qw(Bugzilla::WebService Bugzilla::WebService::Bug);
 
 use Bugzilla::Constants;
 use Bugzilla::Error;
-use Bugzilla::Util qw(detaint_natural trick_taint template_var datetime_from);
+use Bugzilla::Util qw(detaint_natural template_var datetime_from);
 use Bugzilla::WebService::Util qw(validate);
 
 use Bugzilla::Extension::MyDashboard::Queries
@@ -38,9 +38,6 @@ sub run_last_changes {
 
   my $dbh  = Bugzilla->dbh;
   my $user = Bugzilla->login(LOGIN_REQUIRED);
-
-  trick_taint($params->{changeddate_api});
-  trick_taint($params->{bug_id});
 
   my $last_comment_sql = "
         SELECT comment_id

--- a/extensions/PhabBugz/lib/Util.pm
+++ b/extensions/PhabBugz/lib/Util.pm
@@ -21,7 +21,6 @@ use Bugzilla::Extension::PhabBugz::Constants;
 use Bugzilla::Extension::PhabBugz::Types qw(:types);
 
 use List::Util qw(first);
-use Taint::Util qw(untaint);
 use Try::Tiny;
 use Type::Params qw( compile );
 use Type::Utils;

--- a/extensions/PhabBugz/lib/WebService.pm
+++ b/extensions/PhabBugz/lib/WebService.pm
@@ -18,7 +18,7 @@ use Bugzilla::Constants;
 use Bugzilla::Error;
 use Bugzilla::Logging;
 use Bugzilla::User;
-use Bugzilla::Util qw(detaint_natural trick_taint);
+use Bugzilla::Util qw(detaint_natural);
 use Bugzilla::WebService::Constants;
 use Types::Standard qw(-types slurpy);
 use Type::Params qw(compile);

--- a/extensions/ProdCompSearch/lib/WebService.pm
+++ b/extensions/ProdCompSearch/lib/WebService.pm
@@ -14,7 +14,7 @@ use warnings;
 use base qw(Bugzilla::WebService);
 
 use Bugzilla::Error;
-use Bugzilla::Util qw(detaint_natural trick_taint trim);
+use Bugzilla::Util qw(detaint_natural trim);
 
 #############
 # Constants #
@@ -90,7 +90,6 @@ sub prod_comp_search {
 
   return {products => []} if !scalar @$enterable_ids;
 
-  trick_taint($search);
   my @terms;
   my @order;
 

--- a/extensions/Push/lib/Admin.pm
+++ b/extensions/Push/lib/Admin.pm
@@ -15,7 +15,7 @@ use Bugzilla;
 use Bugzilla::Error;
 use Bugzilla::Extension::Push::Util;
 use Bugzilla::Token qw(check_hash_token);
-use Bugzilla::Util qw(trim detaint_natural trick_taint);
+use Bugzilla::Util qw(trim detaint_natural );
 
 use base qw(Exporter);
 our @EXPORT = qw(
@@ -69,7 +69,6 @@ sub _update_config_from_form {
   # update
   foreach my $option ($config->options) {
     my $option_name = $option->{name};
-    trick_taint($values->{$option_name});
     $config->{$option_name} = $values->{$option_name};
   }
   $config->update();

--- a/extensions/Push/lib/Connector.disabled/ServiceNow.pm
+++ b/extensions/Push/lib/Connector.disabled/ServiceNow.pm
@@ -24,7 +24,7 @@ use Bugzilla::Field;
 use Bugzilla::Mailer;
 use Bugzilla::Product;
 use Bugzilla::User;
-use Bugzilla::Util qw(trim trick_taint);
+use Bugzilla::Util qw(trim);
 use Email::MIME;
 use FileHandle;
 use LWP;
@@ -122,7 +122,6 @@ sub options {
 sub options_validate {
   my ($self, $config) = @_;
   my $host = $config->{ldap_host};
-  trick_taint($host);
   my $scheme = lc($config->{ldap_scheme});
   eval {
     my $ldap
@@ -400,7 +399,6 @@ sub _ldap_cache {
     my $cache = {};
 
     my $host = $config->{ldap_host};
-    trick_taint($host);
     my $scheme = lc($config->{ldap_scheme});
     my $ldap = Net::LDAP->new($host, scheme => $scheme, onerror => 'die') or die $!;
     $ldap->bind($config->{ldap_user}, password => $config->{ldap_pass});

--- a/extensions/Push/lib/Connectors.pm
+++ b/extensions/Push/lib/Connectors.pm
@@ -14,7 +14,6 @@ use warnings;
 use Bugzilla::Logging;
 use Bugzilla::Extension::Push::Util;
 use Bugzilla::Constants;
-use Bugzilla::Util qw(trick_taint);
 use File::Basename;
 use Try::Tiny;
 
@@ -48,7 +47,6 @@ sub _load {
   foreach my $name (@{$self->{names}}) {
     next if exists $self->{objects}->{$name};
     my $file = $self->{path} . "/$name.pm";
-    trick_taint($file);
     require $file;
     my $package = "Bugzilla::Extension::Push::Connector::$name";
 

--- a/extensions/REMO/Extension.pm
+++ b/extensions/REMO/Extension.pm
@@ -29,7 +29,7 @@ use warnings;
 use base qw(Bugzilla::Extension);
 
 use Bugzilla::Constants;
-use Bugzilla::Util qw(trick_taint trim detaint_natural);
+use Bugzilla::Util qw(trim detaint_natural);
 use Bugzilla::Token;
 use Bugzilla::Error;
 use List::Util qw(first);
@@ -155,7 +155,6 @@ sub _remo_form_payment {
     $bug->update($timestamp);
 
     if ($token) {
-      trick_taint($token);
       $dbh->do('UPDATE tokens SET eventdata = ? WHERE token = ?',
         undef, ("remo_form_payment:" . $attachment->id, $token));
     }

--- a/extensions/Review/lib/WebService.pm
+++ b/extensions/Review/lib/WebService.pm
@@ -16,7 +16,7 @@ use base qw(Bugzilla::WebService);
 use Bugzilla::Bug;
 use Bugzilla::Component;
 use Bugzilla::Error;
-use Bugzilla::Util qw(detaint_natural trick_taint);
+use Bugzilla::Util qw(detaint_natural );
 use Bugzilla::WebService::Util 'filter';
 
 use constant PUBLIC_METHODS => qw(
@@ -111,7 +111,6 @@ sub flag_activity {
   }
 
   if (my $type_name = $params->{type_name}) {
-    trick_taint($type_name);
     my $flag_types = Bugzilla::FlagType::match({name => $type_name});
     $match_criteria{type_id} = [map { $_->id } @$flag_types];
   }

--- a/extensions/SecureMail/Extension.pm
+++ b/extensions/SecureMail/Extension.pm
@@ -33,7 +33,7 @@ use Bugzilla::Comment;
 use Bugzilla::Group;
 use Bugzilla::Object;
 use Bugzilla::User;
-use Bugzilla::Util qw(trim trick_taint is_7bit_clean);
+use Bugzilla::Util qw(trim is_7bit_clean);
 use Bugzilla::Error;
 use Bugzilla::Mailer;
 use Bugzilla::Extension::SecureMail::TCT;
@@ -138,12 +138,6 @@ sub object_validators {
         }
       }
       elsif ($value =~ /BEGIN CERTIFICATE/) {
-
-        # S/MIME Keys must be in PEM format (Base64-encoded X.509)
-        #
-        # Crypt::SMIME seems not to like tainted values - it claims
-        # they aren't scalars!
-        trick_taint($value);
 
         my $smime = Crypt::SMIME->new();
         eval { $smime->setPublicKey([$value]); };

--- a/importxml.pl
+++ b/importxml.pl
@@ -1189,7 +1189,6 @@ sub process_bug {
       "INSERT INTO attach_data (id, thedata)
                                  VALUES ($att_id, ?)"
     );
-    trick_taint($att_data);
     $sth->bind_param(1, $att_data, $dbh->BLOB_TYPE);
     $sth->execute();
 

--- a/quips.cgi
+++ b/quips.cgi
@@ -72,7 +72,6 @@ if ($action eq "add") {
     || 0;
   my $comment = $cgi->param("quip");
   $comment || ThrowUserError("need_quip");
-  trick_taint($comment);    # Used in a placeholder below
 
   $dbh->do("INSERT INTO quips (userid, quip, approved) VALUES (?, ?, ?)",
     undef, ($user->id, $comment, $approved));

--- a/report.cgi
+++ b/report.cgi
@@ -107,13 +107,13 @@ my $valid_columns = Bugzilla::Search::REPORT_COLUMNS;
 
 # Validate the values in the axis fields or throw an error.
 !$row_field
-  || ($valid_columns->{$row_field} && trick_taint($row_field))
+  || $valid_columns->{$row_field}
   || ThrowCodeError("report_axis_invalid", {fld => "x", val => $row_field});
 !$col_field
-  || ($valid_columns->{$col_field} && trick_taint($col_field))
+  || $valid_columns->{$col_field}
   || ThrowCodeError("report_axis_invalid", {fld => "y", val => $col_field});
 !$tbl_field
-  || ($valid_columns->{$tbl_field} && trick_taint($tbl_field))
+  || $valid_columns->{$tbl_field}
   || ThrowCodeError("report_axis_invalid", {fld => "z", val => $tbl_field});
 
 my @axis_fields = grep {$_} ($row_field, $col_field, $tbl_field);

--- a/reports.cgi
+++ b/reports.cgi
@@ -99,7 +99,6 @@ else {
   $image_file = hmac_sha256_base64($image_file, $key) . '.png';
   $image_file =~ s/\+/-/g;
   $image_file =~ s/\//_/g;
-  trick_taint($image_file);
 
   if (!-e "$graph_dir/$image_file") {
     generate_chart($dir, "$graph_dir/$image_file", $product, \@datasets);

--- a/request.cgi
+++ b/request.cgi
@@ -177,14 +177,12 @@ sub queue {
   # Filter results by exact email address of requester or requestee.
   if (defined $cgi->param('requester') && $cgi->param('requester') ne "") {
     my $requester = $dbh->quote($cgi->param('requester'));
-    trick_taint($requester);    # Quoted above
     push(@criteria, $dbh->sql_istrcmp('requesters.login_name', $requester));
     push(@excluded_columns, 'requester') unless $do_union;
   }
   if (defined $cgi->param('requestee') && $cgi->param('requestee') ne "") {
     if ($cgi->param('requestee') ne "-") {
       my $requestee = $dbh->quote($cgi->param('requestee'));
-      trick_taint($requestee);    # Quoted above
       push(@criteria, $dbh->sql_istrcmp('requestees.login_name', $requestee));
     }
     else {
@@ -240,7 +238,6 @@ sub queue {
     if (!$has_attachment_type) { push(@excluded_columns, 'attachment') }
 
     my $quoted_form_type = $dbh->quote($form_type);
-    trick_taint($quoted_form_type);    # Already SQL quoted
     push(@criteria,         "flagtypes.name = " . $quoted_form_type);
     push(@excluded_columns, 'type');
   }
@@ -347,7 +344,6 @@ sub validateStatus {
 
   grep($status eq $_, qw(? +- + - all))
     || ThrowUserError("flag_status_invalid", {status => $status});
-  trick_taint($status);
   return $status;
 }
 
@@ -357,7 +353,6 @@ sub validateGroup {
 
   grep($group eq $_, qw(requester requestee category type))
     || ThrowUserError("request_queue_group_invalid", {group => $group});
-  trick_taint($group);
   return $group;
 }
 

--- a/scripts/fix_all_open_status_queries.pl
+++ b/scripts/fix_all_open_status_queries.pl
@@ -45,7 +45,6 @@ sub do_namedqueries {
       my ($id, $old_query) = @$row;
       my $new_query = all_open_states($new_status, $old_query);
       if ($new_query) {
-        trick_taint($new_query);
         $sth->execute($new_query, $id);
         $replace_count++;
       }
@@ -74,7 +73,6 @@ sub do_series {
       my ($series_id, $old_query) = @$row;
       my $new_query = all_open_states($new_status, $old_query);
       if ($new_query) {
-        trick_taint($new_query);
         $sth->execute($new_query, $series_id);
         $replace_count++;
       }

--- a/scripts/merge-users.pl
+++ b/scripts/merge-users.pl
@@ -61,7 +61,6 @@ if ($old =~ /^id:(\d+)$/) {
   $old_id = $1;
 }
 else {
-  trick_taint($old);
   $old_id = $dbh->selectrow_array(
     'SELECT userid FROM profiles
                                       WHERE login_name = ?', undef, $old
@@ -86,7 +85,6 @@ if ($new =~ /^id:(\d+)$/) {
   );
 }
 else {
-  trick_taint($new);
   $new_id = $dbh->selectrow_array(
     'SELECT userid FROM profiles
                                       WHERE login_name = ?', undef, $new

--- a/scripts/migrate_whiteboard_keyword.pl
+++ b/scripts/migrate_whiteboard_keyword.pl
@@ -39,7 +39,7 @@ use Bugzilla::Constants;
 use Bugzilla::Field;
 use Bugzilla::Keyword;
 use Bugzilla::User;
-use Bugzilla::Util qw(trick_taint trim);
+use Bugzilla::Util qw(trim);
 
 use Getopt::Long;
 use Term::ANSIColor qw(colored);
@@ -77,8 +77,6 @@ my $whiteboard = shift;
 my $keyword    = shift;
 ($whiteboard && $keyword)
   || usage("Whiteboard or keyword strings were not provided\n");
-trick_taint($whiteboard);
-trick_taint($keyword);
 
 # User to make changes as automation@bmo.tld
 my $auto_user = Bugzilla::User->check({name => 'automation@bmo.tld'});

--- a/scripts/reset_default_user.pl
+++ b/scripts/reset_default_user.pl
@@ -15,7 +15,6 @@ use Bugzilla;
 use Bugzilla::Constants;
 use Bugzilla::User;
 use Bugzilla::Field;
-use Bugzilla::Util qw(trick_taint);
 
 use Getopt::Long;
 
@@ -58,7 +57,6 @@ if (!$product
 my $who = Bugzilla::User->new({name => 'nobody@mozilla.org'});
 my $field = Bugzilla::Field->new({name => $field_name});
 
-trick_taint($product);
 my $product_id = $dbh->selectrow_array("SELECT id FROM products WHERE name = ?",
   undef, $product);
 $product_id or die "Can't find product ID for '$product'.\n";
@@ -66,7 +64,6 @@ $product_id or die "Can't find product ID for '$product'.\n";
 my $component_id;
 my $default_user_id;
 if ($component) {
-  trick_taint($component);
   my $colname
     = $field->name eq 'qa_contact' ? 'initialqacontact' : 'initialowner';
   ($component_id, $default_user_id)

--- a/showdependencygraph.cgi
+++ b/showdependencygraph.cgi
@@ -325,7 +325,6 @@ foreach my $f (@files) {
   # $webdot directory. Since we're deleting the file (not following
   # symlinks), this can't escape to delete anything it shouldn't
   # (unless someone moves the location of $webdotdir, of course)
-  trick_taint($f);
   my $mtime = file_mod_time($f);
   if ($mtime && $mtime < $since) {
     unlink $f;

--- a/summarize_time.cgi
+++ b/summarize_time.cgi
@@ -149,8 +149,6 @@ sub sqlize_dates {
   my @date_values;
   if ($start_date) {
 
-    # we've checked, trick_taint is fine
-    trick_taint($start_date);
     $date_bits = " AND longdescs.bug_when > ?";
     push @date_values, $start_date;
   }

--- a/token.cgi
+++ b/token.cgi
@@ -46,9 +46,6 @@ $action || ThrowUserError('unknown_action');
 if ($token) {
   Bugzilla::Token::CleanTokenTable();
 
-  # It's safe to detaint the token as it's used in a placeholder.
-  trick_taint($token);
-
   # Make sure the token exists in the database.
   my ($db_token, $tokentype) = $dbh->selectrow_array(
     'SELECT token, tokentype FROM tokens

--- a/userprefs.cgi
+++ b/userprefs.cgi
@@ -626,8 +626,6 @@ sub SaveSavedSearches {
       # allowed to.
       next unless grep($_ eq $group_id, @{$user->queryshare_groups});
 
-      # $group_id is now definitely a valid ID of a group the
-      # user can share queries with, so we can trick_taint.
       detaint_natural($group_id);
       if ($q->shared_with_group) {
         $sth_update_ngm->execute($group_id, $q->id);
@@ -775,7 +773,6 @@ sub DoMFA {
       || ThrowTemplateError($template->error());
   }
   elsif ($provider =~ /^[a-z]+$/) {
-    trick_taint($provider);
     $template->process("mfa/$provider/enroll.html.tmpl", $vars)
       || ThrowTemplateError($template->error());
   }
@@ -984,9 +981,6 @@ my $mfa_token       = $cgi->param('mfa_token');
 $vars->{'changes_saved'} = $save_changes || $mfa_token;
 
 my $current_tab_name = $cgi->param('tab') || "account";
-
-# The SWITCH below makes sure that this is valid
-trick_taint($current_tab_name);
 
 $vars->{'current_tab_name'} = $current_tab_name;
 


### PR DESCRIPTION
as we no longer use taint mode (and mojo doesn't support it), the unconditional
detaining makes no sense. The detaint_natural() functions are still being used
however.