### PR TITLE
Bug 1559830 - Second line in the Requests dropdown is partially cut if there is secure bug icon

### DIFF
--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -2137,13 +2137,17 @@ table.tabs .clickable_area {
 }
 
 .dropdown-panel .notifications label {
-  display: -webkit-box;
   overflow: hidden;
   max-height: calc(2em * var(--line-height-default));
   white-space: normal;
-  text-overflow: ellipsis;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
+}
+
+@supports (-webkit-line-clamp: 2) {
+  .dropdown-panel .notifications label {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+  }
 }
 
 .dropdown-panel .notifications strong {
@@ -2157,9 +2161,9 @@ table.tabs .clickable_area {
 }
 
 .dropdown-panel .notifications .secure .icon {
-  display: inline;
-  font-size: 16px;
-  vertical-align: text-bottom;
+  width: 16px !important;
+  font-size: 16px !important;
+  vertical-align: text-bottom !important;
 }
 
 .dropdown-panel .notifications .secure .icon::before {


### PR DESCRIPTION
Fix a small UI glitch in the Requests dropdown that can be seen when there’s a secure bug. `@supports` allows to support both the latest and old browsers.

## Bugzilla link

[Bug 1559830 - Second line in the Requests dropdown is partially cut if there is secure bug icon](https://bugzilla.mozilla.org/show_bug.cgi?id=1559830)