### PR TITLE
Bug 1546774 - Show Dependency Tree link even if there’s only one bug

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -973,7 +973,7 @@
         help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#blocks"
     %]
 
-    [% IF bug.dependson.size + bug.blocked.size > 1 %]
+    [% IF bug.dependson.size + bug.blocked.size > 0 %]
       [% WRAPPER bug_modal/field.html.tmpl
           name = "dependencytree"
           container = 1


### PR DESCRIPTION
Fix a regression in the modal UI where the Dependency Tree link is not linked if there’s only one dependency bug, e.g. [Bug 1465851](https://bugzilla.mozilla.org/show_bug.cgi?id=1465851).

## Bugzilla link

[Bug 1546774 - Show Dependency Tree link even if there’s only one bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1546774)