### PR TITLE
Bug 1545002 - Clicking on "Reply to this comment" on a private comment should automatically check the private checkbox

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -142,7 +142,8 @@
               </button>
             [% END %]
             <button type="button" class="reply-btn minor iconic" title="Reply to this comment" aria-label="Reply"
-                    [% 'disabled' IF !comment.body %] data-reply-id="[% comment.count FILTER none %]"
+                    [% 'disabled' IF !comment.body %]
+                    data-id="[% comment.id FILTER none %]" data-no="[% comment.count FILTER none %]"
                     data-reply-name="[% comment.author.name || comment.author.nick FILTER html %]">
               <span class="icon" aria-hidden="true"></span>
             </button>

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -892,10 +892,11 @@ $(function() {
     $('.reply-btn')
         .click(function(event) {
             event.preventDefault();
-            var comment_id = $(event.target).data('reply-id');
+            var comment_id = $(event.target).data('id');
+            var comment_no = $(event.target).data('no');
             var comment_author = $(event.target).data('reply-name');
 
-            var prefix = "(In reply to " + comment_author + " from comment #" + comment_id + ")\n";
+            var prefix = "(In reply to " + comment_author + " from comment #" + comment_no + ")\n";
             var reply_text = "";
 
             var quoteMarkdown = function($comment) {
@@ -934,7 +935,7 @@ $(function() {
             }
 
             if (BUGZILLA.user.settings.quote_replies == 'quoted_reply') {
-                var $comment = $('#ct-' + comment_id);
+                var $comment = $('#ct-' + comment_no);
                 if ($comment.attr('data-ismarkdown')) {
                     quoteMarkdown($comment);
                 } else {


### PR DESCRIPTION
This is a bug due to confusion between the comment ID and comment count. Just make sure which is which.

## Bugzilla link

[Bug 1545002 - Clicking on "Reply to this comment" on a private comment should automatically check the private checkbox](https://bugzilla.mozilla.org/show_bug.cgi?id=1545002)