### PR TITLE
Bug 1543456 - Keep bug type passed to enter_bug.cgi via query, including cloned bug, even after component is selected

### DIFF
--- a/template/en/default/bug/create/create.html.tmpl
+++ b/template/en/default/bug/create/create.html.tmpl
@@ -69,7 +69,7 @@ function initCrashSignatureField() {
 }
 
 const params = new URLSearchParams(location.search);
-let bug_type_specified = params.has('bug_type');
+let bug_type_specified = params.has('bug_type') || params.has('cloned_bug_id');
 
 var initialowners = new Array([% product.components.size %]);
 var last_initialowner;

--- a/template/en/default/bug/create/create.html.tmpl
+++ b/template/en/default/bug/create/create.html.tmpl
@@ -53,7 +53,7 @@ function init() {
   bz_attachment_form.update_requirements(false);
 
   document.querySelector('#bug_type').addEventListener('change', () => {
-    bug_type_changed = true;
+    bug_type_specified = true;
   }, { once: true });
 }
 
@@ -68,10 +68,12 @@ function initCrashSignatureField() {
   [% END %]
 }
 
+const params = new URLSearchParams(location.search);
+let bug_type_specified = params.has('bug_type');
+
 var initialowners = new Array([% product.components.size %]);
 var last_initialowner;
 var default_bug_types = new Array([% product.components.size %]);
-let bug_type_changed = false;
 var initialccs = new Array([% product.components.size %]);
 var components = new Array([% product.components.size %]);
 var comp_desc = new Array([% product.components.size %]);
@@ -136,7 +138,7 @@ function set_assign_to() {
             last_initialowner = owner;
         }
 
-        if (!bug_type_changed) {
+        if (!bug_type_specified) {
           form.bug_type.value = default_bug_types[index];
         }
 


### PR DESCRIPTION
When the URL query param for `enter_bug.cgi` contains `bug_type`, respect it instead of the predefined per-component type.

## Bugzilla link

[Bug 1543456 - Keep bug type passed to enter_bug.cgi via query even after component is selected](https://bugzilla.mozilla.org/show_bug.cgi?id=1543456)