### PR TITLE
Bug 1362951 - CC list implies there's a drop-down menu, but clicking the dropdown button treats it as send email

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -282,6 +282,11 @@ $(function() {
                         $('#ccr-' + $(this).data('n')).css('visibility', 'hidden');
                     }
                 );
+                $('#cc-list .show_usermenu').click(function() {
+                    const $this = $(this);
+                    return show_usermenu($this.data('user-id'), $this.data('user-email'), $this.data('show-edit'),
+                        $this.data('hide-profile'));
+                });
                 $('#cc-list .cc-remove')
                     .click(function(event) {
                         event.preventDefault();


### PR DESCRIPTION
Show the regular user menu when clicking a CC member on the modal UI instead of triggering the `mailto:` link itself.

## Bugzilla link

[Bug 1362951 - CC list implies there's a drop-down menu, but clicking the dropdown button treats it as send email](https://bugzilla.mozilla.org/show_bug.cgi?id=1362951)