### PR TITLE
Bug 1281200 - New show_bug.cgi view should have an option to have fields editable by default.

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -324,6 +324,10 @@
           aria-expanded="false" aria-controls="action-menu" class="dropdown-button minor">&#9662;</button>
         <ul class="dropdown-content left" id="action-menu" role="menu" style="display:none;">
           <li role="presentation">
+            <a id="action-enable-perm-edit" role="menuitemcheckbox" tabindex="-1">Always Enable Edit Mode</a>
+          </li>
+          <li role="separator"></li>
+          <li role="presentation">
             <a id="action-reset" role="menuitem" tabindex="-1">Reset Sections</a>
           </li>
           <li role="presentation">

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -81,8 +81,13 @@ $(function() {
 
     // restore edit mode after navigating back
     function restoreEditMode() {
-        if (!$('#editing').val())
+        if (!$('#editing').val()) {
+            if (localStorage.getItem('modal-perm-edit-mode') === 'true') {
+                $('#mode-btn').click();
+                $('#action-enable-perm-edit').attr('aria-checked', 'true');
+            }
             return;
+        }
         $('.module')
             .each(function() {
                 slide_module($(this), 'hide', true);
@@ -387,6 +392,15 @@ $(function() {
         });
 
     // action button actions
+
+    // enable perm edit mode
+    $('#action-enable-perm-edit')
+        .click(function(event) {
+            event.preventDefault();
+            const enabled = $(this).attr('aria-checked') !== 'true';
+            $(this).attr('aria-checked', enabled);
+            localStorage.setItem('modal-perm-edit-mode', enabled);
+        });
 
     // reset
     $('#action-reset')

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -1971,12 +1971,12 @@ a.controller {
   list-style: none;
 }
 
-.dropdown-content [role="menuitem"],
+.dropdown-content [role^="menuitem"],
 .dropdown-content [role="option"],
 .dropdown-content li > div {
   display: block;
   box-sizing: border-box;
-  padding: 2px 16px;
+  padding: 2px 8px 2px 24px;
   width: 100%;
   color: #555;
   line-height: 1.5;
@@ -1984,17 +1984,17 @@ a.controller {
   background: none transparent;
 }
 
-.dropdown-content [role="menuitem"],
+.dropdown-content [role^="menuitem"],
 .dropdown-content [role="option"] {
   outline: 0;
   text-decoration: none;
   cursor: pointer;
 }
 
-.dropdown-content [role="menuitem"]:hover,
-.dropdown-content [role="menuitem"]:focus,
-.dropdown-content [role="menuitem"]:active,
-.dropdown-content [role="menuitem"].active,
+.dropdown-content [role^="menuitem"]:hover,
+.dropdown-content [role^="menuitem"]:focus,
+.dropdown-content [role^="menuitem"]:active,
+.dropdown-content [role^="menuitem"].active,
 .dropdown-content [role="option"]:hover,
 .dropdown-content [role="option"]:focus,
 .dropdown-content [role="option"]:active,
@@ -2003,7 +2003,7 @@ a.controller {
   background-color: rgba(0, 0, 0, .1) !important;
 }
 
-.dropdown-content button[role="menuitem"] {
+.dropdown-content button[role^="menuitem"] {
   -moz-appearance: none;
   -webkit-appearance: none;
   appearance: none;
@@ -2015,8 +2015,18 @@ a.controller {
   text-align: left;
 }
 
-.dropdown-content button[role="menuitem"]::-moz-focus-inner {
+.dropdown-content button[role^="menuitem"]::-moz-focus-inner {
   border: 0;
+}
+
+.dropdown-content [role="menuitemcheckbox"][aria-checked="true"]::before {
+  display: inline-block;
+  content: '\E5CA';
+  font-size: 18px;
+  line-height: 1;
+  font-family: 'Material Icons';
+  vertical-align: text-bottom;
+  text-indent: -20px;
 }
 
 .dropdown-content [role="separator"] {


### PR DESCRIPTION
Add Permanent Edit Mode to the modal bug page, that can be toggled in the page menu next to the Follow button. In the near future, I’d like to have a rethink about how the modal UI works. In the meantime, the option is stored only in the browser’s local storage, not in Bugzilla’s user preferences.

![Screenshot_2019-04-03 1525563 - Seeking in video causes Windows crashes ](https://user-images.githubusercontent.com/2929505/55454158-c4713480-55ac-11e9-9f26-1cff618a8217.png)

## Bugzilla link

[Bug 1281200 - New show_bug.cgi view should have an option to have fields editable by default.](https://bugzilla.mozilla.org/show_bug.cgi?id=1281200)