### PR TITLE
Bug 1543438 - Enter Bug page: Hide Severity and Mentors as advanced fields

### DIFF
--- a/extensions/Review/template/en/default/hook/bug/create/create-after_custom_fields.html.tmpl
+++ b/extensions/Review/template/en/default/hook/bug/create/create-after_custom_fields.html.tmpl
@@ -6,7 +6,7 @@
   # defined by the Mozilla Public License, v. 2.0.
   #%]
 
-<tr>
+<tr class="expert_fields">
   <th class="field_label">Mentors:</th>
   <td colspan="3" class="field_value">
      [% INCLUDE global/userselect.html.tmpl

--- a/skins/standard/enter_bug.css
+++ b/skins/standard/enter_bug.css
@@ -39,7 +39,7 @@
  * pretty well on all browsers except IE 8.
  */
 #Create #field_container_component { width: 1px; }
-#Create #field_container_reporter  { width: 100%; }
+#Create #required_marker           { width: 100%; }
 
 #Create .comment {
     vertical-align: top;

--- a/template/en/default/bug/create/create.html.tmpl
+++ b/template/en/default/bug/create/create.html.tmpl
@@ -232,19 +232,17 @@ TUI_hide_default('expert_fields');
                                    'bz_default_hidden');
       </script>
     </td>
-    <td colspan="2">
-      (<span class="required_star">*</span> =
-      <span class="required_explanation">Required Field</span>)
-   </td>
+    <td colspan="2">&nbsp;</td>
   </tr>
 
   <tr>
     [% INCLUDE bug/field.html.tmpl
       bug = default, field = bug_fields.product, editable = 0,
       value = product.name %]
-    [% INCLUDE bug/field.html.tmpl
-      bug = default, field = bug_fields.reporter, editable = 0,
-      value = user.login %]
+    <td colspan="2" id="required_marker">
+      (<span class="required_star">*</span> =
+      <span class="required_explanation">Required Field</span>)
+    </td>
   </tr>
 
   [%# We can't use the select block in these two cases for various reasons. %]
@@ -312,9 +310,9 @@ TUI_hide_default('expert_fields');
 
   <tr>
     [% INCLUDE "bug/field-label.html.tmpl"
-      field = bug_fields.version editable = 1 rowspan = 4
+      field = bug_fields.version editable = 1 rowspan = 3
     %]
-    <td rowspan="4">
+    <td rowspan="3">
       <select name="version" id="version" size="5">
         [%- FOREACH v = version %]
           [% NEXT IF NOT v.is_active %]
@@ -328,12 +326,6 @@ TUI_hide_default('expert_fields');
     [% INCLUDE bug/field.html.tmpl
       bug = default, field = bug_fields.bug_type, editable = 1, use_buttons = 1,
       value = default.bug_type %]
-  </tr>
-
-  <tr>
-    [% INCLUDE bug/field.html.tmpl
-      bug = default, field = bug_fields.bug_severity, editable = 1,
-      value = default.bug_severity %]
   </tr>
 
   [% needs_extra_tr = 1 %]
@@ -394,18 +386,15 @@ TUI_hide_default('expert_fields');
       <td colspan="2">&nbsp;</td>
     [% END %]
   </tr>
-</tbody>
-
-<tbody class="expert_fields">
-  <tr>
-    <td colspan="4">&nbsp;</td>
-  </tr>
 
   <tr>
     [% INCLUDE bug/field.html.tmpl
       bug = default, field = bug_fields.bug_status,
       editable = (bug_status.size > 1), value = default.bug_status
       override_legal_values = bug_status %]
+    [% INCLUDE bug/field.html.tmpl
+      bug = default, field = bug_fields.bug_severity, editable = 1,
+      value = default.bug_severity %]
   </tr>
 
   <tr>


### PR DESCRIPTION
* Remove the necessary **Reporter** name
* Hide the **Severity** field by default just like **Priority**
* Hide the **Mentors** custom field as well

## Bugzilla link

[Bug 1543438 - Enter Bug page: Hide Severity and Mentors as advanced fields](https://bugzilla.mozilla.org/show_bug.cgi?id=1543438)