### PR TITLE
Bug 1544132 - Allow editing empty Descriptions

### DIFF
--- a/extensions/BugModal/lib/ActivityStream.pm
+++ b/extensions/BugModal/lib/ActivityStream.pm
@@ -179,14 +179,6 @@ sub _add_comments_to_stream {
       $comment->{collapsed_reason} = $comment->author->name;
     }
 
-    if ( $comment->type != CMT_ATTACHMENT_CREATED
-      && $comment->count == 0
-      && length($comment->body) == 0)
-    {
-      $comment->{collapsed}        = 1;
-      $comment->{collapsed_reason} = 'empty';
-    }
-
 # If comment type is resolved as duplicate, do not add '...marked as duplicate...' string to comment body
     if ($comment->type == CMT_DUPE_OF) {
       $comment->set_type(0);

--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -290,13 +290,19 @@
     [% comment_tag = 'pre' %]
   [% END %]
 
-  [% IF comment.body %]
+  [%# Description (Comment 0) can be empty %]
+  [% IF comment.body || comment.count == 0 %]
     <[% comment_tag FILTER none %]
-        class="comment-text [%= "markdown-body" IF comment.is_markdown %] [%= "bz_private" IF comment.is_private %]"
+        class="comment-text [%= "markdown-body" IF comment.is_markdown %] [%= "bz_private" IF comment.is_private %]
+               [% "empty" IF !comment.body %]"
         id="ct-[% comment.count FILTER none %]" data-comment-id="[% comment.id FILTER none %]"
         [% IF comment.is_markdown +%] data-ismarkdown="true" [% END ~%]
         [% IF comment.collapsed +%] style="display:none"[% END ~%]>
-      [%~ comment.body_full({ exclude_attachment => 1 }) FILTER renderMarkdown(bug, comment) ~%]
+      [%~ IF comment.body ~%]
+        [%~ comment.body_full({ exclude_attachment => 1 }) FILTER renderMarkdown(bug, comment) ~%]
+      [%~ ELSE ~%]
+        <em>No description provided.</em>
+      [%~ END ~%]
     </[% comment_tag FILTER none %]>
   [% END %]
 [% END %]

--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -142,7 +142,7 @@
               </button>
             [% END %]
             <button type="button" class="reply-btn minor iconic" title="Reply to this comment" aria-label="Reply"
-                    data-reply-id="[% comment.count FILTER none %]"
+                    [% 'disabled' IF !comment.body %] data-reply-id="[% comment.count FILTER none %]"
                     data-reply-name="[% comment.author.name || comment.author.nick FILTER html %]">
               <span class="icon" aria-hidden="true"></span>
             </button>

--- a/extensions/EditComments/template/en/default/hook/bug_modal/activity_stream-comment_action.html.tmpl
+++ b/extensions/EditComments/template/en/default/hook/bug_modal/activity_stream-comment_action.html.tmpl
@@ -7,7 +7,7 @@
   #%]
 
 [%
-  RETURN IF comment.body == '';
+  RETURN UNLESS comment.body || comment.count == 0;
   RETURN UNLESS user.is_insider
     || Param('edit_comments_group') && user.in_group(Param('edit_comments_group')) && comment.author.id == user.id;
   RETURN UNLESS

--- a/extensions/EditComments/template/en/default/pages/comment-revisions.html.tmpl
+++ b/extensions/EditComments/template/en/default/pages/comment-revisions.html.tmpl
@@ -40,6 +40,8 @@
     <div class="body">
       [% IF !user.is_insider && a.is_hidden %]
         <div class="hidden-comment">(Hidden by Administrator)</div>
+      [% ELSIF comment.count == 0 && !a.new %]
+        <div class="empty-comment">No description provided.</div>
       [% ELSE %]
         <pre class="bz_comment_text">[% a.new FILTER quoteUrls(bug) %]</pre>
       [% END %]

--- a/extensions/EditComments/web/js/inline-editor.js
+++ b/extensions/EditComments/web/js/inline-editor.js
@@ -143,7 +143,7 @@ Bugzilla.InlineCommentEditor = class InlineCommentEditor {
 
     // Let the user edit Description (Comment 0) immediately if it's empty
     if (this.is_empty) {
-      this.fetch_onload({ comments: { [this.comment_id] : '' }});
+      this.fetch_onload({ comments: { [this.comment_id]: '' } });
       return;
     }
 
@@ -291,7 +291,7 @@ Bugzilla.InlineCommentEditor = class InlineCommentEditor {
 
   /**
    * Enable or disable buttons on the comment actions toolbar (not the editor's own toolbar) while editing the comment
-   * to avoid any unexpected behaviour.
+   * to avoid any unexpected behaviour. The Reply button should always be disabled if the comment is empty.
    * @param {Boolean} disabled Whether the buttons should be disabled.
    */
   toggle_toolbar_buttons(disabled) {

--- a/extensions/EditComments/web/js/inline-editor.js
+++ b/extensions/EditComments/web/js/inline-editor.js
@@ -48,7 +48,8 @@ Bugzilla.InlineCommentEditor = class InlineCommentEditor {
 
     this.$edit_button.addEventListener('click', event => this.edit_button_onclick(event));
 
-    // Check if the comment is written in Markdown
+    // Check if the comment is empty or written in Markdown
+    this.is_empty = this.$body.matches('.empty');
     this.is_markdown = this.$body.matches('[data-ismarkdown="true"]');
   }
 
@@ -139,6 +140,12 @@ Bugzilla.InlineCommentEditor = class InlineCommentEditor {
 
     // Adjust the height of `<textarea>`
     this.$textarea.style.height = `${this.$textarea.scrollHeight}px`;
+
+    // Let the user edit Description (Comment 0) immediately if it's empty
+    if (this.is_empty) {
+      this.fetch_onload({ comments: { [this.comment_id] : '' }});
+      return;
+    }
 
     // Retrieve the raw comment text
     bugzilla_ajax({
@@ -323,6 +330,12 @@ Bugzilla.InlineCommentEditor = class InlineCommentEditor {
   save_onsuccess(data) {
     this.$body.innerHTML = data.html;
     this.finish();
+
+    // Remove the empty state (new comment cannot be empty)
+    if (this.is_empty) {
+      this.is_empty = false;
+      this.$body.classList.remove('empty');
+    }
 
     // Highlight code if possible
     if (Prism) {

--- a/extensions/EditComments/web/js/inline-editor.js
+++ b/extensions/EditComments/web/js/inline-editor.js
@@ -295,7 +295,9 @@ Bugzilla.InlineCommentEditor = class InlineCommentEditor {
    * @param {Boolean} disabled Whether the buttons should be disabled.
    */
   toggle_toolbar_buttons(disabled) {
-    this.$change_set.querySelectorAll('.comment-actions button').forEach($button => $button.disabled = disabled);
+    this.$change_set.querySelectorAll('.comment-actions button').forEach($button => {
+      $button.disabled = $button.matches('.reply-btn') && this.is_empty ? true : disabled;
+    });
   }
 
   /**
@@ -329,13 +331,14 @@ Bugzilla.InlineCommentEditor = class InlineCommentEditor {
    */
   save_onsuccess(data) {
     this.$body.innerHTML = data.html;
-    this.finish();
 
     // Remove the empty state (new comment cannot be empty)
     if (this.is_empty) {
       this.is_empty = false;
       this.$body.classList.remove('empty');
     }
+
+    this.finish();
 
     // Highlight code if possible
     if (Prism) {

--- a/extensions/EditComments/web/styles/revisions.css
+++ b/extensions/EditComments/web/styles/revisions.css
@@ -23,6 +23,7 @@
   flex: none;
 }
 
+.revision .empty-comment,
 .revision .hidden-comment {
   padding: 10px;
   font-style: italic;

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -2171,6 +2171,10 @@ pre.comment-text {
     border: 1px dashed darkred;
 }
 
+.comment-text.empty {
+  color: #666;
+}
+
 /* Markdown styling adapted from https://github.com/sindresorhus/github-markdown-css */
 
 .markdown-body {


### PR DESCRIPTION
Show empty descriptions (comment 0) with a placeholder “No description provided” and let the user edit the content later if needed. This is the same behaviour as GitHub issues.

![Screenshot_2019-04-12 1526478 - Re-implement Custom Search UI](https://user-images.githubusercontent.com/2929505/56072253-f6c82200-5d62-11e9-9dbe-623bdfd1c4bd.png)

## Bugzilla link

[Bug 1544132 - Allow editing empty Descriptions](https://bugzilla.mozilla.org/show_bug.cgi?id=1544132)