### PR TITLE
Bug 1559248 - Integrate iprepd with BMO

### DIFF
--- a/Bugzilla/App/Plugin/BlockIP.pm
+++ b/Bugzilla/App/Plugin/BlockIP.pm
@@ -12,15 +12,16 @@ use Type::Library -base, -declare => qw( ResponseType);
 use Type::Utils -all;
 use Types::Standard -all;
 
-declare ResponseType, as Dict [
+declare ResponseType,
+  as Dict [
   object      => Str,
   type        => Str,
   reputation  => Int,
   reviewed    => JSONBool,
   lastupdated => Str,
-  decayafter  => Optional[Str],
+  decayafter  => Optional [Str],
   slurpy Any,
-];
+  ];
 
 use constant BLOCK_TIMEOUT => 60 * 60;
 
@@ -34,7 +35,7 @@ sub register {
   $app->hook(before_routes => \&_before_routes);
   $app->helper(block_ip   => \&_block_ip);
   $app->helper(unblock_ip => \&_unblock_ip);
-  $app->helper(check_ip => \&_check_ip);
+  $app->helper(check_ip   => \&_check_ip);
 
   $app->hook(
     before_server_start => sub {
@@ -42,8 +43,7 @@ sub register {
       $template->process('global/ip-blocked.html.tmpl',
         {block_timeout => BLOCK_TIMEOUT, block_type => 'internal'},
         \$BLOCKED_INTERNAL_HTML);
-      $template->process('global/ip-blocked.html.tmpl',
-        {block_type => 'external'},
+      $template->process('global/ip-blocked.html.tmpl', {block_type => 'external'},
         \$BLOCKED_EXTERNAL_HTML);
       undef $template;
       utf8::encode($BLOCKED_INTERNAL_HTML);
@@ -90,8 +90,8 @@ sub _check_ip {
       return '';
     }
 
-    my $tx     = $c->ua->get($url => {Authorization => "APIKey $iprepd_key"});
-    my $code   = $tx->result->code;
+    my $tx   = $c->ua->get($url => {Authorization => "APIKey $iprepd_key"});
+    my $code = $tx->result->code;
     if ($code == 200) {
       my $response = $tx->result->json;
       my $error    = ResponseType->validate($response);

--- a/Bugzilla/App/Plugin/BlockIP.pm
+++ b/Bugzilla/App/Plugin/BlockIP.pm
@@ -19,6 +19,7 @@ declare ResponseType, as Dict [
   reviewed    => JSONBool,
   lastupdated => Str,
   decayafter  => Optional[Str],
+  slurpy Any,
 ];
 
 use constant BLOCK_TIMEOUT => 60 * 60;

--- a/Bugzilla/App/Plugin/BlockIP.pm
+++ b/Bugzilla/App/Plugin/BlockIP.pm
@@ -2,12 +2,30 @@ package Bugzilla::App::Plugin::BlockIP;
 use 5.10.1;
 use Mojo::Base 'Mojolicious::Plugin';
 
+use Bugzilla::Logging;
 use Bugzilla::Memcached;
+use Bugzilla::Types qw(JSONBool);
+use Mojo::Path;
+use Mojo::URL;
+use Try::Tiny;
+use Type::Library -base, -declare => qw( ResponseType);
+use Type::Utils -all;
+use Types::Standard -all;
+
+declare ResponseType, as Dict [
+  object      => Str,
+  type        => Str,
+  reputation  => Int,
+  reviewed    => JSONBool,
+  lastupdated => Str,
+  decayafter  => Optional[Str],
+];
 
 use constant BLOCK_TIMEOUT => 60 * 60;
 
-my $MEMCACHED    = Bugzilla::Memcached->new()->{memcached};
-my $BLOCKED_HTML = "";
+my $MEMCACHED             = Bugzilla::Memcached->new()->{memcached};
+my $BLOCKED_INTERNAL_HTML = "";
+my $BLOCKED_EXTERNAL_HTML = "";
 
 sub register {
   my ($self, $app, $conf) = @_;
@@ -15,15 +33,25 @@ sub register {
   $app->hook(before_routes => \&_before_routes);
   $app->helper(block_ip   => \&_block_ip);
   $app->helper(unblock_ip => \&_unblock_ip);
+  $app->helper(check_ip => \&_check_ip);
 
   $app->hook(
     before_server_start => sub {
       my $template = Bugzilla::Template->create();
       $template->process('global/ip-blocked.html.tmpl',
-        {block_timeout => BLOCK_TIMEOUT},
-        \$BLOCKED_HTML);
+        {block_timeout => BLOCK_TIMEOUT, block_type => 'internal'},
+        \$BLOCKED_INTERNAL_HTML);
+      $template->process('global/ip-blocked.html.tmpl',
+        {block_type => 'external'},
+        \$BLOCKED_EXTERNAL_HTML);
       undef $template;
-      utf8::encode($BLOCKED_HTML);
+      utf8::encode($BLOCKED_INTERNAL_HTML);
+      utf8::encode($BLOCKED_EXTERNAL_HTML);
+
+      my $iprepd_url = Bugzilla->localconfig->iprepd_url;
+      my $iprepd_key = Bugzilla->localconfig->iprepd_key;
+      WARN("iprepd_url is not set") unless $iprepd_url;
+      WARN("iprepd_key is not set") unless $iprepd_key;
     }
   );
 }
@@ -38,18 +66,79 @@ sub _unblock_ip {
   $MEMCACHED->delete("block_ip:$ip") if $MEMCACHED;
 }
 
+sub _check_ip {
+  my ($c, $ip) = @_;
+
+  state $iprepd_url = Bugzilla->localconfig->iprepd_url;
+  state $iprepd_key = Bugzilla->localconfig->iprepd_key;
+
+  if ($MEMCACHED && $MEMCACHED->get("block_ip:$ip")) {
+    return 'block_internal';
+  }
+
+  if ($iprepd_url && $iprepd_key) {
+    my $params = Bugzilla->params;
+    my $path   = Mojo::Path->new('/type/ip/')->merge($ip);
+    my $url    = Mojo::URL->new($iprepd_url)->path($path);
+
+    return '' unless $params->{iprepd_active};
+
+    my $filter = Bugzilla::Bloomfilter->lookup("rate_limit_whitelist");
+    if ($filter->test($ip)) {
+      INFO("$ip is in the rate limit whitelist, ignoring iprepd.");
+      return '';
+    }
+
+    my $tx     = $c->ua->get($url => {Authorization => "APIKey $iprepd_key"});
+    my $code   = $tx->result->code;
+    if ($code == 200) {
+      my $response = $tx->result->json;
+      my $error    = ResponseType->validate($response);
+      if ($error) {
+        die "JSON Response from $iprepd_url does not meet expectations: $error";
+      }
+      if ($response->{reputation} < $params->{iprepd_min_reputation}) {
+        return 'block_external';
+      }
+    }
+    elsif ($code == 404) {
+      INFO("No reputation for $ip");
+    }
+    else {
+      my $message = $tx->result->message;
+      die "Unexpected HTTP response $code, message: $message";
+    }
+  }
+
+  return '';
+}
+
 sub _before_routes {
   my ($c) = @_;
   return if $c->stash->{'mojo.static'};
 
-  my $ip = $c->tx->remote_address;
-  if ($MEMCACHED && $MEMCACHED->get("block_ip:$ip")) {
-    $c->block_ip($ip);
-    $c->res->code(429);
-    $c->res->message('Too Many Requests');
-    $c->write($BLOCKED_HTML);
-    $c->finish;
+  state $better_xff = Bugzilla->has_feature('better_xff');
+  my $ip = $better_xff ? $c->forwarded_for : $c->tx->remote_address;
+  try {
+    my $blocked = $c->check_ip($ip);
+
+    if ($blocked eq 'block_internal') {
+      $c->block_ip($ip);
+      $c->res->code(429);
+      $c->res->message('Too Many Requests');
+      $c->write($BLOCKED_INTERNAL_HTML);
+      $c->finish;
+    }
+    elsif ($blocked eq 'block_external') {
+      $c->res->code(403);
+      $c->res->message('Forbidden');
+      $c->write($BLOCKED_EXTERNAL_HTML);
+      $c->finish;
+    }
   }
+  catch {
+    ERROR($_);
+  };
 }
 
 1;

--- a/Bugzilla/App/Plugin/BlockIP.pm
+++ b/Bugzilla/App/Plugin/BlockIP.pm
@@ -90,6 +90,10 @@ sub _check_ip {
       return '';
     }
 
+    # API may not be slower than 200ms
+    $c->ua->connect_timeout(0.100);
+    $c->ua->inactivity_timeout(0.100);
+    $c->ua->request_timeout(0.200);
     my $tx   = $c->ua->get($url => {Authorization => "APIKey $iprepd_key"});
     my $code = $tx->result->code;
     if ($code == 200) {

--- a/Bugzilla/Config/Admin.pm
+++ b/Bugzilla/Config/Admin.pm
@@ -44,6 +44,12 @@ sub get_param_list {
       updater => \&update_rate_limit_rules,
     },
 
+    {name => 'iprepd_active', type => 'b', default => 1},
+
+    {name => 'iprepd_email', type => 't', default => ''},
+
+    {name => 'iprepd_min_reputation', type => 't', default => 75},
+
     {name => 'log_user_requests', type => 'b', default => 0},
 
     {name => 'block_user_agent', type => 't', default => ''},

--- a/Bugzilla/Install/Localconfig.pm
+++ b/Bugzilla/Install/Localconfig.pm
@@ -80,6 +80,8 @@ use constant LOCALCONFIG_VARS => (
     # is larger than anybody would ever be able to brute-force.
     default => sub { generate_random_password(64) },
   },
+  {name => 'iprepd_url', default => '',},
+  {name => 'iprepd_key', default => '',},
   {name => 'jwt_secret', default => sub { generate_random_password(64) },},
   {
     name    => 'param_override',

--- a/README.rst
+++ b/README.rst
@@ -363,6 +363,12 @@ BMO_inbound_proxies
   This can be '*' if only the load balancer can connect to this container.
   Setting this to '*' means that BMO will trust the X-Forwarded-For header.
 
+BMO_iprepd_url
+  This is the url to iprepd, probably something like https://iprepd.prod.mozaws.net/
+
+BMO_iprepd_key
+  This is an API key to iprepd.
+
 BMO_memcached_namespace
   The global namespace for the memcached servers.
 

--- a/scripts/fake-iprepd.pl
+++ b/scripts/fake-iprepd.pl
@@ -1,0 +1,47 @@
+#!/usr/bin/env perl
+BEGIN { $ENV{MOJO_LISTEN} = 'http://*:8025' }
+use Mojolicious::Lite;
+use Mojo::JSON qw(true false);
+
+my %database = (
+  '1.2.3.4' => 10,
+);
+
+get '/' => sub {
+  my $c = shift;
+  $c->render(template => 'index');
+};
+
+get '/type/ip/*ip' => sub {
+  my $c  = shift;
+  my $ip = $c->param('ip');
+  if (exists $database{$ip}) {
+    $c->render(
+      json => {
+        object      => $ip,
+        type        => 'ip',
+        reputation  => $database{$ip},
+        reviewed    => false,
+        lastupdated => '2018-04-23T18=>25=>43.511Z',
+      }
+    );
+  }
+  else {
+    $c->reply->not_found;
+  }
+};
+
+app->start;
+__DATA__
+
+@@ index.html.ep
+% layout 'default';
+% title 'Welcome';
+<h1>Welcome to the Mojolicious real-time web framework!</h1>
+
+@@ layouts/default.html.ep
+<!DOCTYPE html>
+<html>
+  <head><title><%= title %></title></head>
+  <body><%= content %></body>
+</html>

--- a/scripts/fake-iprepd.pl
+++ b/scripts/fake-iprepd.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
+use strict;
+use warnings;
+
 BEGIN { $ENV{MOJO_LISTEN} = 'http://*:8025' }
+
 use Mojolicious::Lite;
 use Mojo::JSON qw(true false);
 

--- a/template/en/default/admin/params/admin.html.tmpl
+++ b/template/en/default/admin/params/admin.html.tmpl
@@ -55,6 +55,12 @@ over 60 seconds. Valid keys are <code>get_b[%''%]ug</code> which covers JSONRPC,
 
   rate_limit_rules => rate_limit_rules_desc
 
+  iprepd_active => "Allow $terms.Bugzilla to query iprepd and block requests with low reputation"
+
+  iprepd_email => "Email address that will be a point of contact for blocked people"
+
+  iprepd_min_reputation => "The minimum level of reputation allowed."
+
   log_user_requests => "This option controls logging of authenticated requests in the user_request_log table"}
 
 %]

--- a/template/en/default/global/ip-blocked.html.tmpl
+++ b/template/en/default/global/ip-blocked.html.tmpl
@@ -3,8 +3,8 @@
 
 [% SWITCH block_type %]
   [% CASE 'internal' %]
-  [% title = "Too Many Requests" %]
-  [% user_message = BLOCK %]
+    [% title = "Too Many Requests" %]
+    [% user_message = BLOCK %]
     <p>
       We’re sorry, but you have sent too many requests to us recently.
       You will be unblocked in [% block_timeout / 60 FILTER none %] minutes.

--- a/template/en/default/global/ip-blocked.html.tmpl
+++ b/template/en/default/global/ip-blocked.html.tmpl
@@ -1,15 +1,31 @@
 [% PROCESS global/variables.none.tmpl %]
 
-[% title = "Too Many Requests" %]
+
+[% SWITCH block_type %]
+  [% CASE 'internal' %]
+  [% title = "Too Many Requests" %]
+  [% user_message = BLOCK %]
+    <p>
+      We’re sorry, but you have sent too many requests to us recently.
+      You will be unblocked in [% block_timeout / 60 FILTER none %] minutes.
+    </p>
+  [% END %]
+
+  [% CASE 'external' %]
+    [% title = "Forbidden" %]
+    [% user_message = BLOCK %]
+      <p>
+        We’re sorry, but we have blocked access to [% terms.Bugzilla %] from this location.
+        Please email [% Param('iprepd_email') FILTER html %] to regain access.
+      </p>
+    [% END %]
+[% END %]
 
 [% PROCESS global/header.html.tmpl
            robots = 'noindex' %]
 
 <h1>[% title FILTER html %]</h1>
 
-<p>
-    We’re sorry, but you have sent too many requests to us recently.
-    You will be unblocked in [% block_timeout / 60 FILTER none %] minutes.
-</p>
+[% user_message FILTER none %]
 
 [% PROCESS global/footer.html.tmpl %]

--- a/template/en/default/setup/strings.txt.pl
+++ b/template/en/default/setup/strings.txt.pl
@@ -189,6 +189,8 @@ This is a list of IP addresses that we expect proxies to come from.
 This can be '*' if only the load balancer can connect.
 Setting this to '*' means that we can trust the X-Forwarded-For header.
 END
+  localconfig_iprepd_url => 'This is the url to iprepd, probably something like https://iprepd.prod.mozaws.net/',
+  localconfig_iprepd_key => 'This is an API key to iprepd.',
   localconfig_index_html => <<'END',
 Most web servers will allow you to use index.cgi as a directory
 index, and many come preconfigured that way, but if yours doesn't


### PR DESCRIPTION
# NEW localconfig / environment configuration

- BMO_iprepd_url -- the url to the iprepd instance
- BMO_iprepd_key -- the api key

# NEW admin / runtime configuration

These settings are on the admin panel, and the bmo admins can tweak them at runtime without a deployment.

- iprepd_min_reputation -- the min level of reputation needed for an IP to not be blocked.
- iprepd_active -- a boolean to turn off iprepd if it is misbehaving.
- iprepd_email -- an email address, displayed on the block page. This could be the only communication channel open to the person that was blocked, and ideally it would go to both bmo ops and iprepd ops