### PR TITLE
Bug 1538047 - Plain text attachment cut off due to wrong charset detection (UTF-8 as Windows-1252)

### DIFF
--- a/Bugzilla/Util.pm
+++ b/Bugzilla/Util.pm
@@ -913,6 +913,12 @@ sub detect_encoding {
     $encoding = $decoded_as if $decoded_as;
   }
 
+  # Encode::Detect sometimes mis-detects UTF-8 as Windows-1252
+  if ($encoding && $encoding eq 'cp1252') {
+    my $decoder = guess_encoding($data, ('utf8', 'cp1252'));
+    $encoding = $decoder->name if ref $decoder;
+  }
+
   return $encoding;
 }
 


### PR DESCRIPTION
Correct bad charset detection for plain text files.

## Bugzilla link

[Bug 1538047 - Plain text attachment cut off due to wrong charset detection (UTF-8 as Windows-1252)](https://bugzilla.mozilla.org/show_bug.cgi?id=1538047)