### PR TITLE
Bug 1560133 - Bug filed as a regression should be given type "defect"

### DIFF
--- a/enter_bug.cgi
+++ b/enter_bug.cgi
@@ -313,7 +313,9 @@ if ($cloned_bug_id) {
 else {
   $default{'component_'} = formvalue('component');
   $default{'bug_type'}
-    = formvalue('bug_type', Bugzilla->params->{'default_bug_type'});
+    = defined $cgi->param('regressed_by')
+    ? 'defect'
+    : formvalue('bug_type', Bugzilla->params->{'default_bug_type'});
   $default{'priority'}
     = formvalue('priority', Bugzilla->params->{'defaultpriority'});
   $default{'bug_severity'}

--- a/template/en/default/bug/create/create.html.tmpl
+++ b/template/en/default/bug/create/create.html.tmpl
@@ -69,7 +69,7 @@ function initCrashSignatureField() {
 }
 
 const params = new URLSearchParams(location.search);
-let bug_type_specified = params.has('bug_type') || params.has('cloned_bug_id');
+let bug_type_specified = params.has('bug_type') || params.has('cloned_bug_id') || params.has('regressed_by');
 
 var initialowners = new Array([% product.components.size %]);
 var last_initialowner;


### PR DESCRIPTION
Use the defect bug type for a regression by default when the URL param contains `regressed_by`.

## Bugzilla link

[Bug 1560133 - Bug filed as a regression should be given type "defect”](https://bugzilla.mozilla.org/show_bug.cgi?id=1560133)