### PR TITLE
no bug - Fix Triage Owner list throwing if predefined product is not found

### DIFF
--- a/extensions/BMO/lib/Reports/Triage.pm
+++ b/extensions/BMO/lib/Reports/Triage.pm
@@ -57,11 +57,9 @@ sub unconfirmed {
         ? $input->{'component'}
         : [$input->{'component'}];
       foreach my $component_name (@$ra_components) {
-        my $component
-          = Bugzilla::Component->new({name => $component_name, product => $product})
-          || ThrowUserError('invalid_object',
-          {object => 'Component', value => $component_name});
-        push @component_ids, $component->id;
+        next unless my $component = Bugzilla::Component->new(
+          {name => $component_name, product => $product, cache => 1});
+        push(@component_ids, $component->id);
       }
     }
 
@@ -261,7 +259,8 @@ sub owners {
     my @product_names
       = $input->{product} ? ($input->{product}) : DEFAULT_OWNER_PRODUCTS;
     foreach my $name (@product_names) {
-      push(@products, Bugzilla::Product->check({name => $name}));
+      next unless my $product = Bugzilla::Product->new({name => $name, cache => 1});
+      push(@products, $product);
     }
   }
 
@@ -272,9 +271,9 @@ sub owners {
       ? $input->{'component'}
       : [$input->{'component'}];
     foreach my $component_name (@$ra_components) {
-      my $component = Bugzilla::Component->check(
-        {name => $component_name, product => $products[0]});
-      push @component_ids, $component->id;
+      next unless my $component = Bugzilla::Component->new(
+        {name => $component_name, product => $products[0], cache => 1});
+      push(@component_ids, $component->id);
     }
   }
 


### PR DESCRIPTION
Fix the [issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1543127#c3) found by @purelogiq while testing the [Triage Owners page on the dev server](https://bugzilla-dev.allizom.org/page.cgi?id=triage_owners.html). If any predefined product, DevTools in this case, cannot be found in the database, simply skip it instead of throwing. You can test this by adding a fake product to the `DEFAULT_OWNER_PRODUCTS` list in `Triage.pm`.