### PR TITLE
Bug 1555409 - D32774 not moved out of Draft state

### DIFF
--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -508,8 +508,12 @@ sub process_revision_change {
     $attachment->update($timestamp);
   }
 
-  # Set status to request-review if revision is new and in draft state
-  if ($is_new && $revision->status eq 'draft') {
+  # Set status to request-review if revision is new and
+  # in draft state and not changes-planned
+  if ($is_new
+      && $revision->status ne 'changes-planned'
+      && ($revision->is_draft && !$revision->hold_as_draft))
+  {
     INFO("Moving from draft to needs-review");
     $revision->set_status('request-review');
   }

--- a/extensions/PhabBugz/lib/Revision.pm
+++ b/extensions/PhabBugz/lib/Revision.pm
@@ -33,6 +33,8 @@ has phid             => (is => 'ro',   isa => Str);
 has title            => (is => 'ro',   isa => Str);
 has summary          => (is => 'ro',   isa => Str);
 has status           => (is => 'ro',   isa => Str);
+has is_draft         => (is => 'ro',   isa => Bool | JSONBool);
+has hold_as_draft    => (is => 'ro',   isa => Bool | JSONBool);
 has creation_ts      => (is => 'ro',   isa => Str);
 has modification_ts  => (is => 'ro',   isa => Str);
 has author_phid      => (is => 'ro',   isa => Str);
@@ -105,6 +107,8 @@ sub BUILDARGS {
   $params->{title}           = $params->{fields}->{title};
   $params->{summary}         = $params->{fields}->{summary};
   $params->{status}          = $params->{fields}->{status}->{value};
+  $params->{is_draft}        = $params->{fields}->{isDraft};
+  $params->{hold_as_draft}   = $params->{fields}->{holdAsDraft};
   $params->{creation_ts}     = $params->{fields}->{dateCreated};
   $params->{modification_ts} = $params->{fields}->{dateModified};
   $params->{author_phid}     = $params->{fields}->{authorPHID};


### PR DESCRIPTION
The new change will not update status if the revision is a draft and the status is 'changes-planned'. This happens when someone submits a review using 'moz-phab submit --wip'. Otherwise it should still do the old behavior of moving to 'needs-review'.

Bugzilla Link:
[Bug 1555409 - D32774 not moved out of Draft state](https://bugzilla.mozilla.org/show_bug.cgi?id=1555409)