### PR TITLE
Bug 1543760 - When cloning a bug, the bug is added to 'Regressed by' of the new bug

### DIFF
--- a/enter_bug.cgi
+++ b/enter_bug.cgi
@@ -264,7 +264,7 @@ if ($cloned_bug_id) {
   $vars->{'keywords'}     = $cloned_bug->keywords;
   $vars->{'dependson'}    = join(", ", $cloned_bug_id, @{$cloned_bug->dependson});
   $vars->{'blocked'}      = join(", ", @{$cloned_bug->blocked});
-  $vars->{'regressed_by'} = join(", ", $cloned_bug_id, @{$cloned_bug->regressed_by});
+  $vars->{'regressed_by'} = formvalue('regressed_by');
   $vars->{'deadline'}     = $cloned_bug->deadline;
   $vars->{'estimated_time'}    = $cloned_bug->estimated_time;
   $vars->{'status_whiteboard'} = $cloned_bug->status_whiteboard;


### PR DESCRIPTION
Fix a cloned bug wrongly adding the original bug to the Regressed by field.

## Bugzilla link

[Bug 1543760 - When cloning a bug, the bug is added to 'Regressed by' of the new bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1543760)