### PR TITLE
no bug - remove explicit mention of the bugzilla admin email address

### DIFF
--- a/extensions/BMO/template/en/default/account/create.html.tmpl
+++ b/extensions/BMO/template/en/default/account/create.html.tmpl
@@ -174,12 +174,6 @@ function onSubmit() {
 </tr>
 </table>
 
-<p id="bmo-admin">
-  If you think there's something wrong with [% terms.Bugzilla %], you can
-  <a href="mailto:bugzilla-admin@mozilla.org">send an email to the admins</a>, but
-  remember, they can't file [% terms.bugs %] for you, or solve tech support problems.
-</p>
-
 [% PROCESS global/footer.html.tmpl %]
 
 [% BLOCK product %]


### PR DESCRIPTION
I suspect this is one of the ways people are finding our email address.