### PR TITLE
bump version to 20190329.2

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20190329.1';
+our $VERSION = '20190329.2';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
the following changes will be pushed to bugzilla.mozilla.org:
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1535075" target="_blank">1535075</a>] Change sort key for Priority so P1 will be first when sorting bugs</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=994896" target="_blank">994896</a>] Add the ability to get comments, attachments, and history using Bug.get</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1535376" target="_blank">1535376</a>] add support for upstream phabricator to the see-also fields</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1286448" target="_blank">1286448</a>] Remove Splinter Review for GitHub PRs</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1535498" target="_blank">1535498</a>] Go directly to the blocklisting form when selecting blocklist policy requests on the enter_bug page.</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1513956" target="_blank">1513956</a>] The summary in the history contains additional white spaces</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1537012" target="_blank">1537012</a>] Add creator_detail field to Get Attachment API</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1535191" target="_blank">1535191</a>] Can't scroll attachments in lightbox view</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1536279" target="_blank">1536279</a>] Sort suggested users by last seen date, not last login date</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1538047" target="_blank">1538047</a>] Plain text attachment cut off due to wrong charset detection (UTF-8 as Windows-1252)</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1538712" target="_blank">1538712</a>] Add notice to end of secbugs report concerning rare history changes</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1538989" target="_blank">1538989</a>] Update blocklist form wording</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1508695" target="_blank">1508695</a>] Incorrect or missing tracking flags on search results in REST API</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1461492" target="_blank">1461492</a>] Add an optional regressed-by field in bugs</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1522348" target="_blank">1522348</a>] Bulk assign open bugs to task, enhancement, defect field</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1522341" target="_blank">1522341</a>] Implement new field for indicating if a bug is a task, enhancement, or defect</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1539442" target="_blank">1539442</a>] Fix secbugs event builder to get more than the lastest event.</li>
</ul>
discuss these changes on <a href="https://lists.mozilla.org/listinfo/tools-bmo" target="_blank">mozilla.tools.bmo</a>.
