### PR TITLE
Bug 1536279 - Sort suggested users by last seen date, not last login date

### DIFF
--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -145,7 +145,7 @@ sub suggest {
 
   my $dbh    = Bugzilla->dbh;
   my @select = ('userid AS id', 'realname AS real_name', 'login_name AS name');
-  my $order  = 'last_seen_date DESC';
+  my $order  = 'last_activity_ts DESC';
   my $where;
   state $have_mysql = $dbh->isa('Bugzilla::DB::Mysql');
 


### PR DESCRIPTION
So the most active users will be at the top of the list.

## Bugzilla link

[Bug 1536279 - Sort suggested users by last seen date, not last login date](https://bugzilla.mozilla.org/show_bug.cgi?id=1536279)