### PR TITLE
Bug 1556836 - Feed daemon needs to add security-revision and bmo security tags back to revision if removed by user or other process

### DIFF
--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -439,6 +439,9 @@ sub process_revision_change {
       $revision->make_private($set_project_names);
     }
 
+    # Always make sure secure-revison and proper bmo-<group> project tags are on the revision.
+    $revision->set_private_project_tags($set_project_names);
+
     # Subscriber list of the private revision should always match
     # the bug roles such as assignee, qa contact, and cc members.
     my $subscribers = get_bug_role_phids($bug);

--- a/extensions/PhabBugz/lib/Revision.pm
+++ b/extensions/PhabBugz/lib/Revision.pm
@@ -429,15 +429,10 @@ sub remove_project {
 sub make_private {
   my ($self, $project_names) = @_;
 
-  my $secure_revision_project
-    = Bugzilla::Extension::PhabBugz::Project->new_from_query({
-    name => 'secure-revision'
-    });
-
   my @set_projects;
   foreach my $name (@$project_names) {
-    my $set_project
-      = Bugzilla::Extension::PhabBugz::Project->new_from_query({name => $name});
+    my $set_project = $self->{"_project_${name}"} ||=
+      Bugzilla::Extension::PhabBugz::Project->new_from_query({name => $name});
     push @set_projects, $set_project;
   }
 
@@ -445,18 +440,14 @@ sub make_private {
   $self->set_policy('view', $new_policy->phid);
   $self->set_policy('edit', $new_policy->phid);
 
-  foreach my $project ($secure_revision_project, @set_projects) {
-    $self->add_project($project->phid);
-  }
-
   return $self;
 }
 
 sub make_public {
   my ($self) = @_;
 
-  my $editbugs
-    = Bugzilla::Extension::PhabBugz::Project->new_from_query({
+  my $editbugs = $self->{'_project_bmo-editbugs-team'} ||=
+    Bugzilla::Extension::PhabBugz::Project->new_from_query({
     name => 'bmo-editbugs-team'
     });
 
@@ -470,6 +461,26 @@ sub make_public {
   }
 
   return $self;
+}
+
+sub set_private_project_tags {
+  my ($self, $project_names) = @_;
+
+  my $secure_revision_project = $self->{'_project_secure-revision'} ||=
+    Bugzilla::Extension::PhabBugz::Project->new_from_query({
+    name => 'secure-revision'
+    });
+
+  my @set_projects;
+  foreach my $name (@$project_names) {
+    my $set_project = $self->{"_project_${name}"} ||=
+      Bugzilla::Extension::PhabBugz::Project->new_from_query({name => $name});
+    push @set_projects, $set_project;
+  }
+
+  foreach my $project ($secure_revision_project, @set_projects) {
+    $self->add_project($project->phid);
+  }
 }
 
 1;


### PR DESCRIPTION
Bugzilla Link:
[Bug 1556836 - Feed daemon needs to add security-revision and bmo security tags back to revision if removed by user or other process](https://bugzilla.mozilla.org/show_bug.cgi?id=1556836)