### PR TITLE
Bug 1463874 - Update Default Products and Remove Buglist Queries from triage_owners.html

### DIFF
--- a/extensions/BMO/lib/Reports/Triage.pm
+++ b/extensions/BMO/lib/Reports/Triage.pm
@@ -28,7 +28,7 @@ use constant MAX_NUMBER_BUGS => 4000;
 use constant DEFAULT_OWNER_PRODUCTS => (
   'Core', 'DevTools', 'External Software Affecting Firefox',
   'Firefox', 'Firefox for Android', 'Firefox Build System',
-  'GeckoView', 'Remote Protocol', 'Testing', 
+  'GeckoView', 'NSPR', 'NSS', 'Remote Protocol', 'Testing',
   'Toolkit', 'WebExtensions',
 );
 


### PR DESCRIPTION
Add NSPR and NSS to the default triage owner query.

## Bugzilla link

[Bug 1463874 - Update Default Products and Remove Buglist Queries from triage_owners.html](https://bugzilla.mozilla.org/show_bug.cgi?id=1463874)