### PR TITLE
Bug 1546444 - Parameterize time that the security bugs report uses

### DIFF
--- a/Bugzilla/Report/SecurityRisk.pm
+++ b/Bugzilla/Report/SecurityRisk.pm
@@ -280,7 +280,7 @@ sub _build_events {
   my ($self) = @_;
   return [] if !(@{$self->initial_bug_ids});
   my $bug_ids    = join ', ', @{$self->initial_bug_ids};
-  my $start_date = $self->start_date->ymd('-');
+  my $start_date = $self->start_date->strftime('%Y-%m-%d %H:%M:%S');
   my $query      = qq{
         SELECT
             bug_id,
@@ -295,7 +295,7 @@ sub _build_events {
         WHERE
             bug_id IN ($bug_ids)
             AND field.name IN ('keywords' , 'bug_status')
-            AND bug_when >= '$start_date 00:00:00'
+            AND bug_when >= '$start_date'
         GROUP BY bug_id , bug_when , field.name
     };
   # Don't use selectall_hashref as it only gets the latest event each bug.

--- a/scripts/secbugsreport.pl
+++ b/scripts/secbugsreport.pl
@@ -7,7 +7,8 @@
 # This Source Code Form is "Incompatible With Secondary Licenses", as
 # defined by the Mozilla Public License, v. 2.0.
 #
-# Usage secbugsreport.pl YYYY MM DD, e.g. secbugsreport.pl $(date +'%Y %m %d')
+# Usage secbugsreport.pl YYYY MM DD HH MM SS +|-ZZZZ
+#  e.g. secbugsreport.pl $(date +'%Y %m %d %H %M %S %z')
 
 use 5.10.1;
 use strict;
@@ -32,14 +33,30 @@ use Types::Standard qw(Int);
 BEGIN { Bugzilla->extensions }
 Bugzilla->usage_mode(USAGE_MODE_CMDLINE);
 
-my ($year, $month, $day) = @ARGV;
+my ($year, $month, $day, $hour, $minute, $second, $time_zone_offset) = @ARGV;
 
 exit 0 unless Bugzilla->params->{report_secbugs_active};
-exit 0 unless Int->check($year) && Int->check($month) && Int->check($day);
+exit 0
+  unless Int->check($year)
+  && Int->check($month)
+  && Int->check($day)
+  && Int->check($hour)
+  && Int->check($minute)
+  && Int->check($second);
 
 my $html;
-my $template     = Bugzilla->template();
-my $end_date     = DateTime->new(year => $year, month => $month, day => $day);
+my $template = Bugzilla->template();
+my $end_date = DateTime->new(
+  year      => $year,
+  month     => $month,
+  day       => $day,
+  hour      => $hour,
+  minute    => $minute,
+  second    => $second,
+  time_zone => $time_zone_offset
+);
+$end_date->set_time_zone('UTC');
+
 my $start_date   = $end_date->clone()->subtract(months => 12);
 my $report_week  = $end_date->ymd('-');
 my $teams        = decode_json(Bugzilla->params->{report_secbugs_teams});
@@ -94,7 +111,7 @@ my @parts = (
         encoding     => 'base64',
       },
       body => $report->graphs->{$_}->slurp,
-      )
+    )
   } sort { $a cmp $b } keys %{$report->graphs}
 );
 

--- a/scripts/secbugsreport.pl
+++ b/scripts/secbugsreport.pl
@@ -33,16 +33,16 @@ use Types::Standard qw(Int);
 BEGIN { Bugzilla->extensions }
 Bugzilla->usage_mode(USAGE_MODE_CMDLINE);
 
-my ($year, $month, $day, $hour, $minute, $second, $time_zone_offset) = @ARGV;
+my ($year, $month, $day, $hours, $minutes, $seconds, $time_zone_offset) = @ARGV;
 
 exit 0 unless Bugzilla->params->{report_secbugs_active};
 exit 0
   unless Int->check($year)
   && Int->check($month)
   && Int->check($day)
-  && Int->check($hour)
-  && Int->check($minute)
-  && Int->check($second);
+  && Int->check($hours)
+  && Int->check($minutes)
+  && Int->check($seconds);
 
 my $html;
 my $template = Bugzilla->template();
@@ -50,9 +50,9 @@ my $end_date = DateTime->new(
   year      => $year,
   month     => $month,
   day       => $day,
-  hour      => $hour,
-  minute    => $minute,
-  second    => $second,
+  hour      => $hours,
+  minute    => $minutes,
+  second    => $seconds,
   time_zone => $time_zone_offset
 );
 $end_date->set_time_zone('UTC');


### PR DESCRIPTION
Prior to this commit the report could specify a date to base the report
of off, but, it didn't accept a time (hour, min, second).

With this commit the report can be based on the exact day and time it
was run instead of just 0000 UTC of the specified date.

E.g. secbugsreport.pl $(date +'%Y %m %d %H %M %S %z').