### PR TITLE
bump version to 20190318.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20190312.1';
+our $VERSION = '20190318.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
We need to fix #1155 to avoid browser hangs due to certain SVG images. A potential ride-along: #1147 that solves a [bit confusing UI](https://bugzilla.mozilla.org/show_bug.cgi?id=1478901#c3).