### PR TITLE
Bug 1477931 follow-up - Make sure Gravatar and requests are loaded via API

### DIFF
--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -187,10 +187,8 @@ sub suggest {
     name      => $self->type(email  => $_->{name}),
   } } @$results;
 
-  unless ($params->{fast_mode}) {
-    Bugzilla::Hook::process('webservice_user_suggest',
-      {webservice => $self, params => $params, users => \@users});
-  }
+  Bugzilla::Hook::process('webservice_user_suggest',
+    {webservice => $self, params => $params, users => \@users});
 
   return {users => \@users};
 }

--- a/js/field.js
+++ b/js/field.js
@@ -715,7 +715,6 @@ $(function() {
         serviceUrl: `${BUGZILLA.config.basepath}rest/user/suggest`,
         params: {
             Bugzilla_api_token: BUGZILLA.api_token,
-            fast_mode: 1
         },
         paramName: 'match',
         deferRequestBy: 250,


### PR DESCRIPTION
Let’s try this again once #1212 is merged. This will finish #684 by showing the user’s avatar as well as # of requests or blocking status.

## Bugzilla link

[Bug 1477931 - Show number of review/feedback/needinfo in user autocomplete and prevent person from being added if requests are blocked](https://bugzilla.mozilla.org/show_bug.cgi?id=1477931)