### PR TITLE
Bug 1286448 - Remove Splinter Review for GitHub PRs

### DIFF
--- a/extensions/Splinter/template/en/default/hook/attachment/edit-action.html.tmpl
+++ b/extensions/Splinter/template/en/default/hook/attachment/edit-action.html.tmpl
@@ -19,8 +19,7 @@
   #                 David Lawrence <dkl@mozilla.com>
   #%]
 
-[% IF attachment.ispatch
-   || (attachment.mimetype == "text/x-github-pull-request" && attachment.external_redirect) %]
+[% IF attachment.ispatch %]
   &#x0020; |
   <a href="[% Bugzilla.splinter_review_url(attachment.bug_id, attachment.id) FILTER none %]">Review</a>
 [% END %]

--- a/extensions/Splinter/template/en/default/hook/attachment/list-action.html.tmpl
+++ b/extensions/Splinter/template/en/default/hook/attachment/list-action.html.tmpl
@@ -19,8 +19,7 @@
   #                 David Lawrence <dkl@mozilla.com>
   #%]
 
-[% IF attachment.ispatch
-   || (attachment.mimetype == "text/x-github-pull-request" && attachment.can_review) %]
+[% IF attachment.ispatch %]
   &#x0020; |
   <a href="[% Bugzilla.splinter_review_url(bugid, attachment.id) FILTER none %]">Splinter Review</a>
 [% END %]

--- a/extensions/Splinter/template/en/default/pages/splinter.html.tmpl
+++ b/extensions/Splinter/template/en/default/pages/splinter.html.tmpl
@@ -79,7 +79,7 @@
 
     [% FOREACH attachment = bug.attachments %]
       [% NEXT IF attachment.isprivate && !user.is_insider && attachment.attacher.id != user.id %]
-      [% NEXT IF !attachment.ispatch && !(attachment.mimetype == "text/x-github-pull-request" && attachment.external_redirect) %]
+      [% NEXT UNLESS attachment.ispatch %]
       var attachid = parseInt('[% attachment.id FILTER js %]');
       var attachment = new Splinter.Bug.Attachment('', attachid);
       [% IF attachment.id == attach_id %]
@@ -94,7 +94,7 @@
       attachment.date = Splinter.Bug.parseDate('[% attachment.attached FILTER time("%Y-%m-%d %T %z") FILTER js %]');
       attachment.whoName = Splinter.Utils.strip('[% attachment.attacher.name FILTER js %]');
       attachment.whoEmail = Splinter.Utils.strip('[% attachment.attacher.email FILTER js %]');
-      attachment.isPatch = [% attachment.ispatch || (attachment.mimetype == "text/x-github-pull-request" && attachment.external_redirect) ? 1 : 0 %];
+      attachment.isPatch = [% attachment.ispatch ? 1 : 0 %];
       attachment.isObsolete = [% attachment.isobsolete ? 1 : 0 %];
       attachment.isPrivate = [% attachment.isprivate ? 1 : 0 %];
       attachment.isCRLF = [% attach_is_crlf ? 1 : 0 %];


### PR DESCRIPTION
Remove the Splinter Review support for GitHub pull requests, which are currently showing “ Splinter Review” link on the attachment list.

## Bugzilla link

[Bug 1286448 - Remove Splinter Review for GitHub PRs](https://bugzilla.mozilla.org/show_bug.cgi?id=1286448)