### PR TITLE
Bug 1546877 - Slow Script warning on bugzilla page when loading preview of large json file

### DIFF
--- a/extensions/BugModal/web/comments.js
+++ b/extensions/BugModal/web/comments.js
@@ -562,7 +562,6 @@ Bugzilla.BugModal.Comments = class Comments {
     const name = $att.querySelector('[itemprop="name"]').content;
     const type = $att.querySelector('[itemprop="encodingFormat"]').content;
     const size = Number($att.querySelector('[itemprop="contentSize"]').content);
-    const max_size = 2000000;
 
     // Skip if the attachment is marked as binary
     if (type.match(/^application\/(?:octet-stream|binary)$/)) {
@@ -570,7 +569,7 @@ Bugzilla.BugModal.Comments = class Comments {
     }
 
     // Show image smaller than 2 MB, excluding SVG and non-standard formats
-    if (type.match(/^image\/(?!vnd|svg).+$/) && size < max_size) {
+    if (type.match(/^image\/(?!vnd|svg).+$/) && size < 2000000) {
       $att.insertAdjacentHTML('beforeend', `
         <a href="${link}" class="outer lightbox"><img src="${link}" alt="${name.htmlEncode()}" itemprop="image"></a>`);
 
@@ -601,8 +600,8 @@ Bugzilla.BugModal.Comments = class Comments {
     const is_source = !!name.match(/\.(?:cpp|es|h|js|json|rs|rst|sh|toml|ts|tsx|xml|yaml|yml)$/);
     const is_text = type.match(/^text\/(?!x-).+$/) || is_patch || is_markdown || is_source;
 
-    // Show text smaller than 2 MB
-    if (is_text && size < max_size) {
+    // Show text smaller than 50 KB
+    if (is_text && size < 50000) {
       // Load text body
       bugzilla_ajax({ url: `${BUGZILLA.config.basepath}rest/bug/attachment/${id}?include_fields=data` }, data => {
         if (data.error) {


### PR DESCRIPTION
Show and syntax-highlight the preview of text files only when the size is under 50 KB.

## Bugzilla link

[Bug 1546877 - Slow Script warning on bugzilla page when loading preview of large json file](https://bugzilla.mozilla.org/show_bug.cgi?id=1546877)