### PR TITLE
Bug 1376609 - Make needinfo field more visible when filing a new bug

### DIFF
--- a/extensions/Needinfo/Extension.pm
+++ b/extensions/Needinfo/Extension.pm
@@ -69,6 +69,20 @@ sub install_before_final_checks {
   });
 }
 
+sub bug_end_of_create {
+  my ($self, $args) = @_;
+  my $params = Bugzilla->input_params;
+
+  return unless $params->{needinfo_from};
+
+  # Add extra params
+  $params->{needinfo} = 1;
+  $params->{needinfo_role} = 'other';
+
+  # Do the rest
+  $self->bug_start_of_update($args);
+}
+
 # Clear the needinfo? flag if comment is being given by
 # requestee or someone used the override flag.
 sub bug_start_of_update {

--- a/extensions/Needinfo/template/en/default/bug/needinfo.html.tmpl
+++ b/extensions/Needinfo/template/en/default/bug/needinfo.html.tmpl
@@ -184,7 +184,7 @@ $(function() {
       </td>
       <td>
         <label for="needinfo" id="needinfo_from_label">
-          Need more information from
+          Request information from
         </label>
         <select name="needinfo_type" id="needinfo_type" style="display:none;">
           <option value="needinfo_from" selected="true">Need more information from</option>

--- a/extensions/Needinfo/template/en/default/hook/bug/create/create-after_custom_fields.html.tmpl
+++ b/extensions/Needinfo/template/en/default/hook/bug/create/create-after_custom_fields.html.tmpl
@@ -7,7 +7,7 @@
   #%]
 
 <tr>
-  <th valign="middle">Need info from:</th>
+  <th>Request information from:</th>
   <td colspan="3">
     <span id="needinfo_from_container">
       [% INCLUDE global/userselect.html.tmpl

--- a/extensions/Needinfo/template/en/default/hook/bug/create/create-after_custom_fields.html.tmpl
+++ b/extensions/Needinfo/template/en/default/hook/bug/create/create-after_custom_fields.html.tmpl
@@ -1,0 +1,24 @@
+[%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  #
+  # This Source Code Form is "Incompatible With Secondary Licenses", as
+  # defined by the Mozilla Public License, v. 2.0.
+  #%]
+
+<tr>
+  <th valign="middle">Need info from:</th>
+  <td colspan="3">
+    <span id="needinfo_from_container">
+      [% INCLUDE global/userselect.html.tmpl
+          id          => "needinfo_from"
+          name        => "needinfo_from"
+          value       => ""
+          size        => 30
+          multiple    => 5
+          field_title => "Enter one or more comma separated users to request more information from"
+          request_type => "needinfo"
+      %]
+    </span>
+  </td>
+</tr>


### PR DESCRIPTION
Make it easier to request info on the Enter Bug page by adding a dedicated field. Currently it requires you to set the `needinfo?` flag hidden in the advanced fields, which is quite unintuitive.

![image](https://user-images.githubusercontent.com/2929505/58440850-292ba580-80ab-11e9-94f4-baf2af64ef55.png)

## Bugzilla link

[Bug 1376609 - Make needinfo field more visible when filing a new bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1376609)