### PR TITLE
Bug 1531968 - Allow to search bugs by Firefox merge dates

### DIFF
--- a/Bugzilla/Hook.pm
+++ b/Bugzilla/Hook.pm
@@ -557,6 +557,22 @@ Params:
 
 =back
 
+=head2 search_timestamp_translate
+
+This happens in L<Bugzilla::Search/_timestamp_translate> and allows you to
+support pronouns for specific dates, such as a product release date. Check the
+`value` argument and replace it with actual date where needed.
+
+Params:
+
+=over
+
+=item C<search> - The L<Bugzilla::Search> object.
+
+=item C<args> - The original arguments including C<value>.
+
+=back
+
 =head2 search_operator_field_override
 
 This allows you to modify L<Bugzilla::Search/OPERATOR_FIELD_OVERRIDE>,

--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -2207,6 +2207,10 @@ sub _timestamp_translate {
   my $value = $args->{value};
   my $dbh   = Bugzilla->dbh;
 
+  # Allow to support custom date pronouns
+  Bugzilla::Hook::process('search_timestamp_translate',
+    {search => $self, args => $args});
+
   return if $value !~ /^(?:[\+\-]?\d+[hdwmy]s?|now)$/i;
 
   $value = SqlifyDate($value);

--- a/extensions/BMO/template/en/default/hook/global/user-error-errors.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/global/user-error-errors.html.tmpl
@@ -46,9 +46,14 @@
   You cannot set this [% terms.bug %]'s status to ASSIGNED because the
   [%+ terms.bug %] is not assigned to a person.
 
-[% ELSIF error == "product_versions_unavailable" %]
-  [% title = "Product Version Info Unavailable" %]
+[% ELSIF error == "product_version_pronouns_unavailable" %]
+  [% title = "Product Version Pronouns Unavailable" %]
   The pronouns for Status and Tracking Flags cannot be used at this time.
   Please try again later or use actual version numbers instead.
+
+[% ELSIF error == "product_date_pronouns_unavailable" %]
+  [% title = "Product Date Pronouns Unavailable" %]
+  The pronoun for the merge date and release date cannot be used at this time.
+  Please try again later or use actual dates instead.
 
 [% END %]


### PR DESCRIPTION
Allow to use Firefox release date pronouns for date fields, including `%LAST_MERGE_DATE%`, `%LAST_RELEASE_DATE%` and `%LAST_SOFTFREEZE_DATE%`, in advanced search queries. These dates are from [`firefox_versions.json`](https://product-details.mozilla.org/1.0/firefox_versions.json).

## Bugzilla link

[Bug 1531968 - Allow to search bugs by Firefox merge dates](https://bugzilla.mozilla.org/show_bug.cgi?id=1531968)