### PR TITLE
Bug 1541204 - Bug type field is reset to default when selecting/changing a component, breaks "remember values as bookmarkable template"

### DIFF
--- a/template/en/default/bug/create/create.html.tmpl
+++ b/template/en/default/bug/create/create.html.tmpl
@@ -51,6 +51,10 @@ function init() {
   initCrashSignatureField();
   init_take_handler('[% user.login FILTER js %]');
   bz_attachment_form.update_requirements(false);
+
+  document.querySelector('#bug_type').addEventListener('change', () => {
+    bug_type_changed = true;
+  }, { once: true });
 }
 
 function initCrashSignatureField() {
@@ -67,6 +71,7 @@ function initCrashSignatureField() {
 var initialowners = new Array([% product.components.size %]);
 var last_initialowner;
 var default_bug_types = new Array([% product.components.size %]);
+let bug_type_changed = false;
 var initialccs = new Array([% product.components.size %]);
 var components = new Array([% product.components.size %]);
 var comp_desc = new Array([% product.components.size %]);
@@ -131,7 +136,10 @@ function set_assign_to() {
             last_initialowner = owner;
         }
 
-        form.bug_type.value = default_bug_types[index];
+        if (!bug_type_changed) {
+          form.bug_type.value = default_bug_types[index];
+        }
+
         document.getElementById('initial_cc').innerHTML = initialccs[index];
         document.getElementById('comp_desc').innerHTML = comp_desc[index];
 


### PR DESCRIPTION
Keep the Type field regardless of the component default value once the user changes it manually.

## Bugzilla link

[Bug 1541204 - Bug type field is reset to default when selecting/changing a component, breaks "remember values as bookmarkable template"](https://bugzilla.mozilla.org/show_bug.cgi?id=1541204)