### PR TITLE
no bug - Include js/util.js on all pages

### DIFF
--- a/extensions/BMO/template/en/default/bug/create/create-automative.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-automative.html.tmpl
@@ -86,7 +86,7 @@ function validateAndSubmit() {
    style = inline_style
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',
-                       'js/field.js', 'js/util.js' ]
+                       'js/field.js' ]
 %]
 
 [% USE Bugzilla %]

--- a/extensions/BMO/template/en/default/bug/create/create-blocklist.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-blocklist.html.tmpl
@@ -79,7 +79,7 @@ function compileDescription() {
     ["Platforms affected", platformVersions],
     ["Block severity", severity]
   ]);
-  
+
   descr += "\n### Reason\n" + unlink(reason);
   descr += "\n\n### Extension GUIDs\n```\n" + backtick(guids) + "\n```";
 
@@ -111,7 +111,7 @@ window.addEventListener("DOMContentLoaded", function() {
    style = inline_style
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',
-                       'js/field.js', 'js/util.js' ]
+                       'js/field.js' ]
 %]
 
 [% USE Bugzilla %]

--- a/extensions/BMO/template/en/default/bug/create/create-client-bounty.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-client-bounty.html.tmpl
@@ -103,7 +103,7 @@ function validateAndSubmit() {
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',
                        'extensions/BMO/web/js/attach-desc.js',
-                       'js/field.js', 'js/util.js' ]
+                       'js/field.js' ]
 %]
 
 [% USE Bugzilla %]

--- a/extensions/BMO/template/en/default/bug/create/create-costume.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-costume.html.tmpl
@@ -130,7 +130,7 @@ YAHOO.util.Event.onDOMReady(function() {
    style = inline_style
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',
-                       'js/field.js', 'js/util.js' ]
+                       'js/field.js' ]
 %]
 
 <h1>Firefox Costume Request Form</h1>

--- a/extensions/BMO/template/en/default/bug/create/create-creative.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-creative.html.tmpl
@@ -114,7 +114,7 @@ function toggleTypeOther(element) {
    style = inline_style
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',
-                       'js/field.js', 'js/util.js' ]
+                       'js/field.js' ]
 %]
 
 [% USE Bugzilla %]

--- a/extensions/BMO/template/en/default/bug/create/create-crm.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-crm.html.tmpl
@@ -73,7 +73,7 @@ $(document).ready(function() {
                           "js/jquery/plugins/datetimepicker/datetimepicker.css" ]
    style              = inline_style
    javascript         = inline_javascript
-   javascript_urls    = [ "js/field.js", "js/util.js" ]
+   javascript_urls    = [ "js/field.js" ]
    jquery             = [ "datetimepicker" ]
 %]
 

--- a/extensions/BMO/template/en/default/bug/create/create-data-compliance.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-data-compliance.html.tmpl
@@ -67,7 +67,6 @@
    style_urls = [ 'skins/standard/enter_bug.css' ]
    javascript = inline_javascript
    javascript_urls = [ 'js/field.js',
-                       'js/util.js',
                        'extensions/BMO/web/js/form_validate.js' ]
 %]
 

--- a/extensions/BMO/template/en/default/bug/create/create-finance.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-finance.html.tmpl
@@ -67,7 +67,7 @@
    style_urls = [ 'skins/standard/enter_bug.css' ]
    javascript = inline_js
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',
-                       'js/attachment.js', 'js/field.js', 'js/util.js' ]
+                       'js/attachment.js', 'js/field.js' ]
    onload = "showCompDesc(document.getElementById('component'));"
 %]
 

--- a/extensions/BMO/template/en/default/bug/create/create-fsa-budget.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-fsa-budget.html.tmpl
@@ -73,7 +73,6 @@ function validateAndSubmit() {
    style_urls = [ 'skins/standard/enter_bug.css' ]
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',
-                       'js/util.js',
                        'js/field.js' ]
 %]
 

--- a/extensions/BMO/template/en/default/bug/create/create-ipp.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-ipp.html.tmpl
@@ -60,7 +60,7 @@ function validateAndSubmit() {
    style = inline_style
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',
-                       'js/field.js', 'js/util.js', 'js/bug.js' ]
+                       'js/field.js', 'js/bug.js' ]
 %]
 
 [% USE Bugzilla %]

