### PR TITLE
Bug 1541484 - Move the bug type from header to module and de-emphasize it so it’s not confused with bug status

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -225,12 +225,6 @@
         no_label = 1
         hide_on_edit = 1
     %]
-      [% IF bug.bug_type %]
-      <span class="bug-type-label iconic-text" data-type="[% bug.bug_type FILTER html %]">
-        <span class="icon" aria-hidden="true"></span>
-        [%~ bug.bug_type FILTER html ~%]
-      </span>
-      [% END %]
       <b class="bz_status_[% bug.bug_status FILTER html %]">
         [% bug.bug_status FILTER html %]
         [%+ bug.resolution FILTER html IF bug.resolution %]
@@ -472,10 +466,12 @@
     [% WRAPPER bug_modal/field.html.tmpl
         field      = bug_fields.bug_type
         field_type = constants.FIELD_TYPE_SINGLE_SELECT
-        hide_on_view = 1  # Because it's displayed on the header
         help       = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#bug_type"
     %]
-      [% bug.bug_type FILTER html %]
+      <span class="bug-type-label iconic-text" data-type="[% bug.bug_type FILTER html %]">
+        <span class="icon" aria-hidden="true"></span>
+        [%~ bug.bug_type FILTER html ~%]
+      </span>
     [% END %]
 
     [%# importance %]

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -2835,8 +2835,8 @@ pre.comment-text {
 /* Bug types */
 
 :root {
-  --bug-type-color-defect: #D62935;
-  --bug-type-color-enhancement: #2BC028;
+  --bug-type-color-defect: #EA3C3D;
+  --bug-type-color-enhancement: #2ABA27;
   --bug-type-color-task: #2886C9;
 }
 
@@ -2848,12 +2848,12 @@ pre.comment-text {
 }
 
 .bug-type-label[data-type="defect"] .icon::before {
-  content: '\E85F';
+  content: '\E3AC';
   color: var(--bug-type-color-defect);
 }
 
 .bug-type-label[data-type="enhancement"] .icon::before {
-  content: '\E862';
+  content: '\E146';
   color: var(--bug-type-color-enhancement);
 }
 
@@ -2867,27 +2867,6 @@ pre.comment-text {
   vertical-align: middle;
 }
 
-.bug-type-label.iconic-text {
-  border-radius: .2em;
-  padding: .2em .4em .2em .2em;
-  color: #FFF;
-  background-color: #666;
-  line-height: 16px;
-  font-weight: 600;
-}
-
-.bug-type-label.iconic-text[data-type="defect"] {
-  background-color: var(--bug-type-color-defect);
-}
-
-.bug-type-label.iconic-text[data-type="enhancement"] {
-  background-color: var(--bug-type-color-enhancement);
-}
-
-.bug-type-label.iconic-text[data-type="task"] {
-  background-color: var(--bug-type-color-task);
-}
-
 .bug-type-label.iconic-text .icon {
   margin-right: .2em;
   font-size: 16px;
@@ -2895,6 +2874,5 @@ pre.comment-text {
 }
 
 .bug-type-label.iconic-text .icon::before {
-  color: #FFF !important;
   vertical-align: bottom;
 }


### PR DESCRIPTION
People confuse the bug type label with bug status, so this PR removes the label from the modal bug header and instead shows it in the Status module. Also change the icon and colour of the defect and enhancement types.

![Screenshot_2019-04-05 1209148 - Stop using short-life token for internal REST API auth, which is problematic especially on ](https://user-images.githubusercontent.com/2929505/55648331-074e2a80-57ae-11e9-8b4d-acfd00812dc1.png)

![Screenshot_2019-04-05 Bug List](https://user-images.githubusercontent.com/2929505/55648221-bb9b8100-57ad-11e9-8322-175a20a53427.png)

## Bugzilla link

[Bug 1541484 - Move the bug type from header to module and de-emphasize it so it’s not confused with bug status](https://bugzilla.mozilla.org/show_bug.cgi?id=1541484)