### PR TITLE
Bug 1539442 - Fix secbugs event builder to get more than the lastest event

### DIFF
--- a/Bugzilla/Report/SecurityRisk.pm
+++ b/Bugzilla/Report/SecurityRisk.pm
@@ -303,12 +303,12 @@ sub _build_events {
   my $result = Bugzilla->dbh->selectall_arrayref($query);
 
   my @events = map {
-    {
-      'bug_id' => @$_[0],
-      'bug_when' => datetime_from(@$_[1]),
-      'field_name' => @$_[2],
-      'removed' => @$_[3],
-      'added' => @$_[4],
+    +{
+      'bug_id'     => $_->[0],
+      'bug_when'   => datetime_from($_->[1]),
+      'field_name' => $_->[2],
+      'removed'    => $_->[3],
+      'added'      => $_->[4],
     }
   } @$result;
 

--- a/Bugzilla/Report/SecurityRisk.pm
+++ b/Bugzilla/Report/SecurityRisk.pm
@@ -299,11 +299,18 @@ sub _build_events {
             AND bug_when >= '$start_date 00:00:00'
         GROUP BY bug_id , bug_when , field.name
     };
-  my $result = Bugzilla->dbh->selectall_hashref($query, 'bug_id');
-  my @events = values %$result;
-  foreach my $event (@events) {
-    $event->{bug_when} = datetime_from($event->{bug_when});
-  }
+  # Don't use selectall_hashref as it only gets the latest event each bug.
+  my $result = Bugzilla->dbh->selectall_arrayref($query);
+
+  my @events = map {
+    {
+      'bug_id' => @$_[0],
+      'bug_when' => datetime_from(@$_[1]),
+      'field_name' => @$_[2],
+      'removed' => @$_[3],
+      'added' => @$_[4],
+    }
+  } @$result;
 
   # We sort by reverse chronological order instead of ORDER BY
   # since values %hash doesn't guareentee any order.


### PR DESCRIPTION
WIP: Gonna further test this fix and add a unit test for it.

This should fix the problems that dveditz and others have been reporting with the secbugs report
where bugs that have been marked as verified don't always have their histories replayed correctly.

The root cause here is the use of `dbh->selectall_hashref`. This method is used to ensure that the
results from the SQL query are mapped to their corresponding column names in a hash for easy access.
But, since the key of the hashmap is the bug id it appears that only the last event for that bug id
is returned. This went unnoticed because the SQL queries were returning the proper data (all events)
and in my testing when I set a bug as resolved that most often was the last event on that bug so it's
history would replay correctly during tests.

You can use bug 1443092 in the latest BMO development database dump to debug this problem yourself.

This PR fixes this problem by switching to `dbh->selectall_arrayref` (which properly gets all events)
and then manually mapping items in the array to their expected hashmap keys.