### PR TITLE
Bug 1547414 - Create Last Major Update field that excludes minor, bulk and automated changes

### DIFF
--- a/Bugzilla/DB/Schema.pm
+++ b/Bugzilla/DB/Schema.pm
@@ -283,6 +283,7 @@ use constant ABSTRACT_SCHEMA => {
       remaining_time      => {TYPE => 'decimal(7,2)', NOTNULL => 1, DEFAULT => '0'},
       deadline            => {TYPE => 'DATETIME'},
       alias               => {TYPE => 'varchar(40)'},
+      major_change_ts     => {TYPE => 'DATETIME'},
     ],
     INDEXES => [
       bugs_alias_idx            => {FIELDS => ['alias'], TYPE => 'UNIQUE'},
@@ -301,6 +302,7 @@ use constant ABSTRACT_SCHEMA => {
       bugs_resolution_idx       => ['resolution'],
       bugs_target_milestone_idx => ['target_milestone'],
       bugs_qa_contact_idx       => ['qa_contact'],
+      bugs_major_change_ts_idx  => ['major_change_ts'],
     ],
   },
 

--- a/Bugzilla/Field.pm
+++ b/Bugzilla/Field.pm
@@ -435,6 +435,12 @@ use constant DEFAULT_FIELDS => (
     type    => FIELD_TYPE_DATETIME,
     buglist => 1,
   },
