### PR TITLE
Bug 1533717 - Add a search keyword "Whatever"

### DIFF
--- a/Bugzilla/Field.pm
+++ b/Bugzilla/Field.pm
@@ -486,6 +486,9 @@ use constant DEFAULT_FIELDS => (
     type    => FIELD_TYPE_USER,
     buglist => 1,
   },
+
+  # Special field that allows to search everything with Custom Search queries
+  {name => 'anything', desc => 'Any field'},
 );
 
 ################

--- a/Bugzilla/Field.pm
+++ b/Bugzilla/Field.pm
@@ -488,7 +488,7 @@ use constant DEFAULT_FIELDS => (
   },
 
   # Special field that allows to search everything with Custom Search queries
-  {name => 'whatever', desc => 'Whatever'},
+  {name => 'anything', desc => 'Any field'},
 );
 
 ################

--- a/Bugzilla/Field.pm
+++ b/Bugzilla/Field.pm
@@ -486,6 +486,9 @@ use constant DEFAULT_FIELDS => (
     type    => FIELD_TYPE_USER,
     buglist => 1,
   },
+
+  # Special field that allows to search everything with Custom Search queries
+  {name => 'whatever', desc => 'Whatever'},
 );
 
 ################

--- a/Bugzilla/Field.pm
+++ b/Bugzilla/Field.pm
@@ -486,9 +486,6 @@ use constant DEFAULT_FIELDS => (
     type    => FIELD_TYPE_USER,
     buglist => 1,
   },
-
-  # Special field that allows to search everything with Custom Search queries
-  {name => 'anything', desc => 'Any field'},
 );
 
 ################

