### PR TITLE
Bump version to 20190613.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20190606.1';
+our $VERSION = '20190613.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1557779" target="_blank">1557779</a>] OAuth flow broken when user is not already logged in *and* uses duo auth</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1557186" target="_blank">1557186</a>] No official documentation for relative dates</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1557726" target="_blank">1557726</a>] Remove author column from Phabricator table to avoid revision owner vs. commit author confusion</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1540425" target="_blank">1540425</a>] Remove Array.forEach from sorttable.js</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1558494" target="_blank">1558494</a>] Fix some more issues in the post-Sandstone skin</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1556836" target="_blank">1556836</a>] Feed daemon needs to add security-revision and bmo security tags back to revision if removed by user or other process</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1362951" target="_blank">1362951</a>] CC list implies there's a drop-down menu, but clicking the dropdown button treats it as send email</li>
</ul>