### PR TITLE
Bug 1503483 - Convert redirects to absolute path

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -303,11 +303,9 @@ sub login {
       my $self_url     = trim($cgi->self_url);
       my $sig_type     = 'prev_url:' . $authenticated_user->id;
       my $self_url_sig = issue_hash_sig($sig_type, $self_url);
-      my $redir_url
-        = URI->new(Bugzilla->localconfig->{urlbase} . "reset_password.cgi");
+      my $redir_url    = URI->new('reset_password.cgi');
       $redir_url->query_form(prev_url => $self_url, prev_url_sig => $self_url_sig);
-      print $cgi->redirect($redir_url);
-      exit;
+      $cgi->base_redirect($redir_url->as_string);
     }
   }
   elsif (!i_am_webservice()
@@ -329,8 +327,7 @@ sub login {
 
     if ($grace_period == 0 || $expired) {
       if (!($on_mfa_page || $on_token_page || $do_logout)) {
-        print Bugzilla->cgi->redirect("userprefs.cgi?tab=mfa");
-        exit;
+        $cgi->base_redirect('userprefs.cgi?tab=mfa');
       }
     }
     else {

--- a/Bugzilla/App/Plugin/Glue.pm
+++ b/Bugzilla/App/Plugin/Glue.pm
@@ -73,7 +73,7 @@ sub register {
       my ($c, $type) = @_;
 
       if ($type == LOGIN_REQUIRED) {
-        $c->redirect_to('/login');
+        $c->redirect_to(Bugzilla->localconfig->{basepath} . 'login');
         return undef;
       }
       else {

--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -885,6 +885,15 @@ sub redirect_to_urlbase {
   exit;
 }
 
+sub base_redirect {
+  my ($self, $path, $is_perm) = @_;
+  print $self->redirect(
+    -location => Bugzilla->localconfig->{basepath} . ($path || ''),
+    -status   => $is_perm ? '301 Moved Permanently' : '302 Found'
+  );
+  exit;
+}
+
 sub url_is_attachment_base {
   my ($self, $id) = @_;
   return 0 if !use_attachbase() or !i_am_cgi();
@@ -1041,6 +1050,11 @@ instead of calling this directly.
 =item C<redirect_to_urlbase>
 
 Redirects from the current URL to one prefixed by the urlbase parameter.
+
+=item C<base_redirect>
+
+Redirects to the given path relative to the `basepath` parameter which is
+typically the root (`/`).
 
 =item C<set_dated_content_disp>
 

--- a/Bugzilla/MFA.pm
+++ b/Bugzilla/MFA.pm
@@ -89,8 +89,7 @@ sub verify_token {
   my $event = get_token_extra_data($token);
   delete_token($token);
   if (!$event) {
-    print Bugzilla->cgi->redirect('index.cgi');
-    exit;
+    Bugzilla->cgi->base_redirect();
   }
   return $event;
 }

--- a/Bugzilla/Search/Quicksearch.pm
+++ b/Bugzilla/Search/Quicksearch.pm
@@ -282,11 +282,8 @@ sub quicksearch {
   my $modified_query_string = $cgi->canonicalise_query(@params_to_strip);
 
   if ($cgi->param('load')) {
-    my $urlbase = Bugzilla->localconfig->{urlbase};
-
     # Param 'load' asks us to display the query in the advanced search form.
-    print $cgi->redirect(
-      -uri => "${urlbase}query.cgi?format=advanced&amp;" . $modified_query_string);
+    $cgi->base_redirect("query.cgi?format=advanced&$modified_query_string");
   }
 
   # Otherwise, pass the modified query string to the caller.
@@ -333,9 +330,7 @@ sub _bug_numbers_only {
   if ($searchstring !~ /,/ && !i_am_webservice()) {
 
     # Single bug number; shortcut to show_bug.cgi.
-    print $cgi->redirect(
-      -uri => Bugzilla->localconfig->{urlbase} . "show_bug.cgi?id=$searchstring");
-    exit;
+    $cgi->base_redirect("show_bug.cgi?id=$searchstring");
   }
   else {
     # List of bug numbers.

--- a/attachment.cgi
+++ b/attachment.cgi
@@ -266,8 +266,7 @@ sub get_attachment {
         unless ($userid && $valid_token) {
 
           # Not a valid token.
-          print $cgi->redirect('-location' => Bugzilla->localconfig->{urlbase} . $path);
-          exit;
+          $cgi->base_redirect($path);
         }
 
         # Change current user without creating cookies.
@@ -389,12 +388,10 @@ sub view {
     {do_redirect => \$do_redirect});
 
   if ($do_redirect) {
-    my $uri = URI->new(Bugzilla->localconfig->{urlbase} . 'attachment.cgi');
+    my $uri = URI->new('attachment.cgi');
     $uri->query_param(id => $attachment->id);
     $uri->query_param(content_type => $contenttype) if $contenttype_override;
-
-    print $cgi->redirect('-location' => $uri);
-    exit 0;
+    $cgi->base_redirect($uri->as_string);
   }
 
   # Don't send a charset header with attachments--they might not be UTF-8.

--- a/chart.cgi
+++ b/chart.cgi
@@ -62,10 +62,8 @@ if (!Bugzilla->feature('new_charts')) {
 # Go back to query.cgi if we are adding a boolean chart parameter.
 if (grep(/^cmd-/, $cgi->param())) {
   my $params = $cgi->canonicalise_query("format", "ctype", "action");
-  print $cgi->redirect("query.cgi?format="
-      . $cgi->param('query_format')
-      . ($params ? "&$params" : ""));
-  exit;
+  $cgi->base_redirect("query.cgi?format="
+      . $cgi->param('query_format') . ($params ? "&$params" : ''));
 }
 
 my $action    = $cgi->param('action');
@@ -87,8 +85,7 @@ $action ||= "assemble";
 # Go to buglist.cgi if we are doing a search.
 if ($action eq "search") {
   my $params = $cgi->canonicalise_query("format", "ctype", "action");
-  print $cgi->redirect("buglist.cgi" . ($params ? "?$params" : ""));
-  exit;
+  $cgi->base_redirect('buglist.cgi' . ($params ? "?$params" : ""));
 }
 
 $user->in_group(Bugzilla->params->{"chartgroup"}) || ThrowUserError(
@@ -224,11 +221,9 @@ elsif ($action eq "convert_search") {
     my $params = new Bugzilla::CGI($query->edit_link);
 
     # These two parameters conflict with the one below.
-    $url = $params->canonicalise_query('format', 'query_format');
-    $url = '&amp;' . html_quote($url);
+    $url = '&' . $params->canonicalise_query('format', 'query_format');
   }
-  print $cgi->redirect(-location => Bugzilla->localconfig->{urlbase}
-      . "query.cgi?format=create-series$url");
+  $cgi->base_redirect("query.cgi?format=create-series$url");
 }
 else {
   ThrowUserError('unknown_action', {action => $action});

--- a/colchange.cgi
+++ b/colchange.cgi
@@ -139,15 +139,7 @@ if (defined $cgi->param('rememberedquery')) {
 
   my $params = new Bugzilla::CGI($cgi->param('rememberedquery'));
   $params->param('columnlist', join(",", @collist));
-  $vars->{'redirect_url'} = "buglist.cgi?" . $params->query_string();
-
-  # If we're running on Microsoft IIS, $cgi->redirect discards
-  # the Set-Cookie lines. In mod_perl, $cgi->redirect with cookies
-  # causes the page to be rendered as text/plain.
-  # Workaround is to use the old-fashioned  redirection mechanism.
-  # See bug 214466 and bug 376044 for details.
-  print $cgi->redirect($vars->{'redirect_url'});
-  exit;
+  $cgi->base_redirect('buglist.cgi?' . $params->query_string());
 }
 
 if (defined $cgi->param('columnlist')) {

--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -230,7 +230,7 @@ sub page_before_template {
     Bugzilla::Extension::BMO::Reports::Internship::report($vars);
   }
   elsif ($page eq 'email_queue.html') {
-    print Bugzilla->cgi->redirect('view_job_queue.cgi');
+    Bugzilla->cgi->base_redirect('view_job_queue.cgi');
   }
   elsif ($page eq 'release_tracking_report.html') {
     require Bugzilla::Extension::BMO::Reports::ReleaseTracking;
@@ -305,8 +305,7 @@ sub bounty_attachment {
 
     Bugzilla::BugMail::Send($bug->id, {changer => $user});
 
-    print Bugzilla->cgi->redirect('show_bug.cgi?id=' . $bug->id);
-    exit;
+    Bugzilla->cgi->base_redirect('show_bug.cgi?id=' . $bug->id);
   }
 
   if ($attachment) {

--- a/extensions/BMO/lib/Reports/Groups.pm
+++ b/extensions/BMO/lib/Reports/Groups.pm
@@ -84,8 +84,7 @@ sub membership_report {
   my $who = $cgi->param('who');
   if (!defined($who) || $who eq '') {
     if ($page eq 'group_membership.txt') {
-      print $cgi->redirect("page.cgi?id=group_membership.html&output=txt");
-      exit;
+      $cgi->base_redirect('page.cgi?id=group_membership.html&output=txt');
     }
     $vars->{'output'} = $cgi->param('output');
     return;

--- a/extensions/BMO/lib/Reports/ReleaseTracking.pm
+++ b/extensions/BMO/lib/Reports/ReleaseTracking.pm
@@ -304,11 +304,7 @@ sub report {
     my $bugs = $dbh->selectcol_arrayref($query, undef, @params);
     push @$bugs, 0 unless @$bugs;
 
-    my $urlbase = Bugzilla->localconfig->{urlbase};
-    my $cgi     = Bugzilla->cgi;
-    print $cgi->redirect(
-      -url => "${urlbase}buglist.cgi?bug_id=" . join(',', @$bugs));
-    exit;
+    Bugzilla->cgi->base_redirect('buglist.cgi?bug_id=' . join(',', @$bugs));
   }
 
   #

--- a/extensions/GuidedBugEntry/Extension.pm
+++ b/extensions/GuidedBugEntry/Extension.pm
@@ -42,12 +42,11 @@ sub enter_bug_start {
 
     # skip the first step if a product is provided
     if ($cgi->param('product')) {
-      print $cgi->redirect('enter_bug.cgi?format=guided'
+      $cgi->base_redirect('enter_bug.cgi?format=guided'
           . ($cgi->param('format_forced') ? '&format_forced=1' : '')
           . '#h=dupes' . '|'
           . url_quote($cgi->param('product')) . '|'
           . url_quote($cgi->param('component') || ''));
-      exit;
     }
 
     # Do not redirect to product forms if we came from there already

--- a/extensions/Voting/Extension.pm
+++ b/extensions/Voting/Extension.pm
@@ -534,8 +534,7 @@ sub _update_votes {
       exit;
     }
     elsif ($cgi->param('delete_all_votes') == 0) {
-      print $cgi->redirect("page.cgi?id=voting/user.html");
-      exit;
+      $cgi->base_redirect('page.cgi?id=voting/user.html');
     }
   }
   else {

--- a/github.cgi
+++ b/github.cgi
@@ -73,13 +73,12 @@ elsif (lc($cgi->request_method) eq 'get') {
   my $state_cookie = $cgi->cookie('github_state');
 
   # If the state or params are missing, or the github_state cookie is missing
-  # we just redirect to index.cgi.
+  # we just redirect to the homepage.
   unless ($state_param
     && $state_cookie
     && ($cgi->param('code') || $cgi->param('email')))
   {
-    print $cgi->redirect($urlbase . "index.cgi");
-    exit;
+    $cgi->base_redirect();
   }
 
   my $invalid_request = $state_param ne $state_cookie;
@@ -118,13 +117,13 @@ elsif (lc($cgi->request_method) eq 'get') {
   $target_uri->query_param_delete('logout');
 
   if ($target_uri->path =~ /attachment\.cgi/) {
-    my $attachment_uri = URI->new($urlbase . "attachment.cgi");
+    my $attachment_uri = URI->new('attachment.cgi');
     $attachment_uri->query_param(id => scalar $target_uri->query_param('id'));
     if ($target_uri->query_param('action')) {
       $attachment_uri->query_param(
         action => scalar $target_uri->query_param('action'));
     }
-    print $cgi->redirect($attachment_uri);
+    $cgi->base_redirect($attachment_uri->as_string);
   }
   else {
     print $cgi->redirect($target_uri);

--- a/long_list.cgi
+++ b/long_list.cgi
@@ -38,4 +38,4 @@ my @ids = split(/[\s,]+/, $buglist);
 
 my $ids = join('', map { $_ = "&id=" . $_ } @ids);
 
-print $cgi->redirect("show_bug.cgi?format=multiple$ids");
+$cgi->base_redirect("show_bug.cgi?format=multiple$ids");

--- a/new_bug.cgi
+++ b/new_bug.cgi
@@ -123,8 +123,7 @@ if (lc($cgi->request_method) eq 'post') {
     push(@all_mail_results, $ref_sent);
   }
 
-  print $cgi->redirect(
-    Bugzilla->localconfig->{urlbase} . 'show_bug.cgi?id=' . $new_bug->bug_id);
+  $cgi->base_redirect('show_bug.cgi?id=' . $new_bug->bug_id);
 }
 else {
   print $cgi->header();

--- a/post_bug.cgi
+++ b/post_bug.cgi
@@ -44,8 +44,7 @@ my $vars     = {};
 
 # redirect to enter_bug if no field is passed.
 unless ($cgi->param()) {
-  print $cgi->redirect(Bugzilla->localconfig->{urlbase} . 'enter_bug.cgi');
-  exit;
+  $cgi->base_redirect('enter_bug.cgi');
 }
 
 # BMO: Don't allow updating of bugs if disabled

--- a/relogin.cgi
+++ b/relogin.cgi
@@ -31,9 +31,8 @@ my $target;
 
 if (!$action) {
 
-  # redirect to index.cgi if no action is defined.
-  print $cgi->redirect(Bugzilla->localconfig->{urlbase} . 'index.cgi');
-  exit;
+  # redirect to the homepage if no action is defined.
+  $cgi->base_redirect();
 }
 
 # prepare-sudo: Display the sudo information & login page

--- a/report.cgi
+++ b/report.cgi
@@ -30,13 +30,8 @@ $cgi->content_security_policy(report_only => 0);
 # Go straight back to query.cgi if we are adding a boolean chart.
 if (grep(/^cmd-/, $cgi->param())) {
   my $params = $cgi->canonicalise_query("format", "ctype");
-  my $location
-    = "query.cgi?format="
-    . $cgi->param('query_format')
-    . ($params ? "&$params" : "");
-
-  print $cgi->redirect($location);
-  exit;
+  $cgi->base_redirect('query.cgi?format='
+      . $cgi->param('query_format') . ($params ? "&$params" : ''));
 }
 
 Bugzilla->login();

--- a/showattachment.cgi
+++ b/showattachment.cgi
@@ -36,9 +36,4 @@ my $id = $cgi->param('attach_id');
 detaint_natural($id) if defined $id;
 $id ||= "";
 
-print $cgi->redirect(
-  -location => "attachment.cgi?id=$id",
-  -status   => '301 Permanent Redirect'
-);
-
-exit;
+$cgi->base_redirect("attachment.cgi?id=$id", 1);

--- a/token.cgi
+++ b/token.cgi
@@ -461,8 +461,13 @@ sub verify_mfa_login {
   my $token = shift;
   my ($user, $event) = mfa_event_from_token($token);
   $user->authorizer->mfa_verified($user, $event);
-  print Bugzilla->cgi->redirect($event->{url} // 'index.cgi');
-  exit;
+
+  if ($event->{url}) {
+    print Bugzilla->cgi->redirect($event->{url});
+    exit;
+  }
+
+  Bugzilla->cgi->base_redirect();
 }
 
 sub mfa_event_from_token {
@@ -475,8 +480,7 @@ sub mfa_event_from_token {
   # sanity check
   if (!$user->mfa) {
     delete_token($token);
-    print Bugzilla->cgi->redirect('index.cgi');
-    exit;
+    Bugzilla->cgi->base_redirect();
   }
 
   # verify

--- a/userprefs.cgi
+++ b/userprefs.cgi
@@ -214,8 +214,7 @@ sub DisableAccount {
   $user->update();
 
   Bugzilla->logout();
-  print Bugzilla->cgi->redirect(Bugzilla->localconfig->{urlbase});
-  exit;
+  Bugzilla->cgi->base_redirect();
 }
 
 sub DoSettings {

--- a/votes.cgi
+++ b/votes.cgi
@@ -48,5 +48,4 @@ else {
   ThrowUserError('unknown_action', {action => $action});
 }
 
-print $cgi->redirect('page.cgi?' . $cgi->query_string);
-exit;
+$cgi->base_redirect('page.cgi?' . $cgi->query_string);

--- a/xml.cgi
+++ b/xml.cgi
@@ -40,4 +40,4 @@ if (defined $cgi->param('id')) {
 
 my $ids = join('', map { $_ = "&id=" . $_ } @ids);
 
-print $cgi->redirect("show_bug.cgi?ctype=xml$ids");
+$cgi->base_redirect("show_bug.cgi?ctype=xml$ids");


### PR DESCRIPTION
Make sure all the internal redirects are absolute URLs starting with the `basepath` param, which is `/` on BMO. Once this is merged, we can use pretty URLs like `/bug/1503483` or `/user/kohei`.

## Bugzilla link

[Bug 1503483 - Convert redirects to absolute path](https://bugzilla.mozilla.org/show_bug.cgi?id=1503483)