### PR TITLE
Bug 1225902 follow up - Change labels on My Dashboard

### DIFF
--- a/extensions/MyDashboard/template/en/default/pages/mydashboard.html.tmpl
+++ b/extensions/MyDashboard/template/en/default/pages/mydashboard.html.tmpl
@@ -138,7 +138,7 @@
           <h2 class="query_heading">[% title FILTER html_light %]</h2>
           <span id="[% name FILTER html %]_loading" class="items_found">Loading...</span>
           <span id="[% name FILTER html %]_count_refresh" class="bz_default_hidden">
-          <span class="items_found" id="[% name FILTER html %]_flags_found">0 reviews found</span>
+          <span class="items_found" id="[% name FILTER html %]_flags_found">0 requests found</span>
           | <a class="refresh" href="javascript:void(0);" id="[% name FILTER html %]_refresh">Refresh</a>
           | <a class="buglist" href="javascript:void(0);" id="[% name FILTER html %]_buglist">Buglist</a>
           </span>
@@ -146,8 +146,8 @@
         </div>
       [% END %]
 
-      [% PROCESS requests_table name='requestee' title='Flags Requested of You' %]
-      [% PROCESS requests_table name='requester' title='Flags You Have Requested' %]
+      [% PROCESS requests_table name='requestee' title='Requests for You' %]
+      [% PROCESS requests_table name='requester' title='Requests from You' %]
     </div>
 
     <div style="clear:both;"></div>

--- a/extensions/MyDashboard/web/js/flags.js
+++ b/extensions/MyDashboard/web/js/flags.js
@@ -145,7 +145,7 @@ $(function () {
         dataTable.requestee = new Y.DataTable({
             columns: [
                 { key: "requester", label: "Requester", sortable: true },
-                { key: "type", label: "Flag", sortable: true,
+                { key: "type", label: "Type", sortable: true,
                 formatter: flagNameFormatter, allowHTML: true },
                 { key: "bug_id", label: "Bug", sortable: true,
                 formatter: bugLinkFormatter, allowHTML: true },
@@ -153,7 +153,7 @@ $(function () {
                 formatter: updatedFormatter, allowHTML: true }
             ],
             strings: {
-                emptyMessage: 'No flags requested of you.',
+                emptyMessage: 'No requests found.',
             }
         });
 
@@ -195,7 +195,7 @@ $(function () {
             columns: [
                 { key:"requestee", label:"Requestee", sortable:true,
                 formatter: requesteeFormatter, allowHTML: true },
-                { key:"type", label:"Flag", sortable:true,
+                { key:"type", label:"Type", sortable:true,
                 formatter: flagNameFormatter, allowHTML: true },
                 { key:"bug_id", label:"Bug", sortable:true,
                 formatter: bugLinkFormatter, allowHTML: true },
@@ -203,7 +203,7 @@ $(function () {
                 formatter: updatedFormatter, allowHTML: true }
             ],
             strings: {
-                emptyMessage: 'No requested flags found.',
+                emptyMessage: 'No requests found.',
             }
         });
 


### PR DESCRIPTION
I forgot to include this in #1274. My Dashboard now only shows requests, not all the flags, so the labels have to be updated accordingly. UX-wise it’s better to avoid using “flag” anyway because it’s jargon.

## Bugzilla link

[Bug 1225902 - Show only flags with requestee in the "Flags You Have Requested" section](https://bugzilla.mozilla.org/show_bug.cgi?id=1225902)