### PR TITLE
Bug 1563312 - Needinfo links at top of bug goes to #c0 rather than relevant comment

### DIFF
--- a/Bugzilla/DB/Mysql.pm
+++ b/Bugzilla/DB/Mysql.pm
@@ -205,7 +205,7 @@ sub sql_to_days {
 sub sql_date_format {
   my ($self, $date, $format) = @_;
 
-  $format = "%Y.%m.%d %H:%i:%s" if !$format;
+  $format = "%Y-%m-%d %H:%i:%s" if !$format;
 
   return "DATE_FORMAT($date, " . $self->quote($format) . ")";
 }

--- a/Bugzilla/DB/Oracle.pm
+++ b/Bugzilla/DB/Oracle.pm
@@ -177,7 +177,7 @@ sub sql_fulltext_search {
 sub sql_date_format {
   my ($self, $date, $format) = @_;
 
-  $format = "%Y.%m.%d %H:%i:%s" if !$format;
+  $format = "%Y-%m-%d %H:%i:%s" if !$format;
 
   $format =~ s/\%Y/YYYY/g;
   $format =~ s/\%y/YY/g;

--- a/Bugzilla/DB/Pg.pm
+++ b/Bugzilla/DB/Pg.pm
@@ -135,7 +135,7 @@ sub sql_to_days {
 sub sql_date_format {
   my ($self, $date, $format) = @_;
 
-  $format = "%Y.%m.%d %H:%i:%s" if !$format;
+  $format = "%Y-%m-%d %H:%i:%s" if !$format;
 
   $format =~ s/\%Y/YYYY/g;
   $format =~ s/\%y/YY/g;

--- a/Bugzilla/DB/Sqlite.pm
+++ b/Bugzilla/DB/Sqlite.pm
@@ -223,7 +223,7 @@ sub sql_to_days {
 
 sub sql_date_format {
   my ($self, $date, $format) = @_;
-  $format = "%Y.%m.%d %H:%M:%S" if !$format;
+  $format = "%Y-%m-%d %H:%M:%S" if !$format;
   $format =~ s/\%i/\%M/g;
   return "STRFTIME(" . $self->quote($format) . ", $date)";
 }

--- a/Bugzilla/Flag.pm
+++ b/Bugzilla/Flag.pm
@@ -80,9 +80,9 @@ sub DB_COLUMNS {
     requestee_id
     setter_id
     status),
-    $dbh->sql_date_format('creation_date', '%Y.%m.%d %H:%i:%s')
+    $dbh->sql_date_format('creation_date', '%Y-%m-%d %H:%i:%s')
     . ' AS creation_date',
-    $dbh->sql_date_format('modification_date', '%Y.%m.%d %H:%i:%s')
+    $dbh->sql_date_format('modification_date', '%Y-%m-%d %H:%i:%s')
     . ' AS modification_date';
 }
 
@@ -479,7 +479,7 @@ sub update {
     $dbh->do('UPDATE flags SET modification_date = ? WHERE id = ?',
       undef, ($timestamp, $self->id));
     $self->{'modification_date'}
-      = format_time($timestamp, '%Y.%m.%d %T', Bugzilla->local_timezone);
+      = format_time($timestamp, '%Y-%m-%d %T', Bugzilla->local_timezone);
     Bugzilla->memcached->clear({table => 'flags', id => $self->id});
   }
 
@@ -530,8 +530,8 @@ sub update_flags {
       # This is a new flag.
       my $flag = $class->create($new_flag, $timestamp);
       $new_flag->{id}                = $flag->id;
-      $new_flag->{creation_date}     = format_time($timestamp, '%Y.%m.%d %H:%i:%s');
-      $new_flag->{modification_date} = format_time($timestamp, '%Y.%m.%d %H:%i:%s');
+      $new_flag->{creation_date}     = format_time($timestamp, '%Y-%m-%d %H:%i:%s');
+      $new_flag->{modification_date} = format_time($timestamp, '%Y-%m-%d %H:%i:%s');
       $class->notify($new_flag, undef, $self, $timestamp);
     }
     else {

--- a/extensions/BMO/lib/Reports/UserActivity.pm
+++ b/extensions/BMO/lib/Reports/UserActivity.pm
@@ -114,7 +114,7 @@ sub report {
                    bugs_activity.bug_id,
                    bugs_activity.attach_id,
                    "
-      . $dbh->sql_date_format('bugs_activity.bug_when', '%Y.%m.%d %H:%i:%s')
+      . $dbh->sql_date_format('bugs_activity.bug_when', '%Y-%m-%d %H:%i:%s')
       . " AS ts,
                    bugs_activity.removed,
                    bugs_activity.added,
@@ -140,7 +140,7 @@ sub report {
                    NULL as attach_id,
                    "
       . $dbh->sql_date_format('longdescs_tags_activity.bug_when',
-      '%Y.%m.%d %H:%i:%s')
+      '%Y-%m-%d %H:%i:%s')
       . " AS bug_when,
                    longdescs_tags_activity.removed,
                    longdescs_tags_activity.added,
@@ -163,7 +163,7 @@ sub report {
                    bugs.bug_id,
                    NULL AS attach_id,
                    "
-      . $dbh->sql_date_format('bugs.creation_ts', '%Y.%m.%d %H:%i:%s') . " AS ts,
+      . $dbh->sql_date_format('bugs.creation_ts', '%Y-%m-%d %H:%i:%s') . " AS ts,
                    '(new bug)' AS removed,
                    bugs.short_desc AS added,
                    profiles.login_name,
@@ -182,7 +182,7 @@ sub report {
                    'longdesc' AS name,
                    longdescs.bug_id,
                    NULL AS attach_id,
-                   DATE_FORMAT(longdescs.bug_when, '%Y.%m.%d %H:%i:%s') AS ts,
+                   DATE_FORMAT(longdescs.bug_when, '%Y-%m-%d %H:%i:%s') AS ts,
                    '' AS removed,
                    '' AS added,
                    profiles.login_name,
@@ -203,7 +203,7 @@ sub report {
                    attachments.bug_id,
                    attachments.attach_id,
                    "
-      . $dbh->sql_date_format('attachments.creation_ts', '%Y.%m.%d %H:%i:%s')
+      . $dbh->sql_date_format('attachments.creation_ts', '%Y-%m-%d %H:%i:%s')
       . " AS ts,
                    '(new attachment)' AS removed,
                    attachments.description AS added,

--- a/extensions/InlineHistory/Extension.pm
+++ b/extensions/InlineHistory/Extension.pm
@@ -208,7 +208,7 @@ sub _add_duplicates {
   my $dbh = Bugzilla->dbh;
   my $sth = $dbh->prepare("
         SELECT profiles.login_name, "
-      . $dbh->sql_date_format('bug_when', '%Y.%m.%d %H:%i:%s') . ",
+      . $dbh->sql_date_format('bug_when', '%Y-%m-%d %H:%i:%s') . ",
                extra_data
           FROM longdescs
                INNER JOIN profiles ON profiles.userid = longdescs.who

--- a/request.cgi
+++ b/request.cgi
@@ -104,7 +104,7 @@ sub queue {
                 flags.attach_id, attachments.description,
                 requesters.realname, requesters.login_name,
                 requestees.realname, requestees.login_name, COUNT(privs.group_id),
-    " . $dbh->sql_date_format('flags.modification_date', '%Y.%m.%d %H:%i') . ",
+    " . $dbh->sql_date_format('flags.modification_date', '%Y-%m-%d %H:%i') . ",
                 attachments.mimetype,
                 attachments.ispatch,
                 bugs.bug_status,


### PR DESCRIPTION
This is due to a wrong date comparison between `%Y-%m-%d` (hyphens) and `%Y.%m.%d` (dots) in [`find_activity_id_for_flag()`](https://github.com/mozilla-bteam/bmo/blob/master/extensions/BugModal/lib/ActivityStream.pm#L97-L128). Use `%Y-%m-%d` intensively to solve the issue.

## Bugzilla link

[Bug 1563312 - Needinfo links at top of bug goes to #c0 rather than relevant comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1563312)