### PR TITLE
Bug 929502 - bugs with very long but unwrappable summaries cause the tables to overlap when the window is small

### DIFF
--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -707,9 +707,11 @@ sub create {
       # * `test<wbr>_switch<wbr>_window<wbr>_content<wbr>.py`
       # * `Test<wbr>Switch<wbr>To<wbr>Window<wbr>Content`
       # * `<a href="https://www.mozilla.org/">mozilla<wbr>.org</a>`
+      # * `MOZILLA<wbr>_PKIX<wbr>_ERROR<wbr>_MITM_DETECTED`
       wbr => sub {
         my ($var) = @_;
-        $var =~ s/([a-z])([A-Z\._])(?![^<]*>)/$1<wbr>$2/g;
+        $var =~ s/([a-z])([A-Z])(?![^<]*>)/$1<wbr>$2/g;
+        $var =~ s/([A-Za-z0-9])([\._])(?![^<]*>)/$1<wbr>$2/g;
         return $var;
       },
 

--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -707,7 +707,7 @@ sub create {
       # * `test<wbr>_switch<wbr>_window<wbr>_content<wbr>.py`
       # * `Test<wbr>Switch<wbr>To<wbr>Window<wbr>Content`
       # * `<a href="https://www.mozilla.org/">mozilla<wbr>.org</a>`
-      # * `MOZILLA<wbr>_PKIX<wbr>_ERROR<wbr>_MITM_DETECTED`
+      # * `MOZILLA<wbr>_PKIX<wbr>_ERROR<wbr>_MITM<wbr>_DETECTED`
       wbr => sub {
         my ($var) = @_;
         $var =~ s/([a-z])([A-Z])(?![^<]*>)/$1<wbr>$2/g;

--- a/extensions/MyDashboard/web/js/query.js
+++ b/extensions/MyDashboard/web/js/query.js
@@ -149,7 +149,7 @@ $(function() {
 
         const link_formatter = ({ data, value }) =>
           `<a href="${BUGZILLA.config.basepath}show_bug.cgi?id=${data.bug_id}" target="_blank">
-          ${String(value).htmlEncode()}</a>`;
+          ${isNaN(value) ? value.htmlEncode().wbr() : value}</a>`;
 
         lastChangesQuery = new Y.DataSource.IO({ source: `${BUGZILLA.config.basepath}jsonrpc.cgi` });
 

--- a/js/global.js
+++ b/js/global.js
@@ -210,6 +210,25 @@ if (!String.prototype.htmlEncode) {
     })();
 }
 
+// Insert `<wbr>` HTML tags to camel and snake case words as well as
+// words containing dots in the given string so a long bug summary,
+// for example, will be wrapped in a preferred manner rather than
+// overflowing or expanding the parent element. This conversion
+// should exclude existing HTML tags such as links. Examples:
+// * `test<wbr>_switch<wbr>_window<wbr>_content<wbr>.py`
+// * `Test<wbr>Switch<wbr>To<wbr>Window<wbr>Content`
+// * `<a href="https://www.mozilla.org/">mozilla<wbr>.org</a>`
+// * `MOZILLA<wbr>_PKIX<wbr>_ERROR<wbr>_MITM<wbr>_DETECTED`
+// This is the JavaScript version of `wbr` in Bugzilla/Template.pm.
+if (!String.prototype.wbr) {
+    (function() {
+        String.prototype.wbr = function() {
+            return this.replace(/([a-z])([A-Z])(?![^<]*>)/g, '$1<wbr>$2')
+                       .replace(/([A-Za-z0-9])([\._])(?![^<]*>)/g, '$1<wbr>$2');
+        };
+    })();
+}
+
 // our auto-completion disables browser native autocompletion, however this
 // excludes it from being restored by bf-cache.  trick the browser into
 // restoring by changing the autocomplete attribute when a page is hidden and


### PR DESCRIPTION
Insert `<wbr>` to bug summaries on My Dashboard, just like regular bug lists and bug page, so the query table won’t overlap with the request tables. This also applies the `<wbr>` hack to all uppercase + camel case symbols such as `MOZILLA_PKIX_ERROR_ADDITIONAL_POLICY_CONSTRAINT_FAILED`. Updated the Perl implementation along with the new JavaScript helper function. Tested previously regressed cases to make sure the change won’t break them again.

## Bugzilla link

[Bug 929502 - bugs with very long but unwrappable summaries cause the tables to overlap when the window is small](https://bugzilla.mozilla.org/show_bug.cgi?id=929502)