### PR TITLE
no bug - Fix indent on dependency tree

### DIFF
--- a/skins/standard/dependency-tree.css
+++ b/skins/standard/dependency-tree.css
@@ -30,7 +30,7 @@
 [role="tree"] ul {
   display: block;
   margin: 0;
-  padding: 0 0 0 22px;
+  padding: 0 0 0 44px;
 }
 
 [role="tree"] li {


### PR DESCRIPTION
Fix wrong indentation on the dependency tree. With the current indent, child bugs may look like on the same level as their parent depending on the grouping. 

Fixed screenshot of [Bug 1451850 dependency tree](https://bugzilla.mozilla.org/showdependencytree.cgi?id=1451850&hide_resolved=1):

![image](https://user-images.githubusercontent.com/2929505/60108358-7779a600-9736-11e9-8843-12feddca3324.png)