### PR TITLE
Bug 1481106 - Start logging bug_user_last_visit for all visited bugs even if the user is not involved

### DIFF
--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -1363,17 +1363,6 @@ sub update {
     $self->{delta_ts} = $delta_ts;
   }
 
-  # Update last-visited
-  if ($user->can_see_bug($self->id)) {
-    $self->update_user_last_visit($user, $delta_ts);
-  }
-
-  # If a user is no longer involved, remove their last visit entry
-  my $last_visits = Bugzilla::BugUserLastVisit->match({bug_id => $self->id});
-  foreach my $lv (@$last_visits) {
-    $lv->remove_from_db() unless $lv->user->can_see_bug($self->id);
-  }
-
   # Update bug ignore data if user wants to ignore mail for this bug
   if (exists $self->{'bug_ignored'}) {
     my $bug_ignored_changed;

--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -1364,15 +1364,7 @@ sub update {
   }
 
   # Update last-visited
-  if ($user->is_involved_in_bug($self)) {
-    $self->update_user_last_visit($user, $delta_ts);
-  }
-
-  # If a user is no longer involved, remove their last visit entry
-  my $last_visits = Bugzilla::BugUserLastVisit->match({bug_id => $self->id});
-  foreach my $lv (@$last_visits) {
-    $lv->remove_from_db() unless $lv->user->is_involved_in_bug($self);
-  }
+  $self->update_user_last_visit($user, $delta_ts);
 
   # Update bug ignore data if user wants to ignore mail for this bug
   if (exists $self->{'bug_ignored'}) {

--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -1364,7 +1364,15 @@ sub update {
   }
 
   # Update last-visited
-  $self->update_user_last_visit($user, $delta_ts);
+  if ($user->can_see_bug($self->id)) {
+    $self->update_user_last_visit($user, $delta_ts);
+  }
+
+  # If a user is no longer involved, remove their last visit entry
+  my $last_visits = Bugzilla::BugUserLastVisit->match({bug_id => $self->id});
+  foreach my $lv (@$last_visits) {
+    $lv->remove_from_db() unless $lv->user->can_see_bug($self->id);
+  }
 
   # Update bug ignore data if user wants to ignore mail for this bug
   if (exists $self->{'bug_ignored'}) {

--- a/Bugzilla/WebService/BugUserLastVisit.pm
+++ b/Bugzilla/WebService/BugUserLastVisit.pm
@@ -44,8 +44,7 @@ sub update {
   foreach my $bug_id (@$ids) {
     my $bug = Bugzilla::Bug->check({id => $bug_id, cache => 1});
 
-    ThrowUserError('bug_access_denied', {bug_id => $bug->id})
-      unless $user->can_see_bug($bug->id);
+    next unless $user->can_see_bug($bug->id);
 
     $bug->update_user_last_visit($user, $last_visit_ts);
 

--- a/Bugzilla/WebService/BugUserLastVisit.pm
+++ b/Bugzilla/WebService/BugUserLastVisit.pm
@@ -44,8 +44,8 @@ sub update {
   foreach my $bug_id (@$ids) {
     my $bug = Bugzilla::Bug->check({id => $bug_id, cache => 1});
 
-    ThrowUserError('user_not_involved', {bug_id => $bug->id})
-      unless $user->is_involved_in_bug($bug);
+    ThrowUserError('bug_access_denied', {bug_id => $bug->id})
+      unless $user->can_see_bug($bug->id);
 
     $bug->update_user_last_visit($user, $last_visit_ts);
 

--- a/Bugzilla/WebService/Constants.pm
+++ b/Bugzilla/WebService/Constants.pm
@@ -219,9 +219,6 @@ use constant WS_ERROR_CODE => {
   # Search errors are 1000-1100
   buglist_parameters_required => 1000,
 
-  # BugUserLastVisited errors
-  user_not_involved => 1300,
-
   # Job queue errors 1400-1500
   jobqueue_status_error => 1400,
 

--- a/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
@@ -84,7 +84,7 @@
   [% END %]
 
   [%# update last-visited %]
-  [% IF user.id && user.is_involved_in_bug(bug) %]
+  [% IF user.id %]
     document.addEventListener('DOMContentLoaded', () => show_new_changes_indicator(), { once: true });
   [% END %]
 

--- a/template/en/default/bug/show-header.html.tmpl
+++ b/template/en/default/bug/show-header.html.tmpl
@@ -67,7 +67,7 @@
     YAHOO.util.Event.onDOMReady(function() {
       initDirtyFieldTracking();
 
-      [% IF user.id AND user.is_involved_in_bug(bug) %]
+      [% IF user.id %]
         YAHOO.bugzilla.bugUserLastVisit.update([ [% bug.bug_id FILTER none %] ]);
       [% END %]
     });

--- a/template/en/default/global/user-error.html.tmpl
+++ b/template/en/default/global/user-error.html.tmpl
@@ -1909,11 +1909,6 @@
     Sorry, but you are not allowed to (un)mark comments or attachments
     as private.
 
-  [% ELSIF error == "user_not_involved" %]
-    [% title = "User Not Involved with $terms.Bug" %]
-    Sorry, but you are not involved with [% terms.Bug %] [%+
-        bug_id FILTER bug_link(bug_id) FILTER none %].
-
   [% ELSIF error == "webdot_too_large" %]
     [% title = "Dependency Graph Too Large" %]
     The dependency graph contains too many [% terms.bugs %] to display (more


### PR DESCRIPTION
[Update the last-visited time for the specified bug and current user](https://bmo.readthedocs.io/en/latest/api/core/v1/bug-user-last-visit.html#update-last-visited) even if the user is not directly involved in. This change allows to enhance the UX, like

* Show the new comments/changes indicator on any bug
* Highlight any bug updated since last visit (like GitHub issue list)
* Search any recently visited bug from the quick search bar (#778)
* Style any visited bug reliably among multiple devices

## Bugzilla link

[Bug 1481106 - Start logging bug_user_last_visit for all visited bugs even if the user is not involved](https://bugzilla.mozilla.org/show_bug.cgi?id=1481106)