### PR TITLE
Bug 1527053 - Can't search for "video" to find all relevant bugs

### DIFF
--- a/Bugzilla/Search/Quicksearch.pm
+++ b/Bugzilla/Search/Quicksearch.pm
@@ -145,8 +145,6 @@ sub quicksearch {
     _bug_numbers_only($searchstring);
   }
   else {
-    _handle_alias($searchstring);
-
     # Retain backslashes and quotes, to know which strings are quoted,
     # and which ones are not.
     my @words = _parse_line('\s+', 1, $searchstring);
@@ -344,27 +342,6 @@ sub _bug_numbers_only {
     $cgi->param('bug_id',      $searchstring);
     $cgi->param('order',       'bugs.bug_id');
     $cgi->param('bug_id_type', 'anyexact');
-  }
-}
-
-sub _handle_alias {
-  my $searchstring = shift;
-  if ($searchstring =~ /^([^,\s]+)$/) {
-    my $alias = $1;
-
-    # We use this direct SQL because we want quicksearch to be VERY fast.
-    my $bug_id
-      = Bugzilla->dbh->selectrow_array(q{SELECT bug_id FROM bugs WHERE alias = ?},
-      undef, $alias);
-
-    # If the user cannot see the bug or if we are using a webservice,
-    # do not resolve its alias.
-    if ($bug_id && Bugzilla->user->can_see_bug($bug_id) && !i_am_webservice()) {
-      $alias = url_quote($alias);
-      print Bugzilla->cgi->redirect(
-        -uri => Bugzilla->localconfig->{urlbase} . "show_bug.cgi?id=$alias");
-      exit;
-    }
   }
 }
 

--- a/template/en/default/pages/quicksearch.html.tmpl
+++ b/template/en/default/pages/quicksearch.html.tmpl
@@ -54,7 +54,7 @@
 <p>This is an overview of how to effectively use search in [% terms.Bugzilla %].
   For more general information about [% terms.Bugzilla %] usage, including the jargon and
   shorthand that the Mozilla commmunity uses in [% terms.bug %] discussions, please look at
-  <a href="https://wiki.mozilla.org/Introduction_to_B[% %]ugzilla">Introduction to 
+  <a href="https://wiki.mozilla.org/Introduction_to_B[% %]ugzilla">Introduction to
   [% terms.Bugzilla %]</a> page on <a href="https://wiki.mozilla.org/">Wiki.m.o</a>.</p>
 
 <h2 id="basics">The Basics</h2>
@@ -71,12 +71,7 @@
     and [% field_descs.longdesc FILTER html %] fields for your word or words.</li>
 
   <li>Typing just a <strong>number</strong> in the search box will take
-    you directly to the [% terms.bug %] with that ID.
-    [% IF Param('usebugaliases') %]
-      Also, just typing the <strong>alias</strong> of [% terms.abug %]
-      will take you to that [% terms.bug %].
-    [% END %]
-  </li>
+    you directly to the [% terms.bug %] with that ID.</li>
 
   <li>Adding more terms <strong>narrows down</strong> the search, it does not
      expand it. (In other words, [% terms.Bugzilla %] searches for


### PR DESCRIPTION
Stop treating a word entered in the search bar as a bug alias to avoid unexpected results for users.

## Bugzilla link

[Bug 1527053 - Can't search for "video" to find all relevant bugs](https://bugzilla.mozilla.org/show_bug.cgi?id=1527053)