### PR TITLE
Bug 1540425 - Remove Array.forEach from sorttable.js

### DIFF
--- a/extensions/BMO/web/js/sorttable.js
+++ b/extensions/BMO/web/js/sorttable.js
@@ -30,12 +30,7 @@ sorttable = {
 
     sorttable.DATE_RE = /^(\d\d?)[\/\.-](\d\d?)[\/\.-]((\d\d)?\d\d)$/;
 
-    forEach(document.getElementsByTagName('table'), function(table) {
-      if (table.className.search(/\bsortable\b/) != -1) {
-        sorttable.makeSortable(table);
-      }
-    });
-
+    document.querySelectorAll('table.sortable').forEach($table => sorttable.makeSortable($table));
   },
 
   /*
@@ -652,58 +647,3 @@ fixEvent.preventDefault = function() {
 fixEvent.stopPropagation = function() {
   this.cancelBubble = true;
 }
-
-// Dean's forEach: http://dean.edwards.name/base/forEach.js
-/*
-  forEach, version 1.0
-  Copyright 2006, Dean Edwards
-  License: http://www.opensource.org/licenses/mit-license.php
-*/
-
-// array-like enumeration
-if (!Array.forEach) { // mozilla already supports this
-  Array.forEach = function(array, block, context) {
-    for (var i = 0; i < array.length; i++) {
-      block.call(context, array[i], i, array);
-    }
-  };
-}
-
-// generic enumeration
-Function.prototype.forEach = function(object, block, context) {
-  for (var key in object) {
-    if (typeof this.prototype[key] == "undefined") {
-      block.call(context, object[key], key, object);
-    }
-  }
-};
-
-// character enumeration
-String.forEach = function(string, block, context) {
-  Array.forEach(string.split(""), function(chr, index) {
-    block.call(context, chr, index, string);
-  });
-};
-
-// globally resolve forEach enumeration
-var forEach = function(object, block, context) {
-  if (object) {
-    var resolve = Object; // default
-    if (object instanceof Function) {
-      // functions have a "length" property
-      resolve = Function;
-    } else if (object.forEach instanceof Function) {
-      // the object implements a custom forEach method so use that
-      object.forEach(block, context);
-      return;
-    } else if (typeof object == "string") {
-      // the object is a string
-      resolve = String;
-    } else if (typeof object.length == "number") {
-      // the object is array-like
-      resolve = Array;
-    }
-    resolve.forEach(object, block, context);
-  }
-};
-


### PR DESCRIPTION
The legacy `forEach` polyfill that comes with [sorttable.js](https://github.com/mozilla-bteam/bmo/blob/master/extensions/BMO/web/js/sorttable.js) needs to be removed. `Array`/`String` generics have been [deprecated since Firefox 53](https://www.fxsitecompat.com/en-CA/docs/2016/non-standard-array-string-generics-have-been-deprecated/) and will be removed in the near future.