### PR TITLE
Bug 1557799 - Search By Change History: date range is ignored when field is not specified

### DIFF
--- a/extensions/BMO/web/js/advanced-search.js
+++ b/extensions/BMO/web/js/advanced-search.js
@@ -6,15 +6,15 @@
  * defined by the Mozilla Public License, v. 2.0. */
 
 /**
- * Reference or define the Bugzilla app namespace.
+ * Reference or define the BMO app namespace.
  * @namespace
  */
-var Bugzilla = Bugzilla || {}; // eslint-disable-line no-var
+var BMO = BMO || {}; // eslint-disable-line no-var
 
 /**
  * Implement Advanced Search page features.
  */
-Bugzilla.AdvancedSearch = class AdvancedSearch {
+BMO.AdvancedSearch = class AdvancedSearch {
   /**
    * Initialize a new AdvancedSearch instance.
    */
@@ -44,4 +44,4 @@ Bugzilla.AdvancedSearch = class AdvancedSearch {
   }
 };
 
-window.addEventListener('DOMContentLoaded', () => new Bugzilla.AdvancedSearch(), { once: true });
+window.addEventListener('DOMContentLoaded', () => new BMO.AdvancedSearch(), { once: true });

--- a/extensions/BMO/web/js/advanced-search.js
+++ b/extensions/BMO/web/js/advanced-search.js
@@ -6,15 +6,21 @@
  * defined by the Mozilla Public License, v. 2.0. */
 
 /**
- * Reference or define the BMO app namespace.
+ * Reference or define the Bugzilla app namespace.
  * @namespace
  */
-var BMO = BMO || {}; // eslint-disable-line no-var
+var Bugzilla = Bugzilla || {}; // eslint-disable-line no-var
+
+/**
+ * Reference or define the BMO extension namespace.
+ * @namespace
+ */
+Bugzilla.BMO = Bugzilla.BMO || {};
 
 /**
  * Implement Advanced Search page features.
  */
-BMO.AdvancedSearch = class AdvancedSearch {
+Bugzilla.BMO.AdvancedSearch = class AdvancedSearch {
   /**
    * Initialize a new AdvancedSearch instance.
    */
@@ -44,4 +50,4 @@ BMO.AdvancedSearch = class AdvancedSearch {
   }
 };
 
-window.addEventListener('DOMContentLoaded', () => new BMO.AdvancedSearch(), { once: true });
+window.addEventListener('DOMContentLoaded', () => new Bugzilla.BMO.AdvancedSearch(), { once: true });

--- a/js/advanced-search.js
+++ b/js/advanced-search.js
@@ -27,8 +27,8 @@ Bugzilla.AdvancedSearch.HistoryFilter = class HistoryFilter {
     this.$chfieldto = document.querySelector('#chfieldto');
     this.$chfieldto_button = document.querySelector('#chfieldto + button');
 
-    this.$chfieldfrom.addEventListener('input', event => this.on_date_change(event.target));
-    this.$chfieldto.addEventListener('input', event => this.on_date_change(event.target));
+    this.$chfieldfrom.addEventListener('input', event => this.on_date_change(event));
+    this.$chfieldto.addEventListener('input', event => this.on_date_change(event));
 
     // Use on-event handler because `field.js` will update it
     this.$chfieldfrom_button.onclick = () => showCalendar('chfieldfrom');

--- a/js/advanced-search.js
+++ b/js/advanced-search.js
@@ -11,6 +11,48 @@
  */
 var Bugzilla = Bugzilla || {}; // eslint-disable-line no-var
 
+Bugzilla.AdvancedSearch = {};
+
+/**
+ * Implement features in the Search By Change History section.
+ */
+Bugzilla.AdvancedSearch.HistoryFilter = class HistoryFilter {
+  /**
+   * Initialize a new HistoryFilter instance.
+   */
+  constructor() {
+    this.$chfield = document.querySelector('#chfield');
+    this.$chfieldfrom = document.querySelector('#chfieldfrom');
+    this.$chfieldfrom_button = document.querySelector('#chfieldfrom + button');
+    this.$chfieldto = document.querySelector('#chfieldto');
+    this.$chfieldto_button = document.querySelector('#chfieldto + button');
+
+    this.$chfieldfrom.addEventListener('input', event => this.on_date_change(event.target));
+    this.$chfieldto.addEventListener('input', event => this.on_date_change(event.target));
+
+    // Use on-event handler because `field.js` will update it
+    this.$chfieldfrom_button.onclick = () => showCalendar('chfieldfrom');
+    this.$chfieldto_button.onclick = () => showCalendar('chfieldto');
+
+    createCalendar('chfieldfrom');
+    createCalendar('chfieldto');
+  }
+
+  /**
+   * Called whenever the date field value is updated.
+   * @param {InputEvent} event `input` event fired on date fields.
+   */
+  on_date_change(event) {
+    // Update the calendar when the user enters a date manually
+    if (event.isTrusted) {
+      updateCalendarFromField(event.target);
+    }
+
+    // Mark `<select>` required if the value is not empty
+    this.$chfield.required = !!this.$chfieldfrom.value.trim() || !!this.$chfieldto.value.trim();
+  }
+};
+
 /**
  * Implement Custom Search features.
  */
@@ -659,4 +701,7 @@ Bugzilla.CustomSearch.DropTarget = class CustomSearchDropTarget {
   }
 };
 
-window.addEventListener('DOMContentLoaded', () => new Bugzilla.CustomSearch(), { once: true });
+window.addEventListener('DOMContentLoaded', () => {
+  new Bugzilla.AdvancedSearch.HistoryFilter();
+  new Bugzilla.CustomSearch();
+}, { once: true });

--- a/js/field.js
+++ b/js/field.js
@@ -197,6 +197,7 @@ function setFieldFromCalendar(type, args, date_field) {
     }
 
     date_field.value = dateStr;
+    date_field.dispatchEvent(new Event('input'));
     hideCalendar(date_field.id);
 }
 

--- a/qa/t/test_bug_edit.t
+++ b/qa/t/test_bug_edit.t
@@ -311,7 +311,7 @@ $sel->type_ok("email2", $config->{QA_Selenium_TEST_user_login});
 screenshot_page($sel, '/app/artifacts/line271.png');
 $sel->click_ok("Search");
 check_page_load($sel,
-  q{http://HOSTNAME/buglist.cgi?emailreporter2=1&emailtype2=exact&order=Importance&list_id=__LIST_ID__&emailtype1=exact&emailcc2=1&query_format=advanced&emailassigned_to1=1&emailqa_contact2=1&email2=QA-Selenium-TEST%40mozilla.test&email1=admin%40mozilla.test&emailassigned_to2=1&product=TestProduct}
+  q{http://HOSTNAME/buglist.cgi?emailreporter2=1&order=Importance&emailtype2=exact&list_id=__LIST_ID__&emailtype1=exact&emailcc2=1&emailassigned_to1=1&query_format=advanced&emailqa_contact2=1&email2=QA-Selenium-TEST%40mozilla.test&emailassigned_to2=1&email1=admin%40mozilla.test&product=TestProduct}
 );
 $sel->title_is("Bug List");
 screenshot_page($sel, '/app/artifacts/line275.png');

--- a/skins/standard/search_form.css
+++ b/skins/standard/search_form.css
@@ -59,8 +59,12 @@
   font-weight: normal;
 }
 
+.bz_search_section .field_help {
+  white-space: nowrap;
+}
+
 #bug_id_container .field_help {
-  font-size: var(--font-size-x-small);
+  display: block;
 }
 
 .search_field_row {

--- a/template/en/default/search/form.html.tmpl
+++ b/template/en/default/search/form.html.tmpl
@@ -258,7 +258,7 @@ TUI_hide_default('custom_search_query');
     <div id="bug_id_container">
       <input type="text" name="bug_id" id="bug_id"
            value="[% default.bug_id.0 FILTER html %]" size="20">
-           <div class="field_help">(comma-separated list)</div>
+           <small class="field_help">(comma-separated list)</small>
     </div>
     should be
     <select name="bug_id_type" id="bug_id_type">
@@ -391,25 +391,14 @@ TUI_hide_default('custom_search_query');
   </li>
   <li>
     <label for="chfieldfrom">between:</label>
-    <input name="chfieldfrom" id="chfieldfrom" size="10"
-           value="[% default.chfieldfrom.0 FILTER html %]" onchange="updateCalendarFromField(this)">
-           <button type="button" class="calendar_button"
-                          id="button_calendar_chfieldfrom"
-                          onclick="showCalendar('chfieldfrom')"><span>Calendar</span></button>
-           and
-           <div id="con_calendar_chfieldfrom"></div>
-          <input name="chfieldto" size="10" id="chfieldto"
-                 value="[% default.chfieldto.0 || "Now" FILTER html %]"
-                 onchange="updateCalendarFromField(this)">
-          <button type="button" class="calendar_button"
-                         id="button_calendar_chfieldto"
-                         onclick="showCalendar('chfieldto')"><span>Calendar</span></button>
-          <div id="con_calendar_chfieldto"></div>
-    (YYYY-MM-DD or relative dates)
-    <script [% script_nonce FILTER none %]>
-      createCalendar('chfieldfrom');
-      createCalendar('chfieldto');
-    </script>
+    <input name="chfieldfrom" id="chfieldfrom" size="10" value="[% default.chfieldfrom.0 FILTER html %]">
+    <button type="button" class="calendar_button" id="button_calendar_chfieldfrom"><span>Calendar</span></button>
+    and
+    <div id="con_calendar_chfieldfrom"></div>
+    <input name="chfieldto" size="10" id="chfieldto" value="[% default.chfieldto.0 FILTER html %]" placeholder="Now">
+    <button type="button" class="calendar_button" id="button_calendar_chfieldto"><span>Calendar</span></button>
+    <div id="con_calendar_chfieldto"></div>
+    <small class="field_help">(YYYY-MM-DD or <a href="[% docs_urlbase FILTER html %]using/finding.html#relative-dates">relative dates</a>)</small>
   </li>
 </ul>
 


### PR DESCRIPTION
* <del>Select **[Bug creation]** by default because people sometimes forget to select a field name and unexpected results will be returned. It will be simply ignored unless a date range is specified</del>
* Mark `<select name="chfield">` required when a date range is specified
* Remove inline script from the section (and eventually from the entire Advanced Search page)
* Add a link to the relative dates doc being added in #1320

## Bugzilla link

[Bug 1557799 - Search By Change History: date range is ignored when field is not specified](https://bugzilla.mozilla.org/show_bug.cgi?id=1557799)