### PR TITLE
Bug 1541555 - Add facility for requiring an API Key to always come from the same IP address

### DIFF
--- a/docs/en/rst/using/preferences.rst
+++ b/docs/en/rst/using/preferences.rst
@@ -132,9 +132,14 @@ change your password everywhere.
 You can create more than one API key if required. Each API key has an optional
 description which can help you record what it is used for.
 
-On this page, you can unrevoke, revoke and change the description of existing
+On this page, you can unrevoke, revoke, make sticky, and change the description of existing
 API keys for your login. A revoked key means that it cannot be used. The
 description is optional and purely for your information.
+
+Sticky API keys may only be used from one IP address, which reduces the risk
+of the key being leaked. The IP address is the one the key was last used
+from. The expected workflow is that the sticky bit will be set once your application
+(or script) is setup. The sticky attribute may only be set, it can't ever be unset.
 
 You can also create a new API key by selecting the checkbox under the 'New
 API key' section of the page.

--- a/template/en/default/account/prefs/apikey.html.tmpl
+++ b/template/en/default/account/prefs/apikey.html.tmpl
@@ -31,6 +31,7 @@ here.</p>
     <th>API key</th>
     <th>Description (optional)</th>
     <th>Last used</th>
+    <th>Sticky</th>
     <th>Revoked</th>
   </tr>
 
@@ -51,6 +52,12 @@ here.</p>
       [% ELSE %]
         <td class="center"><i>never used</i></td>
       [% END %]
+      <td class="center">
+      <input type="checkbox" value="1"
+          name="sticky_[% api_key.id FILTER html %]"
+          id="sticky_[% api_key.id FILTER html %]"
+        [% IF api_key.sticky %] checked="checked" disabled="disabled" [% END %]>
+      </td>
       <td class="center">
         <input type="checkbox" value="1"
           name="revoked_[% api_key.id FILTER html %]"

--- a/template/en/default/account/prefs/apikey.html.tmpl
+++ b/template/en/default/account/prefs/apikey.html.tmpl
@@ -14,8 +14,9 @@
 <p>
   API keys are used to authenticate WebService API calls. You can create more than
   one API key if required. Each API key has an optional description which can help
-  you record what each key is used for.<br>
-  <br>
+  you record what each key is used for.
+</p>
+<p>
   Documentation on how to log in is available
   <a href="https://bmo.readthedocs.io/en/latest/api/core/v1/general.html#authentication">
     here</a>.
@@ -24,7 +25,7 @@
 <h3>Existing API keys</h3>
 
 <p>You can update the description, and revoke or unrevoke existing API keys
-here.</p>
+here. Sticky keys may only be used from the last IP that used the API key, and cannot be unset.</p>
 
 <table id="email_prefs">
   <tr class="column_header">

--- a/userprefs.cgi
+++ b/userprefs.cgi
@@ -850,8 +850,12 @@ sub SaveApiKey {
   foreach my $api_key (@$api_keys) {
     my $description = $cgi->param('description_' . $api_key->id);
     my $revoked     = !!$cgi->param('revoked_' . $api_key->id);
+    my $sticky      = !!$cgi->param('sticky_' . $api_key->id);
 
-    if ($description ne $api_key->description || $revoked != $api_key->revoked) {
+    if ( $description ne $api_key->description
+      || $revoked != $api_key->revoked
+      || $sticky != $api_key->sticky)
+    {
       if ($user->mfa && !$revoked && $api_key->revoked) {
         push @mfa_events,
           {
@@ -862,7 +866,9 @@ sub SaveApiKey {
           };
       }
       else {
-        $api_key->set_all({description => $description, revoked => $revoked,});
+        $sticky = 1 if $api_key->sticky;
+        $api_key->set_all(
+          {description => $description, revoked => $revoked, sticky => $sticky});
         $api_key->update();
         if ($revoked) {
           Bugzilla->log_user_request(undef, undef, 'api-key-revoke');


### PR DESCRIPTION
It's been requested that an API key for a service owned by @calixteman be accessible from only a single source. This is presumably to hedge against the risk of the key leaking.

We already store the IP that last used an API key, so it seems easiest to add a "sticky" bit that makes the key not work when the IP doesn't match the previous one.

This PR adds the "sticky" column, and if the `last_used_ip` is set (e.g. the API key has been used) it can't be used from another IP. The sticky bit cannot be unset.

# TODO
- [x] file bug
- [x] split out schema change
- [x] docs