### PR TITLE
Bug 1553780 - Can't type/paste text into attachment contents and set text/html mimetype

### DIFF
--- a/js/attachment.js
+++ b/js/attachment.js
@@ -631,7 +631,6 @@ Bugzilla.AttachmentForm = class AttachmentForm {
     this.update_validation();
     this.$type_input.value = is_ghpr ? 'text/x-github-pull-request' : '';
     this.update_ispatch(is_patch);
-    this.$type_outer.querySelectorAll('[name]').forEach($input => $input.disabled = has_text);
   }
 
   /**


### PR DESCRIPTION
Stop disabling the MIME type selector when text is added to the attachment uploader, so the user can select `text/html` or enter whatever manually.

## Bugzilla link

[Bug 1553780 - Can't type/paste text into attachment contents and set text/html mimetype](https://bugzilla.mozilla.org/show_bug.cgi?id=1553780)