### PR TITLE
Bug 1513956 - The summary in the history contains additional white spaces

### DIFF
--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -4638,7 +4638,7 @@ sub _join_activity_entries {
     return $current_change . $new_change;
   }
   else {
-    return $current_change . ' ' . $new_change;
+    return $current_change . ($current_change && $new_change ? ' ' : '') . $new_change;
   }
 }
 


### PR DESCRIPTION
Remove an extra space from bug activities, which could be seen when the change set is corrupted.