### PR TITLE
Bug 1535075 - Change sort key for Priority so P1 will be first when sorting bugs

### DIFF
--- a/scripts/generate_bmo_data.pl
+++ b/scripts/generate_bmo_data.pl
@@ -78,20 +78,21 @@ foreach my $pref (keys %user_prefs) {
 ############################################################
 
 my @priorities = qw(
-  --
   P1
   P2
   P3
   P4
   P5
+  --
 );
 
 if (!$dbh->selectrow_array("SELECT 1 FROM priority WHERE value = 'P1'")) {
   $dbh->do("DELETE FROM priority");
-  my $count = 100;
+  my $count = 1;
   foreach my $priority (@priorities) {
     $dbh->do("INSERT INTO priority (value, sortkey) VALUES (?, ?)",
-      undef, ($priority, $count + 100));
+      undef, ($priority, $count));
+    $count++;
   }
 }
 


### PR DESCRIPTION
Update the Primary field sort key in the BMO data generation script to make P1 the highest. BMO production has already been updated by Emma through the admin page.

## Bugzilla link

[Bug 1535075 - Change sort key for Priority so P1 will be first when sorting bugs](https://bugzilla.mozilla.org/show_bug.cgi?id=1535075)