### PR TITLE
Bug 1539941 - Link keywords and flags in bug detail to searches (and later graphing)

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -353,6 +353,11 @@
           [%+
         ELSIF change.fieldname == 'reporter_accessible';
           "";
+        ELSIF change.fieldname.match('^cf_(status|tracking)_');
+          %]
+          <a href="[% basepath FILTER none %]buglist.cgi?f1=[% change.fieldname FILTER uri %]&amp;o1=isnotempty">
+            [%~ field_descs.${change.fieldname} FILTER html %]</a>:
+          [%+
         ELSE;
           field_descs.${change.fieldname} _ ": " FILTER html;
         END;
@@ -415,6 +420,14 @@
           "Not accessible to reporter";
         END;
 
+      CASE 'keywords';
+        FOREACH keyword IN value.split(', ');
+          %]
+            <a href="[% basepath FILTER none %]buglist.cgi?keywords=[% keyword FILTER uri %]&amp;resolution=---">
+              [%~ keyword FILTER html %]</a>[% ", " UNLESS loop.last %]
+          [%+
+        END;
+
       CASE;
         IF change.fieldtype == constants.FIELD_TYPE_DATETIME;
           INCLUDE bug_modal/rel_time.html.tmpl ts=value;
@@ -422,6 +435,11 @@
         ELSIF change.buglist;
           value FILTER bug_list_link;
 
+        ELSIF change.fieldname.match('^cf_(status|tracking)_') && value != '---';
+          %]
+          <a href="[% basepath FILTER none %]buglist.cgi?f1=[% change.fieldname FILTER uri %]&amp;o1=equals&amp;v1=
+            [%~ value FILTER uri %]">[% value FILTER html %]</a>
+          [%+
         ELSE;
           value FILTER truncate(256, '…') FILTER html;
 

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -893,7 +893,14 @@
         hide_on_view = bug.keyword_objects.size == 0
         help = basepath _ "describekeywords.cgi"
     %]
-      [% bug.keyword_objects.pluck("name").join(", ") || "---" FILTER html %]
+      [% IF bug.keyword_objects.size %]
+        [% FOREACH keyword IN bug.keyword_objects.pluck("name") %]
+          <a href="[% basepath FILTER none %]buglist.cgi?keywords=[% keyword FILTER html %]&amp;resolution=---">
+            [%~ keyword FILTER html %]</a>[% ", " UNLESS loop.last %]
+        [% END %]
+      [% ELSE %]
+        [% "---" FILTER html %]
+      [% END %]
     [% END %]
 
     [% UNLESS cf_hidden_in_product('cf_fx_iteration', bug.product, bug.component, bug) %]

--- a/extensions/BugModal/template/en/default/bug_modal/tracking_flags.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/tracking_flags.html.tmpl
@@ -43,9 +43,23 @@
         <tr>
           <td class="tracking-flag-name">[% row.name FILTER html %]</td>
           [% IF type == "tracking" %]
-            <td class="tracking-flag-tracking">[% tracking_value FILTER html %]</td>
+            <td class="tracking-flag-tracking">
+              [% IF tracking_value != '---' %]
+                <a href="[% basepath FILTER none %]buglist.cgi?f1=[% row.tracking.name FILTER uri ~%]
+                  &amp;o1=equals&amp;v1=[% tracking_value FILTER uri %]">
+              [% END %]
+              [%~ tracking_value FILTER html ~%]
+              [% '</a>' IF tracking_value != '---' %]
+            </td>
           [% END %]
-          <td class="tracking-flag-status">[% status_value FILTER html %]</td>
+          <td class="tracking-flag-status">
+            [% IF status_value != '---' %]
+              <a href="[% basepath FILTER none %]buglist.cgi?f1=[% row.status.name FILTER uri ~%]
+                &amp;o1=equals&amp;v1=[% status_value FILTER uri %]">
+            [% END %]
+            [%~ status_value FILTER html ~%]
+            [% '</a>' IF status_value != '---' %]
+          </td>
         </tr>
       [% END %]
     </table>


### PR DESCRIPTION
Link keywords and status/tracking flags on the modal bug page to the relevant search results page for faster access.

## Bugzilla link

[Bug 1539941 - Link keywords and flags in bug detail to searches (and later graphing)](https://bugzilla.mozilla.org/show_bug.cgi?id=1539941)