### PR TITLE
Bug 1527178 - If an uplift request answers Yes to needing manual QA, automatically set the qe-verify flag

### DIFF
--- a/extensions/BMO/template/en/default/hook/flag/type_comment-form.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/flag/type_comment-form.html.tmpl
@@ -45,7 +45,7 @@
         <th id="_ar_beta_i5_label">Needs manual test from QE?</th>
         <td>
           <div role="radiogroup" class="buttons toggle" aria-labelledby="_ar_beta_i5_label">
-            <div class="item"><input id="_ar_beta_i5_r1" type="radio" name="_ar_beta_i5_radio" value="Yes"><label for="_ar_beta_i5_r1">Yes</label></div>
+            <div class="item"><input id="_ar_beta_i5_r1" type="radio" name="_ar_beta_i5_radio" value="Yes" data-bug-flag="qe-verify"><label for="_ar_beta_i5_r1">Yes</label></div>
             <div class="item"><input id="_ar_beta_i5_r2" type="radio" name="_ar_beta_i5_radio" value="No"><label for="_ar_beta_i5_r2">No</label></div>
           </div>
         </td>

--- a/extensions/FlagTypeComment/web/js/ftc.js
+++ b/extensions/FlagTypeComment/web/js/ftc.js
@@ -282,6 +282,21 @@ Bugzilla.FlagTypeComment = class FlagTypeComment {
       }
     })));
 
+    // Collect bug flags from checkboxes
+    const bug_flags = [...this.$fieldset_wrapper.querySelectorAll('input[data-bug-flag]:checked')]
+      .map($input => ({ name: $input.getAttribute('data-bug-flag'), status: '?' }));
+
+    // Update bug flags if needed
+    if (bug_flags.length) {
+      await new Promise(resolve => {
+        bugzilla_ajax({
+          type: 'PUT',
+          url: `${BUGZILLA.config.basepath}rest/bug/${this.bug_id}`,
+          data: { flags: bug_flags },
+        }, () => resolve(), () => resolve());
+      });
+    }
+
     // Redirect to the bug once everything is done
     location.href = `${BUGZILLA.config.basepath}show_bug.cgi?id=${this.bug_id}`;
 


### PR DESCRIPTION
A small change on top of #802. If the uplift “Needs manual test from QE,” send an API request in background to set the `qe-verify?` flag.

## Bugzilla link

[Bug 1527178 - If an uplift request answers Yes to needing manual QA, automatically set the qe-verify flag](https://bugzilla.mozilla.org/show_bug.cgi?id=1527178)