### PR TITLE
Bug 1513644 - Redirect removed forms to proper destination whenever possible

### DIFF
--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -2962,8 +2962,7 @@ sub app_startup {
   $r->any( '/:REWRITE_dev_engagement_event' =>
     [ REWRITE_dev_engagement_event => qr{form[\.:]dev[\.\-:]engagement[\.\-\:]event} ]
     => sub { my $c = shift; $c->redirect_to('https://mzl.la/devevents'); });
-  $r->any( '/:REWRITE_ipc' =>
-    [ REWRITE_dev_engagement_event => qr{form[\.:](?:ipc|IPC)} ]
+  $r->any( '/:REWRITE_ipc' => [ REWRITE_ipc => qr{form[\.:](?:ipc|IPC)} ]
     => sub { my $c = shift; $c->redirect_to('https://mzl.la/snippet-submit-form'); });
 }
 

--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -2957,6 +2957,14 @@ sub app_startup {
       [REWRITE_client_bounty => qr{form[\.:]client[\.:]bounty}])
     ->to(
     'CGI#enter_bug_cgi' => {'product' => 'Firefox', 'format' => 'client-bounty'});
+
+  # Redirects to external forms
+  $r->any( '/:REWRITE_dev_engagement_event' =>
+    [ REWRITE_dev_engagement_event => qr{form[\.:]dev[\.\-:]engagement[\.\-\:]event} ]
+    => sub { my $c = shift; $c->redirect_to('https://mzl.la/devevents'); });
+  $r->any( '/:REWRITE_ipc' =>
+    [ REWRITE_dev_engagement_event => qr{form[\.:](?:ipc|IPC)} ]
+    => sub { my $c = shift; $c->redirect_to('https://mzl.la/snippet-submit-form'); });
 }
 
 __PACKAGE__->NAME;


### PR DESCRIPTION
Add redirects to external forms that were moved from BMO, including `form.dev-engagement-event` and `form.ipc`.

## Bugzilla link

[Bug 1513644 - Redirect removed forms to proper destination whenever possible](https://bugzilla.mozilla.org/show_bug.cgi?id=1513644)