### PR TITLE
make it so the security headers are always set.

### DIFF
--- a/Bugzilla/App.pm
+++ b/Bugzilla/App.pm
@@ -131,15 +131,17 @@ sub startup {
   }
   $self->hook(after_dispatch => sub {
     my ($c) = @_;
-    if ($c->req->is_secure
-      && ! $c->res->headers->strict_transport_security
+    my ($req, $res) = ($c->req, $c->res);
+
+    if ( $req->is_secure
+      && !$res->headers->strict_transport_security
       && Bugzilla->params->{'strict_transport_security'} ne 'off')
     {
       my $sts_opts = 'max-age=' . MAX_STS_AGE;
       if (Bugzilla->params->{'strict_transport_security'} eq 'include_subdomains') {
         $sts_opts .= '; includeSubDomains';
       }
-      $c->res->headers->strict_transport_security($sts_opts);
+      $res->headers->strict_transport_security($sts_opts);
     }
   });
   Bugzilla::WebService::Server::REST->preload;

--- a/Bugzilla/App.pm
+++ b/Bugzilla/App.pm
@@ -143,6 +143,10 @@ sub startup {
       }
       $res->headers->strict_transport_security($sts_opts);
     }
+
+    unless ($c->url_is_attachment_base) {
+      $res->headers->header('X-Frame-Options' => 'SAMEORIGIN');
+    }
   });
   Bugzilla::WebService::Server::REST->preload;
 

