### PR TITLE
Bug 1547098 - Limit the height of code in Markdown so the horizontal scrollbar can be found and used easily

### DIFF
--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -2755,6 +2755,7 @@ pre.comment-text {
 }
 
 .markdown-body pre {
+  max-height: 600px;
   word-wrap: normal;
 }
 


### PR DESCRIPTION
Apply CSS `max-height` to Markdown code blocks so [long intermittent log](https://github.com/mozilla/treeherder/pull/4888) and other snippets can be scrolled easily both in vertically and horizontally.

## Bugzilla link

[Bug 1547098 - Limit the height of code in Markdown so the horizontal scrollbar can be found and used easily](https://bugzilla.mozilla.org/show_bug.cgi?id=1547098)