### PR TITLE
Bug 1535498 - Go directly to the blocklisting form when selecting blocklist policy requests on the enter_bug page.

### DIFF
--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -2344,7 +2344,7 @@ sub enter_bug_start {
       $cgi->param('format_forced', 1);
     }
   }
-  elsif (my $format = forced_format($cgi->param('product'))) {
+  elsif (my $format = forced_format($cgi->param('product'), $cgi->param('component'))) {
     $cgi->param('format', $format);
   }
 
@@ -2389,7 +2389,7 @@ sub _map_groups {
 sub forced_format {
 
   # note: this is also called from the guided bug entry extension
-  my ($product) = @_;
+  my ($product, $component) = @_;
   return undef unless defined $product;
 
   # always work on the correct product name
@@ -2399,6 +2399,9 @@ sub forced_format {
 
   # check for a forced-format entry
   my $forced = $create_bug_formats{$product->name} || return;
+
+  # check if the form is component-specific
+  return if $forced->{component} && $forced->{component} ne $component;
 
   # should this user be included?
   my $user = Bugzilla->user;

--- a/extensions/BMO/lib/Data.pm
+++ b/extensions/BMO/lib/Data.pm
@@ -267,6 +267,8 @@ our %create_bug_formats = (
   'developer.mozilla.org' => {'format' => 'mdn',        'include' => 'everyone',},
   'Legal'                 => {'format' => 'legal',      'include' => 'everyone',},
   'Recruiting'            => {'format' => 'recruiting', 'include' => 'everyone',},
+  'Toolkit'               => {'component' => 'Blocklist Policy Requests',
+                              'format' => 'blocklist', 'include' => 'everyone',},
   'Internet Public Policy' => {'format' => 'ipp', 'include' => 'everyone',},
 );
 

--- a/extensions/BMO/template/en/default/bug/create/create-blocklist.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-blocklist.html.tmpl
@@ -46,6 +46,18 @@
 #blocklist_form.noscript {
   display: none;
 }
+
+#standard_link {
+  margin-top: 2em;
+}
+
+#standard_link img {
+  vertical-align: middle;
+}
+
+#standard_link a {
+  cursor: pointer;
+}
 [% END %]
 
 [% inline_javascript = BLOCK %]
@@ -101,6 +113,12 @@ function validateAndSubmit() {
 
 window.addEventListener("DOMContentLoaded", function() {
   document.getElementById("blocklist_form").classList.remove("noscript");
+
+  const canonical_path = `${BUGZILLA.config.basepath}form.blocklist`;
+
+  if (location.pathname != canonical_path) {
+    history.replaceState(null, document.title, canonical_path);
+  }
 });
 
 [% END %]
@@ -227,5 +245,12 @@ window.addEventListener("DOMContentLoaded", function() {
 <noscript>
   This form requires JavaScript to be enabled.
 </noscript>
+
+<div id="standard_link">
+  <a href="[% basepath FILTER none %]enter_bug.cgi?product=Toolkit&amp;component=Blocklist%20Policy%20Requests&amp;format=__standard__">
+    <img src="[% basepath FILTER none %]extensions/BMO/web/images/advanced.png" width="16" height="16" border="0">
+    Switch to the standard [% terms.bug %] entry form</a>
+  </a>
+</div>
 
 [% PROCESS global/footer.html.tmpl %]

--- a/extensions/BMO/template/en/default/bug/create/create-blocklist.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-blocklist.html.tmpl
@@ -116,7 +116,7 @@ window.addEventListener("DOMContentLoaded", function() {
 
   const canonical_path = `${BUGZILLA.config.basepath}form.blocklist`;
 
-  if (location.pathname != canonical_path) {
+  if (location.pathname !== canonical_path) {
     history.replaceState(null, document.title, canonical_path);
   }
 });


### PR DESCRIPTION
Show the [custom blocklist form](https://bugzilla.mozilla.org/form.blocklist) when users are visiting the [Toolkit :: Blocklist Policy Requests bug report page](https://bugzilla.mozilla.org/enter_bug.cgi?product=Toolkit&component=Blocklist%20Policy%20Requests). Add a link to “Switch to the standard bug entry form” to the bottom of the page.

## Bugzilla link

[Bug 1535498 - Go directly to the blocklisting form when selecting blocklist policy requests on the enter_bug page.](https://bugzilla.mozilla.org/show_bug.cgi?id=1535498)