### PR TITLE
Bug 1550439 - Type is reset on hard-refresh with "Always Enable Edit Mode"

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -1384,9 +1384,6 @@ $(function() {
             saveBugComment(event.target.value);
         });
 
-    // finally switch to edit mode if we navigate back to a page that was editing
-    $(window).on('pageshow', restoreEditMode);
-    $(window).on('pageshow', restoreSavedBugComment);
     restoreEditMode();
     restoreSavedBugComment();
 });


### PR DESCRIPTION
Remove `pageshow` event handlers that lead to the unexpected behaviour.

## Bugzilla link

[Bug 1550439 - Type is reset on hard-refresh with "Always Enable Edit Mode”](https://bugzilla.mozilla.org/show_bug.cgi?id=1550439)