### PR TITLE
Bug 1543881 - Modify relative date labels like “a day ago” and “a year ago“

### DIFF
--- a/Bugzilla/Util.pm
+++ b/Bugzilla/Util.pm
@@ -654,17 +654,17 @@ sub time_ago {
   my $mo = round($dd / 30);
   my $yy = round($mo / 12);
 
-  return 'just now'           if $ss < 10;
+  return 'Just now'           if $ss < 10;
   return $ss . ' seconds ago' if $ss < 45;
-  return 'a minute ago'       if $ss < 90;
+  return '1 minute ago'       if $ss < 90;
   return $mm . ' minutes ago' if $mm < 45;
-  return 'an hour ago'        if $mm < 90;
+  return 'Last hour'          if $mm < 90;
   return $hh . ' hours ago'   if $hh < 24;
-  return 'a day ago'          if $hh < 36;
+  return 'Yesterday'          if $hh < 36;
   return $dd . ' days ago'    if $dd < 30;
-  return 'a month ago'        if $dd < 45;
+  return 'Last month'         if $dd < 45;
   return $mo . ' months ago'  if $mo < 12;
-  return 'a year ago'         if $mo < 18;
+  return 'Last year'          if $mo < 18;
   return $yy . ' years ago';
 }
 

--- a/js/util.js
+++ b/js/util.js
@@ -355,16 +355,16 @@ function timeAgo(param) {
         dd = Math.round(hh / 24),
         mo = Math.round(dd / 30),
         yy = Math.round(mo / 12);
-    if (ss < 10) return 'just now';
+    if (ss < 10) return 'Just now';
     if (ss < 45) return ss + ' seconds ago';
-    if (ss < 90) return 'a minute ago';
+    if (ss < 90) return '1 minute ago';
     if (mm < 45) return mm + ' minutes ago';
-    if (mm < 90) return 'an hour ago';
+    if (mm < 90) return 'Last hour';
     if (hh < 24) return hh + ' hours ago';
-    if (hh < 36) return 'a day ago';
+    if (hh < 36) return 'Yesterday';
     if (dd < 30) return dd + ' days ago';
-    if (dd < 45) return 'a month ago';
+    if (dd < 45) return 'Last month';
     if (mo < 12) return mo + ' months ago';
-    if (mo < 18) return 'a year ago';
+    if (mo < 18) return 'Last year';
     return yy + ' years ago';
 }


### PR DESCRIPTION
Make relative dates sound more natural by saying Yesterday or Last hour/month/year.

## Bugzilla link

[Bug 1543881 - Modify relative date labels like “a day ago” and “a year ago“](https://bugzilla.mozilla.org/show_bug.cgi?id=1543881)