### PR TITLE
Bug 1527841 - Add ability to search for bugs where assignee or needinfo’d people have last seen gt/lt X

### DIFF
--- a/Bugzilla/Hook.pm
+++ b/Bugzilla/Hook.pm
@@ -533,6 +533,25 @@ The hash of changed fields. C<< $changes->{field} = [old, new] >>
 
 =back
 
+=head2 buglist_special_parsing
+
+This happens in L<Bugzilla::Search/SPECIAL_PARSING>, which defines special
+parsing methods for user input, such as relative date formats or user pronouns.
+
+Params:
+
+=over
+
+=item C<parsers> - A hashref, where the keys are unique string identifiers
+for the column being defined and the values is an arbitrary parser method.
+This example allows to accept a relative date:
+
+ $parsers->{$id} = \&Bugzilla::Search::_date_translate;
+
+Use built-in parsers as a reference if you need to implement a custom one.
+
+=back
+
 =head2 buglist_columns
 
 This happens in L<Bugzilla::Search/COLUMNS>, which determines legal bug

--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -393,6 +393,9 @@ sub SPECIAL_PARSING {
       $map->{$field->name} = \&_date_translate;
     }
   }
+
+  Bugzilla::Hook::process('buglist_special_parsing', {parsers => \%$map});
+
   return $map;
 }
 

--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -1694,6 +1694,13 @@ sub _user_to_hash {
     email     => $self->type('email',  $user->email),
     },
     $types, $prefix;
+
+  # Add the `last_activity` field currently implemented in the UserProfile
+  # extension, if the user is logged in. TODO: move it to the core.
+  if (Bugzilla->user->id && $user->last_activity_ts) {
+    $item->{last_activity} = $self->type('dateTime', $user->last_activity_ts),
+  }
+
   return $item;
 }
 

--- a/extensions/BugmailFilter/lib/Constants.pm
+++ b/extensions/BugmailFilter/lib/Constants.pm
@@ -34,6 +34,7 @@ use constant FAKE_FIELD_NAMES => [
 
 use constant IGNORE_FIELDS => qw(
   assignee_last_login
+  assignee_last_seen
   attach_data.thedata
   attachments.count
   attachments.submitter
@@ -52,6 +53,8 @@ use constant IGNORE_FIELDS => qw(
   last_visit_ts
   longdesc
   longdescs.count
+  needinfo
+  needinfo_last_seen
   owner_idle_time
   regressed_by.count
   regresses.count

--- a/extensions/Needinfo/template/en/default/hook/global/field-descs-end.none.tmpl
+++ b/extensions/Needinfo/template/en/default/hook/global/field-descs-end.none.tmpl
@@ -1,0 +1,11 @@
+[%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  #
+  # This Source Code Form is "Incompatible With Secondary Licenses", as
+  # defined by the Mozilla Public License, v. 2.0.
+  #%]
+
+[% IF in_template_var %]
+  [% vars.field_descs.needinfo = "Needinfo" %]
+[% END %]

--- a/extensions/UserProfile/template/en/default/hook/global/field-descs-end.none.tmpl
+++ b/extensions/UserProfile/template/en/default/hook/global/field-descs-end.none.tmpl
@@ -1,0 +1,12 @@
+[%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  #
+  # This Source Code Form is "Incompatible With Secondary Licenses", as
+  # defined by the Mozilla Public License, v. 2.0.
+  #%]
+
+[% IF in_template_var %]
+  [% vars.field_descs.assignee_last_seen = "Assignee Last Seen Date" %]
+  [% vars.field_descs.needinfo_last_seen = "Needinfo Last Seen Date" %]
+[% END %]


### PR DESCRIPTION
Add new `assignee_last_seen`, `needinfo` and `needinfo_last_seen` fields to let people search bugs based on assignee or needinfo’d user’s last activity. A typical custom search criteria will be:

* Needinfo / is not empty
* Needinfo Last Seen Date / is less than / -2y

## Bugzilla link

[Bug 1527841 - Add ability to search for bugs where assignee or needinfo’d people have last seen gt/lt X](https://bugzilla.mozilla.org/show_bug.cgi?id=1527841)