### PR TITLE
Bug 1541111 - Separate bugs on Triage Owners page by type

### DIFF
--- a/extensions/BMO/template/en/default/pages/triage_owners.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/triage_owners.html.tmpl
@@ -93,15 +93,30 @@
     <small>Each triage owner links to a buglist of all open [% terms.bugs %], since 2016-06-01, without a pending needinfo, where the priority is '--'.</small>
   </p>
   [% current_product = "" %]
-  <table border="0" cellspacing="0" id="report" width="100%">
-    </tr>
+  <table id="report">
     [% FOREACH r = results %]
       [% count = loop.count() %]
       [% IF current_product != r.product %]
         [% current_product = r.product %]
-        <tr class="product_header">
-          <th colspan="3">[% r.product FILTER html %]</th>
-        </tr>
+        <thead>
+          <tr>
+            <th>[% r.product FILTER html %]</th>
+            <th>Owner</th>
+            [% FOREACH c IN r.bug_counts %]
+              <th class="count">
+                [% IF c.key == "total"%]
+                  Total
+                [% ELSE %]
+                  <span class="bug-type-label iconic" title="[% c.key FILTER html %]"
+                        aria-label="[% c.key FILTER html %]" data-type="[% c.key FILTER html %]">
+                    <span class="icon" aria-hidden="true"></span>
+                  </span>
+                [% END %]
+              </th>
+            [% END %]
+          </tr>
+        </thead>
+        <tbody>
       [% END %]
       <tr class="bz_bugitem [% count % 2 == 1 ? "bz_row_odd" : "bz_row_even" %]">
         <td>
@@ -114,17 +129,23 @@
             <em>None</em>
           [% END %]
         </td>
-        <td>
-          [% IF r.buglist_url %]
-            <a href="[% basepath FILTER none %]buglist.cgi?product=[% r.product FILTER uri %]&component=[% r.component FILTER uri %]&[% r.buglist_url FILTER none %]">
-              [% r.bug_count FILTER html +%] [%+ terms.bugs %] found.
-            </a>
-          [% ELSE %]
-            None
-          [% END %]
-        </td>
+        [% FOREACH c IN r.bug_counts %]
+          <td class="count">
+            [% IF c.value %]
+              <a href="[% basepath FILTER none %]buglist.cgi?product=
+              [%~ r.product FILTER uri %]&amp;component=[% r.component FILTER uri %]
+              [%~ IF c.key != "total" %]&amp;bug_type=[% c.key FILTER html; END %]&amp;
+              [%~ r.buglist_url FILTER html %]">
+            [% END %]
+              [%~ c.value FILTER html ~%]
+            [% IF c.value %]
+              </a>
+            [% END %]
+          </td>
+        [% END %]
       </tr>
     [% END %]
+    </tbody>
   </table>
   <p>
     Found [% results.size %] component[% 's' IF results.size != 1 %]:

--- a/extensions/BMO/web/styles/triage_reports.css
+++ b/extensions/BMO/web/styles/triage_reports.css
@@ -17,27 +17,46 @@
     width: 20em;
 }
 
-#report tr.bugitem:hover {
-  background: #ccccff;
-}
-
-#report th, #report td {
-  padding: 1px 10px 1px 10px;
-}
-
-#report-header {
-  background: #dddddd;
-}
-
-tr.product_header {
-  background: #dddddd;
-}
-
 #triage_owners_form th {
   text-align: right;
   vertical-align: top;
 }
 
-#report th, #report td {
-    text-align: left;
+#report {
+  position: relative;
+  width: 100%;
+  border-collapse: collapse;
+}
+
+#report thead {
+  position: sticky;
+  top: 0;
+  left: 0;
+  background: #dddddd;
+}
+
+#report tr.bugitem:hover {
+  background: #ccccff;
+}
+
+#report th,
+#report td {
+  padding: 4px 8px;
+  text-align: left;
+}
+
+#report th.count,
+#report td.count {
+  width: 1em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+#report td.count {
+  color: #CCC;
+}
+
+#report td.count a {
+  display: block;
+  width: 100%;
 }


### PR DESCRIPTION
Update the [Triage Owners](https://bugzilla.mozilla.org/page.cgi?id=triage_owners.html) page to add bug counts by type. Also improve the style (sticky table header) and markup.

![Screenshot_2019-04-02 Triage Owners](https://user-images.githubusercontent.com/2929505/55429939-b1ce0f80-555a-11e9-99e3-5dab0d063268.png)

## Bugzilla link

[Bug 1541111 - Separate bugs on Triage Owners page by type](https://bugzilla.mozilla.org/show_bug.cgi?id=1541111)