### PR TITLE
Bug 1539908 - Replace no_break filter with CSS nowrap

### DIFF
--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -702,14 +702,6 @@ sub create {
         return $var;
       },
 
-      # Prevents line break on hyphens and whitespaces.
-      no_break => sub {
-        my ($var) = @_;
-        $var =~ s/ /\&nbsp;/g;
-        $var =~ s/-/\&#8209;/g;
-        return $var;
-      },
-
       # Insert `<wbr>` HTML tags to camel and snake case words as well as
       # words containing dots in the given string so a long bug summary,
       # for example, will be wrapped in a preferred manner rather than

--- a/extensions/BMO/template/en/default/global/choose-product.html.tmpl
+++ b/extensions/BMO/template/en/default/global/choose-product.html.tmpl
@@ -180,12 +180,12 @@
           [% IF p.name == "Mozilla PR" AND target == "enter_bug.cgi" AND NOT format AND NOT cgi.param("debug") %]
             <a href="[% basepath FILTER none %][% target FILTER uri %]?product=[% p.name FILTER uri -%]
                   [%- IF cloned_bug_id %]&amp;cloned_bug_id=[% cloned_bug_id FILTER uri %][% END %]&amp;format=mozpr">
-            [% p.name FILTER html FILTER no_break %]</a>:&nbsp;
+            [% p.name FILTER html %]</a>:&nbsp;
           [% ELSE %]
             <a href="[% basepath FILTER none %][% target FILTER uri %]?product=[% p.name FILTER uri -%]
                   [%- IF cloned_bug_id %]&amp;cloned_bug_id=[% cloned_bug_id FILTER uri %][% END -%]
                   [%- IF format %]&amp;format=[% format FILTER uri %][% END %]">
-            [% p.name FILTER html FILTER no_break %]</a>:&nbsp;
+            [% p.name FILTER html %]</a>:&nbsp;
           [% END %]
           </th>
           <td valign="top">[% p.description FILTER html_light %]</td>

--- a/extensions/BMO/template/en/default/pages/triage_reports.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/triage_reports.html.tmpl
@@ -161,7 +161,7 @@ Show UNCONFIRMED [% terms.bugs %] with:
       <tr class="bz_bugitem [% count % 2 == 1 ? "bz_row_odd" : "bz_row_even" %]">
         <td>
           [% bug.id FILTER bug_link(bug.id) FILTER none %]<br>
-          [% bug.creation_ts.replace(' .*' '') FILTER html FILTER no_break %]
+          <time>[% bug.creation_ts.replace(' .*' '') FILTER html %]</time>
         </td>
         <td>
           [% bug.summary FILTER html %]
@@ -173,7 +173,7 @@ Show UNCONFIRMED [% terms.bugs %] with:
           [% END %]
         </td>
         <td>
-          [% bug.comment_ts FILTER html FILTER no_break %]
+          <time>[% bug.comment_ts FILTER html %]</time>
         </td>
         <td>
           [% bug.comment FILTER html %]

--- a/extensions/BMO/template/en/default/pages/user_activity.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/user_activity.html.tmpl
@@ -132,11 +132,11 @@
               <td>[% operation.who FILTER email FILTER html %]</td>
             [% END %]
             [% IF group == 'when' %]
-              <td>[% change.when FILTER time FILTER no_break %]</td>
+              <td><time datetime="[% change.when FILTER time('%Y-%m-%d %H:%M:%S') %]">[% change.when FILTER time %]</time></td>
               <td>[% operation.bug FILTER bug_link(operation.bug) FILTER none %]</td>
             [% ELSE %]
               <td>[% operation.bug FILTER bug_link(operation.bug) FILTER none %]</td>
-              <td>[% change.when FILTER time FILTER no_break %]</td>
+              <td><time datetime="[% change.when FILTER time('%Y-%m-%d %H:%M:%S') %]">[% change.when FILTER time %]</time></td>
             [% END %]
           [% ELSE %]
             [% IF who_count > 1 %]
@@ -146,7 +146,7 @@
             [% IF group == 'when' %]
               <td>&nbsp;</td>
             [% ELSE %]
-              <td>[% change.when FILTER time FILTER no_break %]</td>
+              <td><time datetime="[% change.when FILTER time('%Y-%m-%d %H:%M:%S') %]">[% change.when FILTER time %]</time></td>
             [% END %]
           [% END %]
           <td>

--- a/extensions/BMO/web/styles/reports.css
+++ b/extensions/BMO/web/styles/reports.css
@@ -61,6 +61,10 @@
     border: 0px;
 }
 
