### PR TITLE
Bug 1549007 - "From Reporter" populates 64-bit Windows 8.1 as x86

### DIFF
--- a/Bugzilla/UserAgent.pm
+++ b/Bugzilla/UserAgent.pm
@@ -27,7 +27,7 @@ use constant PLATFORMS_MAP => (
   # AMD64, Intel x86_64
   qr/\(.*[ix0-9]86 (?:on |\()x86_64.*\)/ => ["IA32",  "x86",    "PC"],
   qr/\(.*amd64.*\)/                      => ["AMD64", "x86_64", "PC"],
-  qr/\(.*x86_64.*\)/                     => ["AMD64", "x86_64", "PC"],
+  qr/\(.*x(?:86_)?64.*\)/                => ["AMD64", "x86_64", "PC"],
   qr/\(.*Intel Mac OS X.*\)/             => ["x86_64"],
 
   # Intel IA64


### PR DESCRIPTION
Detect `x64` UA strings properly as a 64-bit platform, just like `x86_64`.

## Bugzilla link

[Bug 1549007 - "From Reporter" populates 64-bit Windows 8.1 as x86](https://bugzilla.mozilla.org/show_bug.cgi?id=1549007)