### PR TITLE
Bug 1453272 - Don't set specifically requestable flags, including needinfo, when it's empty

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -810,10 +810,11 @@ $(function() {
             var id = target.prop('id').replace(/^flag(_type)?-(\d+)/, "#requestee$1-$2");
             if (target.val() == '?') {
                 $(id + '-container').show();
-                $(id).focus().select();
+                $(id).focus().select().prop('required', true);
             }
             else {
                 $(id + '-container').hide();
+                $(id).prop('required', false);
             }
         });
 

--- a/js/flag.js
+++ b/js/flag.js
@@ -38,9 +38,12 @@ function toggleRequesteeField(flagField, no_focus)
   // of the flag field.
   if (flagField.value == "?") {
       YAHOO.util.Dom.removeClass(requesteeField.parentNode, 'bz_default_hidden');
+      requesteeField.required = true;
       if (!no_focus) requesteeField.focus();
-  } else
+  } else {
       YAHOO.util.Dom.addClass(requesteeField.parentNode, 'bz_default_hidden');
+      requesteeField.required = false;
+  }
 }
 
 // Hides requestee fields when the window is loaded since they shouldn't

--- a/qa/t/test_flags.t
+++ b/qa/t/test_flags.t
@@ -270,8 +270,11 @@ ok(
 # the MTA.
 
 $sel->select_ok("flag_type-$flagtype1_id", "label=?");
+$sel->type_ok("requestee_type-$flagtype1_id", "test@bugzilla.test");
 $sel->select_ok("flag_type-$flagtype2_id", "label=?");
+$sel->type_ok("requestee_type-$flagtype2_id", "test@bugzilla.test");
 $sel->select_ok("flag_type-$flagtype3_id", "label=?");
+$sel->type_ok("requestee_type-$flagtype3_id", "test@bugzilla.test");
 $sel->type_ok("comment", "Setting all 3 flags to ?");
 $sel->click_ok("commit");
 $sel->wait_for_page_to_load_ok(WAIT_TIME);

--- a/qa/t/test_flags.t
+++ b/qa/t/test_flags.t
@@ -274,7 +274,6 @@ $sel->type_ok("requestee_type-$flagtype1_id", $config->{admin_user_login});
 $sel->select_ok("flag_type-$flagtype2_id", "label=?");
 $sel->type_ok("requestee_type-$flagtype2_id", $config->{admin_user_login});
 $sel->select_ok("flag_type-$flagtype3_id", "label=?");
-$sel->type_ok("requestee_type-$flagtype3_id", $config->{admin_user_login});
 $sel->type_ok("comment", "Setting all 3 flags to ?");
 $sel->click_ok("commit");
 $sel->wait_for_page_to_load_ok(WAIT_TIME);
@@ -362,9 +361,7 @@ ok(
 # Let's generate some "flagmail", first with no requestee.
 
 $sel->select_ok("flag_type-$aflagtype1_id", "label=?");
-$sel->type_ok("requestee_type-$flagtype1_id", $config->{admin_user_login});
 $sel->select_ok("flag_type-$aflagtype2_id", "label=?");
-$sel->type_ok("requestee_type-$flagtype2_id", $config->{admin_user_login});
 $sel->type_ok("comment", "patch for testing purposes only");
 $sel->click_ok("create");
 $sel->wait_for_page_to_load_ok(WAIT_TIME);

--- a/qa/t/test_flags.t
+++ b/qa/t/test_flags.t
@@ -270,11 +270,11 @@ ok(
 # the MTA.
 
 $sel->select_ok("flag_type-$flagtype1_id", "label=?");
-$sel->type_ok("requestee_type-$flagtype1_id", "test@bugzilla.test");
+$sel->type_ok("requestee_type-$flagtype1_id", $config->{admin_user_login});
 $sel->select_ok("flag_type-$flagtype2_id", "label=?");
-$sel->type_ok("requestee_type-$flagtype2_id", "test@bugzilla.test");
+$sel->type_ok("requestee_type-$flagtype2_id", $config->{admin_user_login});
 $sel->select_ok("flag_type-$flagtype3_id", "label=?");
-$sel->type_ok("requestee_type-$flagtype3_id", "test@bugzilla.test");
+$sel->type_ok("requestee_type-$flagtype3_id", $config->{admin_user_login});
 $sel->type_ok("comment", "Setting all 3 flags to ?");
 $sel->click_ok("commit");
 $sel->wait_for_page_to_load_ok(WAIT_TIME);
@@ -362,7 +362,9 @@ ok(
 # Let's generate some "flagmail", first with no requestee.
 
 $sel->select_ok("flag_type-$aflagtype1_id", "label=?");
+$sel->type_ok("requestee_type-$flagtype1_id", $config->{admin_user_login});
 $sel->select_ok("flag_type-$aflagtype2_id", "label=?");
+$sel->type_ok("requestee_type-$flagtype2_id", $config->{admin_user_login});
 $sel->type_ok("comment", "patch for testing purposes only");
 $sel->click_ok("create");
 $sel->wait_for_page_to_load_ok(WAIT_TIME);

--- a/qa/t/test_flags.t
+++ b/qa/t/test_flags.t
@@ -358,10 +358,12 @@ ok(
   "Inactive SeleniumAttachmentFlag3Test flag type not displayed"
 );
 
-# Let's generate some "flagmail", first with no requestee.
+# Let's generate some "flagmail" first.
 
 $sel->select_ok("flag_type-$aflagtype1_id", "label=?");
+$sel->type_ok("requestee_type-$aflagtype1_id", $config->{admin_user_login});
 $sel->select_ok("flag_type-$aflagtype2_id", "label=?");
+$sel->type_ok("requestee_type-$aflagtype2_id", $config->{admin_user_login});
 $sel->type_ok("comment", "patch for testing purposes only");
 $sel->click_ok("create");
 $sel->wait_for_page_to_load_ok(WAIT_TIME);

--- a/qa/t/test_flags2.t
+++ b/qa/t/test_flags2.t
@@ -229,6 +229,7 @@ $sel->select_ok("component", "label=c1");
 $sel->is_editable_ok("flag_type-$flagtype1_id",
   "The selenium bug flag type is not selectable");
 $sel->select_ok("flag_type-$flagtype1_id", "label=?");
+$sel->type_ok("requestee_type-$flagtype1_id", $config->{admin_user_login});
 $sel->type_ok("short_desc", "Create a new selenium flag for c2");
 $sel->type_ok("comment",    ".");
 $sel->click_ok("commit");


### PR DESCRIPTION
When `needinfo` or any other “specifically requestable” flag is changed to `?`, make the corresponding requestee field required.

## Bugzilla link

[Bug 1453272 - Don't set specifically requestable flags, including needinfo, when it's empty](https://bugzilla.mozilla.org/show_bug.cgi?id=1453272)