### PR TITLE
Bug 1535191 - Can't scroll attachments in lightbox view

### DIFF
--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -1045,6 +1045,8 @@ a.lightbox-icon.markdown {
 
 #lb_overlay2 {
     position: absolute;
+    overflow: auto;
+    bottom: 0;
     left: 0px;
     width: 100%;
     text-align: center;


### PR DESCRIPTION
Let users scroll the lightbox overlay when images are larger than the viewport.

## Bugzilla link

[Bug 1535191 - Can't scroll attachments in lightbox view](https://bugzilla.mozilla.org/show_bug.cgi?id=1535191)