### PR TITLE
Bug 1543741 - Blocklist requests getting filed as 'defect' instead of 'task' because of custom form

### DIFF
--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -907,9 +907,12 @@ sub create {
 
   # Bug type can be defined at the component, product or instance level
   unless (defined $params->{bug_type}) {
-    my $product = Bugzilla::Product->new({name => $params->{product}, cache => 1});
+    my $product
+      = (defined $params->{product})
+      ? Bugzilla::Product->new({name => $params->{product}, cache => 1})
+      : undef;
     my $component
-      = ($product)
+      = ($product && defined $params->{component})
       ? Bugzilla::Component->new({name => $params->{component}, product => $product, cache => 1})
       : undef;
     $params->{bug_type}

--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -915,11 +915,11 @@ sub create {
       = ($product && defined $params->{component})
       ? Bugzilla::Component->new({name => $params->{component}, product => $product, cache => 1})
       : undef;
+    # The component's default bug type inherits or overrides the default bug
+    # type of the product or instance
     $params->{bug_type}
-      = ($component && $component->default_bug_type)
+      = ($component)
       ? $component->default_bug_type
-      # : ($product && $product->default_bug_type)
-      # ? $product->default_bug_type
       : Bugzilla->params->{default_bug_type};
   }
 

--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -915,8 +915,8 @@ sub create {
     $params->{bug_type}
       = ($component && $component->default_bug_type)
       ? $component->default_bug_type
-      : ($product && $product->default_bug_type)
-      ? $product->default_bug_type
+      # : ($product && $product->default_bug_type)
+      # ? $product->default_bug_type
       : Bugzilla->params->{default_bug_type};
   }
 


### PR DESCRIPTION
Properly check for the bug type defined at not only the instance level but also the component and product level when a new bug is filed without a user-defined type.

## Bugzilla link

[Bug 1543741 - Blocklist requests getting filed as 'defect' instead of 'task' because of custom form](https://bugzilla.mozilla.org/show_bug.cgi?id=1543741)