### PR TITLE
Bug 1543718 - Obsolete attachments should have a strikethrough

### DIFF
--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -793,8 +793,14 @@ h3.change-name {
     color: grey;
 }
 
-.change-set .attachment .label [itemprop="name"] {
+.change-set .attachment .label [itemprop="description"] {
     font-weight: 600;
+}
+
+.change-set .attachment.deleted .label [itemprop="description"],
+.change-set .attachment.obsolete .label [itemprop="description"] {
+    text-decoration: line-through;
+    text-decoration-color: grey;
 }
 
 .change-set .attachment .outer {


### PR DESCRIPTION
Add a strike-through to obsolete inline attachment links on the modal bug page. Plus, fix the font weight (a fallout from #1203).

## Bugzilla link

[Bug 1543718 - Obsolete attachments should have a strikethrough](https://bugzilla.mozilla.org/show_bug.cgi?id=1543718)