### PR TITLE
Bump version to 20190418.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20190410.3';
+our $VERSION = '20190418.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
[release tag](https://github.com/mozilla-bteam/bmo/tree/release-20190418.1)

the following changes have been pushed to bugzilla.mozilla.org:
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1541303" target="_blank">1541303</a>] Default component bug type is not set as expected; enhancement severity is still used for existing bugs</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1543760" target="_blank">1543760</a>] When cloning a bug, the bug is added to 'Regressed by' of the new bug</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1543718" target="_blank">1543718</a>] Obsolete attachments should have a strikethrough</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1543798" target="_blank">1543798</a>] Do not treat email addresses with invalid.bugs as unassigned when displaying bugs</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1544304" target="_blank">1544304</a>] Wrong escaping of quotes in attachment titles.</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1541555" target="_blank">1541555</a>] Add facility for requiring an API Key to always come from the same IP address</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1545295" target="_blank">1545295</a>] socorro lens chart for crash statistics blocked by CSP (Blocked by Content Security Policy)</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1543163" target="_blank">1543163</a>] Make Toolkit :: Blocklist Policy Request component private by default</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1545269" target="_blank">1545269</a>] Request for Bug Dependency Graphs return a 404</li>
</ul>
discuss these changes on <a href="https://lists.mozilla.org/listinfo/tools-bmo" target="_blank">mozilla.tools.bmo</a>.