### PR TITLE
Bug 1546146 - Show bug types in See Also

### DIFF
--- a/Bugzilla/BugUrl/Bugzilla/Local.pm
+++ b/Bugzilla/BugUrl/Bugzilla/Local.pm
@@ -96,4 +96,9 @@ sub local_uri {
   return Bugzilla->localconfig->{urlbase} . "show_bug.cgi?id=$bug_id";
 }
 
+sub bug {
+  my ($self) = @_;
+  return Bugzilla::Bug->new({id => $self->target_bug_id, cache => 1});
+}
+
 1;

--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -775,6 +775,14 @@ sub create {
         1
       ],
 
+      # Create a short, readable label for the given URL.
+      # e.g. https://www.mozilla.org/firefox/ -> mozilla.org/firefox
+      pretty_url => sub {
+        my ($url) = @_;
+        $url =~ s/^\s*(?:https?:\/\/(?:www\.)?)?(.+?)\/?\s*$/$1/g;
+        return $url;
+      },
+
       # In CSV, quotes are doubled, and any value containing a quote or a
       # comma is enclosed in quotes.
       # If a field starts with either "=", "+", "-" or "@", it is preceded

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -1534,11 +1534,14 @@
 [% BLOCK bug_url_link %]
 [%
   IF !link_text.defined;
-    link_text = bug.bug_file_loc FILTER truncate(40);
+    link_text = bug.bug_file_loc FILTER pretty_url FILTER truncate(40);
   END;
 %]
-  <a href="[% bug.bug_file_loc FILTER html %]" target="_blank"
-     rel="noreferrer" title="[% bug.bug_file_loc FILTER truncate(256) FILTER html %]"
-     class="bug-url" data-safe="[% is_safe_url(bug.bug_file_loc) ? 1 : 0 %]"
-  >[% link_text FILTER html %]</a>
+  <div class="link">
+    <a href="[% bug.bug_file_loc FILTER html %]" target="_blank"
+      rel="noreferrer" title="[% bug.bug_file_loc FILTER truncate(256) FILTER html %]"
+      class="bug-url" data-safe="[% is_safe_url(bug.bug_file_loc) ? 1 : 0 %]">
+      [%~ link_text FILTER html ~%]
+    </a>
+  </div>
 [% END %]

--- a/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
@@ -358,20 +358,38 @@ END;
 
 [%# bug-urls, currently just see-also %]
 [% BLOCK bug_urls %]
-  [% FOREACH url IN values %]
-    <div>
-      [% IF url.isa('Bugzilla::BugUrl::Bugzilla::Local') %]
-        [% url.target_bug_id FILTER bug_link(url.target_bug_id, use_alias => 1) FILTER none %]
-      [% ELSE %]
-        <a href="[% url.name FILTER html %]"
-           title="[% url.name FILTER truncate(256) FILTER html %]"
-        >[% url.name FILTER truncate(40) FILTER html %]</a>
-      [% END %]
+  [%
+    # Process internal (bug) and external links separately
+    internal_links = [];
+    external_links = [];
+    FOREACH value IN values;
+      IF value.isa('Bugzilla::BugUrl::Bugzilla::Local');
+        internal_links.push(value);
+      ELSE;
+        external_links.push(value);
+      END;
+    END;
+  %]
+
+  [% IF edit %]
+    [% FOREACH link IN internal_links %]
+      <div class="link">
+        [% link.bug.id FILTER bug_link(link.bug.id, use_alias => 1) FILTER none %]
+        <label><input type="checkbox" name="remove_see_also" value="[% link.name FILTER html %]"> Remove</label>
+      </div>
+    [% END %]
+  [% ELSE %]
+    [%# Show bugs by type %]
+    [% INCLUDE bug_list values=internal_links.pluck('bug') edit=0 %]
+  [% END %]
+
+  [% FOREACH link IN external_links %]
+    <div class="link">
+      <a href="[% link.name FILTER html %]" title="[% link.name FILTER truncate(256) FILTER html %]">
+        [%~ link.name FILTER pretty_url FILTER truncate(40) FILTER html ~%]
+      </a>
       [% IF edit %]
-          <label>
-            <input type="checkbox" name="remove_see_also" value="[% url.name FILTER html %]">
-            Remove
-          </label>
+        <label><input type="checkbox" name="remove_see_also" value="[% link.name FILTER html %]"> Remove</label>
       [% END %]
     </div>
   [% END %]

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -137,6 +137,10 @@ a.activity-ref {
     transition: all .2s;
 }
 
+.module-subtitle .link {
+  display: inline;
+}
+
 .module-spinner[aria-expanded="true"] ~ .module-subtitle {
     opacity: 0;
 }
@@ -382,6 +386,11 @@ input[type="number"] {
 
 .field .value .bug-list .bug-type-label .icon {
   font-size: 16px;
+  vertical-align: text-bottom;
+}
+
+.field .value div.link {
+  line-height: 1.5;
 }
 
 #field-value-dependencytree {


### PR DESCRIPTION
Show bugs in the See Also field by type, just like dependency and regression fields. Show external links separately in a pretty format (that applies to the URL field as well). #1187 merges these fields into the same References module.

![Screenshot_2019-04-22 964097 -  meta  Implement CSSOM-View smooth scrolling spec](https://user-images.githubusercontent.com/2929505/56522812-c461b600-6514-11e9-91b0-07de50a4d00b.png)

## Bugzilla link

[Bug 1546146 - Show bug types in See Also](https://bugzilla.mozilla.org/show_bug.cgi?id=1546146)