### PR TITLE
Bug 1477931 follow-up - Make sure Gravatar and requests are loaded via API

### DIFF
--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -187,10 +187,8 @@ sub suggest {
     name      => $self->type(email  => $_->{name}),
   } } @$results;
 
-  unless ($params->{fast_mode}) {
-    Bugzilla::Hook::process('webservice_user_suggest',
-      {webservice => $self, params => $params, users => \@users});
-  }
+  Bugzilla::Hook::process('webservice_user_suggest',
+    {webservice => $self, params => $params, users => \@users});
 
   return {users => \@users};
 }

--- a/js/field.js
+++ b/js/field.js
@@ -715,7 +715,6 @@ $(function() {
         serviceUrl: `${BUGZILLA.config.basepath}rest/user/suggest`,
         params: {
             Bugzilla_api_token: BUGZILLA.api_token,
-            fast_mode: 1
         },
         paramName: 'match',
         deferRequestBy: 250,

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -1027,7 +1027,8 @@ input.required, select.required, span.required_explanation {
 }
 
 .autocomplete-suggestion [itemtype] > span:first-of-type,
-.autocomplete-suggestion [itemtype] > span:empty {
+.autocomplete-suggestion [itemtype] > span:empty,
+.autocomplete-suggestion [itemtype] > span:empty + span {
     margin-left: 0;
 }
 
@@ -1036,6 +1037,12 @@ input.required, select.required, span.required_explanation {
     border-radius: 50%;
     width: 20px;
     height: 20px;
+}
+
+.autocomplete-suggestion [itemprop="name"] {
+    overflow: hidden;
+    max-width: 20em;
+    text-overflow: ellipsis;
 }
 
 .autocomplete-suggestion [itemtype] .minor {


### PR DESCRIPTION
#1147 was merged but backed out before the last release to avoid an overload. Let’s try again.

## Bugzilla link

[Bug 1477931 follow-up - Make sure Gravatar and requests are loaded via API](https://bugzilla.mozilla.org/show_bug.cgi?id=1477931)