### PR TITLE
bump version to 20190516.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20190418.1';
+our $VERSION = '20190516.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
the following changes will be pushed to bugzilla.mozilla.org:
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1546502" target="_blank">1546502</a>] Miscellaneous tweaks and fixes for 2019 week 16</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1345750" target="_blank">1345750</a>] "Depends on" and "Blocks" bug lists should still show list of bug links in edit mode</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1544059" target="_blank">1544059</a>] Cloning a bug as a blocker doesn't copy the 'component' field</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1543741" target="_blank">1543741</a>] Blocklist requests getting filed as 'defect' instead of 'task' because of custom form</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1543456" target="_blank">1543456</a>] Keep bug type passed to enter_bug.cgi via query, including cloned bug, even after component is selected</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1544132" target="_blank">1544132</a>] Allow editing empty Descriptions</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1546539" target="_blank">1546539</a>] [SEO] Many legacy and printable bug pages are cached by Google</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1546774" target="_blank">1546774</a>] Show Dependency Tree link even if there’s only one bug</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1546624" target="_blank">1546624</a>] Add a 'everchanged' operator</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1546146" target="_blank">1546146</a>] Show bug types in See Also</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1543438" target="_blank">1543438</a>] Enter Bug page: Hide Severity and Mentors as advanced fields</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1543189" target="_blank">1543189</a>] Add search pronouns: %triageowner% and %self%</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1541617" target="_blank">1541617</a>] Allow Products to set a default bug type.</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1547098" target="_blank">1547098</a>] Limit the height of code in Markdown so the horizontal scrollbar can be found and used easily</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1535574" target="_blank">1535574</a>] Reply to Markdown comment adds extra line above quoted text but not below</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1546444" target="_blank">1546444</a>] Security Bugs Report: Parameterize the time that the report is run at</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1547714" target="_blank">1547714</a>] Attachment with application/octet-stream MIME type should not be previewed even if it’s actually text file</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1549007" target="_blank">1549007</a>] "From Reporter" populates 64-bit Windows 8.1 as x86</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1550439" target="_blank">1550439</a>] Type is reset on hard-refresh with "Always Enable Edit Mode"</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1546877" target="_blank">1546877</a>] Slow Script warning on bugzilla page when loading preview of large json file</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1548725" target="_blank">1548725</a>] Change crash signature &amp; report links from crash-stats.mozilla.com to .org</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1550145" target="_blank">1550145</a>] Add 'forget_after_date' field to profiles table</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1549287" target="_blank">1549287</a>] Ghost selection on modal module headers</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1550104" target="_blank">1550104</a>] Add "Has STR" and "Has Regression Range" fields for Graveyard products</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1545330" target="_blank">1545330</a>] Add bug type to open graph data on bug detail page.</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1541618" target="_blank">1541618</a>] Add triage owner to edit components view columns.</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1521423" target="_blank">1521423</a>] Links to comments are not correct in bugmail</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1225902" target="_blank">1225902</a>] Show only flags with requestee in the "Flags You Have Requested" section</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1540715" target="_blank">1540715</a>] Security Bugs Report: Fix date offset of historical dates</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1549637" target="_blank">1549637</a>] Homepage link on the global header is wrong</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1377977" target="_blank">1377977</a>] Implement initial version of post-Sandstone theme including Dark Mode</li>
</ul>
discuss these changes on <a href="https://lists.mozilla.org/listinfo/tools-bmo" target="_blank">mozilla.tools.bmo</a>.