+#report td time {
+    white-space: nowrap;
+}
+
 .disabled {
     color: #888888;
 }

--- a/extensions/BMO/web/styles/triage_reports.css
+++ b/extensions/BMO/web/styles/triage_reports.css
@@ -60,3 +60,7 @@
   display: block;
   width: 100%;
 }
+
+#report td time {
+  white-space: nowrap;
+}

--- a/extensions/BugModal/template/en/default/bug_modal/flags.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/flags.html.tmpl
@@ -124,7 +124,7 @@
 
     <td class="flag-name">
       <label title="[% t.description FILTER html %]" for="[% flag_id FILTER html %]">
-        [%~ t.name FILTER html FILTER no_break ~%]
+        [%~ t.name FILTER html ~%]
       </label>
     </td>
 

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -467,6 +467,7 @@ input[type="number"] {
 
 .flag-name {
     text-align: right;
+    white-space: nowrap;
 }
 
 td.flag-name, td.flag-requestee {

--- a/extensions/BugmailFilter/template/en/default/account/prefs/bugmail_filter.html.tmpl
+++ b/extensions/BugmailFilter/template/en/default/account/prefs/bugmail_filter.html.tmpl
@@ -226,7 +226,7 @@ var cpts = new Array();
         </span>
         <span id="all_flags" class="bz_default_hidden">
       [% END %]
-      [% flag.description FILTER html FILTER no_break %]
+      <span class="flag-description">[% flag.description FILTER html %]</span>
       [% ", " UNLESS loop.last %]
       [% IF loop.last && flag_count > 10 %]
         </span>

--- a/extensions/BugmailFilter/web/style/bugmail-filter.css
+++ b/extensions/BugmailFilter/web/style/bugmail-filter.css
@@ -42,3 +42,7 @@
     background-color: #eeeeee;
     color: #000000;
 }
+
+.flag-description {
+    white-space: nowrap;
+}

--- a/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
+++ b/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
@@ -212,7 +212,7 @@ Other Mozilla products which aren't listed here
     <tr>
       <th align="right" valign="top">
         <a href="javascript:void(0)" onclick="product.select('[% p.name FILTER js %]')">
-        [% p.name FILTER html FILTER no_break %]</a>:&nbsp;
+        [% p.name FILTER html %]</a>:&nbsp;
       </th>
 
       <td valign="top">[% p.description FILTER html_light %]</td>

--- a/extensions/MyDashboard/template/en/default/pages/mydashboard.html.tmpl
+++ b/extensions/MyDashboard/template/en/default/pages/mydashboard.html.tmpl
@@ -170,7 +170,7 @@
           [% FOREACH q = user.queries_subscribed %]
             <li><a href="[% basepath FILTER none %]buglist.cgi?cmdtype=dorem&amp;remaction=run&amp;namedcmd=
                 [% q.name FILTER uri %]&amp;sharer_id=[% q.user.id FILTER uri %]"
-                title="Shared by [% q.user.identity FILTER html %]">[% q.name FILTER html FILTER no_break %]</a></li>
+                title="Shared by [% q.user.identity FILTER html %]">[% q.name FILTER html %]</a></li>
           [% END %]
         </ul>
       </section>

--- a/extensions/MyDashboard/web/styles/mydashboard.css
+++ b/extensions/MyDashboard/web/styles/mydashboard.css
@@ -87,4 +87,5 @@
 #saved_searches_container li {
     margin: 5px;
     display: inline;
+    white-space: nowrap;
 }

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -1764,6 +1764,7 @@ button::-moz-focus-inner {
 
 #flags label {
     font-weight: normal;
+    white-space: nowrap;
 }
 
 /* tabs */

--- a/template/en/default/admin/flag-type/list.html.tmpl
+++ b/template/en/default/admin/flag-type/list.html.tmpl
@@ -131,7 +131,7 @@
     [% FOREACH type = types %]
 
       <tr class="[% IF type.is_active %]active[% ELSE %]inactive[% END %]">
-        <td><a href="[% basepath FILTER none %]editflagtypes.cgi?action=edit&amp;id=[% type.id %]">[% type.name FILTER html FILTER no_break %]</a></td>
+        <th><a href="[% basepath FILTER none %]editflagtypes.cgi?action=edit&amp;id=[% type.id %]">[% type.name FILTER html %]</a></th>
         <td>[% type.description FILTER html %]</td>
         <td align="right">[% type.sortkey FILTER html %]</td>
         <td>

