### PR TITLE
Bug 1557360 - Crash Signature textbox is too narrow

### DIFF
--- a/extensions/BMO/web/js/firefox-crash-table.js
+++ b/extensions/BMO/web/js/firefox-crash-table.js
@@ -330,7 +330,7 @@ window.addEventListener('DOMContentLoaded', () => {
       divButton.setAttribute("id", "crash-stop-usf-button");
       divButton.setAttribute("style", "display:none;");
       button.setAttribute("type", "button");
-      button.setAttribute("style", "position:absolute;right:0;bottom:2px");
+      button.setAttribute("style", "position:absolute;right:0;top:0");
       button.innerText = "Update status flags";
       button.addEventListener("click", updateStatusFlags, false);
       divButton.append(button);

--- a/extensions/BMO/web/styles/bug_modal.css
+++ b/extensions/BMO/web/styles/bug_modal.css
@@ -5,6 +5,11 @@
  * This Source Code Form is "Incompatible With Secondary Licenses", as
  * defined by the Mozilla Public License, v. 2.0. */
 
+#cf_crash_signature {
+  width: 100%;
+  font-size: var(--font-size-medium);
+}
+
 #legal_disclaimer {
   margin: 16px 0;
   border: 1px solid var(--warning-message-border-color);

--- a/extensions/BMO/web/styles/bug_modal.css
+++ b/extensions/BMO/web/styles/bug_modal.css
@@ -7,6 +7,7 @@
 
 #cf_crash_signature {
   width: 100%;
+  height: 6em;
   font-size: var(--font-size-medium);
 }
 


### PR DESCRIPTION
Fix the size of the Crash Signature `<textarea>` plus the position of the Update status flags button in the Crash Data section.

![image](https://user-images.githubusercontent.com/2929505/59044274-dd67c180-884b-11e9-9822-9655c06718b5.png)

## Bugzilla link

[Bug 1557360 - Crash Signature textbox is too narrow](https://bugzilla.mozilla.org/show_bug.cgi?id=1557360)