--- a/extensions/BMO/template/en/default/bug/create/create-mozpr.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-mozpr.html.tmpl
@@ -273,7 +273,7 @@ function validate_form() {
    style = inline_style
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',
-                       'js/field.js', 'js/util.js' ]
+                       'js/field.js' ]
 %]
 
 [% UNLESS user.in_group('pr-private') %]

--- a/extensions/BMO/template/en/default/bug/create/create-swag.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-swag.html.tmpl
@@ -498,7 +498,7 @@ function showGear() {
    style = inline_style
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',
-                       'js/field.js', 'js/util.js' ]
+                       'js/field.js' ]
 %]
 
 <h1>Mozilla Gear</h1>

--- a/extensions/BMO/template/en/default/bug/create/create-user-engagement.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-user-engagement.html.tmpl
@@ -80,7 +80,7 @@ function toggleGoalOther() {
    style = inline_style
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',
-                       'js/field.js', 'js/util.js' ]
+                       'js/field.js' ]
 %]
 
 [% USE Bugzilla %]

--- a/extensions/BMO/template/en/default/bug/create/create-web-bounty.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-web-bounty.html.tmpl
@@ -63,7 +63,7 @@ function validateAndSubmit() {
    style = inline_style
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',
-                       'js/field.js', 'js/util.js' ]
+                       'js/field.js' ]
 %]
 
 [% USE Bugzilla %]

--- a/extensions/BMO/template/en/default/pages/attachment_bounty_form.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/attachment_bounty_form.html.tmpl
@@ -123,7 +123,7 @@ function validateAndSubmit() {
    style = inline_style
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js',
-                       'js/field.js', 'js/util.js' ]
+                       'js/field.js' ]
 %]
 
 [% USE Bugzilla %]

--- a/extensions/BMO/template/en/default/pages/triage_owners.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/triage_owners.html.tmpl
@@ -22,7 +22,7 @@
 
 [% INCLUDE global/header.html.tmpl
   title = "Triage Owners"
-  javascript_urls = [ "js/util.js", "js/field.js", "js/productform.js",
+  javascript_urls = [ "js/field.js", "js/productform.js",
                       "extensions/BMO/web/js/triage_owners.js" ]
   style_urls = [ "skins/standard/buglist.css",
                  "extensions/BMO/web/styles/triage_reports.css" ]

--- a/extensions/BMO/template/en/default/pages/triage_reports.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/triage_reports.html.tmpl
@@ -42,7 +42,7 @@ var selected_components = [
   title = "Unconfirmed Reports"
   generate_api_token = 1
   javascript = js_data
-  javascript_urls = [ "js/util.js", "js/field.js", "js/productform.js",
+  javascript_urls = [ "js/field.js", "js/productform.js",
                       "extensions/BMO/web/js/triage_reports.js" ]
   style_urls = [ "skins/standard/buglist.css",
                  "extensions/BMO/web/styles/triage_reports.css" ]

--- a/extensions/BMO/template/en/default/pages/user_activity.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/user_activity.html.tmpl
@@ -15,7 +15,7 @@
 [% INCLUDE global/header.html.tmpl
   title = "User Activity Report" _ who_title
   generate_api_token = 1
-  javascript_urls = [ "js/util.js", "js/field.js" ]
+  javascript_urls = [ "js/field.js" ]
   style_urls = [ "extensions/BMO/web/styles/reports.css" ]
 
 %]

--- a/extensions/BugModal/template/en/default/bug_modal/common_header.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/common_header.html.tmpl
@@ -40,8 +40,7 @@
     "extensions/BugModal/web/comments.js",
     "js/bugzilla-readable-status-min.js",
     "js/field.js",
-    "js/comments.js",
-    "js/util.js"
+    "js/comments.js"
   );
   jquery.push(
     "datetimepicker",

--- a/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
@@ -57,8 +57,7 @@
     "extensions/ComponentWatching/web/js/overlay.js",
     "js/bugzilla-readable-status-min.js",
     "js/field.js",
-    "js/comments.js",
-    "js/util.js"
+    "js/comments.js"
   );
   jquery.push(
     "contextMenu",

--- a/extensions/MozProjectReview/template/en/default/bug/create/create-moz-project-review.html.tmpl
+++ b/extensions/MozProjectReview/template/en/default/bug/create/create-moz-project-review.html.tmpl
@@ -14,7 +14,7 @@
    style_urls = [ 'skins/standard/create_bug.css',
                   'extensions/MozProjectReview/web/style/moz_project_review.css'
                   'js/jquery/plugins/datetimepicker/datetimepicker.css' ]
-   javascript_urls = [ 'js/field.js', 'js/util.js',
+   javascript_urls = [ 'js/field.js',
                        'extensions/MozProjectReview/web/js/moz_project_review.js' ]
    jquery = ["datetimepicker" ]
 %]

--- a/extensions/REMO/template/en/default/bug/create/create-mozreps.html.tmpl
+++ b/extensions/REMO/template/en/default/bug/create/create-mozreps.html.tmpl
@@ -24,7 +24,7 @@
    generate_api_token = 1
    style_urls         = [ "extensions/REMO/web/styles/moz_reps.css" ]
    jquery             = []
-   javascript_urls    = [ "extensions/REMO/web/js/moz_reps.js", "js/field.js", "js/util.js"]
+   javascript_urls    = [ "extensions/REMO/web/js/moz_reps.js", "js/field.js" ]
 %]
 
 <noscript>

--- a/extensions/REMO/template/en/default/bug/create/create-remo-budget.html.tmpl
+++ b/extensions/REMO/template/en/default/bug/create/create-remo-budget.html.tmpl
@@ -13,7 +13,6 @@
    generate_api_token = 1
    style_urls = [ 'extensions/REMO/web/styles/moz_reps.css' ]
    javascript_urls = [ 'extensions/REMO/web/js/form_validate.js',
-                       'js/util.js',
                        'js/field.js' ]
 %]
 

--- a/extensions/REMO/template/en/default/bug/create/create-remo-swag.html.tmpl
+++ b/extensions/REMO/template/en/default/bug/create/create-remo-swag.html.tmpl
@@ -13,8 +13,7 @@
    generate_api_token = 1
    javascript_urls = [ 'extensions/REMO/web/js/swag.js',
                        'extensions/REMO/web/js/form_validate.js',
-                       'js/field.js',
-                       'js/util.js' ]
+                       'js/field.js' ]
    style_urls = [ "extensions/REMO/web/styles/moz_reps.css" ]
 %]
 

