### PR TITLE
Bug 1549287 - Ghost selection on modal module headers

### DIFF
--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -103,6 +103,9 @@ a.activity-ref {
 .module-latch {
     padding: 2px 10px;
     cursor: pointer;
+    -moz-user-select: none;
+    -webkit-user-select: none;
+    user-select: none;
 }
 
 .module-spinner {


### PR DESCRIPTION
Make the text on module headers unselectable, so it won’t be selected especially when the header is long-tapped on mobile.

## Bugzilla link

[Bug 1549287 - Ghost selection on modal module headers](https://bugzilla.mozilla.org/show_bug.cgi?id=1549287)