### PR TITLE
Bug 1477931 follow-up - Make sure Gravatar and requests are loaded via API

### DIFF
--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -187,10 +187,8 @@ sub suggest {
     name      => $self->type(email  => $_->{name}),
   } } @$results;
 
-  unless ($params->{fast_mode}) {
-    Bugzilla::Hook::process('webservice_user_suggest',
-      {webservice => $self, params => $params, users => \@users});
-  }
+  Bugzilla::Hook::process('webservice_user_suggest',
+    {webservice => $self, params => $params, users => \@users});
 
   return {users => \@users};
 }

--- a/js/field.js
+++ b/js/field.js
@@ -715,7 +715,6 @@ $(function() {
         serviceUrl: `${BUGZILLA.config.basepath}rest/user/suggest`,
         params: {
             Bugzilla_api_token: BUGZILLA.api_token,
-            fast_mode: 1
         },
         paramName: 'match',
         deferRequestBy: 250,

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -1027,7 +1027,8 @@ input.required, select.required, span.required_explanation {
 }
 
 .autocomplete-suggestion [itemtype] > span:first-of-type,
-.autocomplete-suggestion [itemtype] > span:empty {
+.autocomplete-suggestion [itemtype] > span:empty,
+.autocomplete-suggestion [itemtype] > span:empty + span {
     margin-left: 0;
 }
 

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -1039,6 +1039,12 @@ input.required, select.required, span.required_explanation {
     height: 20px;
 }
 
+.autocomplete-suggestion [itemprop="name"] {
+    overflow: hidden;
+    max-width: 20em;
+    text-overflow: ellipsis;
+}
+
 .autocomplete-suggestion [itemtype] .minor {
     opacity: .7;
     font-size: 13px;


### PR DESCRIPTION
Revert #946 so the enhanced user autocomplete added in #684 can load both `gravatar` and `requests` via `/user/suggest` API. Both fields are provided by an extension, so the feature doesn’t work without this backout. I don’t see any performance difference on my local server with a production DB snapshot.

## Bugzilla link

[Bug 1477931 - Show number of review/feedback/needinfo in user autocomplete and prevent person from being added if requests are blocked](https://bugzilla.mozilla.org/show_bug.cgi?id=1477931)