### PR TITLE
Bug 994896 - Add the ability to get comments, attachments, and history using Bug.get

### DIFF
--- a/docs/en/rst/api/core/v1/bug.rst
+++ b/docs/en/rst/api/core/v1/bug.rst
@@ -246,6 +246,12 @@ These fields are returned only by specifying ``_extra`` or the field name in
 ===================  ======  ====================================================
 name                 type    description
 ===================  ======  ====================================================
+attachments          array   Each array item is an Attachment object. See
+                             :ref:`rest_attachments` for details of the object.
+comments             array   Each array item is a Comment object. See
+                             :ref:`rest_comments` for details of the object.
+history              array   Each array item is a History object. See
+                             :ref:`rest_history` for details of the object.
 tags                 array   Each array item is a tag name. Note that tags are
                              personal to the currently logged in user and are not
                              the same as comment tags.

--- a/docs/en/rst/api/core/v1/comment.rst
+++ b/docs/en/rst/api/core/v1/comment.rst
@@ -86,7 +86,10 @@ attachment_id  int       If the comment was made on an attachment, this will be
                          the ID of that attachment. Otherwise it will be null.
 count          int       The number of the comment local to the bug. The
                          Description is 0, comments start with 1.
-text           string    The actual text of the comment.
+text           string    The body of the comment, including any special text
+                         (such as "this bug was marked as a duplicate of...").
+raw_text       string    The body of the comment without any special additional
+                         text.
 creator        string    The login name of the comment's author.
 time           datetime  The time (in Bugzilla's timezone) that the comment was
                          added.

--- a/extensions/EditComments/Extension.pm
+++ b/extensions/EditComments/Extension.pm
@@ -102,21 +102,6 @@ BEGIN {
   no warnings 'redefine';
   *Bugzilla::Comment::activity   = \&_get_activity;
   *Bugzilla::Comment::edit_count = \&_edit_count;
-  *Bugzilla::WebService::Bug::_super_translate_comment
-    = \&Bugzilla::WebService::Bug::_translate_comment;
-  *Bugzilla::WebService::Bug::_translate_comment = \&_new_translate_comment;
-}
-
-sub _new_translate_comment {
-  my ($self, $comment, $filters) = @_;
-
-  my $comment_hash = $self->_super_translate_comment($comment, $filters);
-
-  if (filter_wants $filters, 'raw_text') {
-    $comment_hash->{raw_text} = $self->type('string', $comment->body);
-  }
-
-  return $comment_hash;
 }
 
 sub _edit_count { return $_[0]->{'edit_count'}; }

--- a/extensions/EditComments/Extension.pm
+++ b/extensions/EditComments/Extension.pm
@@ -18,7 +18,6 @@ use Bugzilla::Util;
 use Bugzilla::Error;
 use Bugzilla::Config::Common;
 use Bugzilla::Config::GroupSecurity;
-use Bugzilla::WebService::Bug;
 
 our $VERSION = '1.0';
 

--- a/extensions/EditComments/Extension.pm
+++ b/extensions/EditComments/Extension.pm
@@ -19,7 +19,6 @@ use Bugzilla::Error;
 use Bugzilla::Config::Common;
 use Bugzilla::Config::GroupSecurity;
 use Bugzilla::WebService::Bug;
-use Bugzilla::WebService::Util qw(filter_wants);
 
 our $VERSION = '1.0';
 


### PR DESCRIPTION
* Allow to retrieve comments, attachments and history at once with `/rest/bug/[ID]?include_fields=attachments,comments,history`, just like the legacy BzAPI.
* Moved the Comment object’s `raw_text` field from the EditComments extension to core, so `/rest/bug/[ID/comment` and `/rest/bug/[ID]?include_fields=comments` will be consistent. Otherwise it would require an explicit field option like `/rest/bug/[ID]?include_fields=comments,raw_text`.
* Update relevant docs.

## Bugzilla link

[Bug 994896 - Add the ability to get comments, attachments, and history using Bug.get](https://bugzilla.mozilla.org/show_bug.cgi?id=994896)