### PR TITLE
Bug 1541898 - Allow to search on product/component pair

### DIFF
--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -2871,7 +2871,6 @@ sub _assignee_last_login {
 sub _component_nonchanged {
   my ($self, $args) = @_;
   my $dbh = Bugzilla->dbh;
-  my (@products, @components);
   my $product;
 
   # Allow to search product/component pairs like "Core::General" with a simple
@@ -2891,9 +2890,13 @@ sub _component_nonchanged {
   my $term = $args->{term};
 
   if ($product) {
+    # We need to pass the complete condition and negative option to make sure
+    # both product and components are included or excluded
     $args->{term} = build_subselect('bugs.component_id', 'components.id',
       'components JOIN products ON components.product_id = products.id',
-      $term . ' AND products.name = ' . $dbh->quote($product));
+      'products.name = ' . $dbh->quote($product)
+        . ' AND components.name = ' . $args->{quoted},
+      $args->{operator} eq 'notequals');
   } else {
     $args->{term} = build_subselect('bugs.component_id', 'components.id',
       'components', $term);

--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -2890,8 +2890,8 @@ sub _component_nonchanged {
   my $term = $args->{term};
 
   if ($product) {
-    # We need to pass the complete condition and negative option to make sure
-    # both product and components are included or excluded
+    # Pass the complete condition and negative option to make sure both product
+    # and component are included or excluded
     $args->{term} = build_subselect('bugs.component_id', 'components.id',
       'components JOIN products ON components.product_id = products.id',
       'products.name = ' . $dbh->quote($product)


### PR DESCRIPTION
Allow to use product/component pairs like “Core::General, IPC” for the Component field in Custom Search. This also works with simple queries like `buglist.cgi?component=Core%3A%3AGeneral&component=IPC`.

## Bugzilla link

[Bug 1541898 - Allow to search on product/component pair](https://bugzilla.mozilla.org/show_bug.cgi?id=1541898)