### PR TITLE
Bug 1521423 - Links to comments are not correct in bugmail

### DIFF
--- a/Bugzilla/Markdown.pm
+++ b/Bugzilla/Markdown.pm
@@ -50,7 +50,7 @@ sub render_html {
   local $Bugzilla::Template::COLOR_QUOTES = 0;
 
   if ($markdown =~ /^\s*$MARKDOWN_OFF\n/s) {
-    my $text = $self->bugzilla_shorthand->( trim($markdown) );
+    my $text = $self->bugzilla_shorthand->(trim($markdown), $bug);
     my $dom = Mojo::DOM->new($text);
     $dom->find('*')->each(sub {
       my ($e) = @_;
@@ -88,7 +88,7 @@ sub render_html {
         && any { $child->parent->tag eq $_ } @valid_text_parent_tags)
       {
         my $text = $child->content;
-        $child->replace(Mojo::DOM->new($bugzilla_shorthand->($text)));
+        $child->replace(Mojo::DOM->new($bugzilla_shorthand->($text, $bug)));
       }
       return $child;
     });

--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -234,9 +234,6 @@ sub quoteUrls {
                ("\x{FDD2}" . ($count-1) . "\x{FDD3}")
               ~egmxi;
 
-  # Current bug ID this comment belongs to
-  my $current_bugurl = $bug ? ("show_bug.cgi?id=" . $bug->id) : "";
-
   # This handles bug a, comment b type stuff. Because we're using /g
   # we have to do this in one pattern, and so this is semi-messy.
   # Also, we can't use $bug_re?$comment_re? because that will match the
@@ -248,7 +245,7 @@ sub quoteUrls {
               ~ # We have several choices. $1 here is the link, and $2-4 are set
                 # depending on which part matched
                (defined($2) ? $bug_link_func->($2, $1, { comment_num => $3, user => $user }) :
-                              "<a href=\"$current_bugurl#c$4\">$1</a>")
+                $bug ? $bug_link_func->($bug->id, $1, { comment_num => $4, user => $user }) : $1)
               ~egx;
 
   # Old duplicate markers. These don't use $bug_word because they are old


### PR DESCRIPTION
Fix wrong comment links in email notifications. Currently it’s like 

```html
<a href="#c4”>Comment 4</a>
```

but with this fix, it will be 

```html
<a href="/show_bug.cgi?id=1521423#c4" title=“NEW - Links to comments are not correct in bugmail">Comment 4</a>
```

## Bugzilla link

[Bug 1521423 - Links to comments are not correct in bugmail](https://bugzilla.mozilla.org/show_bug.cgi?id=1521423)