--- a/extensions/REMO/template/en/default/pages/remo-form-payment.html.tmpl
+++ b/extensions/REMO/template/en/default/pages/remo-form-payment.html.tmpl
@@ -26,7 +26,6 @@
    style_urls = [ 'extensions/REMO/web/styles/moz_reps.css' ]
    javascript_urls = [ 'extensions/REMO/web/js/form_validate.js',
                        'extensions/REMO/web/js/payment.js',
-                       'js/util.js',
                        'js/field.js' ]
 %]
 

--- a/extensions/RequestNagger/template/en/default/pages/request_defer.html.tmpl
+++ b/extensions/RequestNagger/template/en/default/pages/request_defer.html.tmpl
@@ -9,7 +9,7 @@
 [% PROCESS global/header.html.tmpl
    title = "Defer Request Reminder"
    style_urls = [ "extensions/RequestNagger/web/style/requestnagger.css" ]
-   javascript_urls = [ "js/util.js" , "extensions/RequestNagger/web/js/requestnagger.js" ]
+   javascript_urls = [ "extensions/RequestNagger/web/js/requestnagger.js" ]
 %]
 
 <h2>Defer Request Reminder</h2>

--- a/extensions/Review/template/en/default/hook/global/header-start.html.tmpl
+++ b/extensions/Review/template/en/default/hook/global/header-start.html.tmpl
@@ -7,7 +7,7 @@
   #%]
 
 [% style_urls.push('extensions/Review/web/styles/badge.css') %]
-[% javascript_urls.push('js/util.js', 'js/lib/md5.min.js', 'extensions/Review/web/js/badge.js') %]
+[% javascript_urls.push('js/lib/md5.min.js', 'extensions/Review/web/js/badge.js') %]
 
 [% RETURN UNLESS template.name == 'attachment/edit.html.tmpl'
       || template.name == 'attachment/create.html.tmpl'

--- a/extensions/Review/template/en/default/pages/review_history.html.tmpl
+++ b/extensions/Review/template/en/default/pages/review_history.html.tmpl
@@ -15,7 +15,6 @@
   javascript_urls = [ 'js/yui3/yui/yui-min.js',
             'extensions/Review/web/js/review_history.js',
             'extensions/Review/web/js/moment.min.js',
-            'js/util.js',
             'js/field.js' ]
 %]
 

