### PR TITLE
Bug 1541231 - Certain Phablicator requests are displayed as inline attachment

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -262,6 +262,7 @@
          class="attachment[% " patch" IF att.ispatch; " obsolete" IF att.isobsolete; " deleted" IF !att.datasize %]"
          data-id="[% att.id FILTER none %]" itemscope itemtype="http://schema.org/MediaObject"
          [% IF comment.collapsed +%] style="display:none"[% END ~%]>
+      <meta itemprop="name" content="[% att.filename FILTER none %]">
       <meta itemprop="contentSize" content="[% att.datasize FILTER none %]">
       <meta itemprop="encodingFormat" content="[% att.mimetype FILTER html %]">
       <div class="label">
@@ -274,7 +275,7 @@
         [% ELSE %]
           <a class="link[% " lightbox" IF att.is_image %]" href="[% link FILTER html %]" itemprop="contentUrl">
         [% END %]
-        <span id="att-[% att.id FILTER none %]-description" itemprop="name">[% att.description FILTER html %]</span></a>
+        <span id="att-[% att.id FILTER none %]-description" itemprop="description">[% att.description FILTER html %]</span></a>
         [% " (obsolete)" IF att.isobsolete; " (deleted)" IF !att.datasize %]
         — <a href="[% link FILTER html %]&amp;action=edit" itemprop="url">Details</a>
         [% IF att.ispatch && Param('splinter_base') %]

--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -262,7 +262,7 @@
          class="attachment[% " patch" IF att.ispatch; " obsolete" IF att.isobsolete; " deleted" IF !att.datasize %]"
          data-id="[% att.id FILTER none %]" itemscope itemtype="http://schema.org/MediaObject"
          [% IF comment.collapsed +%] style="display:none"[% END ~%]>
-      <meta itemprop="name" content="[% att.filename FILTER none %]">
+      <meta itemprop="name" content="[% att.filename FILTER html %]">
       <meta itemprop="contentSize" content="[% att.datasize FILTER none %]">
       <meta itemprop="encodingFormat" content="[% att.mimetype FILTER html %]">
       <div class="label">

--- a/extensions/BugModal/web/comments.js
+++ b/extensions/BugModal/web/comments.js
@@ -560,7 +560,7 @@ Bugzilla.BugModal.Comments = class Comments {
   async show_attachment($att) {
     const id = Number($att.dataset.id);
     const link = $att.querySelector('.link').href;
-    const name = $att.querySelector('[itemprop="name"]').textContent;
+    const name = $att.querySelector('[itemprop="name"]').content;
     const type = $att.querySelector('[itemprop="encodingFormat"]').content;
     const size = Number($att.querySelector('[itemprop="contentSize"]').content);
     const max_size = 2000000;


### PR DESCRIPTION
Fix Phablicator requests with a description ending with `.js` or any source extension being displayed as a text attachment.

## Bugzilla link

[Bug 1541231 - Certain Phablicator requests are displayed as inline attachment](https://bugzilla.mozilla.org/show_bug.cgi?id=1541231)