### PR TITLE
Bug 1344091 - Reorganize the header and modules on modal bug UI

### DIFF
--- a/extensions/BMO/template/en/default/hook/bug_modal/edit-custom_field-cf_crash_signature.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/bug_modal/edit-custom_field-cf_crash_signature.html.tmpl
@@ -9,9 +9,10 @@
 [%
   rendered_custom_fields.push('cf_crash_signature');
   WRAPPER bug_modal/field.html.tmpl
-    field = field
-    field_type = field.type
-    hide_on_view = bug.${field.name} == "" || bug.${field.name} == "---";
+    label = "Signature"
+    field = bug_fields.cf_crash_signature
+    field_type = bug_fields.cf_crash_signature.type
+    hide_on_view = bug.cf_crash_signature == "" || bug.cf_crash_signature == "---";
 %]
   [% IF split_cf_crash_signature.size %]
     [% FOREACH sig IN split_cf_crash_signature %]

--- a/extensions/BMO/web/js/edituser_menu.js
+++ b/extensions/BMO/web/js/edituser_menu.js
@@ -24,7 +24,7 @@ function show_usermenu(id, email, show_edit, hide_profile) {
         }
     ];
     if (!hide_profile) {
-        items.push({
+        items.unshift({
             name: "Profile",
             callback: function () {
                 var href = `${BUGZILLA.config.basepath}user_profile?user_id=${id}`;

--- a/extensions/BMO/web/js/firefox-crash-table.js
+++ b/extensions/BMO/web/js/firefox-crash-table.js
@@ -108,7 +108,7 @@ window.addEventListener('DOMContentLoaded', () => {
   }
 
   let oldWay = false;
-  let container = document.getElementById("module-details-content");
+  let container = document.getElementById("module-crash-data-content");
   if (!container) {
     container = document.getElementById("field_label_cf_crash_signature");
     oldWay = true;
@@ -331,7 +331,8 @@ window.addEventListener('DOMContentLoaded', () => {
       divButton.setAttribute("style", "display:none;");
       button.setAttribute("type", "button");
       button.setAttribute("style", "position:absolute;right:0;top:0");
-      button.innerText = "Update status flags";
+      button.classList.add("minor");
+      button.innerText = "Update Status Flags";
       button.addEventListener("click", updateStatusFlags, false);
       divButton.append(button);
       rightDiv.append(divButton);
@@ -391,7 +392,7 @@ window.addEventListener('DOMContentLoaded', () => {
         mainDiv.setAttribute("class", "field");
         const leftDiv = document.createElement("div");
         leftDiv.setAttribute("class", "name");
-        leftDiv.innerText = "Crash Data:";
+        leftDiv.innerText = "Stats:";
         mainDiv.append(leftDiv, rightDiv);
         container.append(mainDiv);
       }

--- a/extensions/BMO/web/styles/bug_modal.css
+++ b/extensions/BMO/web/styles/bug_modal.css
@@ -21,7 +21,8 @@
 }
 
 .attachment-warning {
-  padding-left: 4px;
+  flex: none;
+  padding: 4px;
 }
 
 .attachment-warning img {

--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -263,7 +263,7 @@
       <meta itemprop="contentSize" content="[% att.datasize FILTER none %]">
       <meta itemprop="encodingFormat" content="[% att.mimetype FILTER html %]">
       <div class="label">
-        Posted [% IF att.is_image %]image
+        Attached [% IF att.is_image %]image
           [% ELSIF att.is_audio %]audio[% ELSIF att.is_video %]video
           [% ELSIF att.ispatch %]patch[% ELSE %]file[% END %]
         [% IF att.ispatch %]

--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -22,8 +22,8 @@
     </ul>
   </div>
   <div class="dropdown">
-    <button type="button" id="view-menu-btn" aria-haspopup="true" aria-label="View"
-      aria-expanded="false" aria-controls="view-menu" class="dropdown-button minor">View &#9662;</button>
+    <button type="button" id="view-menu-btn" aria-haspopup="true" aria-label="Timeline"
+      aria-expanded="false" aria-controls="view-menu" class="dropdown-button minor">Timeline &#9662;</button>
     <ul id="view-menu" role="menu" tabindex="0" class="dropdown-content left" style="display:none">
       <li role="presentation">
         <a id="view-reset" role="menuitem" tabindex="-1">Reset</a>

--- a/extensions/BugModal/template/en/default/bug_modal/attachments.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/attachments.html.tmpl
@@ -12,6 +12,7 @@
   # obsolete_attachments: array of obsolete attachment objects
   #%]
 
+[% IF active_attachments || obsolete_attachments %]
 <table role="table" class="layout-table" id="attachments">
   [% FOREACH attachment IN bug.attachments %]
     [%
@@ -94,12 +95,19 @@
     </tr>
   [% END %]
 </table>
+[% END %]
 
-<div id="attachments-actions">
-  [% IF obsolete_attachments %]
-    <button type="button" id="attachments-obsolete-btn" class="secondary">Show Obsolete Attachments</button>
-  [% END %]
-</div>
-
-[%# BMO - attachment related warnings %]
-[% Hook.process("warnings") %]
+<footer id="attachments-footer">
+  <div id="attachments-actions">
+    [% IF user.id %]
+      <a href="[% basepath FILTER none %]attachment.cgi?bugid=[% bug.id FILTER uri %]&amp;action=enter" id="attachments-add-link">
+        <button type="button" id="attachments-add-btn" class="secondary">Attach New File</button>
+      </a>
+    [% END %]
+    [% IF obsolete_attachments %]
+      <button type="button" id="attachments-obsolete-btn" class="secondary">Show Obsolete</button>
+    [% END %]
+  </div>
+  [%# BMO - attachment related warnings %]
+  [% Hook.process("warnings") %]
+</footer>

--- a/extensions/BugModal/template/en/default/bug_modal/attachments.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/attachments.html.tmpl
@@ -101,7 +101,7 @@
   <div id="attachments-actions">
     [% IF user.id %]
       <a href="[% basepath FILTER none %]attachment.cgi?bugid=[% bug.id FILTER uri %]&amp;action=enter" id="attachments-add-link">
-        <button type="button" id="attachments-add-btn" class="secondary">Attach New File</button>
+        <button type="button" role="none" id="attachments-add-btn" class="secondary">Attach New File</button>
       </a>
     [% END %]
     [% IF obsolete_attachments %]

--- a/extensions/BugModal/template/en/default/bug_modal/cc_list.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/cc_list.html.tmpl
@@ -23,6 +23,8 @@
     [% INCLUDE bug_modal/user.html.tmpl
           u  = cc
           id = "ccu-" _ loop.count
+          gravatar_size = 20
+          nick_only = 1
     %]
   </div>
 [% END %]

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -212,7 +212,7 @@
   [%# buttons %]
 
   <div id="mode-container">
-    <div>
+    <div class="button-row">
       [% IF user.id %]
         <button type="button" class="secondary" id="cc-btn" data-is-cced="[% is_cced ? 1 : 0 %]">
           [%~ is_cced ? "Stop Following" : "Follow" ~%]

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -142,9 +142,110 @@
   <input type="hidden" name="format" value="modal">
   <input type="hidden" name="editing" id="editing" value="">
   <input type="hidden" name="token" value="[% issue_hash_token([bug.id, bug.delta_ts]) FILTER html %]">
-
-  [% PROCESS bug_modal/navigate.html.tmpl %]
 [% END %]
+
+<div role="toolbar" id="page-toolbar">
+  [% IF user.id %]
+    [% PROCESS bug_modal/navigate.html.tmpl %]
+  [% END %]
+  <div role="group" class="buttons">
+    <button type="button" id="copy-summary" class="secondary"
+      title="Copy [% terms.bug %] number and summary to your clipboard">Copy Summary</button>
+    <div id="clip-container" style="display:none"><input type="text" id="clip"></div>
+    [% IF user.id %]
+      <button type="button" class="secondary" id="cc-btn" data-is-cced="[% is_cced ? 1 : 0 %]">
+        [%~ is_cced ? "Stop Following" : "Follow" ~%]
+      </button>
+    [% END %]
+    <div class="dropdown">
+      <button type="button" id="action-menu-btn" aria-haspopup="true" aria-label="View"
+        aria-expanded="false" aria-controls="action-menu" class="dropdown-button secondary">View &#9662;</button>
+      <ul class="dropdown-content left" id="action-menu" role="menu" style="display:none;">
+        [% IF user.id %]
+        <li role="presentation">
+          <a id="action-enable-perm-edit" role="menuitemcheckbox" tabindex="-1">Always Enable Edit Mode</a>
+        </li>
+        <li role="separator"></li>
+        [% END %]
+        <li role="presentation">
+          <a id="action-reset" role="menuitem" tabindex="-1">Reset Sections</a>
+        </li>
+        <li role="presentation">
+          <a id="action-expand-all" role="menuitem" tabindex="-1">Expand All Sections</a>
+        </li>
+        <li role="presentation">
+          <a id="action-collapse-all" role="menuitem" tabindex="-1">Collapse All Sections</a>
+        </li>
+        <li role="separator"></li>
+        <li role="presentation">
+          <a id="action-history" role="menuitem" tabindex="-1">History</a>
+        </li>
+        <li role="separator"></li>
+        <li role="presentation">
+          <a href="[% basepath FILTER none %]rest/bug/[% bug.id FILTER uri %]" role="menuitem" tabindex="-1">JSON</a>
+        </li>
+        <li role="presentation">
+          <a href="[% basepath FILTER none %]show_bug.cgi?ctype=xml&amp;id=[% bug.id FILTER uri %]" role="menuitem" tabindex="-1">XML</a>
+        </li>
+      </ul>
+    </div>
+    [% IF user.id %]
+      <div class="dropdown">
+        <button type="button" id="new-bug-btn" aria-haspopup="true" aria-label="New/Clone [% terms.Bug %]"
+          aria-expanded="false" aria-controls="new-bug-menu" class="dropdown-button secondary">New/Clone &#9662;</button>
+        <ul class="dropdown-content left" id="new-bug-menu" role="menu" style="display:none;">
+          <li role="presentation">
+            <a href="[% basepath FILTER none %]enter_bug.cgi" role="menuitem" tabindex="-1" target="_blank">
+              Create a new [% terms.bug %]</a>
+          </li>
+          <li role="presentation">
+            <a href="[% basepath FILTER none %]enter_bug.cgi?product=[% bug.product FILTER uri %]"
+              role="menuitem" tabindex="-1" target="_blank">&#8230; in this product</a>
+          </li>
+          <li role="presentation">
+            <a href="[% basepath FILTER none %]enter_bug.cgi?product=[% bug.product FILTER uri %]&amp;component=[% bug.component FILTER uri %]"
+              role="menuitem" tabindex="-1" target="_blank">&#8230; in this component</a>
+          </li>
+          <li role="separator"></li>
+          <li role="presentation">
+            <a href="[% basepath FILTER none %]enter_bug.cgi?format=__default__&amp;blocked=[% bug.id FILTER uri %]
+                    [%~%]&amp;product=[% bug.product FILTER uri %]&amp;component=[% bug.component FILTER uri %]"
+              role="menuitem" tabindex="-1" target="_blank">&#8230; that blocks this [% terms.bug %]</a>
+          </li>
+          <li role="presentation">
+            <a href="[% basepath FILTER none %]enter_bug.cgi?format=__default__&amp;dependson=[% bug.id FILTER uri %]
+                    [%~%]&amp;product=[% bug.product FILTER uri %]&amp;component=[% bug.component FILTER uri %]"
+              role="menuitem" tabindex="-1" target="_blank">&#8230; that depends on this [% terms.bug %]</a>
+          </li>
+          <li role="presentation">
+            <a href="[% basepath FILTER none %]enter_bug.cgi?format=__default__&amp;regressed_by=[% bug.id FILTER uri %]
+                    [%~%]&amp;product=[% bug.product FILTER uri %]&amp;component=[% bug.component FILTER uri %]"
+              role="menuitem" tabindex="-1" target="_blank">&#8230; that is regressed by this [% terms.bug %]</a>
+          </li>
+          <li role="separator"></li>
+          <li role="presentation">
+            <a href="[% basepath FILTER none %]enter_bug.cgi?format=__default__&amp;cloned_bug_id=[% bug.id FILTER uri %]
+                    [%~%]&amp;product=[% bug.product FILTER uri %]&amp;component=[% bug.component FILTER uri %]"
+              role="menuitem" tabindex="-1" target="_blank">&#8230; as a clone of this [% terms.bug %]</a>
+          </li>
+          <li role="presentation">
+            <a href="[% basepath FILTER none %]enter_bug.cgi?format=__default__&amp;cloned_bug_id=[% bug.id FILTER uri %]"
+              role="menuitem" tabindex="-1" target="_blank">&#8230; as a clone, in a different product</a>
+          </li>
+        </ul>
+      </div>
+      <button type="button" id="cancel-btn" class="secondary" aria-label="Cancel Editing" style="display:none">Cancel</button>
+      <button type="button" id="mode-btn" class="primary">
+        <span id="mode-btn-readonly" title="Enable editing fields for [% terms.bug %] metadata">Edit [% terms.Bug %]</span>
+        <span id="mode-btn-loading">
+          <img id="edit-throbber" src="[% basepath FILTER none %]extensions/BugModal/web/throbber.gif" width="16" height="11">
+          Fetching
+        </span>
+      </button>
+      <button type="submit" id="commit-btn" class="save-btn primary" style="display:none">Save Changes</button>
+    [% END %]
+  </div>
+</div>
 
 [%# === header === %]
 
@@ -157,23 +258,33 @@
     title = ""
 %]
   <div id="summary-container">
-    [%# bug id, alias, and summary %]
+    [%# status summary %]
     [% WRAPPER bug_modal/field.html.tmpl
         container = 1
+        name = "status_summary"
         no_label = 1
-        view_only = 1
     %]
-      <div id="field-value-bug_id">
+      <span class="bug-status-label text" data-status="[% bug.isopened ? 'open' : 'closed' %]">
+        [%~ bug.isopened ? 'Open' : 'Closed' ~%]
+      </span>
+      <span id="field-value-bug_id">
         <a href="[% basepath _ "show_bug.cgi?id=" _ bug.id FILTER html %]">
           [%~ terms.Bug _ " " _ bug.id FILTER none ~%]
         </a>
         [% IF bug.alias %]
-          <span class="edit-hide">
-            ([% bug.alias FILTER html %])
-          </span>
+          <span class="edit-hide">([% bug.alias FILTER html %])</span>
         [% END %]
-      </div>
+      </span>
+      <span class="edit-hide">
+        <span class="bug-time-label">Opened [% INCLUDE bug_modal/rel_time.html.tmpl ts=bug.creation_ts %]</span>
+        [% IF !bug.isopened %]
+          <span class="bug-time-label">Closed [% INCLUDE bug_modal/rel_time.html.tmpl ts=bug.cf_last_resolved %]</span>
+        [% ELSIF bug.creation_ts != bug.delta_ts %]
+          <span class="bug-time-label">Updated [% INCLUDE bug_modal/rel_time.html.tmpl ts=bug.delta_ts %]</span>
+        [% END %]
+      </span>
     [% END %]
+
     [% WRAPPER bug_modal/field.html.tmpl
         container = 1
         no_label = 1
@@ -190,134 +301,6 @@
         help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#short_desc"
         required = 1
     %]
-
-    [%# status summary %]
-    [% WRAPPER bug_modal/field.html.tmpl
-        name = "status_summary"
-        no_label = 1
-        hide_on_edit = 1
-    %]
-      <span class="bug-status-label text" data-status="[% bug.isopened ? 'open' : 'closed' %]">
-        [%~ bug.isopened ? 'Open' : 'Closed' ~%]
-      </span>
-      <span class="bug-time-label">Opened [% INCLUDE bug_modal/rel_time.html.tmpl ts=bug.creation_ts %]</span>
-      [% IF !bug.isopened %]
-        <span class="bug-time-label">Closed [% INCLUDE bug_modal/rel_time.html.tmpl ts=bug.cf_last_resolved %]</span>
-      [% ELSIF bug.creation_ts != bug.delta_ts %]
-        <span class="bug-time-label">Updated [% INCLUDE bug_modal/rel_time.html.tmpl ts=bug.delta_ts %]</span>
-      [% END %]
-    [% END %]
-  </div>
-
-  [%# buttons %]
-
-  <div id="mode-container">
-    <div class="button-row">
-      [% IF user.id %]
-        <button type="button" class="secondary" id="cc-btn" data-is-cced="[% is_cced ? 1 : 0 %]">
-          [%~ is_cced ? "Stop Following" : "Follow" ~%]
-        </button>
-        <button type="button" id="cancel-btn" class="secondary" style="display:none" aria-label="Cancel Editing">Cancel</button>
-        <button type="button" id="mode-btn" class="primary">
-          <span id="mode-btn-readonly" title="Enable editing fields for [% terms.bug %] metadata">Edit [% terms.Bug %]</span>
-          <span id="mode-btn-loading">
-            <img id="edit-throbber" src="[% basepath FILTER none %]extensions/BugModal/web/throbber.gif" width="16" height="11">
-            Fetching
-          </span>
-        </button>
-        <button type="submit" id="commit-btn" class="save-btn primary" style="display:none">Save Changes</button>
-      [% END %]
-    </div>
-    <div class="button-row">
-      <div class="dropdown">
-        <button type="button" id="format-btn" aria-haspopup="true" aria-label="Format [% terms.Bug %] Menu"
-          aria-expanded="false" aria-controls="format-menu" class="dropdown-button secondary">Copy/Format &#9662;</button>
-        <ul class="dropdown-content left" id="format-menu" role="menu" style="display:none;">
-          <li role="presentation">
-            <a id="copy-summary" role="menuitem" tabindex="-1">Copy Summary</a>
-            <div id="clip-container" style="display:none"><input type="text" id="clip"></div>
-          </li>
-          <li role="separator"></li>
-          <li role="presentation">
-            <a href="[% basepath FILTER none %]rest/bug/[% bug.id FILTER uri %]" role="menuitem" tabindex="-1">JSON</a>
-          </li>
-          <li role="presentation">
-            <a href="[% basepath FILTER none %]show_bug.cgi?ctype=xml&amp;id=[% bug.id FILTER uri %]" role="menuitem" tabindex="-1">XML</a>
-          </li>
-        </ul>
-      </div>
-      [% IF user.id %]
-        <div class="dropdown">
-          <button type="button" id="new-bug-btn" aria-haspopup="true" aria-label="New/Clone [% terms.Bug %] Menu"
-            aria-expanded="false" aria-controls="new-bug-menu" class="dropdown-button secondary">New/Clone &#9662;</button>
-          <ul class="dropdown-content left" id="new-bug-menu" role="menu" style="display:none;">
-            <li role="presentation">
-              <a href="[% basepath FILTER none %]enter_bug.cgi" role="menuitem" tabindex="-1" target="_blank">
-                Create a new [% terms.bug %]</a>
-            </li>
-            <li role="presentation">
-              <a href="[% basepath FILTER none %]enter_bug.cgi?product=[% bug.product FILTER uri %]"
-                role="menuitem" tabindex="-1" target="_blank">&#8230; in this product</a>
-            </li>
-            <li role="presentation">
-              <a href="[% basepath FILTER none %]enter_bug.cgi?product=[% bug.product FILTER uri %]&amp;component=[% bug.component FILTER uri %]"
-                role="menuitem" tabindex="-1" target="_blank">&#8230; in this component</a>
-            </li>
-            <li role="separator"></li>
-            <li role="presentation">
-              <a href="[% basepath FILTER none %]enter_bug.cgi?format=__default__&amp;blocked=[% bug.id FILTER uri %]
-                      [%~%]&amp;product=[% bug.product FILTER uri %]&amp;component=[% bug.component FILTER uri %]"
-                role="menuitem" tabindex="-1" target="_blank">&#8230; that blocks this [% terms.bug %]</a>
-            </li>
-            <li role="presentation">
-              <a href="[% basepath FILTER none %]enter_bug.cgi?format=__default__&amp;dependson=[% bug.id FILTER uri %]
-                      [%~%]&amp;product=[% bug.product FILTER uri %]&amp;component=[% bug.component FILTER uri %]"
-                role="menuitem" tabindex="-1" target="_blank">&#8230; that depends on this [% terms.bug %]</a>
-            </li>
-            <li role="presentation">
-              <a href="[% basepath FILTER none %]enter_bug.cgi?format=__default__&amp;regressed_by=[% bug.id FILTER uri %]
-                      [%~%]&amp;product=[% bug.product FILTER uri %]&amp;component=[% bug.component FILTER uri %]"
-                role="menuitem" tabindex="-1" target="_blank">&#8230; that is regressed by this [% terms.bug %]</a>
-            </li>
-            <li role="separator"></li>
-            <li role="presentation">
-              <a href="[% basepath FILTER none %]enter_bug.cgi?format=__default__&amp;cloned_bug_id=[% bug.id FILTER uri %]
-                      [%~%]&amp;product=[% bug.product FILTER uri %]&amp;component=[% bug.component FILTER uri %]"
-                role="menuitem" tabindex="-1" target="_blank">&#8230; as a clone of this [% terms.bug %]</a>
-            </li>
-            <li role="presentation">
-              <a href="[% basepath FILTER none %]enter_bug.cgi?format=__default__&amp;cloned_bug_id=[% bug.id FILTER uri %]"
-                role="menuitem" tabindex="-1" target="_blank">&#8230; as a clone, in a different product</a>
-            </li>
-          </ul>
-        </div>
-      [% END %]
-      <div class="dropdown">
-        <button type="button" id="action-menu-btn" aria-haspopup="true" aria-label="Actions"
-          aria-expanded="false" aria-controls="action-menu" class="dropdown-button secondary">&#9662;</button>
-        <ul class="dropdown-content left" id="action-menu" role="menu" style="display:none;">
-          [% IF user.id %]
-          <li role="presentation">
-            <a id="action-enable-perm-edit" role="menuitemcheckbox" tabindex="-1">Always Enable Edit Mode</a>
-          </li>
-          <li role="separator"></li>
-          [% END %]
-          <li role="presentation">
-            <a id="action-reset" role="menuitem" tabindex="-1">Reset Sections</a>
-          </li>
-          <li role="presentation">
-            <a id="action-expand-all" role="menuitem" tabindex="-1">Expand All Sections</a>
-          </li>
-          <li role="presentation">
-            <a id="action-collapse-all" role="menuitem" tabindex="-1">Collapse All Sections</a>
-          </li>
-          <li role="separator"></li>
-          <li role="presentation">
-            <a id="action-history" role="menuitem" tabindex="-1">History</a>
-          </li>
-        </ul>
-      </div>
-    </div>
   </div>
 [% END %]
 

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -304,7 +304,7 @@
   </div>
 [% END %]
 
-[%# === triage === %]
+[%# === categories === %]
 
 [%
   sub = [];
@@ -314,7 +314,7 @@
   sub.push(bug.bug_severity) IF bug.bug_severity != "normal";
 %]
 [% WRAPPER bug_modal/module.html.tmpl
-  title = "Triage"
+  title = "Categories"
   subtitle = sub
 %]
   [% WRAPPER fields_lhs %]

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -979,7 +979,7 @@
           field_type = constants.FIELD_TYPE_BUG_LIST
           label = "Duplicates"
           values = bug.duplicates
-          hide_on_edit = 1
+          view_only = 1
           help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#duplicates"
       %]
     [% END %]

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -597,7 +597,7 @@
       [% INCLUDE bug_modal/field.html.tmpl
           field = bug_fields.cf_fx_iteration
           field_type = bug_fields.cf_fx_iteration.type
-          hide_on_view = bug.cf_iteration == ""
+          hide_on_view = bug.cf_fx_iteration == "---"
       %]
     [% END %]
 

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -509,6 +509,7 @@
           aria_label = bug_fields.bug_severity.description
           inline = 1
           label = "Severity"
+          help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#bug_severity"
       %]
       [% UNLESS cf_hidden_in_product('cf_rank', bug.product, bug.component, bug) %]
         [% rendered_custom_fields.push('cf_rank') %]
@@ -519,6 +520,7 @@
             label = "Rank"
             hide_on_view = bug.cf_rank == ""
             hide_on_edit = !user.in_group('rank-setters')
+            help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#rank"
         %]
       [% END %]
     [% END %]

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -96,8 +96,6 @@
   # build Firefox flags subtitle
   firefox_flags = [];
   firefox_fixed_versions = [];
-  scores = {firefox => 0, thunderbird => 0, seamonkey => 0};
-  tracking_flags_title = "Firefox Tracking Flags";
   # project flags
   FOREACH row IN tracking_flags_table;
     NEXT UNLESS row.type == "project";
@@ -127,18 +125,6 @@
       END;
     END;
     firefox_flags.push(blurb);
-    IF row.name.search("^thunderbird");
-      scores.thunderbird = scores.thunderbird + 1;
-    ELSIF row.name.search("^seamonkey");
-      scores.seamonkey = scores.seamonkey + 1;
-    ELSE;
-      scores.firefox = scores.firefox + 1;
-    END;
-  END;
-  IF scores.thunderbird AND NOT scores.firefox;
-    tracking_flags_title = "Thunderbird Tracking Flags";
-  ELSIF scores.seamonkey AND NOT scores.firefox;
-    tracking_flags_title = "SeaMonkey Tracking Flags";
   END;
   firefox_fixed_version = firefox_fixed_versions.join(", ");
   IF firefox_flags.size;
@@ -196,15 +182,6 @@
       <h1 id="field-value-short_desc">[% bug.short_desc FILTER quoteUrls(bug) FILTER wbr %]</h1>
     [% END %]
 
-    [%# alias %]
-    [% INCLUDE bug_modal/field.html.tmpl
-        field = bug_fields.alias
-        field_type = constants.FIELD_TYPE_FREETEXT
-        hide_on_view = 1
-        short_width = 1
-        help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#alias"
-    %]
-
     [%# summary %]
     [% INCLUDE bug_modal/field.html.tmpl
         field = bug_fields.short_desc
@@ -220,63 +197,14 @@
         no_label = 1
         hide_on_edit = 1
     %]
-      <b class="bz_status_[% bug.bug_status FILTER html %]">
-        [% bug.bug_status FILTER html %]
-        [%+ bug.resolution FILTER html IF bug.resolution %]
-      </b>
-      [% IF bug.resolution == "FIXED"
-            && bug.target_milestone
-            && bug.target_milestone != "---"
-      %]
-        in [% firefox_fixed_version || bug.target_milestone FILTER html %]
-      [% ELSIF bug.dup_id %]
-        of [% terms.bug _ " $bug.dup_id" FILTER bug_link(bug.dup_id) FILTER none %]
-      [% ELSIF bug.resolution == "" %]
-        <div id="status-assignee">
-          [%
-            IF unassigned;
-              "Unassigned";
-            ELSE;
-              "Assigned to ";
-              INCLUDE bug_modal/user.html.tmpl u=bug.assigned_to nick_only=1;
-            END;
-          %]
-        </div>
-      [% END %]
-      [% IF needinfo.size %]
-        <div id="status-needinfo">
-          [%~ IF needinfo.size == 1 %]
-            [%
-              ni = needinfo.0;
-              activity_id = bug.find_activity_id_for_flag(ni);
-            %]
-            [% IF activity_id %]
-              (<a href="#[% activity_id FILTER none %]"
-            [% ELSE %]
-              (<span
-            [% END %]
-            [% IF user.setting("ui_use_absolute_time") == "on" %]
-              class="flag-name-status abs-time-title[% " activity-ref" IF activity_id %]"
-              title="[% ni.creation_date FILTER time("%Y-%m-%d %H:%M %Z") FILTER html %]"
-            [% ELSE %]
-              class="flag-name-status rel-time-title[% " activity-ref" IF activity_id %]"
-              title="[% ni.creation_date FILTER time_duration FILTER html %]"
-            [% END %]
-              data-time="[% ni.creation_date FILTER epoch FILTER none %]"
-            >NeedInfo
-            [% activity_id ? "</a>" : "</span>" %]
-            from
-            [%
-              IF ni.requestee;
-                INCLUDE bug_modal/user.html.tmpl u=ni.requestee nick_only=1;
-              ELSE;
-                "anyone";
-              END;
-            %])
-          [% ELSE %]
-            (Needinfo from [% needinfo.size FILTER none %] people)
-          [% END ~%]
-        </div>
+      <span class="bug-status-label text" data-status="[% bug.isopened ? 'open' : 'closed' %]">
+        [%~ bug.isopened ? 'Open' : 'Closed' ~%]
+      </span>
+      <span class="bug-time-label">Opened [% INCLUDE bug_modal/rel_time.html.tmpl ts=bug.creation_ts %]</span>
+      [% IF !bug.isopened %]
+        <span class="bug-time-label">Closed [% INCLUDE bug_modal/rel_time.html.tmpl ts=bug.cf_last_resolved %]</span>
+      [% ELSIF bug.creation_ts != bug.delta_ts %]
+        <span class="bug-time-label">Updated [% INCLUDE bug_modal/rel_time.html.tmpl ts=bug.delta_ts %]</span>
       [% END %]
     [% END %]
   </div>
@@ -286,6 +214,9 @@
   <div id="mode-container">
     <div>
       [% IF user.id %]
+        <button type="button" class="secondary" id="cc-btn" data-is-cced="[% is_cced ? 1 : 0 %]">
+          [%~ is_cced ? "Stop Following" : "Follow" ~%]
+        </button>
         <button type="button" id="cancel-btn" class="secondary" style="display:none" aria-label="Cancel Editing">Cancel</button>
         <button type="button" id="mode-btn" class="primary">
           <span id="mode-btn-readonly" title="Enable editing fields for [% terms.bug %] metadata">Edit [% terms.Bug %]</span>
@@ -294,28 +225,83 @@
             Fetching
           </span>
         </button>
-        <button type="submit" id="commit-btn" class="save-btn major" style="display:none">Save Changes</button>
+        <button type="submit" id="commit-btn" class="save-btn primary" style="display:none">Save Changes</button>
       [% END %]
     </div>
     <div class="button-row">
-      [% IF bug.assigned_to.id == user.id || user.in_group("editbugs") %]
-        <button type="button" id="copy-summary" class="secondary"
-          title="Copy [% terms.bug %] number and summary to your clipboard">Copy Summary</button>
-        <div id="clip-container" style="display:none"><input type="text" id="clip"></div>
-      [% END %]
+      <div class="dropdown">
+        <button type="button" id="format-btn" aria-haspopup="true" aria-label="Format [% terms.Bug %] Menu"
+          aria-expanded="false" aria-controls="format-menu" class="dropdown-button secondary">Copy/Format &#9662;</button>
+        <ul class="dropdown-content left" id="format-menu" role="menu" style="display:none;">
+          <li role="presentation">
+            <a id="copy-summary" role="menuitem" tabindex="-1">Copy Summary</a>
+            <div id="clip-container" style="display:none"><input type="text" id="clip"></div>
+          </li>
+          <li role="separator"></li>
+          <li role="presentation">
+            <a href="[% basepath FILTER none %]rest/bug/[% bug.id FILTER uri %]" role="menuitem" tabindex="-1">JSON</a>
+          </li>
+          <li role="presentation">
+            <a href="[% basepath FILTER none %]show_bug.cgi?ctype=xml&amp;id=[% bug.id FILTER uri %]" role="menuitem" tabindex="-1">XML</a>
+          </li>
+        </ul>
+      </div>
       [% IF user.id %]
-        <button type="button" class="secondary" id="cc-btn" data-is-cced="[% is_cced ? 1 : 0 %]">
-          [% is_cced ? "Stop Following" : "Follow" %]
-        </button>
+        <div class="dropdown">
+          <button type="button" id="new-bug-btn" aria-haspopup="true" aria-label="New/Clone [% terms.Bug %] Menu"
+            aria-expanded="false" aria-controls="new-bug-menu" class="dropdown-button secondary">New/Clone &#9662;</button>
+          <ul class="dropdown-content left" id="new-bug-menu" role="menu" style="display:none;">
+            <li role="presentation">
+              <a href="[% basepath FILTER none %]enter_bug.cgi" role="menuitem" tabindex="-1" target="_blank">
+                Create a new [% terms.bug %]</a>
+            </li>
+            <li role="presentation">
+              <a href="[% basepath FILTER none %]enter_bug.cgi?product=[% bug.product FILTER uri %]"
+                role="menuitem" tabindex="-1" target="_blank">&#8230; in this product</a>
+            </li>
+            <li role="presentation">
+              <a href="[% basepath FILTER none %]enter_bug.cgi?product=[% bug.product FILTER uri %]&amp;component=[% bug.component FILTER uri %]"
+                role="menuitem" tabindex="-1" target="_blank">&#8230; in this component</a>
+            </li>
+            <li role="separator"></li>
+            <li role="presentation">
+              <a href="[% basepath FILTER none %]enter_bug.cgi?format=__default__&amp;blocked=[% bug.id FILTER uri %]
+                      [%~%]&amp;product=[% bug.product FILTER uri %]&amp;component=[% bug.component FILTER uri %]"
+                role="menuitem" tabindex="-1" target="_blank">&#8230; that blocks this [% terms.bug %]</a>
+            </li>
+            <li role="presentation">
+              <a href="[% basepath FILTER none %]enter_bug.cgi?format=__default__&amp;dependson=[% bug.id FILTER uri %]
+                      [%~%]&amp;product=[% bug.product FILTER uri %]&amp;component=[% bug.component FILTER uri %]"
+                role="menuitem" tabindex="-1" target="_blank">&#8230; that depends on this [% terms.bug %]</a>
+            </li>
+            <li role="presentation">
+              <a href="[% basepath FILTER none %]enter_bug.cgi?format=__default__&amp;regressed_by=[% bug.id FILTER uri %]
+                      [%~%]&amp;product=[% bug.product FILTER uri %]&amp;component=[% bug.component FILTER uri %]"
+                role="menuitem" tabindex="-1" target="_blank">&#8230; that is regressed by this [% terms.bug %]</a>
+            </li>
+            <li role="separator"></li>
+            <li role="presentation">
+              <a href="[% basepath FILTER none %]enter_bug.cgi?format=__default__&amp;cloned_bug_id=[% bug.id FILTER uri %]
+                      [%~%]&amp;product=[% bug.product FILTER uri %]&amp;component=[% bug.component FILTER uri %]"
+                role="menuitem" tabindex="-1" target="_blank">&#8230; as a clone of this [% terms.bug %]</a>
+            </li>
+            <li role="presentation">
+              <a href="[% basepath FILTER none %]enter_bug.cgi?format=__default__&amp;cloned_bug_id=[% bug.id FILTER uri %]"
+                role="menuitem" tabindex="-1" target="_blank">&#8230; as a clone, in a different product</a>
+            </li>
+          </ul>
+        </div>
       [% END %]
       <div class="dropdown">
         <button type="button" id="action-menu-btn" aria-haspopup="true" aria-label="Actions"
-          aria-expanded="false" aria-controls="action-menu" class="dropdown-button minor">&#9662;</button>
+          aria-expanded="false" aria-controls="action-menu" class="dropdown-button secondary">&#9662;</button>
         <ul class="dropdown-content left" id="action-menu" role="menu" style="display:none;">
+          [% IF user.id %]
           <li role="presentation">
             <a id="action-enable-perm-edit" role="menuitemcheckbox" tabindex="-1">Always Enable Edit Mode</a>
           </li>
           <li role="separator"></li>
+          [% END %]
           <li role="presentation">
             <a id="action-reset" role="menuitem" tabindex="-1">Reset Sections</a>
           </li>
@@ -326,38 +312,27 @@
             <a id="action-collapse-all" role="menuitem" tabindex="-1">Collapse All Sections</a>
           </li>
           <li role="separator"></li>
-          [% IF user.id %]
-            <li role="presentation">
-              <a id="action-add-comment" role="menuitem" tabindex="-1">Add Comment</a>
-            </li>
-          [% END %]
-          <li role="presentation">
-            <a id="action-last-comment" role="menuitem" tabindex="-1">Last Comment</a>
-          </li>
-          <li role="separator"></li>
           <li role="presentation">
             <a id="action-history" role="menuitem" tabindex="-1">History</a>
           </li>
         </ul>
       </div>
     </div>
-    <div id="user-guide">
-      <a title="User guide for [% terms.Bugzilla %]" href="https://wiki.mozilla.org/BMO/UserGuide">Get help with this page</a>
-    </div>
   </div>
 [% END %]
 
-[%# === status === %]
-[% IF readable_bug_status_json %]
-    [% readable_bug_status_span = BLOCK -%]
-        [%- %]<span id="readable-bug-status" data-readable-bug-status="[% readable_bug_status_json FILTER html %]"></span>
-    [% END %]
+[%# === triage === %]
 
-    [% subtitle = [{ unfiltered = readable_bug_status_span }] %]
-[% END %]
-
+[%
+  sub = [];
+  sub.push(bug.product _ " :: " _ bug.component);
+  sub.push(bug.bug_type);
+  sub.push(bug.priority) IF bug.priority != "--";
+  sub.push(bug.bug_severity) IF bug.bug_severity != "normal";
+%]
 [% WRAPPER bug_modal/module.html.tmpl
-    title = "Status"
+  title = "Triage"
+  subtitle = sub
 %]
   [% WRAPPER fields_lhs %]
 
@@ -458,6 +433,47 @@
       </div>
     [% END %]
 
+    [%# version %]
+    [% INCLUDE bug_modal/field.html.tmpl
+        field = bug_fields.version
+        field_type = constants.FIELD_TYPE_SINGLE_SELECT
+        hide_on_view = bug.version == "---" || bug.version.lower == "unspecified"
+          || bug.version.lower == "trunk" || bug.version.lower == "other"
+        help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#version"
+    %]
+
+    [%# platform %]
+    [% WRAPPER bug_modal/field.html.tmpl
+        container = 1
+        label = "Platform"
+        hide_on_view = (bug.rep_platform == 'All' && bug.op_sys == 'All')
+          || (bug.rep_platform == 'Unspecified' && bug.op_sys == 'Unspecified')
+        help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#rep_platform"
+    %]
+      [% INCLUDE bug_modal/field.html.tmpl
+          field = bug_fields.rep_platform
+          field_type = constants.FIELD_TYPE_SINGLE_SELECT
+          aria_label = bug_fields.rep_platform.description
+          inline = 1
+          no_indent = 1
+      %]
+      [% INCLUDE bug_modal/field.html.tmpl
+          field = bug_fields.op_sys
+          field_type = constants.FIELD_TYPE_SINGLE_SELECT
+          aria_label = bug_fields.op_sys.description
+          inline = 1
+      %]
+      [% WRAPPER bug_modal/field.html.tmpl
+          container = 1
+          inline = 1
+      %]
+        [% Hook.process("after_op_sys", 'bug/edit.html.tmpl') %]
+      [% END %]
+    [% END %]
+
+  [% END %]
+  [% WRAPPER fields_rhs %]
+
     [%# type %]
     [% WRAPPER bug_modal/field.html.tmpl
         field      = bug_fields.bug_type
@@ -505,6 +521,35 @@
       [% END %]
     [% END %]
 
+    [%# points %]
+    [% UNLESS cf_hidden_in_product('cf_fx_points', bug.product, bug.component, bug) %]
+      [% rendered_custom_fields.push('cf_fx_points') %]
+      [% INCLUDE bug_modal/field.html.tmpl
+          field = bug_fields.cf_fx_points
+          field_type = bug_fields.cf_fx_points.type
+          hide_on_view = bug.cf_fx_points == "---"
+      %]
+    [% END %]
+
+  [% END %]
+[% END %]
+
+[%# === tracking === %]
+
+[% IF readable_bug_status_json %]
+  [% readable_bug_status_span = BLOCK -%]
+    [%- %]<span id="readable-bug-status" data-readable-bug-status="[% readable_bug_status_json FILTER html %]"></span>
+  [% END %]
+  [% sub = [{ unfiltered = readable_bug_status_span }] %]
+[% ELSE %]
+  [% sub = [firefox_flags_subtitle] %]
+[% END %]
+[% WRAPPER bug_modal/module.html.tmpl
+  title = "Tracking"
+  subtitle = sub
+%]
+  [% WRAPPER fields_lhs %]
+
     [%# status, resolution %]
     [% IF bug.assigned_to.id != user.id %]
       [% WRAPPER bug_modal/field.html.tmpl
@@ -522,40 +567,89 @@
       [% END %]
     [% END %]
 
+    [%# status/resolution knob %]
+    [% WRAPPER bug_modal/field.html.tmpl
+        name         = "status-edit"
+        container    = 1
+        label        = "Status"
+        hide_on_view = bug.assigned_to.id != user.id
+        help         = "https://wiki.mozilla.org/BMO/UserGuide/BugStatuses"
+    %]
+      [% INCLUDE status_block %]
+    [% END %]
+
+    [%# milestone %]
+    [% INCLUDE bug_modal/field.html.tmpl
+        field = bug_fields.target_milestone
+        field_type = constants.FIELD_TYPE_SINGLE_SELECT
+        label = "Milestone"
+        hide_on_view = bug.target_milestone == "---"
+        help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#target_milestone"
+    %]
+
+    [%# iteration %]
+    [% UNLESS cf_hidden_in_product('cf_fx_iteration', bug.product, bug.component, bug) %]
+      [% rendered_custom_fields.push('cf_fx_iteration') %]
+      [% INCLUDE bug_modal/field.html.tmpl
+          field = bug_fields.cf_fx_iteration
+          field_type = bug_fields.cf_fx_iteration.type
+          hide_on_view = bug.cf_iteration == ""
+      %]
+    [% END %]
+
+    [% UNLESS cf_hidden_in_product('cf_due_date', bug.product, bug.component, bug) %]
+      [% rendered_custom_fields.push('cf_due_date') %]
+      [% INCLUDE bug_modal/field.html.tmpl
+          field = bug_fields.cf_due_date
+          field_type = bug_fields.cf_due_date.type
+          hide_on_view = bug.cf_due_date == ""
+      %]
+    [% END %]
+
+    [% IF project_flags_has %]
+      [%# project flags %]
+      [% WRAPPER bug_modal/field.html.tmpl
+          container    = 1
+          label        = "Project Flags"
+          hide_on_view = !project_flags_set
+          help         = "https://wiki.mozilla.org/BMO/UserGuide#Tracking_Flags"
+      %]
+        [% INCLUDE bug_modal/tracking_flags.html.tmpl
+            type = "project"
+        %]
+      [% END %]
+    [% END %]
+
   [% END %]
   [% WRAPPER fields_rhs %]
 
-    [%# creation time %]
-    [% WRAPPER bug_modal/field.html.tmpl
-        field = bug_fields.creation_ts
-        label = "Opened"
-        view_only = 1
-        help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#creation_ts"
-    %]
-      [% INCLUDE bug_modal/rel_time.html.tmpl ts=bug.creation_ts %]
+    [% IF tracking_flags_has %]
+      [%# tracking flags %]
+      [% WRAPPER bug_modal/field.html.tmpl
+          container    = 1
+          label        = "Tracking Flags"
+          hide_on_view = !tracking_flags_set
+          help         = "https://wiki.mozilla.org/BMO/UserGuide#Tracking_Flags"
+      %]
+        [% INCLUDE bug_modal/tracking_flags.html.tmpl
+            type = "tracking"
+        %]
+      [% END %]
     [% END %]
 
-    [%# last modified %]
-    [% WRAPPER bug_modal/field.html.tmpl
-        field = bug_fields.delta_ts
-        label = "Updated"
-        view_only = 1
-        help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#delta_ts"
-    %]
-      [% INCLUDE bug_modal/rel_time.html.tmpl ts=bug.delta_ts %]
+    [% IF blocking_flags_has %]
+      [%# blocking flags %]
+      [% WRAPPER bug_modal/field.html.tmpl
+          container = 1
+          label = "Blocking Flags"
+          hide_on_view = !blocking_flags_set
+      %]
+        [% INCLUDE bug_modal/tracking_flags.html.tmpl
+            type = "blocking"
+        %]
+      [% END %]
     [% END %]
 
-  [% END %]
-
-  [%# status/resolution knob %]
-  [% WRAPPER bug_modal/field.html.tmpl
-      name         = "status-edit"
-      container    = 1
-      label        = "Status"
-      hide_on_view = bug.assigned_to.id != user.id
-      help         = "https://wiki.mozilla.org/BMO/UserGuide/BugStatuses"
-  %]
-    [% INCLUDE status_block %]
   [% END %]
 [% END %]
 
@@ -632,10 +726,10 @@
       [% IF unassigned %]
         <i>Unassigned</i>
         [% IF bug.check_can_change_field("assigned_to", 0, 1) %]
-          <button type="button" class="take-btn minor" data-field="assigned_to">Take</button>
+          <button type="button" class="take-btn secondary" data-field="assigned_to">Take</button>
         [% END %]
       [% ELSE %]
-        [% INCLUDE bug_modal/user.html.tmpl u=bug.assigned_to %]
+        [% INCLUDE bug_modal/user.html.tmpl u=bug.assigned_to nick_only=1 gravatar_size=20 %]
       [% END %]
     [% END %]
     [% WRAPPER bug_modal/field.html.tmpl
@@ -671,7 +765,7 @@
       [%
         IF bug.mentors.size;
           FOREACH mentor IN bug.mentors;
-            INCLUDE bug_modal/user.html.tmpl u=mentor;
+            INCLUDE bug_modal/user.html.tmpl u=mentor nick_only=1 gravatar_size=20;
           END;
         ELSE;
           "---";
@@ -687,7 +781,7 @@
         hide_on_edit = 1
         help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#qa_contact"
     %]
-      [% INCLUDE bug_modal/user.html.tmpl u=bug.qa_contact %]
+      [% INCLUDE bug_modal/user.html.tmpl u=bug.qa_contact nick_only=1 gravatar_size=20 %]
     [% END %]
     [% WRAPPER bug_modal/field.html.tmpl
         field = bug_fields.qa_contact
@@ -712,6 +806,7 @@
         field = bug_fields.reporter
         field_type = constants.FIELD_TYPE_USER
         view_only = 1
+        hide_on_edit = 1
         help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#reporter"
     %]
 
@@ -721,6 +816,8 @@
         field_type = constants.FIELD_TYPE_USER
         value = bug.component_obj.triage_owner
         view_only = 1
+        hide_on_view = bug.triage_owner == ""
+        hide_on_edit = 1
         help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#triage_owner"
     %]
 
@@ -799,160 +896,41 @@
   [% END %]
 [% END %]
 
-[%# === tracking === %]
+[%# === references === %]
 
 [%
-  col =
-    (bug.version.lower == "unspecified" || bug.version.lower == "other" || bug.version == "---")
-    && bug.target_milestone == "---"
-    && !has_bug_flags
-    && !project_flags_set
-    && !tracking_flags_set
-    && !blocking_flags_set;
   sub = [];
   open_deps = bug.depends_on_obj.only("resolution", "").size;
   IF open_deps;
-    sub.push("Depends on " _ open_deps _ " bug" _ (open_deps == 1 ? "" : "s"));
+    sub.push("Depends on " _ open_deps _ " open bug" _ (open_deps == 1 ? "" : "s"));
   END;
   open_deps = bug.blocks_obj.only("resolution", "").size;
   IF open_deps;
-    sub.push("Blocks " _ open_deps _ " bug" _ (open_deps == 1 ? "" : "s"));
+    sub.push("Blocks " _ open_deps _ " open bug" _ (open_deps == 1 ? "" : "s"));
+  END;
+  open_regs = bug.regresses_obj.only("resolution", "").size;
+  IF open_regs;
+    sub.push("Regressed " _ open_regs _ " open bug" _ (open_regs == 1 ? "" : "s"));
   END;
   IF bug.regressed_by.size;
     sub.push("Regression");
   END;
-  open_regs = bug.regresses_obj.only("resolution", "").size;
-  IF open_regs;
-    sub.push("Regressed " _ open_regs _ " bug" _ (open_regs == 1 ? "" : "s"));
-  END;
-  IF bug.keyword_objects.size;
-    IF bug.keyword_objects.size <= 3;
-      sub.push("{" _ bug.keyword_objects.pluck("name").join(", ") _ "}");
-    ELSE;
-      sub.push(bug.keyword_objects.size _ " keywords");
-    END;
+  IF bug.bug_file_loc != "";
+    loc_html = INCLUDE bug_url_link link_text="URL";
+    sub.push({ unfiltered => loc_html });
   END;
 %]
 [% WRAPPER bug_modal/module.html.tmpl
-  title = "Tracking"
+  title = "References"
   subtitle = sub
-  collapsed = col
+  collapsed = 1
+  hide_on_view = !bug.dependson.size && !bug.blocked.size
+    && !bug.regresses.size && !bug.regressed_by.size
+    && !bug.duplicates.size && !bug.bug_file_loc && !bug.see_also.size;
 %]
   [% WRAPPER fields_lhs %]
 
-    [%# version %]
-    [% INCLUDE bug_modal/field.html.tmpl
-        field = bug_fields.version
-        field_type = constants.FIELD_TYPE_SINGLE_SELECT
-        help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#version"
-    %]
-
-    [%# milestone %]
-    [% INCLUDE bug_modal/field.html.tmpl
-        field = bug_fields.target_milestone
-        field_type = constants.FIELD_TYPE_SINGLE_SELECT
-        label = "Target"
-        help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#target_milestone"
-    %]
-
-    [%# platform, op-sys %]
-    [% WRAPPER bug_modal/field.html.tmpl
-        container = 1
-        label = "Platform"
-        hide_on_view = (bug.rep_platform == 'All' && bug.op_sys == 'All')
-          || (bug.rep_platform == 'Unspecified' && bug.op_sys == 'Unspecified')
-        help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#rep_platform"
-    %]
-      [% INCLUDE bug_modal/field.html.tmpl
-          field = bug_fields.rep_platform
-          field_type = constants.FIELD_TYPE_SINGLE_SELECT
-          aria_label = bug_fields.rep_platform.description
-          inline = 1
-          no_indent = 1
-      %]
-      [% INCLUDE bug_modal/field.html.tmpl
-          field = bug_fields.op_sys
-          field_type = constants.FIELD_TYPE_SINGLE_SELECT
-          aria_label = bug_fields.op_sys.description
-          inline = 1
-      %]
-      [% WRAPPER bug_modal/field.html.tmpl
-          container = 1
-          inline = 1
-      %]
-        [% Hook.process("after_op_sys", 'bug/edit.html.tmpl') %]
-      [% END %]
-    [% END %]
-
-    [%# keywords %]
-    [% WRAPPER bug_modal/field.html.tmpl
-        field = bug_fields.keywords
-        field_type = constants.FIELD_TYPE_KEYWORDS
-        hide_on_view = bug.keyword_objects.size == 0
-        help = basepath _ "describekeywords.cgi"
-    %]
-      [% IF bug.keyword_objects.size %]
-        [% FOREACH keyword IN bug.keyword_objects.pluck("name") %]
-          <a href="[% basepath FILTER none %]buglist.cgi?keywords=[% keyword FILTER html %]&amp;resolution=---">
-            [%~ keyword FILTER html %]</a>[% ", " UNLESS loop.last %]
-        [% END %]
-      [% ELSE %]
-        [% "---" FILTER html %]
-      [% END %]
-    [% END %]
-
-    [% UNLESS cf_hidden_in_product('cf_fx_iteration', bug.product, bug.component, bug) %]
-      [% rendered_custom_fields.push('cf_fx_iteration') %]
-      [% INCLUDE bug_modal/field.html.tmpl
-          field = bug_fields.cf_fx_iteration
-          field_type = bug_fields.cf_fx_iteration.type
-          hide_on_view = bug.cf_iteration == ""
-      %]
-    [% END %]
-
-    [% UNLESS cf_hidden_in_product('cf_fx_points', bug.product, bug.component, bug) %]
-      [% rendered_custom_fields.push('cf_fx_points') %]
-      [% INCLUDE bug_modal/field.html.tmpl
-          field = bug_fields.cf_fx_points
-          field_type = bug_fields.cf_fx_points.type
-          hide_on_view = bug.cf_fx_points == ""
-      %]
-    [% END %]
-
-    [% UNLESS cf_hidden_in_product('cf_cab_review', bug.product, bug.component, bug) %]
-      [% rendered_custom_fields.push('cf_cab_review') %]
-      [% IF bug.cf_cab_review == "---" %]
-        [% WRAPPER bug_modal/field.html.tmpl
-            field = bug_fields.cf_cab_review
-            field_type = bug_fields.cf_cab_review.type
-            container = 1
-            hide_on_view = 1
-        %]
-          <span id="cab-review-gate">
-            <a href="https://mozilla.service-now.com/change_request.do?sysparm_stack=change_request_list.do&amp;sys_id=-1&amp;sysparm_query=active=true" target="_blank" rel="noopener noreferrer">ServiceNow Change Request</a>
-            <button id="cab-review-gate-close" type="button" class="secondary">Use Flag</button>
-          </span>
-          <span id="cab-review-edit" style="display:none">
-            [% INCLUDE bug_modal/field.html.tmpl
-                field = bug_fields.cf_cab_review
-                field_type = bug_fields.cf_cab_review.type
-                inline = 1
-                no_indent = 1
-            %]
-          </span>
-        [% END %]
-      [% ELSE %]
-        [% INCLUDE bug_modal/field.html.tmpl
-            field = bug_fields.cf_cab_review
-            field_type = bug_fields.cf_cab_review.type
-        %]
-      [% END %]
-    [% END %]
-
-  [% END %]
-  [% WRAPPER fields_rhs %]
-
-    [%# depends on %]
+    [%# dependencies %]
     [% INCLUDE bug_modal/field.html.tmpl
         field = bug_fields.dependson
         field_type = constants.FIELD_TYPE_BUG_LIST
@@ -960,8 +938,6 @@
         hide_on_view = bug.dependson.size == 0
         help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#dependson"
     %]
-
-    [%# blocks %]
     [% INCLUDE bug_modal/field.html.tmpl
         field = bug_fields.blocked
         field_type = constants.FIELD_TYPE_BUG_LIST
@@ -969,7 +945,6 @@
         hide_on_view = bug.blocked.size == 0
         help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#blocks"
     %]
-
     [% IF bug.dependson.size + bug.blocked.size > 0 %]
       [% WRAPPER bug_modal/field.html.tmpl
           name = "dependencytree"
@@ -1012,100 +987,45 @@
       %]
     [% END %]
 
-    [%# flags %]
+  [% END %]
+  [% WRAPPER fields_rhs %]
+
+    [%# url %]
     [% WRAPPER bug_modal/field.html.tmpl
-        name = "bug_flags"
-        container = 1
-        label = terms.Bug _ " Flags"
-        hide_on_view = !has_bug_flags
+        field = bug_fields.bug_file_loc
+        field_type = constants.FIELD_TYPE_FREETEXT
+        hide_on_view = bug.bug_file_loc == ""
+        default = "https://"
+        help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#bug_file_loc"
     %]
-      [% INCLUDE bug_modal/flags.html.tmpl
-          types = bug.flag_types.skip("name", "needinfo")
-      %]
+      [% INCLUDE bug_url_link %]
     [% END %]
+
+    [%# see also %]
+    [% INCLUDE bug_modal/field.html.tmpl
+        field = bug_fields.see_also
+        field_type = constants.FIELD_TYPE_BUG_URLS
+        values = bug.see_also
+        hide_on_view = bug.see_also.size == 0
+        help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#see_also"
+    %]
 
   [% END %]
-[% END %]
-
-[% IF tracking_flags.size %]
-
-  [%# === tracking flags === %]
-
-  [% WRAPPER bug_modal/module.html.tmpl
-      title = tracking_flags_title
-      collapsed = 1
-      subtitle = firefox_flags_subtitle
-  %]
-    [% WRAPPER fields_lhs %]
-
-      [% UNLESS tracking_flags_set || project_flags_set || blocking_flags_set %]
-        <p class="edit-hide">
-          This [% terms.bug %] is not currently tracked.
-        </p>
-      [% END %]
-
-      [% IF tracking_flags_has %]
-        [%# tracking flags %]
-        [% WRAPPER bug_modal/field.html.tmpl
-            container    = 1
-            label        = "Tracking Flags"
-            hide_on_view = !tracking_flags_set
-            help         = "https://wiki.mozilla.org/BMO/UserGuide#Tracking_Flags"
-        %]
-          [% INCLUDE bug_modal/tracking_flags.html.tmpl
-              type = "tracking"
-          %]
-        [% END %]
-      [% END %]
-
-    [% END %]
-    [% WRAPPER fields_rhs %]
-
-      [% IF blocking_flags_has %]
-        [%# blocking flags %]
-        [% WRAPPER bug_modal/field.html.tmpl
-            container = 1
-            label = "Blocking Flags"
-            hide_on_view = !blocking_flags_set
-        %]
-          [% INCLUDE bug_modal/tracking_flags.html.tmpl
-              type = "blocking"
-          %]
-        [% END %]
-      [% END %]
-
-      [% IF project_flags_has %]
-        [%# project flags %]
-        [% WRAPPER bug_modal/field.html.tmpl
-            container    = 1
-            label        = "Project Flags"
-            hide_on_view = !project_flags_set
-            help         = "https://wiki.mozilla.org/BMO/UserGuide#Tracking_Flags"
-        %]
-          [% INCLUDE bug_modal/tracking_flags.html.tmpl
-              type = "project"
-          %]
-        [% END %]
-      [% END %]
-
-    [% END %]
-  [% END %]
-
 [% END %]
 
 [%# === details === %]
 
 [%
   sub = [];
+  IF bug.keyword_objects.size;
+    IF bug.keyword_objects.size <= 3;
+      sub.push("{" _ bug.keyword_objects.pluck("name").join(", ") _ "}");
+    ELSE;
+      sub.push(bug.keyword_objects.size _ " keywords");
+    END;
+  END;
   IF bug.status_whiteboard != "";
     sub.push("Whiteboard: " _ bug.status_whiteboard.truncate(256, '…'));
-  END;
-  IF bug.cf_crash_signature != "";
-    sub.push("crash signature");
-  END;
-  IF bug.bug_file_loc != "";
-    loc_html = INCLUDE bug_url_link link_text="URL";
-    sub.push({ unfiltered => loc_html });
   END;
 %]
 [% WRAPPER bug_modal/module.html.tmpl
@@ -1115,30 +1035,78 @@
 %]
   [% WRAPPER fields_lhs %]
 
-    [%# whiteboard %]
+    [%# alias %]
+    [% INCLUDE bug_modal/field.html.tmpl
+        field = bug_fields.alias
+        field_type = constants.FIELD_TYPE_FREETEXT
+        hide_on_view = 1
+        short_width = 1
+        help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#alias"
+    %]
+
+    [%# keywords %]
+    [% WRAPPER bug_modal/field.html.tmpl
+        field = bug_fields.keywords
+        field_type = constants.FIELD_TYPE_KEYWORDS
+        hide_on_view = bug.keyword_objects.size == 0
+        help = basepath _ "describekeywords.cgi"
+    %]
+      [% IF bug.keyword_objects.size %]
+        [% FOREACH keyword IN bug.keyword_objects.pluck("name") %]
+          <a href="[% basepath FILTER none %]buglist.cgi?keywords=[% keyword FILTER html %]&amp;resolution=---">
+            [%~ keyword FILTER html %]</a>[% ", " UNLESS loop.last %]
+        [% END %]
+      [% ELSE %]
+        [% "---" FILTER html %]
+      [% END %]
+    [% END %]
+
+    [%# whiteboards %]
     [% WRAPPER bug_modal/field.html.tmpl
         field = bug_fields.status_whiteboard
         field_type = constants.FIELD_TYPE_FREETEXT
+        hide_on_view = bug.status_whiteboard == ""
         help = "https://wiki.mozilla.org/BMO/UserGuide/Whiteboard"
     %]
       [% bug.status_whiteboard == "" ? "---" : bug.status_whiteboard FILTER html %]
     [% END %]
-
-    [%# votes %]
-    [% IF bug.product_obj.votesperuser %]
-      [% WRAPPER bug_modal/field.html.tmpl
-          container = 1
-          label = "Votes"
-          name = "votes"
-          help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#votes"
+    [% UNLESS cf_hidden_in_product('cf_qa_whiteboard', bug.product, bug.component, bug) %]
+      [% rendered_custom_fields.push('cf_qa_whiteboard') %]
+      [% INCLUDE bug_modal/field.html.tmpl
+          field = bug_fields.cf_qa_whiteboard
+          field_type = bug_fields.cf_qa_whiteboard.type
+          hide_on_view = bug.cf_qa_whiteboard == ""
       %]
-        [% bug.votes FILTER html %]
-        vote[% "s" IF bug.votes != 1 %]
-        [% IF user.id %]
-          <button type="button" class="secondary" id="vote-btn">
-            [% bug.user_votes ? "Remove vote" : "Vote" %]
-          </button>
+    [% END %]
+
+    [%# cab review %]
+    [% UNLESS cf_hidden_in_product('cf_cab_review', bug.product, bug.component, bug) %]
+      [% rendered_custom_fields.push('cf_cab_review') %]
+      [% IF bug.cf_cab_review == "---" %]
+        [% WRAPPER bug_modal/field.html.tmpl
+            field = bug_fields.cf_cab_review
+            field_type = bug_fields.cf_cab_review.type
+            container = 1
+            hide_on_view = 1
+        %]
+          <span id="cab-review-gate">
+            <a href="https://mozilla.service-now.com/change_request.do?sysparm_stack=change_request_list.do&amp;sys_id=-1&amp;sysparm_query=active=true" target="_blank" rel="noopener noreferrer">ServiceNow Change Request</a>
+            <button id="cab-review-gate-close" type="button" class="secondary">Use Flag</button>
+          </span>
+          <span id="cab-review-edit" style="display:none">
+            [% INCLUDE bug_modal/field.html.tmpl
+                field = bug_fields.cf_cab_review
+                field_type = bug_fields.cf_cab_review.type
+                inline = 1
+                no_indent = 1
+            %]
+          </span>
         [% END %]
+      [% ELSE %]
+        [% INCLUDE bug_modal/field.html.tmpl
+            field = bug_fields.cf_cab_review
+            field_type = bug_fields.cf_cab_review.type
+        %]
       [% END %]
     [% END %]
 
@@ -1163,29 +1131,38 @@
       END;
     %]
 
+    [%# votes %]
+    [% IF bug.product_obj.votesperuser %]
+      [% WRAPPER bug_modal/field.html.tmpl
+          container = 1
+          label = "Votes"
+          name = "votes"
+          help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#votes"
+      %]
+        [% bug.votes FILTER html %]
+        [% IF user.id %]
+          <button type="button" class="secondary" id="vote-btn">
+            [%~ bug.user_votes ? "Remove vote" : "Vote" ~%]
+          </button>
+        [% END %]
+      [% END %]
+    [% END %]
+
     [% Hook.process('details_lhs') %]
   [% END %]
   [% WRAPPER fields_rhs %]
 
-    [%# url %]
+    [%# flags %]
     [% WRAPPER bug_modal/field.html.tmpl
-        field = bug_fields.bug_file_loc
-        field_type = constants.FIELD_TYPE_FREETEXT
-        hide_on_view = bug.bug_file_loc == ""
-        default = "https://"
-        help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#bug_file_loc"
+        name = "bug_flags"
+        container = 1
+        label = terms.Bug _ " Flags"
+        hide_on_view = !has_bug_flags
     %]
-      [% INCLUDE bug_url_link %]
+      [% INCLUDE bug_modal/flags.html.tmpl
+          types = bug.flag_types.skip("name", "needinfo")
+      %]
     [% END %]
-
-    [%# see also %]
-    [% INCLUDE bug_modal/field.html.tmpl
-        field = bug_fields.see_also
-        field_type = constants.FIELD_TYPE_BUG_URLS
-        values = bug.see_also
-        hide_on_view = bug.see_also.size == 0
-        help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#see_also"
-    %]
 
     [% Hook.process('details_rhs') %]
   [% END %]
@@ -1194,6 +1171,7 @@
   [%
     FOREACH field IN custom_fields;
       NEXT IF field.type != constants.FIELD_TYPE_TEXTAREA;
+      NEXT IF field.name == "cf_crash_signature"; # Rendered below
       Hook.process('custom_field-' _ field.name);
       NEXT IF rendered_custom_fields.exists(field.name);
       INCLUDE bug_modal/field.html.tmpl
@@ -1202,6 +1180,16 @@
         hide_on_view = bug.${field.name} == "" || bug.${field.name} == "---";
     END;
   %]
+[% END %]
+
+[%# === Crash === %]
+
+[% WRAPPER bug_modal/module.html.tmpl
+  title = "Crash Data"
+  collapsed = 1
+  hide_on_view = bug.cf_crash_signature == ""
+%]
+  [% Hook.process('custom_field-cf_crash_signature'); %]
 [% END %]
 
 [%# === groups === %]
@@ -1343,20 +1331,22 @@
 
 [%# === attachments === %]
 
-[% IF active_attachments || obsolete_attachments %]
+[% IF active_attachments || obsolete_attachments || user.id %]
   [%
     sub = [];
+    IF active_attachments + obsolete_attachments == 0;
+      sub.push("No files");
+    END;
     IF active_attachments;
-      sub.push(active_attachments _ " attachment" _ (active_attachments == 1 ? "" : "s"));
+      sub.push(active_attachments _ " file" _ (active_attachments == 1 ? "" : "s"));
     END;
     IF obsolete_attachments;
-      sub.push(obsolete_attachments _ " obsolete attachment" _ (obsolete_attachments == 1 ? "" : "s"));
+      sub.push(obsolete_attachments _ " obsolete file" _ (obsolete_attachments == 1 ? "" : "s"));
     END;
   %]
   [% WRAPPER bug_modal/module.html.tmpl
       title = "Attachments"
       subtitle = sub
-      collapsed = active_attachments == 0
   %]
     [% INCLUDE bug_modal/attachments.html.tmpl
         active_attachments = active_attachments
@@ -1375,9 +1365,8 @@
 
 [% IF user.id %]
   <div id="top-actions">
-    <a href="[% basepath FILTER none %]attachment.cgi?bugid=[% bug.id FILTER uri %]&amp;action=enter" id="attachments-add-link">Attach File</a>
     [%+ Hook.process('top_actions') %]
-    <button type="submit" class="save-btn major" id="top-save-btn" style="display:none">Save Changes</button>
+    <button type="submit" class="save-btn primary" id="top-save-btn" style="display:none">Save Changes</button>
   </div>
 [% END %]
 
@@ -1400,66 +1389,6 @@
 <div id="bottom-actions">
   <div id="bottom-right-actions">
     <button type="button" id="top-btn" class="secondary" aria-label="Go to Page Top">Top &uarr;</button>
-    <div class="dropdown">
-      <button type="button" id="format-btn" aria-haspopup="true" aria-label="Format [% terms.Bug %]"
-        aria-expanded="false" aria-controls="format-menu" class="dropdown-button minor">Format [% terms.Bug %] &#9652;</button>
-      <ul class="dropdown-content left menu-up" id="format-menu" role="menu" style="display:none;">
-        <li role="presentation">
-          <a href="[% basepath FILTER none %]show_bug.cgi?ctype=xml&amp;id=[% bug.id FILTER uri %]" role="menuitem" tabindex="-1">XML</a>
-        </li>
-        [% IF bug.groups_in.size == 0 %]
-          <li role="presentation">
-            <a href="[% basepath FILTER none %]rest/bug/[% bug.id FILTER uri %]" role="menuitem" tabindex="-1">JSON</a>
-          </li>
-        [% END %]
-      </ul>
-    </div>
-    [% IF user.id %]
-      <div class="dropdown">
-        <button type="button" id="new-bug-btn" aria-haspopup="true" aria-label="New/Clone [% terms.Bug %]"
-          aria-expanded="false" aria-controls="new-bug-menu" class="dropdown-button minor">New/Clone [% terms.Bug %] &#9652;</button>
-        <ul class="dropdown-content left menu-up" id="new-bug-menu" role="menu" style="display:none;">
-          <li role="presentation">
-            <a href="[% basepath FILTER none %]enter_bug.cgi" role="menuitem" tabindex="-1" target="_blank">
-              Create a new [% terms.bug %]</a>
-          </li>
-          <li role="presentation">
-            <a href="[% basepath FILTER none %]enter_bug.cgi?product=[% bug.product FILTER uri %]"
-               role="menuitem" tabindex="-1" target="_blank">&#8230; in this product</a>
-          </li>
-          <li role="presentation">
-            <a href="[% basepath FILTER none %]enter_bug.cgi?product=[% bug.product FILTER uri %]&amp;component=[% bug.component FILTER uri %]"
-               role="menuitem" tabindex="-1" target="_blank">&#8230; in this component</a>
-          </li>
-          <li role="separator"></li>
-          <li role="presentation">
-            <a href="[% basepath FILTER none %]enter_bug.cgi?format=__default__&amp;blocked=[% bug.id FILTER uri %]
-                     [%~%]&amp;product=[% bug.product FILTER uri %]&amp;component=[% bug.component FILTER uri %]"
-               role="menuitem" tabindex="-1" target="_blank">&#8230; that blocks this [% terms.bug %]</a>
-          </li>
-          <li role="presentation">
-            <a href="[% basepath FILTER none %]enter_bug.cgi?format=__default__&amp;dependson=[% bug.id FILTER uri %]
-                     [%~%]&amp;product=[% bug.product FILTER uri %]&amp;component=[% bug.component FILTER uri %]"
-               role="menuitem" tabindex="-1" target="_blank">&#8230; that depends on this [% terms.bug %]</a>
-          </li>
-          <li role="presentation">
-            <a href="[% basepath FILTER none %]enter_bug.cgi?format=__default__&amp;regressed_by=[% bug.id FILTER uri %]
-                     [%~%]&amp;product=[% bug.product FILTER uri %]&amp;component=[% bug.component FILTER uri %]"
-               role="menuitem" tabindex="-1" target="_blank">&#8230; that is regressed by this [% terms.bug %]</a>
-          </li>
-          <li role="separator"></li>
-          <li role="presentation">
-            <a href="[% basepath FILTER none %]enter_bug.cgi?format=__default__&amp;cloned_bug_id=[% bug.id FILTER uri %]
-                     [%~%]&amp;product=[% bug.product FILTER uri %]&amp;component=[% bug.component FILTER uri %]"
-               role="menuitem" tabindex="-1" target="_blank">&#8230; as a clone of this [% terms.bug %]</a>
-          </li>
-          <li role="presentation">
-            <a href="[% basepath FILTER none %]enter_bug.cgi?format=__default__&amp;cloned_bug_id=[% bug.id FILTER uri %]"
-               role="menuitem" tabindex="-1" target="_blank">&#8230; as a clone, in a different product</a>
-          </li>
-        </ul>
-      </div>
-    [% END %]
   </div>
 </div>
 
@@ -1490,7 +1419,7 @@
   [%# === comment actions === %]
   [% IF user.id %]
     <div id="new-comment-actions">
-      <button type="submit" class="save-btn major" id="bottom-save-btn">Save Changes</button>
+      <button type="submit" class="save-btn primary" id="bottom-save-btn">Save Changes</button>
       <div id="resolve-as">
         [%
           IF bug.resolution == "";

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -490,7 +490,8 @@
 
     [%# importance %]
     [% WRAPPER bug_modal/field.html.tmpl
-        label = "Importance"
+        name = "importance"
+        label = "Priority"
         container = 1
         hide_on_view = bug.priority == "--" && bug.bug_severity == "normal"
         help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#priority"
@@ -507,6 +508,7 @@
           field_type = constants.FIELD_TYPE_SINGLE_SELECT
           aria_label = bug_fields.bug_severity.description
           inline = 1
+          label = "Severity"
       %]
       [% UNLESS cf_hidden_in_product('cf_rank', bug.product, bug.component, bug) %]
         [% rendered_custom_fields.push('cf_rank') %]

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -1023,7 +1023,7 @@
   sub = [];
   IF bug.keyword_objects.size;
     IF bug.keyword_objects.size <= 3;
-      sub.push("{" _ bug.keyword_objects.pluck("name").join(", ") _ "}");
+      sub.push("Keywords: " _ bug.keyword_objects.pluck("name").join(", "));
     ELSE;
       sub.push(bug.keyword_objects.size _ " keywords");
     END;

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -668,25 +668,29 @@
       inline = 1
       edit_only = 1
   %]
-  [% UNLESS prefix %]
-    <div id="assigned-container" style="display:none">
-      <button type="button" class="secondary" id="mark-as-assigned-btn">
-        Mark as Assigned
-      </button>
-    </div>
-  [% END %]
   [% IF bug.choices.resolution.only("name", "DUPLICATE").size %]
     <div id="[% prefix FILTER none %]duplicate-container">
       of
       <input id="[% prefix FILTER none %]dup_id" name="[% prefix FILTER none %]dup_id"
         size="6" value="[% bug.dup_id FILTER html %]">
     </div>
-    <div id="[% prefix FILTER none %]duplicate-actions">
-      <button type="button" class="secondary" id="[% prefix FILTER none %]mark-as-dup-btn">
-        Mark as Duplicate
-      </button>
-    </div>
   [% END %]
+  <div id="status-action-buttons">
+    [% IF bug.choices.resolution.only("name", "DUPLICATE").size %]
+      <div id="[% prefix FILTER none %]duplicate-actions">
+        <button type="button" class="secondary" id="[% prefix FILTER none %]mark-as-dup-btn">
+          Mark as Duplicate
+        </button>
+      </div>
+    [% END %]
+    [% UNLESS prefix %]
+      <div id="assigned-container" style="display:none">
+        <button type="button" class="secondary" id="mark-as-assigned-btn">
+          Mark as Assigned
+        </button>
+      </div>
+    [% END %]
+  </div>
 [% END %]
 
 [%# === people === %]

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -476,22 +476,28 @@
         name = "importance"
         label = "Priority"
         container = 1
-        hide_on_view = bug.priority == "--" && bug.bug_severity == "normal"
         help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#priority"
     %]
-      [% INCLUDE bug_modal/field.html.tmpl
+      [% WRAPPER bug_modal/field.html.tmpl
           field = bug_fields.priority
           field_type = constants.FIELD_TYPE_SINGLE_SELECT
           aria_label = bug_fields.priority.description
           no_indent = 1
           inline = 1
       %]
+        [% IF bug.priority == "--" %]
+          <em>Not set</em>
+        [% ELSE %]
+          [% bug.priority FILTER html %]
+        [% END %]
+      [% END %]
       [% INCLUDE bug_modal/field.html.tmpl
           field = bug_fields.bug_severity
           field_type = constants.FIELD_TYPE_SINGLE_SELECT
           aria_label = bug_fields.bug_severity.description
           inline = 1
           label = "Severity"
+          hide_on_view = bug.bug_severity == "normal"
           help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#bug_severity"
       %]
       [% UNLESS cf_hidden_in_product('cf_rank', bug.product, bug.component, bug) %]

--- a/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
@@ -138,7 +138,7 @@ END;
 
           [% CASE constants.FIELD_TYPE_USER %]
             [%# users %]
-            [% INCLUDE bug_modal/user.html.tmpl u=value %]
+            [% INCLUDE bug_modal/user.html.tmpl u=value nick_only=1 gravatar_size=20 %]
 
           [% CASE constants.FIELD_TYPE_BUG_URLS %]
             [%# see also %]

--- a/extensions/BugModal/template/en/default/bug_modal/navigate.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/navigate.html.tmpl
@@ -15,7 +15,7 @@
 %]
 
 <nav id="search-nav" aria-labelledby="search-nav-label">
-  <span id="search-nav-label">[% terms.Bug %] List:</span>
+  <a id="search-nav-label" href="[% basepath FILTER none %]buglist.cgi?regetlastlist=[% search.id FILTER uri %]">[% terms.Bug %] List</a>
   ([% this_bug_idx + 1 %] of [% last_bug_list.size %])
   [% INCLUDE nav_link text="&#10096;&#10096; First" bug_id=last_bug_list.first %]
   [% IF this_bug_idx > 0 %]
@@ -29,7 +29,6 @@
     [% INCLUDE nav_link text="Next &#10097;" bug_id="" %]
   [% END %]
   [% INCLUDE nav_link text="Last &#10097;&#10097;" bug_id=last_bug_list.last %]
-  <a id="search-nav-reget" href="[% basepath FILTER none %]buglist.cgi?regetlastlist=[% search.id FILTER uri %]">Last search results</a>
 </nav>
 
 [% BLOCK nav_link %]

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -306,6 +306,7 @@ input[type="number"] {
   margin-left: 4px;
 }
 
+#mark-as-assigned-btn,
 #mark-as-dup-btn {
   white-space: nowrap;
 }

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -358,6 +358,11 @@ input[type="number"] {
   color: var(--secondary-label-color);
 }
 
+#cc-latch,
+#cc-summary {
+  cursor: default;
+}
+
 #cc-list {
   overflow-y: auto;
   clear: both;

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -296,6 +296,18 @@ input[type="number"] {
   display: none !important; /* Override `inline` */
 }
 
+#field-resolution {
+  padding: 0;
+}
+
+#status-action-buttons,
+#duplicate-container {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: top;
+  white-space: nowrap;
+}
+
 #duplicate-container,
 #duplicate-actions,
 #assigned-container,

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -278,6 +278,14 @@ input[type="number"] {
   color: var(--secondary-label-color);
 }
 
+#field-importance .name {
+  vertical-align: middle;
+}
+
+#field-importance .container {
+  display: flex;
+}
+
 #duplicate-container,
 #duplicate-actions,
 #assigned-container,

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -292,6 +292,10 @@ input[type="number"] {
   display: flex;
 }
 
+#field-bug_severity[style="display:none"] {
+  display: none !important; /* Override `inline` */
+}
+
 #duplicate-container,
 #duplicate-actions,
 #assigned-container,

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -25,9 +25,11 @@
 .inline {
   display: table-cell !important;
   width: auto !important;
+  vertical-align: middle !important;
 }
 
 .gravatar {
+  margin-right: 4px;
   border-radius: 4px;
   vertical-align: middle;
 }
@@ -144,12 +146,12 @@ a.activity-ref {
 }
 
 .module-content {
-  padding: 4px;
+  padding: 5px;
 }
 
 .module .field {
   display: table;
-  margin: 4px;
+  margin: 4px 0;
   width: 100%;
   vertical-align: top;
 }
@@ -252,25 +254,28 @@ input[type="number"] {
 }
 
 #field-status_summary {
-  padding-top: 6px;
-  padding-bottom: 4px;
+  padding-top: 8px;
   color: var(--secondary-label-color);
 }
 
-#status-assignee,
-#status-assignee .vcard,
-#status-needinfo,
-#status-needinfo .vcard {
-  display: inline;
+#field-status_summary .bug-status-label {
+  border-radius: 4px;
+  padding: 2px 8px;
+  color: #FFF;
+  font-weight: bold;
 }
 
-#field-status_summary .bug-type-label {
-  margin-right: 8px;
+#field-status_summary .bug-status-label[data-status="open"] {
+  background-color: var(--bug-status-color-open);
 }
 
-#status-assignee,
-#status-needinfo {
+#field-status_summary .bug-status-label[data-status="closed"] {
+  background-color: var(--bug-status-color-closed);
+}
+
+#field-status_summary .bug-time-label {
   margin-left: 8px;
+  color: var(--secondary-label-color);
 }
 
 #duplicate-container,
@@ -285,6 +290,10 @@ input[type="number"] {
 
 #dup_id {
   margin-left: 4px;
+}
+
+#mark-as-dup-btn {
+  white-space: nowrap;
 }
 
 #resolve-as,
@@ -421,10 +430,14 @@ input[type="number"] {
 #bottom-right-actions,
 .edit-textarea-set-btn {
   float: right;
+  margin-left: 8px;
+}
+
+#new-comment-actions {
+  float: left;
 }
 
 #bottom-actions {
-  margin-top: 8px;
   margin-bottom: 50px;
   max-width: 1024px;
 }
@@ -491,6 +504,17 @@ input[type="number"] {
 
 #attachments .vcard {
   display: inline;
+}
+
+#attachments-footer {
+  display: flex;
+  align-items: center;
+  padding: 4px;
+}
+
+#attachments-actions {
+  flex: auto;
+  display: flex;
 }
 
 #attachments-actions button {
@@ -1004,8 +1028,8 @@ h3.change-name a {
 #mode-container {
   display: table-cell;
   margin: 5px;
-  border-left: 5px solid transparent;
-  padding: 5px;
+  border-left: 10px solid transparent;
+  padding: 10px 5px;
   text-align: right;
   white-space: nowrap;
 }
@@ -1025,11 +1049,6 @@ h3.change-name a {
 
 #commit {
   margin: 5px;
-}
-
-#mode-container .button-row {
-  margin-top: 4px;
-  border-left: 5px solid transparent;
 }
 
 /**

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -132,20 +132,18 @@ a.activity-ref {
   opacity: 0;
 }
 
-.module .fields-lhs {
-  display: table-cell;
-  min-width: 450px;
-  vertical-align: top;
-}
-
+.module .fields-lhs,
 .module .fields-rhs {
-  display: table-cell;
+  flex: none;
+  width: 50%;
   min-width: 450px;
-  width: 100%;
+  display: table-cell;
   vertical-align: top;
 }
 
 .module-content {
+  display: flex;
+  flex-wrap: wrap;
   padding: 5px;
 }
 
@@ -1303,11 +1301,6 @@ a.lightbox-icon.markdown {
 
   #header .inner {
     width: auto !important;
-  }
-
-  .module .fields-lhs,
-  .module .fields-rhs {
-    min-width: 380px;
   }
 
   #main-inner {

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -1059,6 +1059,10 @@ h3.change-name a {
   margin: 5px;
 }
 
+#mode-container .button-row {
+  margin: 4px 0;
+}
+
 /**
  * theme
  */

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -151,6 +151,7 @@ a.activity-ref {
 
 .module .field {
   display: table;
+  box-sizing: border-box;
   margin: 4px 0;
   width: 100%;
   vertical-align: top;
@@ -178,6 +179,7 @@ a.activity-ref {
 }
 
 .module .indent {
+  padding-right: 10px;
   padding-left: 10px;
 }
 
@@ -241,11 +243,12 @@ input[type="number"] {
  */
 
 #field-value-bug_id {
+  margin-left: 8px;
   font-size: var(--font-size-large);
 }
 
 #field-value-bug_id a {
-  color: inherit;
+  color: var(--primary-label-color);
 }
 
 #field-value-short_desc {
@@ -254,7 +257,8 @@ input[type="number"] {
 }
 
 #field-status_summary {
-  padding-top: 8px;
+  padding-top: 4px;
+  padding-bottom: 8px;
   color: var(--secondary-label-color);
 }
 
@@ -276,6 +280,10 @@ input[type="number"] {
 #field-status_summary .bug-time-label {
   margin-left: 8px;
   color: var(--secondary-label-color);
+}
+
+#field-status_summary .bug-time-label span {
+  text-transform: lowercase;
 }
 
 #field-importance .name {
@@ -1073,7 +1081,7 @@ h3.change-name a {
  */
 
 #main-inner {
-  margin: 15px auto;
+  margin: 8px auto;
   max-width: 1024px;
   min-width: 800px;
 }
@@ -1249,9 +1257,8 @@ a.lightbox-icon.markdown {
  */
 
 #search-nav {
-  padding: 4px 8px;
-  color: var(--secondary-label-color);
-  background: var(--primary-region-header-background-color);
+  flex: auto;
+  margin: 4px;
 }
 
 #search-nav-label {
@@ -1261,10 +1268,6 @@ a.lightbox-icon.markdown {
 .search-nav-link,
 .search-nav-disabled {
   margin-left: 4px;
-}
-
-#search-nav-reget {
-  margin-left: 8px;
 }
 
 .search-nav-disabled {

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -169,7 +169,7 @@ $(function() {
     $('#attachments-obsolete-btn')
         .click(function(event) {
             event.preventDefault();
-            $(event.target).text(($('#attachments tr:hidden').length ? 'Hide' : 'Show') + ' Obsolete Attachments');
+            $(event.target).text(($('#attachments tr:hidden').length ? 'Hide Obsolete' : 'Show Obsolete'));
             $('#attachments tr.attach-obsolete').toggle();
         });
 

--- a/qa/t/test_target_milestones.t
+++ b/qa/t/test_target_milestones.t
@@ -40,7 +40,7 @@ $sel->title_is("Milestone Created");
 # Edit the milestone of test_bug_1.
 
 go_to_bug($sel, $test_bug_1);
-$sel->is_text_present_ok("Target:");
+$sel->is_text_present_ok("Milestone:");
 $sel->select_ok("target_milestone", "label=TM1");
 $sel->click_ok("bottom-save-btn");
 $sel->wait_for_page_to_load(WAIT_TIME);

--- a/qa/t/test_votes.t
+++ b/qa/t/test_votes.t
@@ -215,7 +215,7 @@ $sel->is_text_present_ok(
 
 go_to_bug($sel, $bug2_id);
 $text = trim($sel->get_text("field-value-votes"));
-ok($text =~ /4 votes/, "4 votes remaining");
+ok($text =~ /\b4\b/, "4 votes remaining");
 
 # Decrease the number per user. Bugs should keep at least one vote,
 # i.e. not all votes are removed (which was the old behavior).
@@ -236,7 +236,7 @@ $sel->is_text_present_ok("removed votes for bug");
 
 go_to_bug($sel, $bug3_id);
 $text = trim($sel->get_text("field-value-votes"));
-ok($text =~ /2 votes/, "2 votes remaining");
+ok($text =~ /\b2\b/, "2 votes remaining");
 
 # Now disable UNCONFIRMED.
 

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -1939,7 +1939,7 @@ table.tabs .clickable_area {
   position: absolute;
   top: calc(100% + 4px);
   right: 0;
-  z-index: 1;
+  z-index: 10;
   margin: 0;
   border-width: 1px;
   border-style: solid;

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -2752,7 +2752,7 @@ pre.comment-text {
  */
 
 :root {
-  --bug-status-color-open: #229921;
+  --bug-status-color-open: #188716;
   --bug-status-color-closed: #1B6AB8;
   --bug-type-color-defect: #EA3C3D;
   --bug-type-color-enhancement: #2ABA27;

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -1414,6 +1414,21 @@ input[type="radio"]:checked {
 }
 
 /**
+ * Page toolbar
+ */
+
+#page-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  color: var(--secondary-label-color);
+}
+
+#page-toolbar .buttons {
+  flex: none;
+}
+
+/**
  * Link lists
  */
 
@@ -2021,7 +2036,7 @@ table.tabs .clickable_area {
 .dropdown-content li > div {
   display: block;
   box-sizing: border-box;
-  padding: 4px 8px 4px 24px;
+  padding: 4px 24px;
   width: 100%;
   color: inherit;
   background: none transparent;


### PR DESCRIPTION
* Reorganize bug modal modules based on my [information architecture plan](https://bugzilla.mozilla.org/show_bug.cgi?id=1344091#c3) so similar fields are properly grouped.
* Hide more fields if it’s empty or unspecified so the view mode will be cleaner: Version, Target, Points, Whiteboard, Triage Owner
* Toolbar: Include both search navigation and page action buttons
* Header: Remove redundant info and instead add simple status (Open/Closed), reported date and updated/resolved date; add menus that are currently on the page footer
* User names on modules: now displayed as Gravatar + nick
* Attachments module: now always displayed with the Attach New File button-like link
* Misc fixes: simplified URL labels, better module header subtitles, etc.

## Bugzilla link

[Bug 1344091 - Move all the related bug fields into the same module](https://bugzilla.mozilla.org/show_bug.cgi?id=1344091)