### PR TITLE
Bug 1345750 - "Depends on" and "Blocks" bug lists should still show list of bug links in edit mode

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
@@ -98,6 +98,7 @@ END;
             [%~ " indent" IF no_label && !no_indent %]
             [%~ " inline" IF inline %]
             [%~ " contains-buttons" IF use_buttons ~%]
+            [%~ " bug-list" IF field_type == constants.FIELD_TYPE_BUG_LIST ~%]
             [%~ " edit-hide" IF hide_on_edit %]
             [%~ " edit-show" IF hide_on_view && !hide_on_edit %]"
   [% IF name %] id="field-[% name FILTER html %]"[% END %]

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -229,6 +229,12 @@ a.activity-ref {
     vertical-align: middle;
 }
 
+/* Show dependencies and regressions while editing */
+.module .field.bug-list .value[style="display: none;"],
+.module .field.bug-list .value[style="display: none;"] + .value.edit {
+    display: block !important;
+}
+
 .field-button {
     float: right;
     margin-left: 8px;


### PR DESCRIPTION
Make the bug links on the Depends on, Blocks, Regressions, Regressed by fields visible even while editing the bug, just like the non-modal UI. This is a temporary workaround so we can disable the legacy UI sooner. I’ll create a [better UI](https://bugzilla.mozilla.org/show_bug.cgi?id=1539271) for these fields in the near future.

![image](https://user-images.githubusercontent.com/2929505/56594073-42c46380-65ba-11e9-885b-ec7d47b2b546.png)

## Bugzilla link

[Bug 1345750 - "Depends on" and "Blocks" bug lists should still show list of bug links in edit mode](https://bugzilla.mozilla.org/show_bug.cgi?id=1345750)