### PR TITLE
Bug 1543489 - Update firefox-crash-table.js to use cached firefox_versions.json

### DIFF
--- a/extensions/BMO/template/en/default/hook/bug_modal/edit-after_modules.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/bug_modal/edit-after_modules.html.tmpl
@@ -7,3 +7,7 @@
   #%]
 
 [% INCLUDE bug/legal_disclaimer.html.tmpl %]
+
+[% IF firefox_versions %]
+  <meta name="firefox-versions" content="[% json_encode(firefox_versions) FILTER html %]">
+[% END %]

--- a/extensions/BMO/web/js/firefox-crash-table.js
+++ b/extensions/BMO/web/js/firefox-crash-table.js
@@ -12,6 +12,12 @@ window.addEventListener('DOMContentLoaded', () => {
   const VERSION = "0.4.0";
 
   async function fetchProductDetails() {
+    const $meta = document.querySelector('meta[name="firefox-versions"]');
+
+    if ($meta) {
+      return JSON.parse($meta.content);
+    }
+
     const url = "https://product-details.mozilla.org/1.0/firefox_versions.json";
     const response = await fetch(url);
     return await response.json();


### PR DESCRIPTION
Let the Crash Table functionality use a cached version of [firefox_versions.json](https://product-details.mozilla.org/1.0/firefox_versions.json) if available, so an extra API request can be avoided.

## Bugzilla link

[Bug 1543489 - Update firefox-crash-table.js to use cached firefox_versions.json](https://bugzilla.mozilla.org/show_bug.cgi?id=1543489)