### PR TITLE
Bug 1556306 - Edit Attachment As Comment now uses variable rather than fixed width font

### DIFF
--- a/skins/standard/attachment.css
+++ b/skins/standard/attachment.css
@@ -254,6 +254,11 @@ div#update_container {
   white-space: nowrap;
 }
 
+#editFrame {
+  font-size-adjust: .5;
+  font-family: var(--font-family-monospace);
+}
+
 #editFrame,
 #viewDiffFrame,
 #viewFrame {


### PR DESCRIPTION
Show the `<textarea>` for **Edit Attachment As Comment** in a monospace font as before, so it’s easier to comment on a patch. It’s a regression from the new skin.

## Bugzilla link

[Bug 1556306 - Edit Attachment As Comment now uses variable rather than fixed width font](https://bugzilla.mozilla.org/show_bug.cgi?id=1556306)