### PR TITLE
Bug 1537012 - Add creator_detail field to Get Attachment API

### DIFF
--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -1647,9 +1647,8 @@ sub _attachment_to_hash {
   }
 
   if (filter_wants $filters, 'creator', $types, $prefix) {
-    $item->{'creator_detail'} = $self->_user_to_hash(
-      Bugzilla::User->new({name => $attach->attacher->login, cache => 1}),
-      $filters, undef, 'creator');
+    $item->{'creator_detail'}
+      = $self->_user_to_hash($attach->attacher, $filters, undef, 'creator');
   }
 
   if (filter_wants $filters, 'data', $types, $prefix) {

--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -1646,6 +1646,12 @@ sub _attachment_to_hash {
     }
   }
 
+  if (filter_wants $filters, 'creator', $types, $prefix) {
+    $item->{'creator_detail'} = $self->_user_to_hash(
+      Bugzilla::User->new({name => $attach->attacher->login, cache => 1}),
+      $filters, undef, 'creator');
+  }
+
   if (filter_wants $filters, 'data', $types, $prefix) {
     $item->{'data'} = $self->type('base64', $attach->data);
   }
@@ -2331,6 +2337,12 @@ Also returned as C<attacher>, for backwards-compatibility with older
 Bugzillas. (However, this backwards-compatibility will go away in Bugzilla
 5.0.)
 
+=item C<creator_detail>
+
+C<hash> A hash containing detailed user information for the creator. The keys
+included in the user detail hash are the same as ones returned for the Get Bug
+method.
+
 =item C<flags>
 
 An array of hashes containing the information about flags currently set
@@ -2412,6 +2424,8 @@ C<summary>.
 =item The C<flags> array was added in Bugzilla B<4.4>.
 
 =item REST API call added in Bugzilla B<5.0>.
+
+=item The C<creator_detail> field was added in Bugzilla B<6.0>.
 
 =back
 

--- a/docs/en/rst/api/core/v1/attachment.rst
+++ b/docs/en/rst/api/core/v1/attachment.rst
@@ -92,6 +92,9 @@ is_patch          boolean   ``true`` if the attachment is a patch, ``false``
                             otherwise.
 creator           string    The login name of the user that created the
                             attachment.
+creator_detail    object    An object containing detailed user information for
+                            the creator. To see the keys included in the user
+                            detail object, see :ref:`rest_single_bug`.
 flags             array     Array of objects, each containing the information
                             about the flag currently set for each attachment.
                             Each flag object contains items descibed in the


### PR DESCRIPTION
Add `creator_detail` to [/rest/bug/(id)/attachment](https://bmo.readthedocs.io/en/latest/api/core/v1/attachment.html#get-attachment) like `creator_detail` in [/rest/bug/(id)](https://bmo.readthedocs.io/en/latest/api/core/v1/bug.html#get-bug). We don’t need `attacher_detail` because `attacher` is an alias for backward compatibility.