### PR TITLE
Bug 1514000 - Suppress duplicated changes in bug history made at the same time mainly due to mid-air collisions

### DIFF
--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -4461,7 +4461,7 @@ sub GetBugActivity {
     $suppwhere = "AND COALESCE(attachments.isprivate, 0) = 0";
   }
 
-  # Use DISTINCT and value comparison to surpress duplicated changes weirdly
+  # Use DISTINCT and value comparison to suppress duplicated changes weirdly
   # made at the same time by the same user
   my $query
     = "SELECT DISTINCT fielddefs.name, bugs_activity.attach_id, "
@@ -4531,7 +4531,7 @@ sub GetBugActivity {
     my $activity_visible = 1;
     my $last_change = @$changes[-1] || {};
 
-    # Surpress any mid-air collision
+    # Suppress any mid-air collision
     if ( $when eq $operation->{'when'}
       && $fieldname eq $last_change->{'fieldname'}
       && $removed eq $last_change->{'removed'}

--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -4461,7 +4461,7 @@ sub GetBugActivity {
     $suppwhere = "AND COALESCE(attachments.isprivate, 0) = 0";
   }
 
-  # Use DISTINCT and value comparison to surpress duplicated changes wierdly
+  # Use DISTINCT and value comparison to surpress duplicated changes weirdly
   # made at the same time by the same user
   my $query
     = "SELECT DISTINCT fielddefs.name, bugs_activity.attach_id, "


### PR DESCRIPTION
There are duplicated changes in the `bugs_activity` table made at the same time by the same user or different users. Prevent these weird changes from being displayed in both the history UI and API. Tested with all the reported cases including the duplicated bugs. 

## Bugzilla link

[Bug 1514000 - Suppress duplicated changes in bug history made at the same time mainly due to mid-air collisions](https://bugzilla.mozilla.org/show_bug.cgi?id=1514000)