### PR TITLE
Bug 1548725 - Change crash signature & report links from crash-stats.mozilla.com to .org

### DIFF
--- a/Bugzilla/Constants.pm
+++ b/Bugzilla/Constants.pm
@@ -756,7 +756,7 @@ sub DEFAULT_CSP {
       'https://treeherder.mozilla.org/api/failurecount/',
 
       # socorro lens
-      'https://crash-stats.mozilla.com/api/SuperSearch/',
+      'https://crash-stats.mozilla.org/api/SuperSearch/',
     ],
     font_src => [ 'self', 'https://fonts.gstatic.com' ],
     form_action => [

--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -688,7 +688,7 @@ sub bug_format_comment {
         my $args  = shift;
         my $match = html_quote($args->{matches}->[0]);
         return
-          qq{<a href="https://crash-stats.mozilla.com/report/index/$match">bp-$match</a>};
+          qq{<a href="https://crash-stats.mozilla.org/report/index/$match">bp-$match</a>};
       }
     }
   );

--- a/extensions/BMO/template/en/default/hook/bug/edit-custom_field.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/bug/edit-custom_field.html.tmpl
@@ -30,7 +30,7 @@
           [% FOREACH sig = split_cf_crash_signature %]
             [% IF sig.match('^\[\@\s*') && sig.match('\s*\]$') %]
               [% sig = sig.replace('(^\[\@\s*|\s*\]$)', '') %]
-              <a href="https://crash-stats.mozilla.com/signature/?signature=[% sig FILTER uri %]"
+              <a href="https://crash-stats.mozilla.org/signature/?signature=[% sig FILTER uri %]"
                target="_blank" rel="noopener noreferrer">[@ [% sig FILTER html %] ]</a><br>
             [% ELSE %]
               [% sig FILTER html %]<br>

--- a/extensions/BMO/template/en/default/hook/bug_modal/edit-custom_field-cf_crash_signature.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/bug_modal/edit-custom_field-cf_crash_signature.html.tmpl
@@ -18,7 +18,7 @@
       <div>
         [% IF sig.match('^\[\@\s*') && sig.match('\s*\]$') %]
           [% sig = sig.replace('(^\[\@\s*|\s*\]$)', '') %]
-          <a href="https://crash-stats.mozilla.com/signature/?signature=[% sig FILTER uri %]" target="_blank" rel="noopener noreferrer">
+          <a href="https://crash-stats.mozilla.org/signature/?signature=[% sig FILTER uri %]" target="_blank" rel="noopener noreferrer">
             [@ [% sig FILTER html %] ]
           </a>
         [% ELSE %]

--- a/extensions/BMO/web/js/firefox-crash-table.js
+++ b/extensions/BMO/web/js/firefox-crash-table.js
@@ -111,7 +111,7 @@ window.addEventListener('DOMContentLoaded', () => {
   if (container) {
     const signatures = [];
     const selector = oldWay ? "cf_crash_signature_edit_container" : "field-value-cf_crash_signature";
-    const baseCrashUrl = "https://crash-stats.mozilla.com/signature/?signature=";
+    const baseCrashUrl = "https://crash-stats.mozilla.org/signature/?signature=";
     document.querySelectorAll("#" + selector + " a").forEach(a => {
       if (a.href.startsWith(baseCrashUrl)) {
         const encodedSignature = a.href.replace(baseCrashUrl, "")
@@ -125,7 +125,7 @@ window.addEventListener('DOMContentLoaded', () => {
       });
 
       const extraSocorroArgs = []
-      const baseUrl = "https://crash-stats.mozilla.com/search/";
+      const baseUrl = "https://crash-stats.mozilla.org/search/";
       const sayNo = new Set(["_columns", "_facets", "_facets_size", "_sort", "_results_number", "date", "channel", "product", "version", "build_id"]);
       const urlSelector = oldWay ? "bz_url_edit_container" : "field-value-bug_file_loc";
       document.querySelectorAll("#" + urlSelector + " a").forEach(a => {

--- a/public/metricsgraphics/js/main.js
+++ b/public/metricsgraphics/js/main.js
@@ -197,7 +197,7 @@ var items = [];
 var end_date = convertDate(new Date((new Date()).valueOf() - 1000 * 60 * 60 * 24 * 1));
 var start_date = convertDate(new Date((new Date()).valueOf() - 1000 * 60 * 60 * 24 * 180));
 var globals = {
-  "url_base": "https://crash-stats.mozilla.com/search/?",
+  "url_base": "https://crash-stats.mozilla.org/search/?",
   "url": [],
   "mouseover": function (d) {
     var next = new Date(d.date.valueOf() + 1 * 24 * 60 * 60 * 1000);
@@ -326,7 +326,7 @@ function loadGraph(search, match = 'exact') {
       if (!globals.url[i]) globals.url[i] = "";
       globals.url[i] = globals.url_base + signatures[i];
       // Iterate through the Socorro data and create the chart data object
-      var url = "https://crash-stats.mozilla.com/api/SuperSearch/?" + signatures[i] + "&date=%3E%3D" + start_date + "&date=%3C%3D" + end_date + "&_histogram.date=release_channel&_histogram_interval=1d&_results_number=0";
+      var url = "https://crash-stats.mozilla.org/api/SuperSearch/?" + signatures[i] + "&date=%3E%3D" + start_date + "&date=%3C%3D" + end_date + "&_histogram.date=release_channel&_histogram_interval=1d&_results_number=0";
       url = url.replace("/?&signature", "/?signature");
       d3.json(url, function (data) {
         if (data.total > 0) {

--- a/qa/t/test_bmo_autolinkification.t
+++ b/qa/t/test_bmo_autolinkification.t
@@ -32,7 +32,7 @@ $sel->title_like(qr/\d+ \S $bug_summary/, "crash report added");
 $sel->click_ok("link=bug $bug_id");
 $sel->wait_for_page_to_load_ok(WAIT_TIME);
 $sel->attribute_is('link=bp-63f096f7-253b-4ee2-ae3d-8bb782090824@href',
-  'https://crash-stats.mozilla.com/report/index/63f096f7-253b-4ee2-ae3d-8bb782090824'
+  'https://crash-stats.mozilla.org/report/index/63f096f7-253b-4ee2-ae3d-8bb782090824'
 );
 
 $sel->type_ok("comment", "CVE-2010-2884");


### PR DESCRIPTION
With [bug 618185](https://bugzilla.mozilla.org/show_bug.cgi?id=618185#c26) decision has been made to make crash-stats.mozilla.org canonical domain.
This PR is for [bug 1548725](https://bugzilla.mozilla.org/show_bug.cgi?id=1548725).
Made with:
```
git checkout -b crash-stats_org
find . -type f -print0 | xargs -0 sed -i 's,crash-stats.mozilla.com,crash-stats.mozilla.org,g'
git add * && git commit -m "Change crash-stats.mozilla.com to .org"

```