### PR TITLE
Bug 1512497 - Comment editing should be listed on the bug history page and API

### DIFF
--- a/Bugzilla/Hook.pm
+++ b/Bugzilla/Hook.pm
@@ -297,6 +297,40 @@ The hash of changed fields. C<< $changes->{field} = [old, new] >>
 
 =back
 
+=head2 get_bug_activity
+
+This happens in L<Bugzilla::Bug::GetBugActivity>, where you can add custom bug
+activity, such as comment revisions, if needed.
+
+Params:
+
+=over
+
+=item C<bug_id>
+
+The bug ID that the activity belongs to.
+
+=item C<attach_id>
+
+An optional attachment ID that filters the activity.
+
+=item C<start_time>
+
+An optional time that filters the activity.
+
+=item C<include_comment_activity>
+
+Whether any comment activity, including comment tags, should be included.
+
+=item C<list>
+
+The core activity list that you can extend or modify in a hook. An list item is
+an array that should contain field name, activity ID (can be undef), attach ID
+(can be undef), timestamp, removed value, added value, user name and comment ID
+(can be undef).
+
+=back
+
 =head2 bug_check_can_change_field
 
 This hook controls what fields users are allowed to change. You can add code

--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -523,7 +523,7 @@ sub history {
     $item{id} = $self->type('int', $bug_id);
 
     my ($activity)
-      = Bugzilla::Bug::GetBugActivity($bug_id, undef, $params->{new_since});
+      = Bugzilla::Bug::GetBugActivity($bug_id, undef, $params->{new_since}, 1);
 
     my @history;
     foreach my $changeset (@$activity) {
@@ -1533,7 +1533,7 @@ sub _bug_to_hash {
   if (filter_wants $params, 'history', ['extra']) {
     my @result;
     my ($activity)
-      = Bugzilla::Bug::GetBugActivity($bug->id, undef, $params->{new_since});
+      = Bugzilla::Bug::GetBugActivity($bug->id, undef, $params->{new_since}, 1);
     foreach my $changeset (@$activity) {
       push(@result,
            $self->_changeset_to_hash($changeset, $params, ['extra'], 'history'));
@@ -1737,11 +1737,14 @@ sub _changeset_to_hash {
     my $api_field_type = $api_field_types{$field_name} || 'string';
     my $api_field_name = $api_field_names{$field_name} || $field_name;
     my $attach_id      = delete $change->{attachid};
+    my $comment        = delete $change->{comment};
 
     $change->{field_name}    = $self->type('string',        $api_field_name);
     $change->{removed}       = $self->type($api_field_type, $change->{removed});
     $change->{added}         = $self->type($api_field_type, $change->{added});
     $change->{attachment_id} = $self->type('int', $attach_id) if $attach_id;
+    $change->{comment_id}    = $self->type('int', $comment->id) if $comment;
+    $change->{comment_count} = $self->type('int', $comment->count) if $comment;
 
     push (@{$item->{changes}}, $change);
   }

--- a/extensions/EditComments/Extension.pm
+++ b/extensions/EditComments/Extension.pm
@@ -63,6 +63,13 @@ sub install_update_db {
   # because existing admin-edited revisions may contain sensitive info
   $dbh->bz_add_column('longdescs_activity', 'is_hidden',
     {TYPE => 'BOOLEAN', NOTNULL => 1, DEFAULT => 1});
+
+  unless (Bugzilla::Field->new({name => 'comment_revision'})) {
+    Bugzilla::Field->create({
+      name        => 'comment_revision',
+      description => 'Comment Revision',
+    });
+  }
 }
 
 ####################
@@ -260,6 +267,44 @@ sub config_modify_panels {
     default => 'editbugs',
     checker => \&check_group
     };
+}
+
+sub get_bug_activity {
+  my ($self, $args) = @_;
+
+  return unless $args->{include_comment_activity};
+
+  my $list = $args->{list};
+  my $is_insider = Bugzilla->user->is_insider;
+  my $hidden_placeholder = '(Hidden by Administrator)';
+
+  my $edited_comment_ids
+    = Bugzilla->dbh->selectcol_arrayref('
+      SELECT DISTINCT(c.comment_id) from longdescs_activity AS a
+      INNER JOIN longdescs AS c ON c.comment_id = a.comment_id AND c.bug_id = ?
+    ' . ($is_insider ? '' : 'AND c.isprivate = 0'), undef, $args->{bug_id});
+
+  foreach my $comment_id (@$edited_comment_ids) {
+    my $prev_rev = {};
+
+    foreach my $revision (@{Bugzilla::Comment->new($comment_id)->activity}) {
+      # Exclude original comment, because we are interested only in revisions
+      if ($revision->{old}) {
+        push(@$list, [
+          'comment_revision',
+          undef,
+          undef,
+          $revision->{created_time},
+          $prev_rev->{is_hidden} && !$is_insider ? $hidden_placeholder : $revision->{old},
+          $revision->{is_hidden} && !$is_insider ? $hidden_placeholder : $revision->{new},
+          $revision->{author}->{login_name},
+          $comment_id
+        ]);
+      }
+
+      $prev_rev = $revision;
+    }
+  }
 }
 
 sub webservice {

--- a/extensions/EditComments/Extension.pm
+++ b/extensions/EditComments/Extension.pm
@@ -63,13 +63,6 @@ sub install_update_db {
   # because existing admin-edited revisions may contain sensitive info
   $dbh->bz_add_column('longdescs_activity', 'is_hidden',
     {TYPE => 'BOOLEAN', NOTNULL => 1, DEFAULT => 1});
-
-  unless (Bugzilla::Field->new({name => 'comment_revision'})) {
-    Bugzilla::Field->create({
-      name        => 'comment_revision',
-      description => 'Comment Revision',
-    });
-  }
 }
 
 ####################


### PR DESCRIPTION
Add comment revisions to the bug history page and API. Also add comment tag changes to the bug history API.

## Bugzilla link

[Bug 1512497 - Comment editing should be listed on the bug history page and API](https://bugzilla.mozilla.org/show_bug.cgi?id=1512497)