### PR TITLE
Bug 1462268 - Shorten bug links into "Bug X [Comment Y]" and attachment links to "Attachment Z"

### DIFF
--- a/Bugzilla/Markdown.pm
+++ b/Bugzilla/Markdown.pm
@@ -46,6 +46,9 @@ sub render_html {
   my $parser = $self->markdown_parser;
   return escape_html($markdown) unless $parser;
 
+  # Replace internal links first
+  $markdown = Bugzilla::Template::prettify_internal_links($markdown);
+
   # This makes sure we never handle > foo text in the shortcuts code.
   local $Bugzilla::Template::COLOR_QUOTES = 0;
 

--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -129,11 +129,11 @@ sub get_format {
 }
 
 sub prettify_internal_links {
-  my ($text, $bug, $comment, $user, $bug_link_func) = @_;
-  return $text unless $text;
-
+  my ($text) = @_;
   my $urlbase  = Bugzilla->localconfig->{canonical_urlbase};
   my $bug_word = template_var('terms')->{Bug};
+
+  return $text unless $text && $urlbase;
 
   # Replace full bug links with "Bug X" or "Bug X Comment Y"
   # except for quoted URLs which may be a Markdown link


### PR DESCRIPTION
Replace bare, long internal links like https://bugzilla.mozilla.org/show_bug.cgi?id=1462268 to the pretty format like [Bug 1462268](https://bugzilla.mozilla.org/show_bug.cgi?id=1462268). This only changes the rendering, so you’ll see the original link while editing the comment.

## Bugzilla link

[Bug 1462268 - Shorten bug links into “Bug X [Comment Y]” and attachment links to “Attachment Z”](https://bugzilla.mozilla.org/show_bug.cgi?id=1462268)