### PR TITLE
Bug 1541582 - Set qe-verify to + when manual QA requested upon uplift

### DIFF
--- a/extensions/FlagTypeComment/web/js/ftc.js
+++ b/extensions/FlagTypeComment/web/js/ftc.js
@@ -284,7 +284,7 @@ Bugzilla.FlagTypeComment = class FlagTypeComment {
 
     // Collect bug flags from checkboxes
     const bug_flags = [...this.$fieldset_wrapper.querySelectorAll('input[data-bug-flag]:checked')]
-      .map($input => ({ name: $input.getAttribute('data-bug-flag'), status: '?' }));
+      .map($input => ({ name: $input.getAttribute('data-bug-flag'), status: '+' }));
 
     // Update bug flags if needed
     if (bug_flags.length) {


### PR DESCRIPTION
'?' is used ask the dev to asses whether to uplift but that's what the form is already doing.