### PR TITLE
Bug 1544304 - Wrong escaping of quotes in attachment titles.

### DIFF
--- a/extensions/BugModal/web/comments.js
+++ b/extensions/BugModal/web/comments.js
@@ -569,7 +569,7 @@ Bugzilla.BugModal.Comments = class Comments {
     // Show image smaller than 2 MB
     if (type.match(/^image\/(?!vnd).+$/) && size < max_size) {
       $att.insertAdjacentHTML('beforeend', `
-        <a href="${link}" class="outer lightbox"><img src="${link}" alt="${name}" itemprop="image"></a>`);
+        <a href="${link}" class="outer lightbox"><img src="${link}" alt="${name.htmlEncode()}" itemprop="image"></a>`);
 
       // Add lightbox support
       $att.querySelector('.outer.lightbox').addEventListener('click', event => {
@@ -610,7 +610,7 @@ Bugzilla.BugModal.Comments = class Comments {
         const lang = is_patch ? 'diff' : type.match(/\w+$/)[0];
 
         $att.insertAdjacentHTML('beforeend', `
-          <button type="button" role="link" title="${name}" class="outer">
+          <button type="button" role="link" title="${name.htmlEncode()}" class="outer">
           <pre class="language-${lang}" role="img" itemprop="text">${text.htmlEncode()}</pre></button>`);
 
         // Make the button work as a link. It cannot be `<a>` because Prism Autolinker plugin may add links to `<pre>`

--- a/extensions/FlagTypeComment/web/js/ftc.js
+++ b/extensions/FlagTypeComment/web/js/ftc.js
@@ -198,12 +198,15 @@ Bugzilla.FlagTypeComment = class FlagTypeComment {
             (att.is_patch || this.extra_patch_types.includes(att.content_type)));
 
           if (others.length) {
-            $fieldset.querySelector('tbody').insertAdjacentHTML('beforeend',
-              '<tr class="other-patches"><th>Do you want to request approval of these patches as well?</th><td>' +
-              `${others.map(patch =>
-                `<div><label><input type="checkbox" checked data-id="${patch.id}"> ${patch.summary}</label></div>`
-              ).join('')}` +
-              '</td></tr>');
+            $fieldset.querySelector('tbody').insertAdjacentHTML('beforeend', `
+              <tr class="other-patches"><th>Do you want to request approval of these patches as well?</th><td>
+              ${others.map(patch => `
+                <div>
+                  <label><input type="checkbox" checked data-id="${patch.id}"> ${patch.summary.htmlEncode()}</label>
+                </div>
+              `).join('')}
+              </td></tr>
+            `);
           }
         });
       }


### PR DESCRIPTION
Properly escape user-defined attachment names inserted dynamically into the attachment preview and uplift request form. Also checked other uses cases of `insertAdjacentHTML()`.

## Bugzilla link

[Bug 1544304 - Wrong escaping of quotes in attachment titles.](https://bugzilla.mozilla.org/show_bug.cgi?id=1544304)