### PR TITLE
Bug 1529368 - Implement REST API for saved searches

### DIFF
--- a/Bugzilla/Search/Saved.pm
+++ b/Bugzilla/Search/Saved.pm
@@ -296,7 +296,7 @@ sub _whine_subjects {
 
   return $self->{_whine_subjects} if exists $self->{_whine_subjects};
 
-  ($self->{_whine_subjects}) = Bugzilla->dbh->selectcol_arrayref(
+  $self->{_whine_subjects} = Bugzilla->dbh->selectcol_arrayref(
     'SELECT DISTINCT whine_events.subject FROM whine_events
       INNER JOIN whine_queries ON whine_queries.eventid = whine_events.id
       WHERE whine_events.owner_userid = ? AND whine_queries.query_name = ?',

--- a/Bugzilla/Search/Saved.pm
+++ b/Bugzilla/Search/Saved.pm
@@ -128,9 +128,9 @@ sub _check_query {
   my $cgi = new Bugzilla::CGI($query);
   my $query_str = $cgi->param('POSTDATA') || $cgi->param('PUTDATA');
 
-  # The new CGI will inherit the current request method, perhaps of an API call,
-  # so the params will be bogus if sent via POST or PUT. This decodes and fixes
-  # the params before being canonicalizing with `clean_search_url()`.
+  # The new CGI inherits the current request method, perhaps of an API call, so
+  # the params will be bogus if sent via POST or PUT. This decodes and fixes the
+  # params before being canonicalized with `clean_search_url()`.
   if ($query_str) {
     my $uri = URI->new("buglist.cgi?$query_str");
 

--- a/Bugzilla/Search/Saved.pm
+++ b/Bugzilla/Search/Saved.pm
@@ -155,7 +155,7 @@ sub _check_query {
 
 sub create {
   my ($class, $params) = @_;
-  my $user  = Bugzilla->login(LOGIN_REQUIRED);
+  my $user  = Bugzilla->user;
 
   # Prevent duplicated names from being saved
   ThrowUserError('saved_search_same_name')
@@ -247,8 +247,6 @@ sub update {
   my ($self, $params) = @_;
   my ($name, $url) = @$params{qw(name url)};
 
-  Bugzilla->login(LOGIN_REQUIRED);
-
   $self->set_name($name) if $name;
   $self->set_url($url) if $url;
   $self->SUPER::update(@_);
@@ -257,8 +255,6 @@ sub update {
 sub remove {
   my ($self) = @_;
   my $dbh = Bugzilla->dbh;
-
-  Bugzilla->login(LOGIN_REQUIRED);
 
   ThrowUserError('saved_search_used_by_whines', {
     search_name => $self->name,

--- a/Bugzilla/Search/Saved.pm
+++ b/Bugzilla/Search/Saved.pm
@@ -24,6 +24,7 @@ use Bugzilla::Util;
 use Scalar::Util qw(blessed);
 use URI;
 use URI::QueryParam;
+use List::Util qw( any );
 
 #############
 # Constants #
@@ -158,7 +159,7 @@ sub create {
 
   # Prevent duplicated names from being saved
   ThrowUserError('saved_search_same_name')
-    if scalar(grep { lc($_->name) eq lc($params->{name}) } @{$user->queries});
+    if any { lc($_->name) eq lc($params->{name}) } @{$user->queries};
 
   my $dbh = Bugzilla->dbh;
   $class->check_required_create_fields($params);
@@ -308,7 +309,7 @@ sub _whine_subjects {
 sub used_in_whine {
   my ($self) = @_;
 
-  return scalar(@{$self->_whine_subjects}) ? 1 : 0;
+  return @{$self->_whine_subjects} ? 1 : 0;
 }
 
 sub link_in_footer {

--- a/Bugzilla/WebService/Server/REST/Resources/User.pm
+++ b/Bugzilla/WebService/Server/REST/Resources/User.pm
@@ -28,6 +28,30 @@ sub _rest_resources {
     {GET => {method => 'login'}},
     qr{^/logout$},
     {GET => {method => 'logout'}},
+    qr{^/saved_searches$},
+    {
+      GET => {
+        method => 'get_saved_searches',
+      },
+      POST => {
+        method => 'add_saved_search',
+      },
+    },
+    qr{^/saved_searches/(\d+)$},
+    {
+      GET => {
+        method => 'get_saved_search',
+        params => sub { return {id => $_[0]} },
+      },
+      PUT => {
+        method => 'update_saved_search',
+        params => sub { return {id => $_[0]} },
+      },
+      DELETE => {
+        method => 'remove_saved_search',
+        params => sub { return {id => $_[0]} },
+      },
+    },
     qr{^/user$},
     {
       GET  => {method => 'get'},

--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -510,9 +510,9 @@ sub whoami {
 sub add_saved_search {
   my ($self, $params) = @_;
 
-  # The `create` method fails when a saved search with the same name exists. The
-  # UI should ask in advance if the user wants to override the existing one, and
-  # if the answer is yes, use `update_saved_search()` instead.
+  # The `create()` method fails when a saved search with the same name exists.
+  # The UI should ask in advance if the user wants to override the existing one,
+  # and if the answer is yes, use `update_saved_search()` instead.
   my $search = Bugzilla::Search::Saved->create({
     name => $params->{name}, query => $params->{url}, link_in_footer => 1
   });

--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -548,7 +548,7 @@ sub get_saved_search {
 }
 
 sub update_saved_search {
-  state $check = compile(Object, Dict[name => Str, url => Str]);
+  state $check = compile(Object, Dict[id => Int, name => Str, url => Str]);
   my ($self, $params) = $check->(@_);
   my $search = $self->_get_saved_search_by_id($params->{id});
 

--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -20,7 +20,7 @@ use Bugzilla::Group;
 use List::Util qw(first);
 use Type::Params qw( compile );
 use Type::Utils;
-use Types::Standard qw( :types )
+use Types::Standard qw( :types );
 use Bugzilla::User;
 use Bugzilla::Util qw(trim detaint_natural);
 use Bugzilla::WebService::Util qw(filter filter_wants validate

--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -514,6 +514,8 @@ sub add_saved_search {
   state $check = compile(Object, Dict[name => Str, url => Str]);
   my ($self, $params) = $check->(@_);
 
+  Bugzilla->login(LOGIN_REQUIRED);
+
   # The `create()` method fails when a saved search with the same name exists.
   # The UI should ask in advance if the user wants to override the existing one,
   # and if the answer is yes, use `update_saved_search()` instead.

--- a/buglist.cgi
+++ b/buglist.cgi
@@ -29,6 +29,7 @@ use Bugzilla::Status;
 use Bugzilla::Token;
 
 use Date::Parse;
+use List::Util qw(first);
 
 my $cgi      = Bugzilla->cgi;
 my $dbh      = Bugzilla->dbh;
@@ -216,7 +217,7 @@ sub InsertNamedQuery {
 
   $query_name = trim($query_name);
   my $query_obj
-    = first { lc($_->name) eq lc($query_name) } @{Bugzilla->user->queries};
+    = first { lc($_->{name}) eq lc($query_name) } @{Bugzilla->user->queries};
 
   if ($query_obj) {
     $query_obj->update({name => $query_name, url => $query});

--- a/buglist.cgi
+++ b/buglist.cgi
@@ -219,7 +219,7 @@ sub InsertNamedQuery {
     = grep { lc($_->name) eq lc($query_name) } @{Bugzilla->user->queries};
 
   if ($query_obj) {
-    $query_obj->update({name => $query_name, query => $query});
+    $query_obj->update({name => $query_name, url => $query});
   }
   else {
     Bugzilla::Search::Saved->create({

--- a/buglist.cgi
+++ b/buglist.cgi
@@ -215,8 +215,8 @@ sub InsertNamedQuery {
   my $dbh = Bugzilla->dbh;
 
   $query_name = trim($query_name);
-  my ($query_obj)
-    = grep { lc($_->name) eq lc($query_name) } @{Bugzilla->user->queries};
+  my $query_obj
+    = first { lc($_->name) eq lc($query_name) } @{Bugzilla->user->queries};
 
   if ($query_obj) {
     $query_obj->update({name => $query_name, url => $query});
@@ -349,7 +349,7 @@ if ($cmdtype eq "dorem") {
     $user = Bugzilla->login(LOGIN_REQUIRED);
 
     my $qname = $cgi->param('namedcmd');
-    my ($search) = grep { lc($_->{name}) eq lc($qname) } @{$user->queries};
+    my $search = first { lc($_->{name}) eq lc($qname) } @{$user->queries};
 
     if ($search) {
       # Make sure the user really wants to delete their saved search.

--- a/template/en/default/global/user-error.html.tmpl
+++ b/template/en/default/global/user-error.html.tmpl
@@ -1726,12 +1726,18 @@
     [% title = "Resolution Not Allowed" %]
     You cannot set a resolution for open [% terms.bugs %].
 
+  [% ELSIF error == "saved_search_same_name" %]
+    A saved search with the same name already exists.
+
+  [% ELSIF error == "saved_search_not_found" %]
+    A saved search with the given ID could not be found.
+
   [% ELSIF error == "saved_search_used_by_whines" %]
     [% title = "Saved Search In Use" %]
     [% docslinks = {'whining.html' => 'About Whining'} %]
     The saved search <em>[% search_name FILTER html %]</em> is being used
     by <a href="[% basepath FILTER none %]editwhines.cgi">Whining events</a> with the following subjects:
-    [%+ subjects FILTER html %]
+    [%+ subjects.join(', ') FILTER html %]
 
   [% ELSIF error == "search_content_without_matches" %]
     [% title = "Illegal Search" %]


### PR DESCRIPTION
Implement `/rest/saved_searches` so the new search results page can allow user to add/edit/remove a search with one click. I'm not adding a doc for the new API method for now because it's mainly for internal use and we are moving to REST API v2 or GraphQL API in the not-so-distant future.

## Bugzilla link

[Bug 1529368 - Implement REST API for saved searches](https://bugzilla.mozilla.org/show_bug.cgi?id=1529368)