### PR TITLE
Bug 1522348 part 2 - Add support for bugbug-generated bug list

### DIFF
--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -2565,6 +2565,9 @@ sub install_filesystem {
     contents  => $json->encode($version_obj),
   };
 
+  $files->{"$extensions_dir/BMO/bin/migrate-bug-type.pl"}
+    = {perms => Bugzilla::Install::Filesystem::OWNER_EXECUTE};
+
   $files->{"$extensions_dir/BMO/bin/migrate-github-pull-requests.pl"}
     = {perms => Bugzilla::Install::Filesystem::OWNER_EXECUTE};
 }

--- a/extensions/BMO/bin/migrate-bug-type.pl
+++ b/extensions/BMO/bin/migrate-bug-type.pl
@@ -14,8 +14,8 @@ use 5.10.1;
 use lib qw(. lib local/lib/perl5);
 
 use Bugzilla;
-
-use Getopt::Long;
+use Mojo::File qw(path);
+use Mojo::Util qw(getopt);
 
 # List of products and components that use a bug type other than "defect"
 my @MIGRATION_MAP = (
@@ -150,10 +150,11 @@ foreach my $target (@MIGRATION_MAP) {
   }
 }
 
-my %switch;
-GetOptions(\%switch, 'csv=s');
+my $csv_file;
+getopt \@ARGV, 'csv=s' => \$csv_file;
 
-if ($switch{'csv'} && open(my $fh, '<', $switch{'csv'})) {
+if ($csv_file) {
+  my $fh = path($csv_file)->open('<');
   say 'Change the type of bugs according to bugbug';
   my $bug_ids = {defect => [], enhancement => []};
 


### PR DESCRIPTION
* Allow to read a bug type migration list generated by [bugbug](https://github.com/mozilla/bugbug). @marco-c will give us the latest file later.
* Run it with `perl extensions/BMO/bin/migrate-bug-type.pl --csv=bugbug_results.csv`. It took <2 minutes on my VM.
* Set the file permission properly.

## Bugzilla link

[Bug 1522348 - Bulk assign open bugs to task, enhancement, defect field](https://bugzilla.mozilla.org/show_bug.cgi?id=1522348)