### PR TITLE
Bug 1539849 - Multiple uplift request is not working as expected

### DIFF
--- a/extensions/BMO/template/en/default/hook/flag/type_comment-form.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/flag/type_comment-form.html.tmpl
@@ -8,7 +8,7 @@
 
 <meta name="extra-patch-types" content="text/x-phabricator-request">
 
-<template class="approval-request" data-flags="approval‑mozilla‑beta approval‑mozilla‑release">
+<template class="approval-request" data-flags="approval-mozilla-beta approval-mozilla-release">
   <section>
     <header>
       <h3>Beta/Release Uplift Approval Request</h3>
@@ -80,7 +80,7 @@
   </section>
 </template>
 
-<template class="approval-request" data-flags="approval‑mozilla‑esr*">
+<template class="approval-request" data-flags="approval-mozilla-esr*">
   <section>
     <header>
       <h3>ESR Uplift Approval Request</h3>
@@ -123,7 +123,7 @@
   </section>
 </template>
 
-<template class="approval-request" data-flags="approval‑mozilla‑geckoview*">
+<template class="approval-request" data-flags="approval-mozilla-geckoview*">
   <section>
     <header>
       <h3>GeckoView Uplift Approval Request</h3>
@@ -166,7 +166,7 @@
   </section>
 </template>
 
-<template class="approval-request" data-flags="sec‑approval">
+<template class="approval-request" data-flags="sec-approval">
   <section>
     <header>
       <h3>Security Approval Request</h3>

--- a/extensions/FlagTypeComment/web/js/ftc.js
+++ b/extensions/FlagTypeComment/web/js/ftc.js
@@ -121,7 +121,7 @@ Bugzilla.FlagTypeComment = class FlagTypeComment {
   create_comment($fieldset) {
     return [
       `### ${$fieldset.querySelector('h3').innerText}`,
-      ...[...$fieldset.querySelectorAll('tr')].map($tr => {
+      ...[...$fieldset.querySelectorAll('tr:not(.other-patches)')].map($tr => {
         const checkboxes = [...$tr.querySelectorAll('input[type="checkbox"]:checked')];
         const $radio = $tr.querySelector('input[type="radio"]:checked');
         const $input = $tr.querySelector('textarea,select,input');

--- a/template/en/default/flag/list.html.tmpl
+++ b/template/en/default/flag/list.html.tmpl
@@ -131,7 +131,7 @@
                 title="[% type.description FILTER html %]"
                 onchange="toggleRequesteeField(this);"
                 class="flag_select flag_type-[% type.id %]"
-                data-id="[% type.id %]" data-name="[% type.name FILTER html FILTER no_break %]"
+                data-id="[% type.id %]" data-name="[% type.name FILTER html %]"
                 [% IF !can_edit_flag %] disabled="disabled"[% END %]>
         [% IF dontchange %]
           <option value="[% dontchange FILTER html %]" selected>[% dontchange FILTER html %]</option>


### PR DESCRIPTION
#802 didn’t work properly 😞

* The flag IDs set up locally and coded in the uplift template were wrong, because these were copy & pasted from the UI which included **non-breaking hyphens**. So you’ve got a “flag not found” API error due to an ID mismatch. Remove the unnecessary `no_break` filter and fix the template.
* Remove the unnecessary question “Do you want to request approval of these patches as well?” from the comment body.