### PR TITLE
Bug 1283312 - Advanced Search page doesn’t list Flags and many other fields in Search By Change History

### DIFF
--- a/extensions/TrackingFlags/Extension.pm
+++ b/extensions/TrackingFlags/Extension.pm
@@ -411,15 +411,6 @@ sub bug_create_cf_accessors {
   }
 }
 
-sub bug_editable_bug_fields {
-  my ($self, $args) = @_;
-  my $fields         = $args->{'fields'};
-  my @tracking_flags = Bugzilla::Extension::TrackingFlags::Flag->get_all;
-  foreach my $flag (@tracking_flags) {
-    push(@$fields, $flag->name);
-  }
-}
-
 sub search_operator_field_override {
   my ($self, $args) = @_;
   my $operators      = $args->{'operators'};

--- a/query.cgi
+++ b/query.cgi
@@ -162,12 +162,22 @@ if (Bugzilla->params->{'usetargetmilestone'}) {
 }
 
 my @chfields;
+my $search_fields = Bugzilla::Search::search_fields({obsolete => 0});
+my $uneditable_fields_re = join('|', qw(
+  attachments\.submitter
+  bug_id
+  commenter
+  creation_ts
+  delta_ts
+  lastdiffed
+  reporter
+));
 
 push @chfields, "[Bug creation]";
 
 # This is what happens when you have variables whose definition depends
 # on the DB schema, and then the underlying schema changes...
-foreach my $val (editable_bug_fields()) {
+foreach my $val (keys %$search_fields) {
   if ($val eq 'classification_id') {
     $val = 'classification';
   }
@@ -176,6 +186,9 @@ foreach my $val (editable_bug_fields()) {
   }
   elsif ($val eq 'component_id') {
     $val = 'component';
+  }
+  elsif ($val =~ /^(?:$uneditable_fields_re)$/) {
+    next;
   }
   push @chfields, $val;
 }
@@ -204,7 +217,7 @@ $vars->{'resolution'}
 
 # Boolean charts
 my @fields = sort { lc($a->description) cmp lc($b->description) }
-  values %{Bugzilla::Search::search_fields({obsolete => 0})};
+  values %$search_fields;
 unshift(@fields, {name => "noop", description => "---"});
 $vars->{'fields'} = \@fields;
 


### PR DESCRIPTION
Fix the **Search By Change History** section on the Advanced Search page not listing all the available fields due to unusable `editable_bug_fields()`. Simply list all fields just like Custom Search, then exclude several uneditable ones including Bug ID and Reporter. This is just an UI issue; searches have been possible if you build query manually.

## Bugzilla link

[Bug 1283312 - Allow searching for bugs which have had a flag value (r?, needinfo?, r-, …) set for some period of time](https://bugzilla.mozilla.org/show_bug.cgi?id=1283312)