### PR TITLE
Bug 1543189 - Add search pronouns: %triageowner% and %self%

### DIFF
--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -337,6 +337,8 @@ sub SPECIAL_PARSING {
     commenter               => \&_commenter_pronoun,
     qa_contact              => \&_contact_pronoun,
     reporter                => \&_contact_pronoun,
+    'requestees.login_name' => \&_contact_pronoun,
+    'setters.login_name'    => \&_contact_pronoun,
 
     # Date Fields that accept the 1d, 1w, 1m, 1y, etc. format.
     creation_ts => \&_datetime_translate,
@@ -2310,7 +2312,7 @@ sub SqlifyDate {
 
 sub pronoun {
   my ($noun, $user) = (@_);
-  if ($noun eq "%user%") {
+  if ($noun eq "%user%" || $noun eq "%self%") {
     if ($user->id) {
       return $user->id;
     }
@@ -2320,6 +2322,11 @@ sub pronoun {
   }
   if ($noun eq "%reporter%") {
     return "bugs.reporter";
+  }
+  if ($noun eq "%triageowner%") {
+    return "(SELECT COALESCE(userid, 0) FROM profiles
+      JOIN components ON components.triage_owner_id = profiles.userid
+      WHERE bugs.component_id = components.id)";
   }
   if ($noun eq "%assignee%") {
     return "bugs.assigned_to";
@@ -2463,7 +2470,7 @@ sub _triage_owner_pronoun {
   my ($self, $args) = @_;
   my $value = $args->{value};
   my $user  = $self->_user;
-  if ($value eq "%user%") {
+  if ($value eq "%user%" || $value eq "%self%") {
     if ($user->id) {
       $args->{value}       = $user->id;
       $args->{quoted}      = $args->{value};

--- a/docs/en/rst/using/finding.rst
+++ b/docs/en/rst/using/finding.rst
@@ -184,12 +184,13 @@ example, you may want to find all bugs that are assigned to the person
 who reported them.
 
 When the :guilabel:`Custom Search` operator is either :guilabel:`equals` or
-:guilabel:`notequals`, the value can be "%reporter%", "%assignee%",
-"%qacontact%", or "%user%". These are known as "pronouns". The user pronoun
-refers to the user who is executing the query or, in the case
-of whining reports, the user who will be the recipient
-of the report. The reporter, assignee, and qacontact
-pronouns refer to the corresponding fields in the bug.
+:guilabel:`notequals`, the value can be ``%reporter%``, ``%triageowner%``,
+``%assignee%``, ``%qacontact%``, ``%user%`` or ``%self%``. These are known as
+"pronouns". The ``%user%`` pronoun and its alias ``%self%`` refer to the user
+who is executing the query (that's you) or, in the case of whining reports, the
+user who will be the recipient of the report. The ``%reporter%``,
+``%triageowner%``, ``%assignee%`` and ``%qacontact%`` pronouns refer to the
+corresponding fields in the bug.
 
 This feature also lets you search by a user's group memberships. If the
 operator is either :guilabel:`equals`, :guilabel:`notequals` or


### PR DESCRIPTION
* Add `%self%` as an alias of `%user%` pronoun
* Add `%triageowner%` pronoun
* Make pronoun substitutions work with Flag Setter/Requestee fields
* Update the document

## Bugzilla link

[Bug 1543189 - Add search pronouns: %triageowner% and %self%](https://bugzilla.mozilla.org/show_bug.cgi?id=1543189)