### PR TITLE
Bug 1535723 - Don't show inline attachments for bugs that have the keywords "hang", "assertion", or "crash"

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -94,7 +94,8 @@
 [% END %]
 
 [% BLOCK comment_header %]
-  <div class="comment" data-id="[% comment.id FILTER none %]" data-no="[% comment.count FILTER none %]">
+  <div class="comment" data-id="[% comment.id FILTER none %]" data-no="[% comment.count FILTER none %]"
+       data-tags="[% comment.tags.join(' ') FILTER html %]">
     [%# normal comment header %]
     <table class="layout-table change-head [% extra_class FILTER none %]" id="ch-[% comment.count FILTER none %]"
       [% IF comment.collapsed +%] style="display:none"[% END %]>

--- a/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
@@ -92,7 +92,7 @@
   BUGZILLA.bug_title = '[% unfiltered_title FILTER js %]';
   BUGZILLA.bug_summary = '[% bug.short_desc FILTER js %]';
   BUGZILLA.bug_url = '[% Bugzilla.localconfig.canonical_urlbase _ "show_bug.cgi?id=" _ bug.id FILTER js %]';
-  BUGZILLA.bug_keywords = '[% bug.keywords %]',
+  BUGZILLA.bug_keywords = '[% bug.keywords FILTER js %]',
   BUGZILLA.user = {
     id: [% user.id FILTER none %],
     login: '[% user.login FILTER js %]',

--- a/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
@@ -92,6 +92,7 @@
   BUGZILLA.bug_title = '[% unfiltered_title FILTER js %]';
   BUGZILLA.bug_summary = '[% bug.short_desc FILTER js %]';
   BUGZILLA.bug_url = '[% Bugzilla.localconfig.canonical_urlbase _ "show_bug.cgi?id=" _ bug.id FILTER js %]';
+  BUGZILLA.bug_keywords = '[% bug.keywords %]',
   BUGZILLA.user = {
     id: [% user.id FILTER none %],
     login: '[% user.login FILTER js %]',

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -802,10 +802,6 @@ h3.change-name {
     max-width: 426px;
 }
 
-.change-set .attachment [content="image/svg+xml"] ~ .outer img {
-    width: 426px;
-}
-
 .change-set .attachment pre {
     position: relative;
     overflow: hidden;

--- a/extensions/BugModal/web/comments.js
+++ b/extensions/BugModal/web/comments.js
@@ -544,8 +544,10 @@ Bugzilla.BugModal.Comments = class Comments {
       const $comment = $set.querySelector('.comment:not([data-tags~="hide-attachment"])');
       // Skip if the attachment is obsolete or deleted
       const $attachment = $set.querySelector('.attachment:not(.obsolete):not(.deleted)');
+      // Skip if the attachment is SVG image
+      const is_svg = !!$set.querySelector('.attachment [itemprop="encodingFormat"][content="image/svg+xml"]');
 
-      if ($comment && $attachment) {
+      if ($comment && $attachment && !is_svg) {
         observer.observe($attachment);
       }
     });

--- a/extensions/BugModal/web/comments.js
+++ b/extensions/BugModal/web/comments.js
@@ -320,6 +320,7 @@ $(function() {
             root.append(span);
         });
         $('#ctag-' + commentNo + ' .comment-tags').append($('#ctag-error'));
+        $(`.comment[data-no="${commentNo}"]`).attr('data-tags', tags.join(' '));
     }
 
     var refreshXHR;
@@ -522,9 +523,10 @@ Bugzilla.BugModal.Comments = class Comments {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/Network_Information_API
    */
   prepare_inline_attachments() {
-    // Check the user setting, API support and connectivity
-    if (!BUGZILLA.user.settings.inline_attachments || typeof IntersectionObserver !== 'function' ||
-        (navigator.connection && navigator.connection.type === 'cellular')) {
+    // Check the connectivity, API support, user setting and sensitive keywords
+    if ((navigator.connection && navigator.connection.type === 'cellular') ||
+        typeof IntersectionObserver !== 'function' || !BUGZILLA.user.settings.inline_attachments ||
+        BUGZILLA.bug_keywords.split(', ').find(keyword => keyword.match(/^(hang|assertion|crash)$/))) {
       return;
     }
 
@@ -537,9 +539,16 @@ Bugzilla.BugModal.Comments = class Comments {
       }
     }), { root: document.querySelector('#bugzilla-body') });
 
-    // Show attachments except for obsolete or deleted ones
-    document.querySelectorAll('.change-set .attachment:not(.obsolete):not(.deleted)')
-      .forEach($att => observer.observe($att));
+    document.querySelectorAll('.change-set').forEach($set => {
+      // Skip if the comment has the `hide-attachment` tag
+      const $comment = $set.querySelector('.comment:not([data-tags~="hide-attachment"])');
+      // Skip if the attachment is obsolete or deleted
+      const $attachment = $set.querySelector('.attachment:not(.obsolete):not(.deleted)');
+
+      if ($comment && $attachment) {
+        observer.observe($attachment);
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
Hide inline attachments if the bug has any of sensitive keywords or the comment has `hide-attachment` tag, because some images are known to hang the browser.

## Bugzilla link

[Bug 1535723 - Don't show inline attachments for bugs that have the keywords "hang", "assertion", or "crash"](https://bugzilla.mozilla.org/show_bug.cgi?id=1535723)