### PR TITLE
Bug 1538383 - Allow to hide inline preview when attaching a file, e.g. SVG crashtests.

### DIFF
--- a/Bugzilla/Attachment.pm
+++ b/Bugzilla/Attachment.pm
@@ -845,6 +845,7 @@ sub remove_from_db {
 sub get_content_type {
   my $cgi = Bugzilla->cgi;
 
+  return 'application/octet-stream' if ($cgi->param('hide_preview'));
   return 'text/plain' if ($cgi->param('ispatch') || $cgi->param('attach_text'));
 
   my $content_type;

--- a/js/attachment.js
+++ b/js/attachment.js
@@ -312,6 +312,7 @@ Bugzilla.AttachmentForm = class AttachmentForm {
     this.$description = document.querySelector('#att-description');
     this.$error_message = document.querySelector('#att-error-message');
     this.$ispatch = document.querySelector('#att-ispatch');
+    this.$hide_preview = document.querySelector('#att-hide-preview');
     this.$type_outer = document.querySelector('#att-type-outer');
     this.$type_list = document.querySelector('#att-type-list');
     this.$type_manual = document.querySelector('#att-type-manual');
@@ -334,6 +335,7 @@ Bugzilla.AttachmentForm = class AttachmentForm {
     this.$description.addEventListener('input', () => this.description_oninput());
     this.$description.addEventListener('change', () => this.description_onchange());
     this.$ispatch.addEventListener('change', () => this.ispatch_onchange());
+    this.$hide_preview.addEventListener('change', () => this.hide_preview_onchange());
     this.$type_select.addEventListener('change', () => this.type_select_onchange());
     this.$type_input.addEventListener('change', () => this.type_input_onchange());
 
@@ -752,6 +754,23 @@ Bugzilla.AttachmentForm = class AttachmentForm {
     // Reassign the bug to the user if the attachment is a patch or GitHub Pull Request
     if (this.$takebug && this.$takebug.clientHeight > 0 && this.$takebug.dataset.takeIfPatch) {
       this.$takebug.checked = is_patch || is_ghpr;
+    }
+  }
+
+  /**
+   * Called whenever the "hide preview" checkbox is checked or unchecked. Change the Content Type to binary if checked
+   * so the file will always be downloaded.
+   */
+  hide_preview_onchange() {
+    const hide_preview = this.$hide_preview.checked;
+
+    this.$type_outer.querySelectorAll('[name]').forEach($input => $input.disabled = hide_preview);
+
+    if (hide_preview) {
+      this.original_type = this.$type_input.value || this.$type_select.value;
+      this.update_content_type('application/octet-stream');
+    } else if (this.original_type) {
+      this.update_content_type(this.original_type);
     }
   }
 

--- a/js/attachment.js
+++ b/js/attachment.js
@@ -650,7 +650,7 @@ Bugzilla.AttachmentForm = class AttachmentForm {
 
   /**
    * Show the preview of a user-selected file. Display a thumbnail if it's a regular image (PNG, GIF, JPEG, etc.) or
-   * small plaintext file.
+   * small plaintext file. Don't show the preview of SVG image because it can be a crash test.
    * @param {File} file A file to be previewed.
    * @param {Boolean} [is_text=false] `true` if the file is a plaintext file, `false` otherwise.
    */
@@ -658,7 +658,7 @@ Bugzilla.AttachmentForm = class AttachmentForm {
     this.$preview_name.textContent = file.name;
     this.$preview_type.content = file.type;
     this.$preview_text.textContent = '';
-    this.$preview_image.src = file.type.match(/^image\/(?!vnd)/) ? URL.createObjectURL(file) : '';
+    this.$preview_image.src = file.type.match(/^image\/(?!vnd|svg)/) ? URL.createObjectURL(file) : '';
     this.$preview.hidden = false;
 
     if (is_text && file.size < 500000) {

--- a/template/en/default/attachment/createformcontents.html.tmpl
+++ b/template/en/default/attachment/createformcontents.html.tmpl
@@ -72,6 +72,8 @@
     [% Hook.process("patch_notes") %]
     <input id="att-ispatch" type="checkbox" name="ispatch">
     <label for="att-ispatch">patch</label><br><br>
+    <em>If the attachment can crash or hang the browser, check the box below.</em><br>
+    <label><input id="att-hide-preview" type="checkbox" name="hide_preview"> hide preview</label><br><br>
     <div id="att-type-outer">
       <em>Otherwise, choose a method for determining the content type.</em>
       <div>

--- a/template/en/default/attachment/createformcontents.html.tmpl
+++ b/template/en/default/attachment/createformcontents.html.tmpl
@@ -72,7 +72,7 @@
     [% Hook.process("patch_notes") %]
     <input id="att-ispatch" type="checkbox" name="ispatch">
     <label for="att-ispatch">patch</label><br><br>
-    <em>If the attachment can crash or hang the browser, check the box below.</em><br>
+    <em>If the attachment is not suitable for preview in the browser, check the box below.</em><br>
     <label><input id="att-hide-preview" type="checkbox" name="hide_preview"> hide preview</label><br><br>
     <div id="att-type-outer">
       <em>Otherwise, choose a method for determining the content type.</em>


### PR DESCRIPTION
Add “hide preview” checkbox to the New Attachment that forces the `application/octet-stream` binary content type.

## Bugzilla link

[Bug 1538383 - Allow to hide inline preview when attaching a file, e.g. SVG crashtests.](https://bugzilla.mozilla.org/show_bug.cgi?id=1538383)