### PR TITLE
Bug 1344427 - Display "nn people including you" if current user is cc'ed on a bug.

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -780,7 +780,7 @@
               IF bug.cc.size == 1;
                 is_cced ? "Just you" : "1 person";
               ELSE;
-                bug.cc.size _ " people";
+                bug.cc.size _ " people" _ (is_cced ? " including you" : "");
               END;
             %]
           </span>

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -663,7 +663,7 @@ $(function() {
                 $('#cc-summary').text(is_cced ? 'Just you' : '1 person');
             }
             else {
-                $('#cc-summary').text(cc_count + ' people');
+                $('#cc-summary').text(`${cc_count} people${is_cced ? ' including you' : ''}`);
             }
 
             // clear/update user list


### PR DESCRIPTION
Show the “including you” label on the modal UI’s CC field just like the legacy UI. The current state is inconsistent because it says “Just you” if only you’re CCed.

![Screenshot_2019-04-03 866102 - (webkit-line-clamp) ellipsis multiple lines text doesn't work (i e add support for -webkit-l](https://user-images.githubusercontent.com/2929505/55455307-26339d80-55b1-11e9-8c8f-f4495333ce71.png)

## Bugzilla link

[Bug 1344427 - Display "nn people including you" if current user is cc'ed on a bug.](https://bugzilla.mozilla.org/show_bug.cgi?id=1344427)