### PR TITLE
Bug 1071066 - For bugs with aliases, inline history displays the bug number rather than the bug alias

### DIFF
--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -777,7 +777,7 @@ sub create {
           return sub {
             my $buglist = shift;
             return join(", ",
-              map(get_bug_link($_, $_, $options), split(/ *, */, $buglist)));
+              map { get_bug_link($_, $_, $options) } split(/\s*,\s*/, $buglist));
           };
         },
         1

--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -771,11 +771,17 @@ sub create {
         1
       ],
 
-      bug_list_link => sub {
-        my ($buglist, $options) = @_;
-        return
-          join(", ", map(get_bug_link($_, $_, $options), split(/ *, */, $buglist)));
-      },
+      bug_list_link => [
+        sub {
+          my ($context, $options) = @_;
+          return sub {
+            my $buglist = shift;
+            return join(", ",
+              map(get_bug_link($_, $_, $options), split(/ *, */, $buglist)));
+          };
+        },
+        1
+      ],
 
       # In CSV, quotes are doubled, and any value containing a quote or a
       # comma is enclosed in quotes.

--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -399,7 +399,7 @@
       CASE 'see_also';
         FOREACH see_also IN value;
           IF see_also.bug_id;
-            "$terms.bug $see_also.bug_id" FILTER bug_link(see_also.bug_id);
+            see_also.bug_id FILTER bug_link(see_also.bug_id, use_alias => 1);
           ELSE;
             %]
             <a href="[% see_also.url FILTER html %]" target="_blank" rel="noreferrer">[% see_also.url FILTER html %]</a>
@@ -423,7 +423,7 @@
           INCLUDE bug_modal/rel_time.html.tmpl ts=value;
 
         ELSIF change.buglist;
-          value FILTER bug_list_link;
+          value FILTER bug_list_link(use_alias => 1);
 
         ELSE;
           value FILTER truncate(256, '…') FILTER html;

--- a/template/en/default/bug/activity/table.html.tmpl
+++ b/template/en/default/bug/activity/table.html.tmpl
@@ -104,7 +104,16 @@
                change.fieldname == 'dependson' ||
                change.fieldname == 'regresses' ||
                change.fieldname == 'regressed_by' %]
-        [% change_type FILTER bug_list_link FILTER none %]
+        [% change_type FILTER bug_list_link(use_alias => 1) FILTER none %]
+      [% ELSIF change.fieldname == 'see_also' %]
+        [% FOREACH url IN change_type.split(', ') %]
+          [% IF (matches = url.match("^${urlbase}show_bug\\.cgi\\?id=(\\d+)$")) %]
+            [% matches.0 FILTER bug_link(matches.0, use_alias => 1) FILTER none %]
+          [% ELSE %]
+            [% display_value(change.fieldname, url) FILTER html %]
+          [% END %]
+          [% ', ' UNLESS loop.last %]
+        [% END %]
       [% ELSIF change.fieldname == 'assigned_to' ||
                change.fieldname == 'reporter' ||
                change.fieldname == 'qa_contact' ||


### PR DESCRIPTION
Use aliases, if available, for the history of bug list fields like Blocks and Regressions. The same applies to the See Also field that currently shows a bug ID prefixed with “bug”. This PR makes change to both the inline history on the modal bug page and the history page.

## Bugzilla link

[Bug 1071066 - For bugs with aliases, inline history displays the bug number rather than the bug alias](https://bugzilla.mozilla.org/show_bug.cgi?id=1071066)