### PR TITLE
Bug 1225902 - Show only flags with requestee in the "Flags You Have Requested" section

### DIFF
--- a/extensions/MyDashboard/lib/Queries.pm
+++ b/extensions/MyDashboard/lib/Queries.pm
@@ -14,6 +14,7 @@ use warnings;
 use Bugzilla;
 use Bugzilla::Bug;
 use Bugzilla::CGI;
+use Bugzilla::Constants;
 use Bugzilla::Search;
 use Bugzilla::Flag;
 use Bugzilla::Status qw(is_open_state);
@@ -258,6 +259,8 @@ sub query_flags {
   }
   else {
     $match_params->{'setter_id'} = $user->id;
+    # Exclude flags without a requestee, such as `in-testsuite?`
+    $match_params->{'requestee_id'} = NOT_NULL;
   }
 
   my $matched = Bugzilla::Flag->match($match_params);
@@ -312,9 +315,6 @@ sub query_flags {
 
     # Skip this flag if the bug is not visible to the user
     next if !$visible_bugs{$flag->{'bug_id'}};
-
-    # Skip this flag unless it's specifically requestable and has a requestee
-    next unless $flag->{'requestee'};
 
     # Include bug status and summary with each flag
     $flag->{'bug_status'}  = $visible_bugs{$flag->{'bug_id'}}->{'bug_status'};

--- a/extensions/MyDashboard/lib/Queries.pm
+++ b/extensions/MyDashboard/lib/Queries.pm
@@ -313,6 +313,9 @@ sub query_flags {
     # Skip this flag if the bug is not visible to the user
     next if !$visible_bugs{$flag->{'bug_id'}};
 
+    # Skip this flag unless it's specifically requestable and has a requestee
+    next unless $flag->{'requestee'};
+
     # Include bug status and summary with each flag
     $flag->{'bug_status'}  = $visible_bugs{$flag->{'bug_id'}}->{'bug_status'};
     $flag->{'bug_summary'} = $visible_bugs{$flag->{'bug_id'}}->{'short_desc'};

--- a/extensions/MyDashboard/web/js/flags.js
+++ b/extensions/MyDashboard/web/js/flags.js
@@ -111,9 +111,7 @@ $(function () {
         };
 
         var requesteeFormatter = function(o) {
-            return o.value
-                ? o.value.htmlEncode()
-                : '<i>anyone</i>';
+            return o.value.htmlEncode();
         };
 
         var flagNameFormatter = function(o) {


### PR DESCRIPTION
Hide flags without a requestee from My Dashboard, including `in-testsuite?` and `qe-verify?`, so only important info will be displayed.

## Bugzilla link

[Bug 1225902 - Show only flags with requestee in the "Flags You Have Requested" section](https://bugzilla.mozilla.org/show_bug.cgi?id=1225902)