### PR TITLE
no bug - Do not create qa data if not running qa tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ defaults:
         <<: *bmo_env
         BZ_QA_CONF_FILE: /app/.circleci/selenium_test.conf
         BZ_QA_ANSWERS_FILE:  /app/.circleci/checksetup_answers.txt
+        BZ_QA_CONFIG: 1
     - <<: *mysql_image
       environment: *mysql_env
     - <<: *selenium_firefox_image
@@ -173,7 +174,8 @@ jobs:
       - <<: *bmo_slim_image
         environment: *bmo_env
     steps:
-      - checkout
+      - run: |
+          mkdir -p /app && cd /tmp/_circleci_local_build_repo && git ls-files -z | xargs -s 2091853 -0 tar -c | tar -x -C /app && cp -a /tmp/_circleci_local_build_repo/.git /app
       - attach_workspace:
           at: /app/build_info
       - run: |

--- a/scripts/entrypoint.pl
+++ b/scripts/entrypoint.pl
@@ -142,9 +142,12 @@ sub cmd_load_test_data {
     '--param',     'use_mailer_queue=0'
   );
 
-  chdir '/app/qa/config';
-  say 'chdir(/app/qa/config)';
-  run('perl', 'generate_test_data.pl');
+  if ($ENV{BZ_QA_CONFIG}) {
+    chdir '/app/qa/config';
+    say 'chdir(/app/qa/config)';
+    run('perl', 'generate_test_data.pl');
+    chdir '/app';
+  }
 }
 
 sub cmd_test_webservices {


### PR DESCRIPTION
Needed to not run script to create legacy QA data when running from conduit-suite or other modes. It should only run when running the webservices and selenium tests in CircleCI.