### PR TITLE
Bug 1531481 - Add bug type labels to My Dashboard

### DIFF
--- a/extensions/MyDashboard/lib/Queries.pm
+++ b/extensions/MyDashboard/lib/Queries.pm
@@ -39,6 +39,7 @@ use constant QUERY_ORDER => ("changeddate desc", "bug_id");
 # Share with buglist.cgi?
 use constant SELECT_COLUMNS => qw(
   bug_id
+  bug_type
   bug_status
   short_desc
   changeddate

--- a/extensions/MyDashboard/web/js/query.js
+++ b/extensions/MyDashboard/web/js/query.js
@@ -53,7 +53,7 @@ $(function() {
         bugQuery.plug(Y.Plugin.DataSourceJSONSchema, {
             schema: {
                 resultListLocator: "result.result.bugs",
-                resultFields: ["bug_id", "changeddate", "changeddate_fancy",
+                resultFields: ["bug_id", "bug_type", "changeddate", "changeddate_fancy",
                             "bug_status", "short_desc", "changeddate_api" ],
                 metaFields: {
                     description: "result.result.description",
@@ -170,6 +170,9 @@ $(function() {
         bugQueryTable = new Y.DataTable({
             columns: [
                 { key: Y.Plugin.DataTableRowExpansion.column_key, label: ' ', sortable: false },
+                { key: "bug_type", label: "T", allowHTML: true, sortable: true,
+                formatter: '<span class="bug-type-label iconic" title="{value}" aria-label="{value}" ' +
+                           'data-type="{value}"><span class="icon" aria-hidden="true"></span></span>' },
                 { key: "bug_id", label: "Bug", allowHTML: true, sortable: true,
                 formatter: `<a href="${BUGZILLA.config.basepath}show_bug.cgi?id={value}" target="_blank">{value}</a>` },
                 { key: "changeddate", label: "Updated", formatter: updatedFormatter,

--- a/extensions/MyDashboard/web/styles/mydashboard.css
+++ b/extensions/MyDashboard/web/styles/mydashboard.css
@@ -13,6 +13,10 @@
     width: 100%;
 }
 
+.yui3-datatable-col-bug_type {
+    text-align: center;
+}
+
 .yui3-datatable-col-changeddate,
 .yui3-datatable-col-created {
     white-space: nowrap;


### PR DESCRIPTION
Add the Type column to the “big query table” on My Dashboard.

![Screenshot_2019-04-02 My Dashboard](https://user-images.githubusercontent.com/2929505/55432935-2bb5c700-5562-11e9-97f0-23074cd81eda.png)

## Bugzilla link

[Bug 1531481 - Add bug type labels to My Dashboard](https://bugzilla.mozilla.org/show_bug.cgi?id=1531481)