--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -3455,7 +3455,7 @@ sub _changedbefore_changedafter {
   my $table;
   my $join = {table => 'bugs_activity', extra => []};
 
-  if ($field eq 'whatever') {
+  if ($field eq 'anything') {
     # Handle special field name to find changes in any field
     $table = $join->{as} = "act_x_$chart_id";
   } else {
@@ -3495,7 +3495,7 @@ sub _changedfrom_changedto {
   my $join = {table => 'bugs_activity', extra => []};
   my $column = ($operator =~ /from/) ? 'removed' : 'added';
 
-  if ($field eq 'whatever') {
+  if ($field eq 'anything') {
     # Handle special field name to find changes in any field
     $table = $join->{as} = "act_x_$chart_id";
   } else {
@@ -3521,7 +3521,7 @@ sub _changedby {
   my $table;
   my $join = {table => 'bugs_activity', extra => []};
 
-  if ($field eq 'whatever') {
+  if ($field eq 'anything') {
     # Handle special field name to find changes in any field
     $table = $join->{as} = "act_x_$chart_id";
   } else {

--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -3452,30 +3452,34 @@ sub _changedbefore_changedafter {
     = @$args{qw(chart_id joins field operator value)};
   my $dbh = Bugzilla->dbh;
 
-  my $field_object = $self->_chart_fields->{$field}
-    || ThrowCodeError("invalid_field_name", {field => $field});
+  my $table;
+  my $join = {table => 'bugs_activity', extra => []};
 
-  # Asking when creation_ts changed is just asking when the bug was created.
-  if ($field_object->name eq 'creation_ts') {
-    $args->{operator}
-      = $operator eq 'changedbefore' ? 'lessthaneq' : 'greaterthaneq';
-    return $self->_do_operator_function($args);
+  if ($field eq 'whatever') {
+    # Handle special field name to find changes in any field
+    $table = $join->{as} = "act_x_$chart_id";
+  } else {
+    my $field_object = $self->_chart_fields->{$field}
+      || ThrowCodeError("invalid_field_name", {field => $field});
+
+    # Asking when creation_ts changed is just asking when the bug was created.
+    if ($field_object->name eq 'creation_ts') {
+      $args->{operator}
+        = $operator eq 'changedbefore' ? 'lessthaneq' : 'greaterthaneq';
+      return $self->_do_operator_function($args);
+    }
+
+    my $field_id = $field_object->id;
+
+    # Charts on changed* fields need to be field-specific. Otherwise,
+    # OR chart rows make no sense if they contain multiple fields.
+    $table = $join->{as} = "act_${field_id}_$chart_id";
+    push(@{$join->{extra}}, "$table.fieldid = $field_id");
   }
 
   my $sql_operator = ($operator =~ /before/) ? '<=' : '>=';
-  my $field_id = $field_object->id;
-
-  # Charts on changed* fields need to be field-specific. Otherwise,
-  # OR chart rows make no sense if they contain multiple fields.
-  my $table = "act_${field_id}_$chart_id";
-
   my $sql_date = $dbh->quote(SqlifyDate($value));
-  my $join     = {
-    table => 'bugs_activity',
-    as    => $table,
-    extra =>
-      ["$table.fieldid = $field_id", "$table.bug_when $sql_operator $sql_date"],
-  };
+  push(@{$join->{extra}}, "$table.bug_when $sql_operator $sql_date");
 
   $args->{term} = "$table.bug_when IS NOT NULL";
   $self->_changed_security_check($args, $join);
@@ -3487,16 +3491,22 @@ sub _changedfrom_changedto {
   my ($chart_id, $joins, $field, $operator, $quoted)
     = @$args{qw(chart_id joins field operator quoted)};
 
+  my $table;
+  my $join = {table => 'bugs_activity', extra => []};
   my $column = ($operator =~ /from/) ? 'removed' : 'added';
-  my $field_object = $self->_chart_fields->{$field}
-    || ThrowCodeError("invalid_field_name", {field => $field});
-  my $field_id = $field_object->id;
-  my $table    = "act_${field_id}_$chart_id";
-  my $join     = {
-    table => 'bugs_activity',
-    as    => $table,
-    extra => ["$table.fieldid = $field_id", "$table.$column = $quoted"],
-  };
+
+  if ($field eq 'whatever') {
+    # Handle special field name to find changes in any field
+    $table = $join->{as} = "act_x_$chart_id";
+  } else {
+    my $field_object = $self->_chart_fields->{$field}
+      || ThrowCodeError("invalid_field_name", {field => $field});
+    my $field_id = $field_object->id;
+    $table = $join->{as} = "act_${field_id}_$chart_id";
+    push(@{$join->{extra}}, "$table.fieldid = $field_id");
+  }
+
+  push(@{$join->{extra}}, "$table.$column = $quoted");
 
   $args->{term} = "$table.bug_when IS NOT NULL";
   $self->_changed_security_check($args, $join);
@@ -3508,16 +3518,22 @@ sub _changedby {
   my ($chart_id, $joins, $field, $operator, $value)
     = @$args{qw(chart_id joins field operator value)};
 
-  my $field_object = $self->_chart_fields->{$field}
-    || ThrowCodeError("invalid_field_name", {field => $field});
-  my $field_id = $field_object->id;
-  my $table    = "act_${field_id}_$chart_id";
-  my $user_id  = login_to_id($value, THROW_ERROR);
-  my $join     = {
-    table => 'bugs_activity',
-    as    => $table,
-    extra => ["$table.fieldid = $field_id", "$table.who = $user_id"],
-  };
+  my $table;
+  my $join = {table => 'bugs_activity', extra => []};
+
+  if ($field eq 'whatever') {
+    # Handle special field name to find changes in any field
+    $table = $join->{as} = "act_x_$chart_id";
+  } else {
+    my $field_object = $self->_chart_fields->{$field}
+      || ThrowCodeError("invalid_field_name", {field => $field});
+    my $field_id = $field_object->id;
+    $table = $join->{as} = "act_${field_id}_$chart_id";
+    push(@{$join->{extra}}, "$table.fieldid = $field_id");
+  }
+
+  my $user_id = login_to_id($value, THROW_ERROR);
+  push(@{$join->{extra}}, "$table.who = $user_id");
 
   $args->{term} = "$table.bug_when IS NOT NULL";
   $self->_changed_security_check($args, $join);

--- a/js/advanced-search.js
+++ b/js/advanced-search.js
@@ -551,12 +551,31 @@ Bugzilla.CustomSearch.Row = class CustomSearchRow extends Bugzilla.CustomSearch.
     this.$element = $placeholder.firstElementChild;
     this.$action_grab = this.$element.querySelector('[data-action="grab"]');
     this.$action_remove = this.$element.querySelector('[data-action="remove"]');
+    this.$select_field = this.$element.querySelector('select.field');
+    this.$select_operator = this.$element.querySelector('select.operator');
+    this.$input_value = this.$element.querySelector('input.value');
 
     this.$element.addEventListener('dragstart', event => this.handle_drag(event));
     this.$element.addEventListener('dragend', event => this.handle_drag(event));
     this.$action_grab.addEventListener('mousedown', () => this.enable_drag());
     this.$action_grab.addEventListener('mouseup', () => this.disable_drag());
     this.$action_remove.addEventListener('click', () => this.remove());
+    this.$select_field.addEventListener('change', () => this.field_onchange());
+  }
+
+  /**
+   * Called whenever a field option is selected.
+   */
+  field_onchange() {
+    const is_whatever = this.$select_field.value === 'whatever';
+
+    // Add support for the "Whatever" special field that allows to search the bug history. When it's selected, disable
+    // search types other than "changed before", "changed after", "changed from", "changed to", "changed by", and make
+    // "changed by" selected for convenience.
+    for (const $option of this.$select_operator.options) {
+      $option.disabled = is_whatever ? !$option.value.match(/changed\w+/) : false;
+      $option.selected = $option.value === (is_whatever ? 'changedby' : 'noop');
+    }
   }
 };
 

--- a/js/advanced-search.js
+++ b/js/advanced-search.js
@@ -567,14 +567,14 @@ Bugzilla.CustomSearch.Row = class CustomSearchRow extends Bugzilla.CustomSearch.
    * Called whenever a field option is selected.
    */
   field_onchange() {
-    const is_whatever = this.$select_field.value === 'whatever';
+    const is_anything = this.$select_field.value === 'anything';
 
-    // Add support for the "Whatever" special field that allows to search the bug history. When it's selected, disable
+    // Add support for the "anything" special field that allows to search the bug history. When it's selected, disable
     // search types other than "changed before", "changed after", "changed from", "changed to", "changed by", and make
     // "changed by" selected for convenience.
     for (const $option of this.$select_operator.options) {
-      $option.disabled = is_whatever ? !$option.value.match(/changed\w+/) : false;
-      $option.selected = $option.value === (is_whatever ? 'changedby' : 'noop');
+      $option.disabled = is_anything ? !$option.value.match(/changed\w+/) : false;
+      $option.selected = $option.value === (is_anything ? 'changedby' : 'noop');
     }
   }
 };

--- a/query.cgi
+++ b/query.cgi
@@ -218,6 +218,7 @@ $vars->{'resolution'}
 # Boolean charts
 my @fields = sort { lc($a->description) cmp lc($b->description) }
   values %$search_fields;
+unshift(@fields, {name => "anything", description => "Any field"});
 unshift(@fields, {name => "noop", description => "---"});
 $vars->{'fields'} = \@fields;
 

--- a/query.cgi
+++ b/query.cgi
@@ -218,7 +218,6 @@ $vars->{'resolution'}
 # Boolean charts
 my @fields = sort { lc($a->description) cmp lc($b->description) }
   values %$search_fields;
-unshift(@fields, {name => "anything", description => "Any field"});
 unshift(@fields, {name => "noop", description => "---"});
 $vars->{'fields'} = \@fields;
 

--- a/template/en/default/global/field-descs.none.tmpl
+++ b/template/en/default/global/field-descs.none.tmpl
@@ -94,7 +94,6 @@ if ( $stash->get("in_template_var") ) {
         "[Bug creation]"          => "[$terms->{Bug} creation]",
         "actual_time"             => "Actual Hours",
         "alias"                   => "Alias",
-        "anything"                => "Any field",
         "assigned_to"             => "Assignee",
         "assigned_to_realname"    => "Assignee Real Name",
         "assignee_last_login"     => "Assignee Last Login Date",

--- a/template/en/default/global/field-descs.none.tmpl
+++ b/template/en/default/global/field-descs.none.tmpl
@@ -94,6 +94,7 @@ if ( $stash->get("in_template_var") ) {
         "[Bug creation]"          => "[$terms->{Bug} creation]",
         "actual_time"             => "Actual Hours",
         "alias"                   => "Alias",
+        "anything"                => "Any field",
         "assigned_to"             => "Assignee",
         "assigned_to_realname"    => "Assignee Real Name",
         "assignee_last_login"     => "Assignee Last Login Date",


### PR DESCRIPTION
Allow to do custom searches like 

* `Whatever / changed by / foo@bar.org`
* `Whatever / changed after / -1m`

## Bugzilla link

[Bug 1533717 - Add a search keyword "Whatever"](https://bugzilla.mozilla.org/show_bug.cgi?id=1533717)