### PR TITLE
Bug 1563269 - Stray "from" when redirecting needinfo

### DIFF
--- a/extensions/Needinfo/template/en/default/bug/needinfo.html.tmpl
+++ b/extensions/Needinfo/template/en/default/bug/needinfo.html.tmpl
@@ -183,7 +183,7 @@ $(function() {
         <input type="checkbox" name="needinfo" id="needinfo" value="1">
       </td>
       <td>
-        <label for="needinfo" id="needinfo_from_label">Request information</label> from
+        <label for="needinfo" id="needinfo_from_label">Request information from</label>
         <select name="needinfo_type" id="needinfo_type" style="display:none;" aria-label="Request info actions">
           <option value="needinfo_from" selected="true">Need more information from</option>
           <option value="redirect_to">Redirect needinfo request to</option>


### PR DESCRIPTION
Fix a wrong label for requesting info.

## Bugzilla link

[Bug 1563269 - Stray "from" when redirecting needinfo](https://bugzilla.mozilla.org/show_bug.cgi?id=1563269)