### PR TITLE
Bug 1540715 - Fix offset of historical dates in secbugs report

### DIFF
--- a/scripts/secbugsreport.pl
+++ b/scripts/secbugsreport.pl
@@ -39,7 +39,7 @@ exit 0 unless Int->check($year) && Int->check($month) && Int->check($day);
 
 my $html;
 my $template     = Bugzilla->template();
-my $end_date     = DateTime->new(year => $year, month => $month, day => $day);
+my $end_date     = DateTime->new(year => $year, month => $month, day => $day, time_zone  => 'America/Los_Angeles');
 my $start_date   = $end_date->clone()->subtract(months => 12);
 my $report_week  = $end_date->ymd('-');
 my $teams        = decode_json(Bugzilla->params->{report_secbugs_teams});

--- a/scripts/secbugsreport.pl
+++ b/scripts/secbugsreport.pl
@@ -39,7 +39,7 @@ exit 0 unless Int->check($year) && Int->check($month) && Int->check($day);
 
 my $html;
 my $template     = Bugzilla->template();
-my $end_date     = DateTime->new(year => $year, month => $month, day => $day, time_zone  => 'America/Los_Angeles');
+my $end_date     = DateTime->new(year => $year, month => $month, day => $day);
 my $start_date   = $end_date->clone()->subtract(months => 12);
 my $report_week  = $end_date->ymd('-');
 my $teams        = decode_json(Bugzilla->params->{report_secbugs_teams});

--- a/template/en/default/reports/email/security-risk.html.tmpl
+++ b/template/en/default/reports/email/security-risk.html.tmpl
@@ -21,7 +21,7 @@
   <tr>
     <th style="padding: 0px 15px 10px 0px;">Team</th>
     <th style="padding: 0px 15px 10px 0px; text-align: right;">
-        Open<br>[% results.reverse.0.date.strftime('%m/%d') FILTER txt %]
+        Open<br>[% results.reverse.0.date.strftime('%m/%d') FILTER html %]
     </th>
     <th style="padding: 0px 15px 10px 0px; text-align: right;">Closed<br />Last Week</th>
     <th style="padding: 0px 15px 10px 0px; text-align: right; border-right: 1px solid grey;">Added<br />Last Week</th>
@@ -29,7 +29,7 @@
       [% NEXT IF loop.count < 2 %]
       [% LAST IF loop.count > 4 %]
       <th style="padding: 0px 15px 10px [% IF loop.count == 2 %] 10px [% ELSE %] 0px [% END %]; text-align: right; [% IF loop.count == 1 %] border-right: 1px solid grey; [% END %]">
-        Open<br>[% result.date.strftime('%m/%d') FILTER txt %]
+        Open<br>[% result.date.strftime('%m/%d') FILTER html %]
       </th>
     [% END %]
   </tr>
@@ -89,7 +89,7 @@
   <tr>
     <th style="padding: 0px 15px 10px 0px;">Category</th>
     <th style="padding: 0px 15px 10px 0px; text-align: right;">
-        Open<br>[% results.reverse.0.date.strftime('%m/%d') FILTER txt %]
+        Open<br>[% results.reverse.0.date.strftime('%m/%d') FILTER html %]
     </th>
     <th style="padding: 0px 15px 10px 0px; text-align: right;">Closed<br />Last Week</th>
     <th style="padding: 0px 15px 10px 0px; text-align: right;">Added<br />Last Week</th>
@@ -100,7 +100,7 @@
       [% NEXT IF loop.count < 2 %]
       [% LAST IF loop.count > 4 %]
       <th style="padding: 0px 15px 10px [% IF loop.count == 2 %] 10px [% ELSE %] 0px [% END %]; text-align: right;  [% IF loop.count == 1 %] border-right: 1px solid grey; [% END %]">
-        Open<br>[% result.date.strftime('%m/%d') FILTER txt %]
+        Open<br>[% result.date.strftime('%m/%d') FILTER html %]
       </th>
     [% END %]
   </tr>

--- a/template/en/default/reports/email/security-risk.html.tmpl
+++ b/template/en/default/reports/email/security-risk.html.tmpl
@@ -21,7 +21,7 @@
   <tr>
     <th style="padding: 0px 15px 10px 0px;">Team</th>
     <th style="padding: 0px 15px 10px 0px; text-align: right;">
-        Open<br>[% results.reverse.0.date FILTER time('%m/%d') %]
+        Open<br>[% results.reverse.0.date.strftime('%m/%d') FILTER txt %]
     </th>
     <th style="padding: 0px 15px 10px 0px; text-align: right;">Closed<br />Last Week</th>
     <th style="padding: 0px 15px 10px 0px; text-align: right; border-right: 1px solid grey;">Added<br />Last Week</th>
@@ -29,7 +29,7 @@
       [% NEXT IF loop.count < 2 %]
       [% LAST IF loop.count > 4 %]
       <th style="padding: 0px 15px 10px [% IF loop.count == 2 %] 10px [% ELSE %] 0px [% END %]; text-align: right; [% IF loop.count == 1 %] border-right: 1px solid grey; [% END %]">
-        Open<br>[% result.date FILTER time('%m/%d') %]
+        Open<br>[% result.date.strftime('%m/%d') FILTER txt %]
       </th>
     [% END %]
   </tr>
@@ -89,7 +89,7 @@
   <tr>
     <th style="padding: 0px 15px 10px 0px;">Category</th>
     <th style="padding: 0px 15px 10px 0px; text-align: right;">
-        Open<br>[% results.reverse.0.date FILTER time('%m/%d') %]
+        Open<br>[% results.reverse.0.date.strftime('%m/%d') FILTER txt %]
     </th>
     <th style="padding: 0px 15px 10px 0px; text-align: right;">Closed<br />Last Week</th>
     <th style="padding: 0px 15px 10px 0px; text-align: right;">Added<br />Last Week</th>
@@ -100,7 +100,7 @@
       [% NEXT IF loop.count < 2 %]
       [% LAST IF loop.count > 4 %]
       <th style="padding: 0px 15px 10px [% IF loop.count == 2 %] 10px [% ELSE %] 0px [% END %]; text-align: right;  [% IF loop.count == 1 %] border-right: 1px solid grey; [% END %]">
-        Open<br>[% result.date FILTER time('%m/%d') %]
+        Open<br>[% result.date.strftime('%m/%d') FILTER txt %]
       </th>
     [% END %]
   </tr>


### PR DESCRIPTION
`FILTER time` from Bugzilla's template helpers was inconsistent on
how it rendered the dates of the columns (due to different system
timezones that change based on where the code is being run).

This patch sets manually formats the time (since FILTER time always wants to convert to the local or user's timezone).