### PR TITLE
Bug 1556320 - Mismatch between changed summary and current summary

### DIFF
--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -4537,7 +4537,6 @@ sub GetBugActivity {
     INNER JOIN profiles
             ON profiles.userid = bugs_activity.who
          WHERE bugs_activity.bug_id = ?
-           AND bugs_activity.removed != bugs_activity.added
                $datepart
                $attachpart
                $suppwhere ";
@@ -4593,12 +4592,13 @@ sub GetBugActivity {
     my $activity_visible = 1;
     my $last_change = @$changes[-1] || {};
 
-    # Suppress any mid-air collision
-    if ( $when eq $operation->{'when'}
+    # Suppress any mid-air collision or duplicated change
+    if (( $when eq $operation->{'when'}
       && $fieldname eq $last_change->{'fieldname'}
       && $removed eq $last_change->{'removed'}
       && $added eq $last_change->{'added'}
       && $attachid eq $last_change->{'attachid'})
+      || $removed eq $added )
     {
       next;
     }


### PR DESCRIPTION
Fix a summary update in history not appearing in the bug history due to a uppercase-to-lowercase change and case insensitive string comparison in MySQL. Just compare the removed and added values in the Perl code.

## Bugzilla link

[Bug 1556320 - Mismatch between changed summary and current summary](https://bugzilla.mozilla.org/show_bug.cgi?id=1556320)