### PR TITLE
Bug 1556725 - Hitting Cancel button during edit mode leads to 404 page

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -761,7 +761,7 @@ $(function() {
     $('#cancel-btn')
         .click(function(event) {
             event.preventDefault();
-            window.location.replace($('#this-bug').attr('href'));
+            window.location.replace(`${BUGZILLA.config.basepath}show_bug.cgi?id=${BUGZILLA.bug_id}`);
         });
 
     // Open help page


### PR DESCRIPTION
Fix a regression where cancelling editing a bug to a 404 Not Found page.

## Bugzilla link

[Bug 1556725 - Hitting Cancel button during edit mode leads to 404 page](https://bugzilla.mozilla.org/show_bug.cgi?id=1556725)