### PR TITLE
Bug 1317224 - Option 'Ignore Bug Mail' is hidden by default on modal UI

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/new_comment.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/new_comment.html.tmpl
@@ -103,7 +103,7 @@
       </tr>
     </table>
 
-    <table class="edit-show" style="display:none">
+    <table class="edit-show">
       <tr>
         <td>
           <input type="checkbox" name="bug_ignored" id="bug-ignored"


### PR DESCRIPTION
Show the “Never email me about this bug” checkbox on the modal UI not only in the edit mode but also in the view mode. It was visible by default on the legacy UI, so it’s considered as a regression.

## Bugzilla link

[Bug 1317224 - Option 'Ignore Bug Mail' is hidden by default on modal UI](https://bugzilla.mozilla.org/show_bug.cgi?id=1317224)