+  {
+    name    => 'major_change_ts',
+    desc    => 'Last Major Update',
+    type    => FIELD_TYPE_DATETIME,
+    buglist => 1,
+  },
   {name => 'longdesc',            desc => 'Comment'},
   {
     name       => 'longdescs.isprivate',

--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -805,6 +805,10 @@ sub update_table_definitions {
   # Bug 1576667 - dkl@mozilla.com
   _populate_api_keys_creation_ts();
 
+  $dbh->bz_add_column('bugs', 'major_change_ts', {TYPE => 'DATETIME'});
+  $dbh->bz_add_index('bugs', 'bugs_major_change_ts_idx',
+    ['major_change_ts']);
+
   ################################################################
   # New --TABLE-- changes should go *** A B O V E *** this point #
   ################################################################

--- a/Bugzilla/Migrate.pm
+++ b/Bugzilla/Migrate.pm
@@ -452,8 +452,7 @@ sub translate_value {
 
   my $field_obj = $self->bug_fields->{$field};
   if (
-       $field eq 'creation_ts'
-    or $field eq 'delta_ts'
+       $field =~ /_ts$/
     or (
       $field_obj
       and

--- a/Bugzilla/Milestone.pm
+++ b/Bugzilla/Milestone.pm
@@ -143,9 +143,9 @@ sub remove_from_db {
     my $timestamp = $dbh->selectrow_array('SELECT NOW()');
 
     $dbh->do(
-      'UPDATE bugs SET target_milestone = ?, delta_ts = ?
+      'UPDATE bugs SET target_milestone = ?, delta_ts = ?, major_change_ts = ?
                    WHERE ' . $dbh->sql_in('bug_id', $bug_ids), undef,
-      ($self->product->default_milestone, $timestamp)
+      ($self->product->default_milestone, $timestamp, $timestamp)
     );
 
     require Bugzilla::Bug;

--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -284,6 +284,7 @@ use constant OPERATOR_FIELD_OVERRIDE => {
     _non_changed  => \&_long_desc_nonchanged,
   },
   'longdescs.isprivate' => MULTI_SELECT_OVERRIDE,
+  major_change_ts => {_default => \&_major_change_ts,},
   owner_idle_time       => {
     greaterthan   => \&_owner_idle_time_greater_less,
     greaterthaneq => \&_owner_idle_time_greater_less,
@@ -370,6 +371,7 @@ sub SPECIAL_PARSING {
     creation_ts => \&_datetime_translate,
     deadline    => \&_date_translate,
     delta_ts    => \&_datetime_translate,
+    major_change_ts => \&_datetime_translate,
 
     # last_visit field that accept both a 1d, 1w, 1m, 1y format and the
     # %last_changed% pronoun.
@@ -622,6 +624,7 @@ sub COLUMNS {
     'regresses.count'    => 'COUNT(DISTINCT map_regresses_count.regresses)',
     'dupe_count'         => 'COUNT(DISTINCT map_dupe_count.dupe)',
 
+    major_change_ts     => 'COALESCE(bugs.major_change_ts, bugs.delta_ts)',
     last_visit_ts       => 'bug_user_last_visit.last_visit_ts',
     bug_interest_ts     => 'bug_interest.modification_time',
     assignee_last_login => 'assignee.last_seen_date',
@@ -2920,6 +2923,12 @@ sub _percentage_complete {
   # We need actual_time in _select_columns, otherwise we can't use
   # it in the expression for searching percentage_complete.
   $self->_add_extra_column('actual_time');
+}
+
+sub _major_change_ts {
+  my ($self, $args) = @_;
+  # Fall back to `delta_ts` if `major_change_ts` is NULL
+  $args->{full_field} = 'COALESCE(bugs.major_change_ts, bugs.delta_ts)';
 }
 
 sub _last_visit_ts {

--- a/buglist.cgi
+++ b/buglist.cgi
@@ -858,6 +858,10 @@ foreach my $row (@$data) {
     $bug->{'changeddate'} = DiffDate($bug->{'changeddate'});
   }
 
+  if ($bug->{'major_change_ts'}) {
+    $bug->{'major_change_ts'} = DiffDate($bug->{'major_change_ts'});
+  }
+
   if ($bug->{'opendate'}) {
     $bug->{'opentime'} = $bug->{'opendate'};                # for iCalendar
     $bug->{'opendate'} = DiffDate($bug->{'opendate'});

--- a/bugzilla.dtd
+++ b/bugzilla.dtd
@@ -5,8 +5,8 @@
           maintainer CDATA #REQUIRED
           exporter CDATA #IMPLIED
 >
-<!ELEMENT bug (bug_id, (alias?, filed_via, creation_ts, short_desc, delta_ts, reporter_accessible,
-    cclist_accessible, classification_id, classification, product, component,
+<!ELEMENT bug (bug_id, (alias?, filed_via, creation_ts, short_desc, delta_ts, major_change_ts,
+    reporter_accessible, cclist_accessible, classification_id, classification, product, component,
     version, rep_platform, op_sys, bug_status, resolution?, dup_id?, duplicates*, see_also*,
     bug_file_loc?, status_whiteboard?, keywords*, bug_type, priority, bug_severity,
     target_milestone?, dependson*, blocked*, regressed_by*, regresses*, everconfirmed,
@@ -34,6 +34,7 @@
           name CDATA #REQUIRED
 >
 <!ELEMENT delta_ts (#PCDATA)>
+<!ELEMENT major_change_ts (#PCDATA)>
 <!ELEMENT component (#PCDATA)>
 <!ELEMENT reporter (#PCDATA)>
 <!ATTLIST reporter

--- a/docs/en/rst/api/core/v1/bug.rst
+++ b/docs/en/rst/api/core/v1/bug.rst
@@ -71,6 +71,7 @@ name              type   description
          "cf_drop_down": "---",
          "summary": "test bug",
          "last_change_time": "2014-09-23T19:12:17Z",
+         "major_change_time": "2014-09-23T17:34:06Z",
          "platform": "All",
          "url": "",
          "classification": "Unclassified",
@@ -195,7 +196,9 @@ is_creator_accessible  boolean   If ``true``, this bug can be accessed by the
                                  creator of the bug, even if they are not a
                                  member of the groups the bug is restricted to.
 keywords               array     Each keyword that is on this bug.
-last_change_time       datetime  When the bug was last changed.
+last_change_time       datetime  When the bug was last updated.
+major_change_time      datetime  When the bug was last updated, excluding minor,
+                                 bulk and automated changes.
 comment_count          int       Number of comments associated with the bug.
 op_sys                 string    The name of the operating system that the bug
                                  was filed against.
@@ -484,94 +487,101 @@ format Bugzilla expects is to first construct your query using the
 Advanced Search UI, execute it and use the query parameters in they URL
 as your query for the REST call.
 
-================  ========  =====================================================
-name              type      description
-================  ========  =====================================================
-alias             string    The unique alias of this bug. A ``null`` value will
-                            be returned if this bug has no alias.
-assigned_to       string    The login name of a user that a bug is assigned to.
-component         string    The name of the Component that the bug is in. Note
-                            that if there are multiple Components with the same
-                            name, and you search for that name, bugs in *all*
-                            those Components will be returned. If you don't want
-                            this, be sure to also specify the ``product`` argument.
-count_only        boolean   If set to true, an object with a single key called
-                            "bug_count" will be returned which is the number of
-                            bugs that matched the search.
-creation_time     datetime  Searches for bugs that were created at this time or
-                            later. May not be an array.
-creator           string    The login name of the user who created the bug. You
-                            can also pass this argument with the name
-                            ``reporter``, for backwards compatibility with
-                            older Bugzillas.
-description       string    The description (initial comment) of the bug.
-filed_via         string    Searches for bugs that were created with this method.
-id                int       The numeric ID of the bug.
-last_change_time  datetime  Searches for bugs that were modified at this time
-                            or later. May not be an array.
-limit             int       Limit the number of results returned. If the value is
-                            unset, zero or greater than the maximum value set by
-                            the administrator, which is 10,000 by default, then
-                            the maximum value will be used instead. This is a
-                            preventive measure against DoS-like attacks on
-                            Bugzilla. Use the ``offset`` argument described below
-                            to retrieve more results.
-longdescs.count   int       The number of comments a bug has. The bug's description
-                            is the first comment. For example, to find bugs which someone
-                            has commented on after they have been filed, search on
-                            ``longdescs.count`` *greater than* 1.
-offset            int       Used in conjunction with the ``limit`` argument,
-                            ``offset`` defines the starting position for the
-                            search. For example, given a search that would
-                            return 100 bugs, setting ``limit`` to 10 and
-                            ``offset`` to 10 would return bugs 11 through 20
-                            from the set of 100.
-op_sys            string    The "Operating System" field of a bug.
-platform          string    The Platform (sometimes called "Hardware") field of
-                            a bug.
-priority          string    The Priority field on a bug.
-product           string    The name of the Product that the bug is in.
-quicksearch       string    Search for bugs using quicksearch syntax.
-resolution        string    The current resolution--only set if a bug is closed.
-                            You can find open bugs by searching for bugs with an
-                            empty resolution.
-severity          string    The Severity field on a bug.
-status            string    The current status of a bug (not including its
-                            resolution, if it has one, which is a separate field
-                            above).
-summary           string    Searches for substrings in the single-line Summary
-                            field on bugs. If you specify an array, then bugs
-                            whose summaries match *any* of the passed substrings
-                            will be returned. Note that unlike searching in the
-                            Bugzilla UI, substrings are not split on spaces. So
-                            searching for ``foo bar`` will match "This is a foo
-                            bar" but not "This foo is a bar". ``['foo', 'bar']``,
-                            would, however, match the second item.
-tags              string    Searches for a bug with the specified tag. If you
-                            specify an array, then any bugs that match *any* of
-                            the tags will be returned. Note that tags are
-                            personal to the currently logged in user.
-target_milestone  string    The Target Milestone field of a bug. Note that even
-                            if this Bugzilla does not have the Target Milestone
-                            field enabled, you can still search for bugs by
-                            Target Milestone. However, it is likely that in that
-                            case, most bugs will not have a Target Milestone set
-                            (it defaults to "---" when the field isn't enabled).
-qa_contact        string    The login name of the bug's QA Contact. Note that
-                            even if this Bugzilla does not have the QA Contact
-                            field enabled, you can still search for bugs by QA
-                            Contact (though it is likely that no bug will have a
-                            QA Contact set, if the field is disabled).
-triage_owner      string    The login name of the Triage Owner of a bug's
-                            component.
-type              string    The Type field on a bug.
-url               string    The "URL" field of a bug.
-version           string    The Version field of a bug.
-whiteboard        string    Search the "Status Whiteboard" field on bugs for a
-                            substring. Works the same as the ``summary`` field
-                            described above, but searches the Status Whiteboard
-                            field.
-================  ========  =====================================================
+=================  ========  ====================================================
+name               type      description
+=================  ========  ====================================================
+alias              string    The unique alias of this bug. A ``null`` value will
+                             be returned if this bug has no alias.
+assigned_to        string    The login name of a user that a bug is assigned to.
+component          string    The name of the Component that the bug is in. Note
+                             that if there are multiple Components with the same
+                             name, and you search for that name, bugs in *all*
+                             those Components will be returned. If you don't want
+                             this, be sure to also specify the ``product``
+                             argument.
+count_only         boolean   If set to true, an object with a single key called
+                             "bug_count" will be returned which is the number of
+                             bugs that matched the search.
+creation_time      datetime  Searches for bugs that were created at this time or
+                             later. May not be an array.
+creator            string    The login name of the user who created the bug. You
+                             can also pass this argument with the name
+                             ``reporter``, for backwards compatibility with
+                             older Bugzillas.
+description        string    The description (initial comment) of the bug.
+filed_via          string    Searches for bugs that were created with this
+                             method.
+id                 int       The numeric ID of the bug.
+last_change_time   datetime  Searches for bugs that were modified at this time
+                             or later. May not be an array.
+major_change_time  datetime  Searches for bugs that were modified at this time or
+                             later, excluding minor, bulk and automated changes.
+                             May not be an array.
+limit              int       Limit the number of results returned. If the value
+                             is unset, zero or greater than the maximum value set
+                             by the administrator, which is 10,000 by default,
+                             then the maximum value will be used instead. This is
+                             a preventive measure against DoS-like attacks on
+                             Bugzilla. Use the ``offset`` argument described
+                             below to retrieve more results.
+longdescs.count    int       The number of comments a bug has. The bug's
+                             description is the first comment. For example, to
+                             find bugs which someone has commented on after they
+                             have been filed, search on ``longdescs.count``
+                             *greater than* 1.
+offset             int       Used in conjunction with the ``limit`` argument,
+                             ``offset`` defines the starting position for the
+                             search. For example, given a search that would
+                             return 100 bugs, setting ``limit`` to 10 and
+                             ``offset`` to 10 would return bugs 11 through 20
+                             from the set of 100.
+op_sys             string    The "Operating System" field of a bug.
+platform           string    The Platform (sometimes called "Hardware") field of
+                             a bug.
+priority           string    The Priority field on a bug.
+product            string    The name of the Product that the bug is in.
+quicksearch        string    Search for bugs using quicksearch syntax.
+resolution         string    The current resolution--only set if a bug is closed.
+                             You can find open bugs by searching for bugs with an
+                             empty resolution.
+severity           string    The Severity field on a bug.
+status             string    The current status of a bug (not including its
+                             resolution, if it has one, which is a separate field
+                             above).
+summary            string    Searches for substrings in the single-line Summary
+                             field on bugs. If you specify an array, then bugs
+                             whose summaries match *any* of the passed substrings
+                             will be returned. Note that unlike searching in the
+                             Bugzilla UI, substrings are not split on spaces. So
+                             searching for ``foo bar`` will match "This is a foo
+                             bar" but not "This foo is a bar".
+                             ``['foo', 'bar']``, would, however, match the second
+                             item.
+tags               string    Searches for a bug with the specified tag. If you
+                             specify an array, then any bugs that match *any* of
+                             the tags will be returned. Note that tags are
+                             personal to the currently logged in user.
+target_milestone   string    The Target Milestone field of a bug. Note that even
+                             if this Bugzilla does not have the Target Milestone
+                             field enabled, you can still search for bugs by
+                             Target Milestone. However, it is likely that in that
+                             case, most bugs will not have a Target Milestone set
+                             (it defaults to "---" when the field isn't enabled).
+qa_contact         string    The login name of the bug's QA Contact. Note that
+                             even if this Bugzilla does not have the QA Contact
+                             field enabled, you can still search for bugs by QA
+                             Contact (though it is likely that no bug will have a
+                             QA Contact set, if the field is disabled).
+triage_owner       string    The login name of the Triage Owner of a bug's
+                             component.
+type               string    The Type field on a bug.
+url                string    The "URL" field of a bug.
+version            string    The Version field of a bug.
+whiteboard         string    Search the "Status Whiteboard" field on bugs for a
+                             substring. Works the same as the ``summary`` field
+                             described above, but searches the Status Whiteboard
+                             field.
+=================  ========  ====================================================
 
 **Response**
 

--- a/extensions/BugmailFilter/lib/Constants.pm
+++ b/extensions/BugmailFilter/lib/Constants.pm
@@ -52,6 +52,7 @@ use constant IGNORE_FIELDS => qw(
   last_visit_ts
   longdesc
   longdescs.count
+  major_change_ts
   owner_idle_time
   regressed_by.count
   regresses.count

--- a/qa/t/webservice_bug_fields.t
+++ b/qa/t/webservice_bug_fields.t
@@ -14,7 +14,7 @@ use List::Util qw(first);
 use QA::Util;
 
 my ($config, @clients) = get_rpc_clients();
-plan tests => ($config->{test_extensions} ? 1416 : 1398);
+plan tests => ($config->{test_extensions} ? 1434 : 1416);
 
 use constant INVALID_FIELD_NAME => 'invalid_field';
 use constant INVALID_FIELD_ID   => -1;
@@ -53,6 +53,7 @@ sub GLOBAL_GENERAL_FIELDS {
     keywords
     longdesc
     longdescs.isprivate
+    major_change_ts
     owner_idle_time
     product
     qa_contact

--- a/query.cgi
+++ b/query.cgi
@@ -196,10 +196,9 @@ my $uneditable_fields_re = join('|', qw(
   attachments\.submitter
   bug_id
   commenter
-  creation_ts
-  delta_ts
   lastdiffed
   reporter
+  \w+_ts
 ));
 
 push @chfields, "[Bug creation]";

--- a/template/en/default/bug/field-help.none.tmpl
+++ b/template/en/default/bug/field-help.none.tmpl
@@ -104,6 +104,10 @@ longdesc =>
   "$terms.Bugs have comments added to them by $terms.Bugzilla users."
   _ " You can search for some text in those comments.",
 
+major_change_ts =>
+  "When the $terms.bug was last updated, excluding minor, bulk and automated
+   changes.",
+
 op_sys =>
   "The operating system the $terms.bug was observed on.",
 

--- a/template/en/default/bug/show.xml.tmpl
+++ b/template/en/default/bug/show.xml.tmpl
@@ -139,7 +139,7 @@
       [% val = val.email FILTER email %]
     [% ELSIF field == 'cc' %]
         [% val = val FILTER email %]
-    [% ELSIF field == 'creation_ts' OR field == 'delta_ts' %]
+    [% ELSIF field.match('_ts$') %]
       [% val = val FILTER time("%Y-%m-%d %T %z") %]
     [% ELSIF field == "see_also" %]
       [% val = val.name %]

--- a/template/en/default/global/field-descs.none.tmpl
+++ b/template/en/default/global/field-descs.none.tmpl
@@ -143,6 +143,7 @@ if ( $stash->get("in_template_var") ) {
         "longdesc"                => "Comment",
         "longdescs.count"         => "Number of Comments",
         "longdescs.isprivate"     => "Comment is private",
+        "major_change_ts"         => "Last Major Update",
         "newcc"                   => "CC",
         "op_sys"                  => "OS",
         "opendate"                => "Opened",

--- a/template/en/default/list/table.html.tmpl
+++ b/template/en/default/list/table.html.tmpl
@@ -218,10 +218,8 @@
     <td [% 'style="white-space: nowrap"' IF NOT col_abbrev.wrap %]
         class="bz_[% column FILTER css_class_quote %]_column"
         [% SWITCH column %]
-          [% CASE 'opendate' %]
-            sorttable_customkey="[% bug.opentime FILTER html %]"
-          [% CASE 'changeddate' %]
-            sorttable_customkey="[% bug.changedtime FILTER html %]"
+          [% CASE ['opendate', 'changeddate', 'major_change_ts'] %]
+            sorttable_customkey="[% bug.$column FILTER html %]"
           [% CASE columns_sortkey.keys %]
             [% SET sortkey = columns_sortkey.$column.${bug.$column} %]
             sorttable_customkey="[% sortkey FILTER html %]"

--- a/template/en/default/pages/bugzilla.dtd.tmpl
+++ b/template/en/default/pages/bugzilla.dtd.tmpl
@@ -41,6 +41,7 @@
                 creation_ts,
                 short_desc,
                 delta_ts,
+                major_change_ts,
                 reporter_accessible,
                 cclist_accessible,
                 classification_id,
@@ -107,6 +108,7 @@
           name CDATA #REQUIRED
 >
 <!ELEMENT delta_ts (#PCDATA)>
+<!ELEMENT major_change_ts (#PCDATA)>
 <!ELEMENT component (#PCDATA)>
 <!ELEMENT reporter (#PCDATA)>
 <!ATTLIST reporter


### PR DESCRIPTION
* Add the new `major_change_ts` field to a bug that will be updated only when a comment or attachment is added, or the status is changed. 
* Changes by silent users including bots will never update the timestamp.
* The new field is searchable and exposed to the API.

## Bugzilla link

[Bug 1547414 - Create Last Major Update field that excludes minor, bulk and automated changes](https://bugzilla.mozilla.org/show_bug.cgi?id=1547414)