### PR TITLE
Bug 1562139 - "Edit Search" broken

### DIFF
--- a/template/en/default/search/custom-search.html.tmpl
+++ b/template/en/default/search/custom-search.html.tmpl
@@ -11,8 +11,8 @@
 PROCESS "global/field-descs.none.tmpl";
 
 _initial = {
-  j_top       => initial.j_top.0 || "AND",
-  conditions  => initial.custom_search || [],
+  j_top       => default.j_top.0 || "AND",
+  conditions  => default.custom_search || [],
 };
 
 _fields = [];


### PR DESCRIPTION
Fix the Custom Search UI not working when a user-defined query is passed via URL params, especially from the Edit Search link. It’s likely due to my bad Replace All during the development.

## Bugzilla link

[Bug 1562139 - "Edit Search" broken](https://bugzilla.mozilla.org/show_bug.cgi?id=1562139)