### PR TITLE
no bug - Show Crash Signature field on Taskcluster bugs

### DIFF
--- a/extensions/BMO/lib/Data.pm
+++ b/extensions/BMO/lib/Data.pm
@@ -126,6 +126,7 @@ tie(
     "Rhino"                               => [],
     "SeaMonkey"                           => [],
     "Tamarin"                             => [],
+    "Taskcluster"                         => [],
     "Tech Evangelism"                     => [],
     "Testing"                             => [],
     "Thunderbird"                         => [],


### PR DESCRIPTION
Reported by @calixteman: The Taskcluster product should display the Crash Signature field. For example, both [Bug 1544536](https://bugzilla.mozilla.org/show_bug.cgi?id=1544536) and [Bug 1540280](https://bugzilla.mozilla.org/show_bug.cgi?id=1540280) have a signature provided by the relman bot, but the field is not visible.