### PR TITLE
Bug 1535574 - Reply to Markdown comment adds extra line above quoted text but not below

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -901,7 +901,7 @@ $(function() {
                     },
                     (data) => {
                         const quoted = data['comments'][uid]['text'].replace(/\n/g, "\n> ");
-                        reply_text = `${prefix}\n> ${quoted}`;
+                        reply_text = `${prefix}> ${quoted}\n\n`;
                         populateNewComment();
                     }
                 );


### PR DESCRIPTION
Improve the behaviour of replying to a Markdown comment, making it consistent with older non-Markdown comments.

## Bugzilla link

[Bug 1535574 - Reply to Markdown comment adds extra line above quoted text but not below](https://bugzilla.mozilla.org/show_bug.cgi?id=1535574)