### PR TITLE
Bug 1543163 - Make Toolkit :: Blocklist Policy Request component private by default

### DIFF
--- a/extensions/BMO/template/en/default/bug/create/create-blocklist.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-blocklist.html.tmpl
@@ -146,6 +146,7 @@ window.addEventListener("DOMContentLoaded", function() {
   <input type="hidden" name="target_milestone" id="target_milestone" value="---">
   <input type="hidden" name="bug_severity" id="bug_severity" value="normal">
   <input type="hidden" name="short_desc" id="short_desc" value="Extension block request">
+  <input type="hidden" name="groups" value="blocklist-requests">
   <input type="hidden" name="comment" id="comment" value="It seems JavaScript is disabled. Please fill in the details again.">
   <input type="hidden" name="token" value="[% token FILTER html %]">
 


### PR DESCRIPTION
For testing you will need to create the following:

Product: Toolkit
Component: Blocklist Policy Requests
Group: blocklist-requests 

And set blocklist-requests to SHOWN/SHOWN for product Toolkit access controls.