### PR TITLE
Bug 1531757 - Allow to search only in bug description (comment 0) with both Quick and Advenced Search as well as API

### DIFF
--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -2667,6 +2667,12 @@ sub _long_desc_nonchanged {
   };
   $self->_do_operator_function($join_args);
 
+  # Allow to search only in bug description (initial comment)
+  if ($self->_params->{longdesc_initial}) {
+    $join_args->{term}
+      .= ($join_args->{term} ? " AND " : "") . "$table.bug_when = bugs.creation_ts";
+  }
+
   # If the user is not part of the insiders group, they cannot see
   # private comments
   if (!$self->_user->is_insider) {

--- a/Bugzilla/Search/Quicksearch.pm
+++ b/Bugzilla/Search/Quicksearch.pm
@@ -131,7 +131,8 @@ use constant COMPONENT_EXCEPTIONS => (
 );
 
 # Quicksearch-wide globals for boolean charts.
-our ($chart, $and, $or, $fulltext, $bug_status_set, $bug_product_set, $ELASTIC);
+our ($chart, $and, $or, $longdesc_initial, $fulltext, $bug_status_set,
+     $bug_product_set, $ELASTIC);
 
 sub quicksearch {
   my ($searchstring) = (@_);
@@ -195,6 +196,12 @@ sub quicksearch {
             {operators => ['NOT', $word], quicksearch => $searchstring});
         }
         unshift(@words, "-$word");
+      }
+
+      # --description and ++description disable or enable description searching
+      elsif ($word =~ /^(--|\+\+)description?$/i) {
+        $longdesc_initial = $1 eq '--' ? 0 : 1;
+        $cgi->param('longdesc_initial', $longdesc_initial);
       }
 
       # --comment and ++comment disable or enable fulltext searching
@@ -387,6 +394,8 @@ sub _handle_special_first_chars {
 
   if ($firstChar eq '#') {
     addChart('short_desc', 'substring', $baseWord, $negate);
+    addChart('longdesc',   'substring', $baseWord, $negate)
+      if $longdesc_initial;
     addChart('content', 'matches', _matches_phrase($baseWord), $negate)
       if $fulltext;
     return 1;
@@ -605,7 +614,8 @@ sub _default_quicksearch_word {
   addChart('alias',             'substring', $word, $negate);
   addChart('short_desc',        'substring', $word, $negate);
   addChart('status_whiteboard', 'substring', $word, $negate);
-  addChart('longdesc',          'substring', $word, $negate) if $ELASTIC;
+  addChart('longdesc',          'substring', $word, $negate)
+    if $longdesc_initial || $ELASTIC;
   addChart('content', 'matches', _matches_phrase($word), $negate)
     if $fulltext && !$ELASTIC;
 

--- a/docs/en/rst/api/core/v1/bug.rst
+++ b/docs/en/rst/api/core/v1/bug.rst
@@ -256,6 +256,7 @@ attachments          array   Each array item is an Attachment object. See
                              :ref:`rest_attachments` for details of the object.
 comments             array   Each array item is a Comment object. See
                              :ref:`rest_comments` for details of the object.
+description          string  The description (initial comment) of the bug.
 history              array   Each array item is a History object. See
                              :ref:`rest_history` for details of the object.
 tags                 array   Each array item is a tag name. Note that tags are
@@ -497,6 +498,7 @@ creator           string    The login name of the user who created the bug. You
                             can also pass this argument with the name
                             ``reporter``, for backwards compatibility with
                             older Bugzillas.
+description       string    The description (initial comment) of the bug.
 id                int       The numeric ID of the bug.
 last_change_time  datetime  Searches for bugs that were modified at this time
                             or later. May not be an array.
@@ -635,9 +637,9 @@ name                type     description
 **summary**         string   A brief description of the bug being filed.
 **version**         string   A version of the product above; the version the
                              bug was found in.
-description         string   (defaulted) The initial description for this bug.
-                             Some Bugzilla installations require this to not be
-                             blank.
+description         string   (defaulted) The description (initial comment) of the
+                             bug. Some Bugzilla installations require this to not
+                             be blank.
 op_sys              string   (defaulted) The operating system the bug was
                              discovered on.
 platform            string   (defaulted) What type of hardware the bug was

--- a/template/en/default/pages/quicksearch.html.tmpl
+++ b/template/en/default/pages/quicksearch.html.tmpl
@@ -361,8 +361,10 @@
       <td class="field_name">Comment Searching</td>
       <td class="field_nickname">
         Allows overriding of the comment searching preference.<br>
-        "<strong>++comments</strong>" will always enable comment searching.<br>
-        "<strong>--comments</strong>" will always disable searching.<br>
+        "<strong>++comments</strong>" enables full-text search (all comments, slow)<br>
+        "<strong>--comments</strong>" disables full-text search<br>
+        "<strong>++description</strong>" enables description search (initial comment only)<br>
+        "<strong>--description</strong>" disables description search<br>
       </td>
     </tr>
     [% IF Param('usestatuswhiteboard') %]

--- a/template/en/default/search/form.html.tmpl
+++ b/template/en/default/search/form.html.tmpl
@@ -233,6 +233,10 @@ TUI_hide_default('information_query');
           value => default.${field_container.field.name}.0
           type_selected => default.$type.0
       %]
+      [% IF field_container.field.name == 'longdesc' %]
+        <label><input type="checkbox" name="longdesc_initial" value="1"
+          [%- " checked" IF default.longdesc_initial.0 == "1" %]> Description (initial comment) only</label>
+      [% END %]
     </div>
   [% END %]
 


### PR DESCRIPTION
* Add a checkbox to the Advanced Search page, which allows to search only in bug description (initial comment)
* Add the `++description` shortcut for Quick Search that enables description search
* Add the `description` field to the [Get Bug API](https://bmo.readthedocs.io/en/latest/api/core/v1/bug.html#get-bug). Unlike #670,
    * It returns comment body text, not a comment object
    * It requires `description` or `_extra` in `include_fields`
* Add the `description` field to the [Search Bugs API](https://bmo.readthedocs.io/en/latest/api/core/v1/bug.html#search-bugs), which also allows to search only in bug description
* Update the docs

## Bugzilla link

[Bug 1531757 - Allow to search only in bug description (comment 0) with both Quick and Advenced Search as well as API](https://bugzilla.mozilla.org/show_bug.cgi?id=1531757)