### PR TITLE
Bug 1273046 - Disable the legacy non-modal bug UI

### DIFF
--- a/Bugzilla/User/Setting.pm
+++ b/Bugzilla/User/Setting.pm
@@ -19,6 +19,7 @@ use base qw(Exporter);
   get_all_settings
   get_defaults
   add_setting
+  remove_setting
   clear_settings_cache
 );
 
@@ -144,18 +145,7 @@ sub add_setting {
   if ($exists) {
 
     # If this setting exists, we delete it and regenerate it.
-    $dbh->do('DELETE FROM setting_value WHERE name = ?', undef, $name);
-    $dbh->do('DELETE FROM setting WHERE name = ?',       undef, $name);
-
-    # Remove obsolete user preferences for this setting.
-    if (defined $options && scalar(@$options)) {
-      my $list = join(', ', map { $dbh->quote($_) } @$options);
-      $dbh->do(
-        "DELETE FROM profile_setting
-                      WHERE setting_name = ? AND setting_value NOT IN ($list)", undef,
-        $name
-      );
-    }
+    remove_setting($name, $options);
   }
   elsif (!$silently) {
     print get_text('install_setting_new', {name => $name}) . "\n";
@@ -176,6 +166,26 @@ sub add_setting {
     $sth->execute($name, $key, $sortindex);
     $sortindex += 5;
   }
+}
+
+sub remove_setting {
+  my ($name, $options) = @_;
+  my $dbh = Bugzilla->dbh;
+
+  return unless _setting_exists($name);
+
+  $dbh->do('DELETE FROM setting_value WHERE name = ?', undef, $name);
+  $dbh->do('DELETE FROM setting WHERE name = ?',       undef, $name);
+
+  my $sql = 'DELETE FROM profile_setting WHERE setting_name = ?';
+
+  # Remove obsolete user preferences for this setting.
+  if (defined $options && scalar(@$options)) {
+    my $list = join(', ', map { $dbh->quote($_) } @$options);
+    $sql .= " AND setting_value NOT IN ($list)";
+  }
+
+  $dbh->do($sql, undef, $name);
 }
 
 sub get_all_settings {
@@ -384,6 +394,13 @@ Params:      C<$name> - string - the name of the new setting
 
 Returns:     a pointer to a hash of settings
 
+=item C<remove_setting($name, \@options)>
+
+Description: Removes an existing setting and the options.
+
+Params:      C<$name> - string - the name of the new setting
+             C<$options> (optional) - arrayref - contains the existing setting
+             choices that shouldn't be removed.
 
 =item C<get_all_settings($user_id)>
 

--- a/Bugzilla/User/Setting.pm
+++ b/Bugzilla/User/Setting.pm
@@ -398,7 +398,7 @@ Returns:     a pointer to a hash of settings
 
 Description: Removes an existing setting and the options.
 
-Params:      C<$name> - string - the name of the new setting
+Params:      C<$name> - string - the name of the setting to be removed.
              C<$options> (optional) - arrayref - contains the existing setting
              choices that shouldn't be removed.
 

--- a/extensions/BugModal/Extension.pm
+++ b/extensions/BugModal/Extension.pm
@@ -61,7 +61,7 @@ sub _alternative_show_bug_format {
     # as the Long Format option
     return $format;
   }
-  return $user->setting('ui_experiments') eq 'on' ? 'modal' : '';
+  return 'modal';
 }
 
 sub template_after_create {
@@ -333,12 +333,7 @@ sub webservice {
 
 sub install_before_final_checks {
   my ($self, $args) = @_;
-  add_setting({
-    name     => 'ui_experiments',
-    options  => ['on', 'off'],
-    default  => 'on',
-    category => 'User Interface'
-  });
+  remove_setting('ui_experiments');
   add_setting({
     name     => 'ui_remember_collapsed',
     options  => ['on', 'off'],

--- a/extensions/BugModal/template/en/default/hook/global/setting-descs-settings.none.tmpl
+++ b/extensions/BugModal/template/en/default/hook/global/setting-descs-settings.none.tmpl
@@ -7,7 +7,6 @@
   #%]
 
 [%
-  setting_descs.ui_experiments = "Use modal user interface"
   setting_descs.ui_remember_collapsed = "Remember visibility of header sections when viewing a bug"
   setting_descs.ui_use_absolute_time = "Use absolute format instead of relative time when viewing a bug"
 %]

--- a/scripts/entrypoint.pl
+++ b/scripts/entrypoint.pl
@@ -138,7 +138,6 @@ sub cmd_load_test_data {
 
   run(
     'perl',        'scripts/generate_bmo_data.pl',
-    '--user-pref', 'ui_experiments=on',
     '--param',     'use_mailer_queue=0'
   );
 


### PR DESCRIPTION
Remove the “experimental UI” setting and always use the modal UI. Goodbye legacy!

Blocked by #1334 and @emceeaich’s “intent to change” email.

## Bugzilla link

[Bug 1273046 - Disable the legacy non-modal bug UI](https://bugzilla.mozilla.org/show_bug.cgi?id=1273046)