### PR TITLE
Bug 1532482 - Improve “new changes since” indicator UX

### DIFF
--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -509,14 +509,28 @@ td.flag-requestee {
 }
 
 .new-changes-link {
-    margin: 8px 0;
+    position: sticky;
+    top: 8px;
+    left: 0;
+    right: 0;
+    z-index: 10;
+    overflow: hidden;
+    margin: 8px -8px;
     border-radius: 4px;
     padding: 4px;
     font-size: 12px;
     text-align: center;
     color: #FFF;
     background: #277AC1;
+    opacity: 1;
     cursor: pointer;
+    transition: all .2s 2s;
+    will-change: transform; /* for performance */
+}
+
+.new-changes-link[hidden] {
+    display: block;
+    opacity: 0;
 }
 
 .new-changes-separator {

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -1438,7 +1438,8 @@ function show_new_changes_indicator() {
             const observer = new IntersectionObserver(entries => entries.forEach(entry => {
                 if (entry.intersectionRatio > 0) {
                     observer.unobserve($separator);
-                    $link.remove();
+                    $link.addEventListener('transitionend', () => $link.remove(), { once: true });
+                    $link.hidden = true;
                 }
             }), { root: document.querySelector('#bugzilla-body') });
 


### PR DESCRIPTION
1. It should remain in the viewport even when you start scrolling. Use `position:sticky`.
2. It should remain visible for a few seconds when you reach new changes.

## Bugzilla link

[Bug 1532482 - Improve “new changes since” indicator UX](https://bugzilla.mozilla.org/show_bug.cgi?id=1532482)