### PR TITLE
no bug - Show <hr> in Markdown comments

### DIFF
--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -2332,6 +2332,7 @@ pre.comment-text {
 }
 
 .markdown-body hr {
+  display: block !important;
   box-sizing: content-box;
   height: 0;
   overflow: visible;


### PR DESCRIPTION
A [feedback](https://twitter.com/nicolaschevobbe/status/1111529317828382722) from @nchevobbe. This overrides the following rule that can be eventually removed once we get rid of all the `<hr>` from templates.

```css
#changeform hr {
    display: none;
}
```