--- a/template/en/default/attachment/list.html.tmpl
+++ b/template/en/default/attachment/list.html.tmpl
@@ -125,7 +125,7 @@ function toggle_display(link) {
                 [% ELSE %]
                   [% flag.setter.nick FILTER html %]:
                 [% END %]
-                [%+ flag.type.name FILTER html FILTER no_break %][% flag.status %]
+                [%+ flag.type.name FILTER html %][% flag.status %]
                 [%+ IF flag.status == "?" && flag.requestee %]
                   [% IF user.id %]
                     (<span title="[% flag.requestee.identity FILTER html %]">[% flag.requestee.nick FILTER html %]</span>)

--- a/template/en/default/bug/show-multiple.html.tmpl
+++ b/template/en/default/bug/show-multiple.html.tmpl
@@ -285,7 +285,7 @@
                     [% ELSE %]
                       [% FOREACH flag = attachment.flags %]
                         [% flag.setter.nick FILTER html %]:
-                        [%+ flag.type.name FILTER html FILTER no_break %][% flag.status %]
+                        [%+ flag.type.name FILTER html %][% flag.status %]
                         [% IF flag.status == "?" && flag.requestee %]
                           ([% flag.requestee.nick FILTER html %])
                         [% END %][% ", " IF not loop.last() %]
@@ -374,7 +374,7 @@
           [% FOREACH type = bug.flag_types %]
             [% FOREACH flag = type.flags %]
                 [% flag.setter.nick FILTER html %]:
-                [%+ flag.type.name FILTER html FILTER no_break %][% flag.status %]
+                [%+ flag.type.name FILTER html %][% flag.status %]
                 [%+ IF flag.status == "?" && flag.requestee %]
                   ([% flag.requestee.nick FILTER html %])
                 [% END %]<br>

--- a/template/en/default/flag/list.html.tmpl
+++ b/template/en/default/flag/list.html.tmpl
@@ -92,7 +92,7 @@
       [% ELSE %]
         [% flag.setter.nick FILTER html %]:
       [% END %]
-      [%+ type.name FILTER html FILTER no_break %][% flag.status %]
+      [%+ type.name FILTER html %][% flag.status %]
       [% IF flag.requestee %]
         [% IF flag.requestee.name %]
           (<span title="[% flag.requestee.name FILTER html %]">[% flag.requestee.nick FILTER html %]</span>)
@@ -120,7 +120,7 @@
       </td>
       <td>
         <label title="[% type.description FILTER html %]" for="[% fid FILTER html %]">
-          [%- type.name FILTER html FILTER no_break -%]</label>
+          [%- type.name FILTER html -%]</label>
       </td>
       <td>
         <input type="hidden" id="[% fid FILTER html %]_dirty">

--- a/template/en/default/global/choose-product.html.tmpl
+++ b/template/en/default/global/choose-product.html.tmpl
@@ -58,7 +58,7 @@
         <a href="[% target %]?product=[% p.name FILTER uri -%]
               [%- IF cloned_bug_id %]&amp;cloned_bug_id=[% cloned_bug_id FILTER uri %][% END -%]
               [%- IF format %]&amp;format=[% format FILTER uri %][% END %]">
-        [% p.name FILTER html FILTER no_break %]</a>:&nbsp;
+        [% p.name FILTER html %]</a>:&nbsp;
       </th>
 
       <td valign="top">[% p.description FILTER html_light %]</td>

--- a/template/en/default/global/header-search-dropdown.html.tmpl
+++ b/template/en/default/global/header-search-dropdown.html.tmpl
@@ -42,7 +42,7 @@
           [% FOREACH q = user.queries_subscribed %]
             <li role="none"><a role="option" href="[% basepath FILTER none %]buglist.cgi?cmdtype=dorem&amp;remaction=run&amp;namedcmd=
                 [% q.name FILTER uri %]&amp;sharer_id=[% q.user.id FILTER uri %]"
-                title="Shared by [% q.user.identity FILTER html %]">[% q.name FILTER html FILTER no_break %]</a></li>
+                title="Shared by [% q.user.identity FILTER html %]">[% q.name FILTER html %]</a></li>
           [% END %]
         </ul>
       </section>


### PR DESCRIPTION
Non-breaking hyphens make it difficult to find and copy actual flag names, etc. on the UI. Replace all of them with CSS `white-space: nowrap` to avoid issues like #1177 in the future.

## Bugzilla link

[Bug 1539908 - Replace no_break filter with CSS nowrap](https://bugzilla.mozilla.org/show_bug.cgi?id=1539908)