--- a/Bugzilla/App/CGI.pm
+++ b/Bugzilla/App/CGI.pm
@@ -49,7 +49,7 @@ sub load_one {
   my ($class, $name, $file) = @_;
   my $package = __PACKAGE__ . "::$name", my $inner_name = "_$name";
   my $content = path(bz_locations->{cgi_path}, $file)->slurp;
-  $content = "package $package; $content";
+  $content = "package $package; local our \$C = \$Bugzilla::App::CGI::C; $content";
   my %options = (package => $package, file => $file, line => 1, no_defer => 1,);
   die "Tried to load $file more than once" if $SEEN{$file}++;
   my $inner = quote_sub $inner_name, $content, {}, \%options;

--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -625,7 +625,6 @@ sub header {
   # Referer (sic) headers to external websites.
   $headers{'-referrer_policy'} = 'same-origin';
 
-  Bugzilla::Hook::process('cgi_headers', {cgi => $self, headers => \%headers});
   $self->{_header_done} = 1;
 
   if (Bugzilla->usage_mode == USAGE_MODE_BROWSER) {

--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -590,19 +590,6 @@ sub header {
     $headers{'-cookie'} = $self->{Bugzilla_cookie_list};
   }
 
-  # Add Strict-Transport-Security (STS) header if this response
-  # is over SSL and the strict_transport_security param is turned on.
-  if ( $self->https
-    && !$self->url_is_attachment_base
-    && Bugzilla->params->{'strict_transport_security'} ne 'off')
-  {
-    my $sts_opts = 'max-age=' . MAX_STS_AGE;
-    if (Bugzilla->params->{'strict_transport_security'} eq 'include_subdomains') {
-      $sts_opts .= '; includeSubDomains';
-    }
-    $headers{'-strict_transport_security'} = $sts_opts;
-  }
-
   # Add X-Frame-Options header to prevent framing and subsequent
   # possible clickjacking problems.
   unless ($self->url_is_attachment_base) {

--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -590,12 +590,6 @@ sub header {
     $headers{'-cookie'} = $self->{Bugzilla_cookie_list};
   }
 
-  # Add X-Frame-Options header to prevent framing and subsequent
-  # possible clickjacking problems.
-  unless ($self->url_is_attachment_base) {
-    $headers{'-x_frame_options'} = 'SAMEORIGIN';
-  }
-
   if ($self->{'_content_disp'}) {
     $headers{'-content_disposition'} = $self->{'_content_disp'};
   }
@@ -884,25 +878,8 @@ sub base_redirect {
 
 sub url_is_attachment_base {
   my ($self, $id) = @_;
-  return 0 if !use_attachbase() or !i_am_cgi();
-  my $attach_base = Bugzilla->localconfig->{'attachment_base'};
-
-  # If we're passed an id, we only want one specific attachment base
-  # for a particular bug. If we're not passed an ID, we just want to
-  # know if our current URL matches the attachment_base *pattern*.
-  my $regex;
-  if ($id) {
-    $attach_base =~ s/\%bugid\%/$id/;
-    $regex = quotemeta($attach_base);
-  }
-  else {
-    # In this circumstance we run quotemeta first because we need to
-    # insert an active regex meta-character afterward.
-    $regex = quotemeta($attach_base);
-    $regex =~ s/\\\%bugid\\\%/\\d+/;
-  }
-  $regex = "^$regex";
-  return ($self->url =~ $regex) ? 1 : 0;
+  return 0 unless $Bugzilla::App::CGI::C;
+  return $Bugzilla::App::CGI::C->url_is_attachment_base($id);
 }
 
 sub set_dated_content_disp {

--- a/Bugzilla/CGI/ContentSecurityPolicy.pm
+++ b/Bugzilla/CGI/ContentSecurityPolicy.pm
@@ -59,22 +59,14 @@ sub _has_directive {
   return $self->$method;
 }
 
-sub header_names {
+sub header_name {
   my ($self) = @_;
-  my @names = ('Content-Security-Policy');
+  my $name = 'Content-Security-Policy';
   if ($self->report_only) {
-    return map { $_ . '-Report-Only' } @names;
+    return  $name . '-Report-Only';
   }
   else {
-    return @names;
-  }
-}
-
-sub add_cgi_headers {
-  my ($self, $headers) = @_;
-  return if $self->disable;
-  foreach my $name ($self->header_names) {
-    $headers->{"-$name"} = $self->value;
+    return $name;
   }
 }
 
@@ -164,7 +156,7 @@ Bugzilla::CGI::ContentSecurityPolicy - Object-oriented interface to generating C
 
 This class provides an object interface to constructing Content Security Policies.
 
-Rather than use this module, scripts should call $cgi->content_security_policy() which constructs the CSP headers
+Rather than use this module, scripts should call $C->content_security_policy() which constructs the CSP headers
 and registers them for the current request.
 
 See L<Bugzilla::CGI> for details.

--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -977,8 +977,8 @@ sub create {
       'current_language' => sub { return Bugzilla->current_language; },
 
       'script_nonce' => sub {
-        my $cgi = Bugzilla->cgi;
-        return $cgi->csp_nonce ? sprintf('nonce="%s"', $cgi->csp_nonce) : '';
+        my $C = $Bugzilla::App::CGI::C or return '';
+        return $C->csp_nonce ? sprintf('nonce="%s"', $C->csp_nonce) : '';
       },
 
       # If an sudo session is in progress, this is the user who

--- a/attachment.cgi
+++ b/attachment.cgi
@@ -71,7 +71,7 @@ if ($action ne 'view'
   && (($action !~ /^(?:interdiff|diff)$/) || $format ne 'raw'))
 {
   do_ssl_redirect_if_required();
-  if ($cgi->url_is_attachment_base) {
+  if ($C->url_is_attachment_base) {
     $cgi->redirect_to_urlbase;
   }
   Bugzilla->login();
@@ -244,7 +244,7 @@ sub get_attachment {
     my $path = 'attachment.cgi?' . join('&', @args);
 
     # Make sure the attachment is served from the correct server.
-    if ($cgi->url_is_attachment_base($bug_id)) {
+    if ($C->url_is_attachment_base($bug_id)) {
 
       # No need to validate the token for public attachments. We cannot request
       # credentials as we are on the alternate host.
@@ -276,7 +276,7 @@ sub get_attachment {
         delete_token($token);
       }
     }
-    elsif ($cgi->url_is_attachment_base) {
+    elsif ($C->url_is_attachment_base) {
 
       # If we come here, this means that each bug has its own host
       # for attachments, and that we are trying to view one attachment
@@ -669,7 +669,7 @@ sub insert {
   Bugzilla::Hook::process('show_bug_format', $show_bug_format);
 
   if ($show_bug_format->{format} eq 'modal') {
-    $cgi->content_security_policy(Bugzilla::CGI::SHOW_BUG_MODAL_CSP($bugid));
+    $C->content_security_policy(SHOW_BUG_MODAL_CSP($bugid));
   }
 
   print $cgi->header();
@@ -851,7 +851,7 @@ sub update {
   Bugzilla::Hook::process('show_bug_format', $show_bug_format);
 
   if ($show_bug_format->{format} eq 'modal') {
-    $cgi->content_security_policy(Bugzilla::CGI::SHOW_BUG_MODAL_CSP($bug->id));
+    $C->content_security_policy(SHOW_BUG_MODAL_CSP($bug->id));
   }
 
   print $cgi->header();
@@ -925,7 +925,7 @@ sub delete_attachment {
     Bugzilla::Hook::process('show_bug_format', $show_bug_format);
 
     if ($show_bug_format->{format} eq 'modal') {
-      $cgi->content_security_policy(Bugzilla::CGI::SHOW_BUG_MODAL_CSP($bug->id));
+      $C->content_security_policy(SHOW_BUG_MODAL_CSP($bug->id));
     }
 
     print $cgi->header();

--- a/chart.cgi
+++ b/chart.cgi
@@ -51,7 +51,7 @@ local our $cgi      = Bugzilla->cgi;
 local our $template = Bugzilla->template;
 local our $vars     = {};
 my $dbh = Bugzilla->dbh;
-$cgi->content_security_policy(report_only => 0);
+$C->content_security_policy(report_only => 0);
 
 my $user = Bugzilla->login(LOGIN_REQUIRED);
 

--- a/index.cgi
+++ b/index.cgi
@@ -68,7 +68,7 @@ if (
 }
 else {
   my $template = Bugzilla->template;
-  $cgi->content_security_policy(
+  $C->content_security_policy(
     script_src => ['self', 'https://www.google-analytics.com']);
 
   # Return the appropriate HTTP response headers.

--- a/post_bug.cgi
+++ b/post_bug.cgi
@@ -305,7 +305,7 @@ $cgi->delete('format');
 
 if ($user->setting('ui_experiments') eq 'on') {
   Bugzilla->cgi->content_security_policy(
-    Bugzilla::CGI::SHOW_BUG_MODAL_CSP($bug->id));
+    SHOW_BUG_MODAL_CSP($bug->id));
 }
 print $cgi->header();
 $template->process($format->{'template'}, $vars)

--- a/process_bug.cgi
+++ b/process_bug.cgi
@@ -437,7 +437,7 @@ my $format_params = {
 Bugzilla::Hook::process('show_bug_format', $format_params);
 if ($format_params->{format} eq 'modal') {
   my $bug_id = $vars->{bug} ? $vars->{bug}->id : undef;
-  $cgi->content_security_policy(Bugzilla::CGI::SHOW_BUG_MODAL_CSP($bug_id));
+  $C->content_security_policy(SHOW_BUG_MODAL_CSP($bug_id));
 }
 my $format = $template->get_format(
   "bug/show",

--- a/report.cgi
+++ b/report.cgi
@@ -25,7 +25,7 @@ my $cgi      = Bugzilla->cgi;
 my $template = Bugzilla->template;
 my $vars     = {};
 
-$cgi->content_security_policy(report_only => 0);
+$C->content_security_policy(report_only => 0);
 
 # Go straight back to query.cgi if we are adding a boolean chart.
 if (grep(/^cmd-/, $cgi->param())) {

--- a/show_bug.cgi
+++ b/show_bug.cgi
@@ -59,7 +59,7 @@ if (!$cgi->param('id') && $single) {
 if ($format_params->{format} eq 'modal') {
   my $bug_id = $cgi->param('id');
   detaint_natural($bug_id);
-  $cgi->content_security_policy(Bugzilla::CGI::SHOW_BUG_MODAL_CSP($bug_id));
+  $C->content_security_policy(SHOW_BUG_MODAL_CSP($bug_id));
 }
 
 

--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -108,12 +108,6 @@
     [% END %]
     [% USE Bugzilla %]
 
-    [% IF Bugzilla.cgi.should_block_referrer %]
-      <meta name="referrer" content="origin">
-    [% ELSE %]
-      <meta name="referrer" content="origin-when-cross-origin">
-    [% END %]
-
     [%- js_BUGZILLA = {
             config => {
                 basepath => basepath,

--- a/xmlrpc.cgi
+++ b/xmlrpc.cgi
@@ -45,7 +45,6 @@ my $stdout = capture_stdout {
 # for setting SOAPAction, which isn't used by XML-RPC.
   $server->on_action(sub { $server->handle_login(WS_DISPATCH, @_) })->handle();
 };
-my $C = $Bugzilla::App::CGI::C;
 my ($header_str, $body) = split(/(?:\r\n\r\n|\n\n)/, $stdout, 2);
 my $headers = Mojo::Headers->new;
 $headers->parse("$header_str\r\n\r\n");


### PR DESCRIPTION
This patch moves the code that sets most of the important headers out of the `Bugzilla::CGI` class and into the mojolicious `after_dispatch` hook. This means it will be run after (nearly all) requests. Some other code had to move (`url_is_attachment_base`) into helpers and the CSP functions are moved to the constants module (though this is not ideal).

This fixes a regression where the bugzilla index didn't set security headers.
Thanks to @claudijd for reporting this.