### PR TITLE
no bug - Fix missing object error when submitting new bug

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20190410.1';
+our $VERSION = '20190410.2';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;

--- a/post_bug.cgi
+++ b/post_bug.cgi
@@ -304,8 +304,7 @@ $format = $template->get_format("bug/create/created",
 $cgi->delete('format');
 
 if ($user->setting('ui_experiments') eq 'on') {
-  Bugzilla->cgi->content_security_policy(
-    SHOW_BUG_MODAL_CSP($bug->id));
+  $C->content_security_policy(SHOW_BUG_MODAL_CSP($bug->id));
 }
 print $cgi->header();
 $template->process($format->{'template'}, $vars)


### PR DESCRIPTION
A fallout from #1218. Fix the following error raised when you submit a new bug:

> Can't locate object method "content_security_policy" via package "Bugzilla::CGI" at post_bug.cgi line 307.

**But there's still another problem**: the new bug's title will be undefined, and the browser console also says:

> TypeError: BUGZILLA.user.settings is undefined