### PR TITLE
Bug 1550145 - Add 'forget_after_date' field to profiles table (schema only)

### DIFF
--- a/Bugzilla/DB/Schema.pm
+++ b/Bugzilla/DB/Schema.pm
@@ -946,6 +946,7 @@ use constant ABSTRACT_SCHEMA => {
       password_change_reason => {TYPE => 'varchar(64)'},
       mfa                    => {TYPE => 'varchar(8)', DEFAULT => "''"},
       mfa_required_date      => {TYPE => 'DATETIME'},
+      forget_after_date      => {TYPE => 'DATETIME'},
     ],
     INDEXES => [
       profiles_login_name_idx  => {FIELDS => ['login_name'], TYPE => 'UNIQUE'},

--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -758,6 +758,10 @@ sub update_table_definitions {
     {TYPE => 'varchar(8)',, DEFAULT => "''"});
 
   $dbh->bz_add_column('profiles', 'mfa_required_date', {TYPE => 'DATETIME'});
+
+  # 2019-05-08 imadueme@mozilla.com - Bug 1550145
+  $dbh->bz_add_column('profiles', 'forget_after_date', {TYPE => 'DATETIME'});
+
   _migrate_group_owners();
 
   $dbh->bz_add_column('groups', 'idle_member_removal',


### PR DESCRIPTION
Adds a datetime `forget_after_date` field to the profiles table.
This field will be used when determining which unresponsive inactive users to forget periodically.

This field will be normally set to 30 days after BMO detects and notifies a user that has been "inactive"
for a very long time, thus, giving the user 30 days to respond to prevent being forgotten.

Another benefit of this datetime field is that we can choose to send reminder emails as their
forget-date approaches (we may choose not to do this for other reasons).

`forget_after_date`:
- If null, the user should not be forgotten.
- If set, the user can & should be forgotten at anytime after the set date.
- This field should be unset anytime the user logs in or specifically requests to not be forgotten.