--- a/template/en/default/account/prefs/prefs.html.tmpl
+++ b/template/en/default/account/prefs/prefs.html.tmpl
@@ -43,7 +43,7 @@
     subheader          = filtered_login
     generate_api_token = 1
     style_urls         = ['skins/standard/admin.css']
-    javascript_urls    = ['js/util.js', 'js/field.js', 'js/TUI.js', 'js/account.js']
+    javascript_urls    = ['js/field.js', 'js/TUI.js', 'js/account.js']
     jquery             = ['bPopup'],
     doc_section        = "using/preferences.html";
 

--- a/template/en/default/admin/custom_fields/create.html.tmpl
+++ b/template/en/default/admin/custom_fields/create.html.tmpl
@@ -26,7 +26,6 @@
 [% PROCESS global/header.html.tmpl
            title = "Add a new Custom Field"
            onload = "document.getElementById('new_bugmail').disabled = true;"
-           javascript_urls = [ 'js/util.js' ]
            doc_section = "custom-fields.html#add-custom-fields"
            style_urls = ['skins/standard/admin.css']
 %]

--- a/template/en/default/admin/custom_fields/edit.html.tmpl
+++ b/template/en/default/admin/custom_fields/edit.html.tmpl
@@ -30,7 +30,6 @@
 [% PROCESS global/header.html.tmpl
            title = title
            onload = "toggleCheckbox(document.getElementById('enter_bug'), 'new_bugmail');"
-           javascript_urls = [ 'js/util.js' ]
            doc_section = "custom-fields.html#edit-custom-fields"
            style_urls = ['skins/standard/admin.css']
 %]

--- a/template/en/default/admin/params/editparams.html.tmpl
+++ b/template/en/default/admin/params/editparams.html.tmpl
@@ -55,7 +55,7 @@
    title = title
    message = message
    style_urls = ['skins/standard/params.css']
-   javascript_urls = ['js/params.js', 'js/util.js']
+   javascript_urls = ['js/params.js']
    doc_section = "parameters.html"
 %]
 

--- a/template/en/default/admin/products/create.html.tmpl
+++ b/template/en/default/admin/products/create.html.tmpl
@@ -26,7 +26,6 @@
   title = title
   generate_api_token = 1
   style_urls = ['skins/standard/admin.css']
