### PR TITLE
Bug 1543798 - Do not treat email addresses with invalid.bugs as unassigned when displaying bugs

### DIFF
--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -995,7 +995,7 @@ sub _bug_reporters_hw_os {
 sub _bug_is_unassigned {
   my ($self) = @_;
   my $assignee = $self->assigned_to->login;
-  return $assignee eq 'nobody@mozilla.org' || $assignee =~ /\.bugs$/;
+  return $assignee eq 'nobody@mozilla.org' || $assignee =~ /@(?!invalid).+\.bugs$/;
 }
 
 sub _bug_has_current_patch {
@@ -1176,7 +1176,7 @@ sub object_start_of_update {
   # and the assignee isn't a real person
   return
     unless $new_bug->assigned_to->login eq 'nobody@mozilla.org'
-    || $new_bug->assigned_to->login =~ /\.bugs$/;
+    || $new_bug->assigned_to->login =~ /@(?!invalid).+\.bugs$/;
 
   # and the user can set the status to NEW
   return

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -20,7 +20,7 @@
   # these are used in a few places
   is_cced = bug.cc.contains(user.login);
   unassigned = (bug.assigned_to.login == "nobody@mozilla.org")
-               || (bug.assigned_to.login.search('\.bugs$'));
+               || (bug.assigned_to.login.search('@(?!invalid).+\.bugs$'));
 
   # custom fields that have custom rendering, or should not be rendered
   rendered_custom_fields = [

--- a/extensions/ComponentWatching/Extension.pm
+++ b/extensions/ComponentWatching/Extension.pm
@@ -243,7 +243,7 @@ sub _check_watch_user {
   if ($value eq '') {
     ThrowUserError('component_watch_missing_watch_user');
   }
-  if ($value !~ /\.bugs$/i) {
+  if ($value !~ /@(?!invalid).+\.bugs$/i) {
     ThrowUserError('component_watch_invalid_watch_user');
   }
   return Bugzilla::User->check($value)->id;

--- a/template/en/default/attachment/create.html.tmpl
+++ b/template/en/default/attachment/create.html.tmpl
@@ -74,7 +74,7 @@
         <td>
           <em>If you want to assign this [% terms.bug %] to yourself,
               check the box below.</em><br>
-          [% IF bug.assigned_to.login == "nobody@mozilla.org" || bug.assigned_to.login.search('.bugs$') %]
+          [% IF bug.assigned_to.login == "nobody@mozilla.org" || bug.assigned_to.login.search('@(?!invalid).+\.bugs$') %]
             [% take_if_patch = 1 %]
           [% END %]
           <input type="checkbox" id="takebug" name="takebug" value="1" [% IF take_if_patch %] data-take-if-patch="1" [% END %]>


### PR DESCRIPTION
Prevent the Unassigned label from being displayed for email addresses ending with `@invalid.bugs`. Other default assignees like `administration@bugzilla.bugs` will still be displayed as Unassigned.

## Bugzilla link

[Bug 1543798 - Do not treat email addresses with invalid.bugs as unassigned when displaying bugs](https://bugzilla.mozilla.org/show_bug.cgi?id=1543798)