### PR TITLE
Bug 1559988 - Make extension hooks faster

### DIFF
--- a/Bugzilla/Extension.pm
+++ b/Bugzilla/Extension.pm
@@ -17,6 +17,8 @@ use Bugzilla::Install::Util qw( extension_code_files );
 
 use File::Basename;
 use File::Spec;
+use List::Util qw(any);
+use Scalar::Util qw(refaddr);
 
 BEGIN { push @INC, \&INC_HOOK }
 
@@ -56,17 +58,6 @@ sub INC_HOOK {
     };
   }
   return;
-}
-
-####################
-# Subclass Methods #
-####################
-
-sub new {
-  my ($class, $params) = @_;
-  $params ||= {};
-  bless $params, $class;
-  return $params;
 }
 
 #######################################
@@ -146,6 +137,8 @@ sub load_all {
     my $package = $class->load(@$file_set);
     push(@$EXTENSIONS, $package);
   }
+
+  Bugzilla::Hook::finalize($EXTENSIONS);
 
   return $EXTENSIONS;
 }

--- a/Bugzilla/Template/Context.pm
+++ b/Bugzilla/Template/Context.pm
@@ -46,6 +46,7 @@ sub process {
 # our stash hasn't been set correctly--the parameters we were passed
 # in the PROCESS or INCLUDE directive haven't been set, and if we're
 # in an INCLUDE, the stash is not yet localized during process().
+our $in_template_before_process = 0;
 sub stash {
   my $self  = shift;
   my $stash = $self->SUPER::stash(@_);
@@ -73,8 +74,9 @@ sub stash {
   if (  $self->{bz_in_process}
     and $name =~ /\./
     and !grep($_ eq $name, @$pre_process)
-    and !Bugzilla::Hook::in('template_before_process'))
+    and !$in_template_before_process)
   {
+    local $in_template_before_process = 1;
     Bugzilla::Hook::process("template_before_process",
       {vars => $stash, context => $self, file => $name});
   }

--- a/extensions/Push/Extension.pm
+++ b/extensions/Push/Extension.pm
@@ -58,22 +58,24 @@ sub _get_instance {
 
 sub _enabled {
   my ($self) = @_;
-  if (!exists $self->{'enabled'}) {
+  my $cache = Bugzilla->request_cache->{+__PACKAGE__} //= {};
+
+  if (!exists $cache->{'enabled'}) {
     my $push = Bugzilla->push_ext;
-    $self->{'enabled'} = $push->config->{enabled} eq 'Enabled';
-    if ($self->{'enabled'}) {
+    $cache->{'enabled'} = $push->config->{enabled} eq 'Enabled';
+    if ($cache->{'enabled'}) {
 
       # if no connectors are enabled, no need to push anything
-      $self->{'enabled'} = 0;
+      $cache->{'enabled'} = 0;
       foreach my $connector (Bugzilla->push_ext->connectors->list) {
         if ($connector->enabled) {
-          $self->{'enabled'} = 1;
+          $cache->{'enabled'} = 1;
           last;
         }
       }
     }
   }
-  return $self->{'enabled'};
+  return $cache->{'enabled'};
 }
 
 #

--- a/extensions/RestrictComments/Extension.pm
+++ b/extensions/RestrictComments/Extension.pm
@@ -42,8 +42,8 @@ sub bug_check_can_change_field {
 sub _can_restrict_comments {
   my ($self, $object) = @_;
   return unless $object->isa('Bugzilla::Bug');
-  $self->{setter_group} ||= Bugzilla->params->{'restrict_comments_enable_group'};
-  return Bugzilla->user->in_group($self->{setter_group});
+  return Bugzilla->user->in_group(
+    Bugzilla->params->{'restrict_comments_enable_group'});
 }
 
 sub object_end_of_set_all {


### PR DESCRIPTION
Every hook is $NUMBER_OF_HOOKS calls to `->can()`.
Some hooks can be called thousands of times per request, or more.

This patch changes how Bugzilla::Hook works. After all extensions are
loaded, the list of packages is passed to Bugzilla::Hook::finalize,
which builds a cache that maps hook names to lists of functions.

Calling a hook is just simple iteration over that list, which is much
faster. In addition, unused hooks have virtually no cost.