### PR TITLE
Bug 1546624 - Add a 'everchanged' operator

### DIFF
--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -159,6 +159,7 @@ use constant OPERATORS => {
   anywords       => \&_anywords,
   allwords       => \&_allwords,
   nowords        => \&_nowords,
+  everchanged    => \&_everchanged,
   changedbefore  => \&_changedbefore_changedafter,
   changedafter   => \&_changedbefore_changedafter,
   changedfrom    => \&_changedfrom_changedto,
@@ -202,6 +203,7 @@ use constant OPERATOR_REVERSE => {
 # For these operators, even if a field is numeric (is_numeric returns true),
 # we won't treat the input like a number.
 use constant NON_NUMERIC_OPERATORS => qw(
+  everchanged
   changedafter
   changedbefore
   changedfrom
@@ -212,6 +214,7 @@ use constant NON_NUMERIC_OPERATORS => qw(
 
 # These operators ignore the entered value
 use constant NO_VALUE_OPERATORS => qw(
+  everchanged
   isempty
   isnotempty
 );
@@ -266,12 +269,14 @@ use constant OPERATOR_FIELD_OVERRIDE => {
   'flagtypes.name' => {_non_changed => \&_flagtypes_nonchanged,},
   longdesc         => {
     changedby     => \&_long_desc_changedby,
+    everchanged   => \&_long_desc_everchanged,
     changedbefore => \&_long_desc_changedbefore_after,
     changedafter  => \&_long_desc_changedbefore_after,
     _non_changed  => \&_long_desc_nonchanged,
   },
   'longdescs.count' => {
     changedby     => \&_long_desc_changedby,
+    everchanged   => \&_long_desc_everchanged,
     changedbefore => \&_long_desc_changedbefore_after,
     changedafter  => \&_long_desc_changedbefore_after,
     changedfrom   => \&_invalid_combination,
@@ -297,6 +302,7 @@ use constant OPERATOR_FIELD_OVERRIDE => {
   percentage_complete => {_non_changed => \&_percentage_complete,},
   work_time           => {
     changedby     => \&_work_time_changedby,
+    everchanged   => \&_work_time_everchanged,
     changedbefore => \&_work_time_changedbefore_after,
     changedafter  => \&_work_time_changedbefore_after,
     _default      => \&_work_time,
@@ -2617,6 +2623,12 @@ sub _long_desc_changedby {
   $args->{term} = "$table.who = $user_id";
 }
 
+sub _long_desc_everchanged {
+  my ($self, $args) = @_;
+  $self->_preprocess_everchanged($args);
+  $self->_long_desc_changedbefore_after($args);
+}
+
 sub _long_desc_changedbefore_after {
   my ($self, $args) = @_;
   my ($chart_id, $operator, $value, $joins)
@@ -2756,6 +2768,12 @@ sub _work_time_changedby {
   push(@$joins, {table => 'longdescs', as => $table});
   my $user_id = login_to_id($value, THROW_ERROR);
   $args->{term} = "$table.who = $user_id AND $table.work_time != 0";
+}
+
+sub _work_time_everchanged {
+  my ($self, $args) = @_;
+  $self->_preprocess_everchanged($args);
+  $self->_work_time_changedbefore_after($args);
 }
 
 sub _work_time_changedbefore_after {
@@ -3398,6 +3416,21 @@ sub _nowords {
   $self->_anywords($args);
   my $term = $args->{term};
   $args->{term} = "NOT($term)";
+}
+
+# Add support for the `everchanged` operator, which is a shortcut for
+# `changedafter`: `1970-01-01`
+sub _preprocess_everchanged {
+  my ($self, $args) = @_;
+  $args->{operator} = 'changedafter';
+  $args->{value}    = EMPTY_DATE;
+  $args->{quoted}   = Bugzilla->dbh->quote(EMPTY_DATE);
+}
+
+sub _everchanged {
+  my ($self, $args) = @_;
+  $self->_preprocess_everchanged($args);
+  $self->_changedbefore_changedafter($args);
 }
 
 sub _changedbefore_changedafter {

--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -203,7 +203,6 @@ use constant OPERATOR_REVERSE => {
 # For these operators, even if a field is numeric (is_numeric returns true),
 # we won't treat the input like a number.
 use constant NON_NUMERIC_OPERATORS => qw(
-  everchanged
   changedafter
   changedbefore
   changedfrom

--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -2625,7 +2625,7 @@ sub _long_desc_changedby {
 
 sub _long_desc_everchanged {
   my ($self, $args) = @_;
-  $self->_preprocess_everchanged($args);
+  $self->_convert_everchanged($args);
   $self->_long_desc_changedbefore_after($args);
 }
 
@@ -2772,7 +2772,7 @@ sub _work_time_changedby {
 
 sub _work_time_everchanged {
   my ($self, $args) = @_;
-  $self->_preprocess_everchanged($args);
+  $self->_convert_everchanged($args);
   $self->_work_time_changedbefore_after($args);
 }
 
@@ -3420,7 +3420,7 @@ sub _nowords {
 
 # Add support for the `everchanged` operator, which is a shortcut for
 # `changedafter`: `1970-01-01`
-sub _preprocess_everchanged {
+sub _convert_everchanged {
   my ($self, $args) = @_;
   $args->{operator} = 'changedafter';
   $args->{value}    = EMPTY_DATE;
@@ -3429,7 +3429,7 @@ sub _preprocess_everchanged {
 
 sub _everchanged {
   my ($self, $args) = @_;
-  $self->_preprocess_everchanged($args);
+  $self->_convert_everchanged($args);
   $self->_changedbefore_changedafter($args);
 }
 

--- a/template/en/default/global/field-descs.none.tmpl
+++ b/template/en/default/global/field-descs.none.tmpl
@@ -47,6 +47,7 @@ $stash->set(
         "anywords"       => "contains any of the words",
         "allwords"       => "contains all of the words",
         "nowords"        => "contains none of the words",
+        "everchanged"    => "ever changed",
         "changedbefore"  => "changed before",
         "changedafter"   => "changed after",
         "changedfrom"    => "changed from",

--- a/template/en/default/list/list.html.tmpl
+++ b/template/en/default/list/list.html.tmpl
@@ -98,7 +98,7 @@
 
 [% SET shown_types = [
   'notequals', 'regexp', 'notregexp', 'lessthan', 'lessthaneq',
-  'greaterthan', 'greaterthaneq', 'changedbefore', 'changedafter',
+  'greaterthan', 'greaterthaneq', 'everchanged', 'changedbefore', 'changedafter',
   'changedfrom', 'changedto', 'changedby', 'notsubstring', 'nowords',
   'nowordssubstr', 'notmatches', 'isempty', 'isnotempty'
 ] %]

--- a/template/en/default/search/boolean-charts.html.tmpl
+++ b/template/en/default/search/boolean-charts.html.tmpl
@@ -40,6 +40,7 @@
   "anywords",
   "allwords",
   "nowords",
+  "everchanged",
   "changedbefore",
   "changedafter",
   "changedfrom",


### PR DESCRIPTION
Allow to search

> (field name) / ever changed

in Custom Search as a shortcut for 

> (field name) / changed after / 1970-01-01

## Bugzilla link

[Bug 1546624 - Add a 'everchanged' operator](https://bugzilla.mozilla.org/show_bug.cgi?id=1546624)