-  javascript_urls = ['js/util.js']
 %]
 
 [% DEFAULT

--- a/template/en/default/admin/products/edit.html.tmpl
+++ b/template/en/default/admin/products/edit.html.tmpl
@@ -29,7 +29,6 @@
 [% PROCESS global/header.html.tmpl
   title = title
   style_urls = ['skins/standard/admin.css']
-  javascript_urls = ['js/util.js']
 %]
 
 [% group_control = {${constants.CONTROLMAPNA}        => 'NA',

--- a/template/en/default/attachment/create.html.tmpl
+++ b/template/en/default/attachment/create.html.tmpl
@@ -35,7 +35,7 @@
   subheader = subheader
   generate_api_token = 1
   style_urls = [ 'skins/standard/attachment.css' ]
-  javascript_urls = [ "js/attachment.js", 'js/field.js', "js/util.js", "js/TUI.js" ]
+  javascript_urls = [ "js/attachment.js", 'js/field.js', "js/TUI.js" ]
   doc_section = "attachments.html"
 %]
 

--- a/template/en/default/bug/create/create.html.tmpl
+++ b/template/en/default/bug/create/create.html.tmpl
@@ -34,7 +34,7 @@
   style_urls = [ 'skins/standard/attachment.css',
                  'skins/standard/enter_bug.css',
                  'skins/standard/create_bug.css' ]
-  javascript_urls = [ "js/attachment.js", "js/util.js",
+  javascript_urls = [ "js/attachment.js",
                       "js/field.js", "js/TUI.js", "js/bug.js",
                       "js/create_bug.js" ]
   onload = "init();"

--- a/template/en/default/bug/show-header.html.tmpl
+++ b/template/en/default/bug/show-header.html.tmpl
@@ -40,7 +40,7 @@
 [% title = title _ filtered_desc %]
 [% generate_api_token = 1 %]
 [% header = "$terms.Bug&nbsp;$bug.bug_id" %]
-[% javascript_urls = [ "js/util.js", "js/field.js" ] %]
+[% javascript_urls = [ "js/field.js" ] %]
 [% javascript_urls.push("js/bug.js") IF user.id  %]
 [% javascript_urls.push('js/comment-tagging.js')
      IF user.id && Param('comment_taggers_group') %]

--- a/template/en/default/bug/summarize-time.html.tmpl
+++ b/template/en/default/bug/summarize-time.html.tmpl
@@ -33,7 +33,7 @@
     header = header
     style_urls = ["skins/standard/summarize-time.css"]
     doc_section = "timetracking.html"
-    javascript_urls = [ "js/util.js", "js/field.js" ]
+    javascript_urls = [ "js/field.js" ]
     %]
 
 [% INCLUDE query_form %]

--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -182,7 +182,7 @@
     [% FOREACH jq_name = jquery.unique %]
       [% starting_js_urls.push("js/jquery/plugins/$jq_name/${jq_name}-min.js") %]
     [% END %]
-    [% starting_js_urls.push('js/global.js', 'js/dropdown.js') %]
+    [% starting_js_urls.push('js/global.js', 'js/util.js', 'js/dropdown.js') %]
 
     [% FOREACH asset_url = starting_js_urls %]
       [% PROCESS format_js_link %]

--- a/template/en/default/list/list.html.tmpl
+++ b/template/en/default/list/list.html.tmpl
@@ -50,7 +50,7 @@
   generate_api_token = dotweak
   style = style
   atomlink = basepath _ "buglist.cgi?$urlquerypart&title=$url_filtered_title&ctype=atom"
-  javascript_urls = [ "js/util.js", "js/field.js", "js/buglist.js" ]
+  javascript_urls = [ "js/field.js", "js/buglist.js" ]
   style_urls = [ "skins/standard/buglist.css" ]
   doc_section = "query.html#list"
 %]

--- a/template/en/default/search/search-advanced.html.tmpl
+++ b/template/en/default/search/search-advanced.html.tmpl
@@ -45,7 +45,7 @@ function remove_token() {
   generate_api_token = 1
   onload = "doOnSelectProduct(0);"
   javascript = js_data
-  javascript_urls = [ "js/productform.js", "js/util.js", "js/TUI.js", "js/field.js"]
+  javascript_urls = [ "js/productform.js", "js/TUI.js", "js/field.js"]
   style_urls = [ "skins/standard/search_form.css" ]
   doc_section = "query.html"
   style = "dl.bug_changes dt {

--- a/template/en/default/search/search-create-series.html.tmpl
+++ b/template/en/default/search/search-create-series.html.tmpl
@@ -35,7 +35,7 @@
   generate_api_token = 1
   onload = "doOnSelectProduct(0);"
   javascript = js_data
-  javascript_urls = [ "js/util.js", "js/productform.js", "js/TUI.js", "js/field.js" ]
+  javascript_urls = [ "js/productform.js", "js/TUI.js", "js/field.js" ]
   style_urls = [ "skins/standard/search_form.css" ]
   doc_section = "reporting.html#charts-new-series"
 %]

--- a/template/en/default/search/search-report-graph.html.tmpl
+++ b/template/en/default/search/search-report-graph.html.tmpl
@@ -34,7 +34,7 @@ var queryform = "reportform"
   generate_api_token = 1
   onload = "doOnSelectProduct(0); chartTypeChanged()"
   javascript = js_data
-  javascript_urls = [ "js/util.js", "js/productform.js", "js/TUI.js", "js/field.js" ]
+  javascript_urls = [ "js/productform.js", "js/TUI.js", "js/field.js" ]
   style_urls = [ "skins/standard/search_form.css" ]
   doc_section = "reporting.html#reports"
 %]

--- a/template/en/default/search/search-report-table.html.tmpl
+++ b/template/en/default/search/search-report-table.html.tmpl
@@ -34,7 +34,7 @@ var queryform = "reportform"
   generate_api_token = 1
   onload = "doOnSelectProduct(0)"
   javascript = js_data
-  javascript_urls = [ "js/util.js", "js/productform.js", "js/TUI.js", "js/field.js" ]
+  javascript_urls = [ "js/productform.js", "js/TUI.js", "js/field.js" ]
   style_urls = [ "skins/standard/search_form.css" ]
   doc_section = "reporting.html#reports"
 %]


### PR DESCRIPTION
This is required for #665 and #778. `js/util.js` is already included in most of the pages so it won’t add a significant performance overhead.