### PR TITLE
Bug 1527459 - Display dependency bugs by type, using the same colour/icon for each

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -974,6 +974,7 @@
 
     [% IF bug.dependson.size + bug.blocked.size > 1 %]
       [% WRAPPER bug_modal/field.html.tmpl
+          name = "dependencytree"
           container = 1
           label = ""
           hide_on_edit = 1

--- a/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
@@ -346,9 +346,22 @@ END;
 [%# bug lists, depencancies, blockers %]
 [% BLOCK bug_list %]
   [% IF NOT edit %]
-    [% FOREACH b IN values %]
-      [% INCLUDE bug/link.html.tmpl bug=b link_text=b.id use_alias=1  %]
-      [% ", " UNLESS loop.last %]
+    [% FOREACH type IN bug_fields.bug_type.legal_values.pluck('name') %]
+      [%
+        bugs = [];
+        FOREACH b IN values; bugs.push(b) IF b.bug_type == type; END;
+        NEXT UNLESS bugs.size > 0;
+      %]
+      <div class="bug-list">
+        <span class="bug-type-label iconic" title="[% type FILTER html %]"
+              aria-label="[% type FILTER html %]" data-type="[% type FILTER html %]">
+          <span class="icon" aria-hidden="true"></span>
+        </span>
+        [% FOREACH b IN bugs %]
+          [% INCLUDE bug/link.html.tmpl bug=b link_text=b.id use_alias=1  %]
+          [% ", " UNLESS loop.last %]
+        [% END %]
+      </div>
     [% END %]
   [% ELSE %]
     <input type="text" id="[% name FILTER html %]" name="[% name FILTER html %]"

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -361,6 +361,26 @@ input[type="number"] {
     text-decoration: underline;
 }
 
+.field .value .bug-list {
+  margin: -2px 0 6px;
+  padding-left: 20px;
+  line-height: 1.5;
+}
+
+.field .value .bug-list .bug-type-label {
+  float: left;
+  margin-left: -20px;
+}
+
+.field .value .bug-list .bug-type-label .icon {
+  font-size: 16px;
+}
+
+#field-value-dependencytree {
+  display: block;
+  margin: -2px 0 8px;
+}
+
 /* actions */
 
 #top-actions {


### PR DESCRIPTION
Show Depends on, Blocks and other bug IDs fields by bug type. For example, [Bug 1451850](https://bugzilla.mozilla.org/show_bug.cgi?id=1451850) will look like this:

![Screenshot_2019-04-05 1451850 - (fission)  meta  Project Fission](https://user-images.githubusercontent.com/2929505/55646095-45e0e680-57a8-11e9-8599-80a18f24fb9f.png)

## Bugzilla link

[Bug 1527459 - Display dependency bugs by type, using the same colour/icon for each](https://bugzilla.mozilla.org/show_bug.cgi?id=1527459)