### PR TITLE
Bug 1562804 - status NEW is not present in the status changed section in a bugzilla user profile

### DIFF
--- a/extensions/UserProfile/template/en/default/pages/user_profile.html.tmpl
+++ b/extensions/UserProfile/template/en/default/pages/user_profile.html.tmpl
@@ -256,7 +256,7 @@
 
 <tr>
   <td>&nbsp;</td>
-  <th>Bugs resolved as</th>
+  <th>[% terms.Bugs %] resolved as</th>
   <td colspan="2">
     RESOLVED ([% statuses.item('RESOLVED') || 0 FILTER html %]),
     FIXED ([% statuses.item('RESOLVED/FIXED') || 0 FILTER html %]),

--- a/extensions/UserProfile/template/en/default/pages/user_profile.html.tmpl
+++ b/extensions/UserProfile/template/en/default/pages/user_profile.html.tmpl
@@ -256,7 +256,7 @@
 
 <tr>
   <td>&nbsp;</td>
-  <th>Statuses changed</th>
+  <th>Bugs resolved as</th>
   <td colspan="2">
     RESOLVED ([% statuses.item('RESOLVED') || 0 FILTER html %]),
     FIXED ([% statuses.item('RESOLVED/FIXED') || 0 FILTER html %]),


### PR DESCRIPTION
## Bugzilla Link

[Bug 1562804 - status NEW is not present in the status changed section in a bugzilla user profile](https://bugzilla.mozilla.org/show_bug.cgi?id=1562804)