### PR TITLE
no-bug - Gravatar URLs are double-HTML-escaped

### DIFF
--- a/extensions/Gravatar/Extension.pm
+++ b/extensions/Gravatar/Extension.pm
@@ -38,7 +38,7 @@ sub _user_gravatar {
       = 'https://secure.gravatar.com/avatar/' . md5_hex(lc($email)) . '?d=mm';
   }
   $size ||= 64;
-  return $self->{gravatar} . '&amp;size=' . $size;
+  return $self->{gravatar} . '&size=' . $size;
 }
 
 sub install_before_final_checks {


### PR DESCRIPTION
Remove an unnecessary `&amp;` from the Gravatar URL generator. These URLs will be HTML-escaped in a template or script.