### PR TITLE
Bug 1538712 - Add note about rare history change to secbugs report

### DIFF
--- a/template/en/default/reports/email/security-risk.html.tmpl
+++ b/template/en/default/reports/email/security-risk.html.tmpl
@@ -166,6 +166,8 @@ this report treats marking a [% terms.bug %] as 'stalled' the same as closing it
 
 <p>Attached to this email are some graphs with stats for the past 12 months.</p>
 
+<p>This report was generated from the live Bugzilla instance. In rare cases, historical statistics may vary from prior reports if [% terms.bugs %] were reclassified after those reports were generated.</p>
+
 [% IF missing_products.size %]
   <p>The following products requested on this report are no longer active in BMO:&nbsp;
   [% FOREACH missing_product IN missing_products %]


### PR DESCRIPTION
It is possible for the history shown in the security bugs report to
change from report to report under rare conditions. This commit adds
a small notice to make users aware of this.