### PR TITLE
bump version to 20190528.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20190516.1';
+our $VERSION = '20190528.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
the following changes will be pushed to bugzilla.mozilla.org:
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1225902" target="_blank">1225902</a>] Show only flags with requestee in the "Flags You Have Requested" section</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1552720" target="_blank">1552720</a>] Linkify bug summaries on My Dashboard query table</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1542554" target="_blank">1542554</a>] Add bug type icons to dependency trees</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1514000" target="_blank">1514000</a>] Suppress duplicated changes in bug history made at the same time mainly due to mid-air collisions</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1523536" target="_blank">1523536</a>] New bug's "Choose from your most-used components" list is slow to show up</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1538115" target="_blank">1538115</a>] Add shortcuts for tracking &amp; status flags</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1553893" target="_blank">1553893</a>] Remove horizontal rule from summary section as well as when email notifications are sent</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1552885" target="_blank">1552885</a>] Fix issues in the post-Sandstone skin including low contrast, visited links and small font size</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1283312" target="_blank">1283312</a>] Advanced Search page doesn’t list Flags and many other fields in Search By Change History</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1543489" target="_blank">1543489</a>] Update firefox-crash-table.js to use cached firefox_versions.json</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1553780" target="_blank">1553780</a>] Can't type/paste text into attachment contents and set text/html mimetype</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1546437" target="_blank">1546437</a>] group reviewers not properly flagged in "Phabricator Revisions" bugzilla section</li>
</ul>