### PR TITLE
bump version to 20190312.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20190221.1';
+our $VERSION = '20190312.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
[release tag](https://github.com/mozilla-bteam/bmo/tree/release-20190312.1)

the following changes have been pushed to bugzilla.mozilla.org:
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=989476" target="_blank">989476</a>] A comment from a "new to bugzilla" user on a mentored [good-first-bug] should trip the needinfo flag.</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1529985" target="_blank">1529985</a>] "Phabricator Revisions" section of bug is stuck at "Loading...." due to typo in phabricator.js</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1496207" target="_blank">1496207</a>] Allow to request uplift of multiple patches at once by adding checkboxes for other patches</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1527178" target="_blank">1527178</a>] If an uplift request answers Yes to needing manual QA, automatically set the qe-verify flag</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1502500" target="_blank">1502500</a>] Adding the qe-verify flag as an editable field when using Bugzilla's "Change Several Bugs at Once" option</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1463874" target="_blank">1463874</a>] Update Default Products and Remove Buglist Queries from triage_owners.html</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1532406" target="_blank">1532406</a>] Removed useless trick_taint() and untaint() calls</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1530010" target="_blank">1530010</a>] Drop support for dangerous 'utf8' characterset in favor of 'utf8mb4'</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1527053" target="_blank">1527053</a>] Can't search for "video" to find all relevant bugs</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1532482" target="_blank">1532482</a>] Improve “new changes since” indicator UX</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1503483" target="_blank">1503483</a>] Convert redirects to absolute path</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1472522" target="_blank">1472522</a>] Show image, video, audio, text attachments inline</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1532409" target="_blank">1532409</a>] Introduce Bugzilla::Model (a DBIx::Class::Schema)</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1532416" target="_blank">1532416</a>] Refactor move_flag_types to use Mojolicious and DBIx::Class</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1477931" target="_blank">1477931</a>] Show number of review/feedback/needinfo in user autocomplete and prevent person from being added if requests are blocked</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1276471" target="_blank">1276471</a>] Document that GET /rest/bug returns a maximum of $max_search_results bugs by default (default: 10000) even with limit=0</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1391439" target="_blank">1391439</a>] Add ability to capture and attach a screenshot through the Bugzilla UI</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1507812" target="_blank">1507812</a>] merge_user.pl should not continue if the old user id has an account in Phabricator</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1532766" target="_blank">1532766</a>] Make the the application root a static, cache-friendly redirect to /home</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1497721" target="_blank">1497721</a>] rest/bug/ API redirects when number of ids in query string is &gt;= 900</li>
</ul>
discuss these changes on <a href="https://lists.mozilla.org/listinfo/tools-bmo" target="_blank">mozilla.tools.bmo</a>.
