### PR TITLE
Bug 1555847 - Bugs in core-security-release and pocket-security-sensitive groups have Confidential header, should be Security

### DIFF
--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -417,7 +417,7 @@
   IF bug && bug.groups_in.size;
     is_security_bug = 0;
     FOREACH group IN bug.groups_in;
-      IF group.name.match('^(.*security|\w+sec)$'); is_security_bug = 1; END;
+      IF group.name.match('^(.*security.*|\w+sec)$'); is_security_bug = 1; END;
     END;
 %]
   <div id="private-bug-banner" class="[% IF is_security_bug %]security[% ELSE %]confidential[% END %]">

--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -417,7 +417,7 @@
   IF bug && bug.groups_in.size;
     is_security_bug = 0;
     FOREACH group IN bug.groups_in;
-      IF group.name.match('^(.*security.*|\w+sec)$'); is_security_bug = 1; END;
+      is_security_bug = 1 IF group.secure_mail;
     END;
 %]
   <div id="private-bug-banner" class="[% IF is_security_bug %]security[% ELSE %]confidential[% END %]">


### PR DESCRIPTION
Show the security issue banner on bugs restricted to the `core-security-release` and `pocket-security-sensitive` groups.

## Bugzilla link

[Bug 1555847 - Bugs in core-security-release and pocket-security-sensitive groups have Confidential header, should be Security](https://bugzilla.mozilla.org/show_bug.cgi?id=1555847)