### PR TITLE
Bug 1541123 - "1 new change since last visit" shown for the change I just submitted

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -1394,8 +1394,8 @@ function show_new_changes_indicator() {
         const new_changes = [...document.querySelectorAll('main .change-set')].filter($change => {
             // Exclude hidden CC changes and the user's own changes
             return $change.clientHeight > 0 &&
-                new Date($change.querySelector('[data-time]').getAttribute('data-time') * 1000) > last_visit_ts &&
-                Number($change.querySelector('.email').getAttribute('data-user-id')) !== BUGZILLA.user.id;
+                Number($change.querySelector('.email').getAttribute('data-user-id')) !== BUGZILLA.user.id &&
+                new Date($change.querySelector('[data-time]').getAttribute('data-time') * 1000) > last_visit_ts;
         });
 
         if (new_changes.length === 0) {

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -1392,9 +1392,10 @@ function show_new_changes_indicator() {
 
         const last_visit_ts = new Date(data[0].last_visit_ts);
         const new_changes = [...document.querySelectorAll('main .change-set')].filter($change => {
-            // Exclude hidden CC changes
+            // Exclude hidden CC changes and the user's own changes
             return $change.clientHeight > 0 &&
-                new Date($change.querySelector('[data-time]').getAttribute('data-time') * 1000) > last_visit_ts;
+                new Date($change.querySelector('[data-time]').getAttribute('data-time') * 1000) > last_visit_ts &&
+                Number($change.querySelector('.email').getAttribute('data-user-id')) !== BUGZILLA.user.id;
         });
 
         if (new_changes.length === 0) {


### PR DESCRIPTION
Hide the “1 new change since last visit“ notification bar on the modal bug page if the change was made by yourself.

## Bugzilla link

[Bug 1541123 - "1 new change since last visit" shown for the change I just submitted](https://bugzilla.mozilla.org/show_bug.cgi?id=1541123).