### PR TITLE
Bug 1523536 follow-up - improve performance

### DIFF
--- a/extensions/ProdCompSearch/lib/WebService.pm
+++ b/extensions/ProdCompSearch/lib/WebService.pm
@@ -15,6 +15,7 @@ use base qw(Bugzilla::WebService);
 
 use Bugzilla::Error;
 use Bugzilla::Util qw(detaint_natural trim);
+use Time::localtime;
 
 #############
 # Constants #
@@ -159,8 +160,8 @@ sub list_frequent_components {
   return {results => []} unless $user->id;
 
   # Select the date of 2 years ago today
-  my ($day, $month, $year) = (localtime(time))[3, 4, 5];
-  my $date = sprintf('%4d-%02d-%02d', $year + 1900 - 2, $month + 1, $day);
+  my $now = localtime;
+  my $date = sprintf('%4d-%02d-%02d', $now->year + 1900 - 2, $now->mon + 1, $now->mday);
 
   my $dbh = Bugzilla->switch_to_shadow_db();
   my $sql = q{


### PR DESCRIPTION
Using selectall_arrayref to build the hash is much faster than using a while loop over single results.
Also avoiding the calls to `->type()`

Not related to performance, but using offsets returned by `localtime()` is discouraged. `Time::localtime` is a core module since 5.10 and has no real performance difference.