### PR TITLE
Bug 1556727 - Replace “Email sent to” message with a toast notification

### DIFF
--- a/Bugzilla/Test/Selenium.pm
+++ b/Bugzilla/Test/Selenium.pm
@@ -91,7 +91,9 @@ sub is_text_present {
   my ($self, $text) = @_;
   TRACE("is_text_present: $text");
   return 0 unless $text;
-  my $body = $self->driver->get_body();
+  # Execute script directly because `get_body()` doesn't contain hidden text
+  my $body = $self->driver->execute_script(
+    "return document.body.textContent.replace(/\\s+/g, ' ')");
   if ($text =~ /^regexp:(.*)$/) {
     return $body =~ /$1/ ? 1 : 0;
   }

--- a/extensions/BugModal/template/en/default/bug/show-modal.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug/show-modal.html.tmpl
@@ -13,7 +13,10 @@
   [% header_done = 1 %]
 [% END %]
 
-[%# Display changes to bugs that happened in the last request #%]
+[%# Display a short summary of the change when a bug or attachment is created or updated.
+  # The user will see a toast notification, and verbose messages are hidden by default. #%]
+[% change_short_summary = '' %]
+
 [% sentmail = c.flash("last_sent_changes") %]
 [% FOREACH item = sentmail %]
   [% INCLUDE bug/process/results.html.tmpl
@@ -21,6 +24,16 @@
      type = item.type
      recipient_count = item.recipient_count
    %]
+  [% IF loop.first %]
+    [% change_short_summary = BLOCK %]
+      [% IF item.type == 'created' %]
+        [% terms.Bug %] created.
+      [% ELSE %]
+        Changes submitted.
+      [% END %]
+      [%+ PROCESS "bug/process/bugmail.html.tmpl" recipient_count = item.recipient_count %]
+    [% END %]
+  [% END %]
 [% END %]
 
 [% sentattachmentmail = c.flash("last_sent_attachment_changes") %]
@@ -31,6 +44,16 @@
      recipient_count = item.recipient_count
      content_type_method = item.content_type_method
    %]
+  [% IF loop.first %]
+    [% change_short_summary = BLOCK %]
+      [% IF item.type == 'created' %]
+        Attachment created.
+      [% ELSE %]
+        Attachment updated.
+      [% END %]
+      [%+ PROCESS "bug/process/bugmail.html.tmpl" recipient_count = item.recipient_count %]
+    [% END %]
+  [% END %]
 [% END %]
 
 [% INCLUDE bug_modal/edit.html.tmpl %]

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -164,7 +164,7 @@
 
 <div role="status" id="io-error" style="display:none"></div>
 <div role="status" id="floating-message" style="display:none">
-  <div id="floating-message-text"></div>
+  <div id="floating-message-text">[% change_short_summary FILTER html %]</div>
 </div>
 
 [% WRAPPER bug_modal/module.html.tmpl

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -1204,6 +1204,14 @@ a.lightbox-icon.markdown {
 }
 
 /**
+ * verbose change summary
+ */
+
+.change-summary {
+  display: none;
+}
+
+/**
  * search navigation
  */
 

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -204,6 +204,11 @@ $(function() {
             $.scrollTo($('#bottom-actions'));
         });
 
+    // show floating message after creating/updating a bug/attachment
+    if ($('#floating-message-text').text()) {
+        $('#floating-message').fadeIn(250).delay(4000).fadeOut();
+    }
+
     // hide floating message when clicked
     $('#floating-message')
         .click(function(event) {

--- a/qa/t/test_bmo_autolinkification.t
+++ b/qa/t/test_bmo_autolinkification.t
@@ -29,8 +29,7 @@ $sel->type_ok("comment", "bp-63f096f7-253b-4ee2-ae3d-8bb782090824");
 $sel->click_ok("bottom-save-btn");
 $sel->wait_for_page_to_load_ok(WAIT_TIME);
 $sel->title_like(qr/\d+ \S $bug_summary/, "crash report added");
-$sel->click_ok("link=bug $bug_id");
-$sel->wait_for_page_to_load_ok(WAIT_TIME);
+go_to_bug($sel, $bug_id);
 attribute_is($sel, 'bp-63f096f7-253b-4ee2-ae3d-8bb782090824',
   'https://crash-stats.mozilla.org/report/index/63f096f7-253b-4ee2-ae3d-8bb782090824'
 );
@@ -39,9 +38,7 @@ $sel->type_ok("comment", "CVE-2010-2884");
 $sel->click_ok("bottom-save-btn");
 $sel->wait_for_page_to_load_ok(WAIT_TIME);
 $sel->title_like(qr/\d+ \S $bug_summary/, "cve added");
-$sel->click_ok("link=bug $bug_id");
-$sel->wait_for_page_to_load_ok(WAIT_TIME);
-
+go_to_bug($sel, $bug_id);
 attribute_is($sel, 'CVE-2010-2884',
   'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2010-2884');
 
@@ -49,9 +46,7 @@ $sel->type_ok("comment", "r12345");
 $sel->click_ok("bottom-save-btn");
 $sel->wait_for_page_to_load_ok(WAIT_TIME);
 $sel->title_like(qr/\d+ \S $bug_summary/, "svn revision added");
-$sel->click_ok("link=bug $bug_id");
-$sel->wait_for_page_to_load_ok(WAIT_TIME);
-
+go_to_bug($sel, $bug_id);
 attribute_is($sel, 'r12345',
   'https://viewvc.svn.mozilla.org/vc?view=rev&revision=12345');
 

--- a/qa/t/test_flags.t
+++ b/qa/t/test_flags.t
@@ -385,8 +385,7 @@ my $attachment1_id = $1;
 
 # Now create another attachment, and set requestees.
 
-$sel->click_ok(
-  "//a[contains(text(),'Create\n Another Attachment to Bug $bug1_id')]");
+$sel->click_ok("link=Attach File");
 $sel->wait_for_page_to_load_ok(WAIT_TIME);
 $sel->title_is("Create New Attachment for Bug #$bug1_id");
 $sel->attach_file('//input[@name="data"]', $config->{attachment_file});
@@ -413,8 +412,7 @@ my $attachment2_id = $1;
 
 # Create a third attachment, but we now set the MIME type manually.
 
-$sel->click_ok(
-  "//a[contains(text(),'Create\n Another Attachment to Bug $bug1_id')]");
+$sel->click_ok("link=Attach File");
 $sel->wait_for_page_to_load_ok(WAIT_TIME);
 $sel->title_is("Create New Attachment for Bug #$bug1_id");
 $sel->attach_file('//input[@name="data"]', $config->{attachment_file});

--- a/qa/t/test_time_summary.t
+++ b/qa/t/test_time_summary.t
@@ -39,8 +39,7 @@ $sel->wait_for_page_to_load_ok(WAIT_TIME);
 $sel->is_text_present_ok("Changes submitted for bug $test_bug_1");
 
 # Make sure the correct bug is redisplayed.
-$sel->click_ok("link=bug $test_bug_1");
-$sel->wait_for_page_to_load_ok(WAIT_TIME);
+go_to_bug($sel, $test_bug_1);
 $sel->title_like(qr/^$test_bug_1/, "Display bug $test_bug_1");
 $sel->is_text_present_ok("I did some work");
 $sel->is_text_present_ok("Hours Worked: 2.6");

--- a/template/en/default/bug/process/attachment-results.html.tmpl
+++ b/template/en/default/bug/process/attachment-results.html.tmpl
@@ -30,7 +30,7 @@
 
 [% PROCESS global/variables.none.tmpl %]
 
-<dl>
+<dl class="change-summary attachment">
   <dt>
     [% IF type == 'created' %]
         <a title="[% attachment.description FILTER html %]"
@@ -62,7 +62,7 @@
   </dd>
 </dl>
 
-<p>
+<p class="change-summary attachment extra">
 <a href="[% basepath FILTER none %]attachment.cgi?bugid=[% attachment.bug_id FILTER none %]&amp;action=enter">Create
  Another Attachment to [% terms.Bug %] [%+ attachment.bug_id FILTER none %]</a>
 </p>

--- a/template/en/default/bug/process/bugmail.html.tmpl
+++ b/template/en/default/bug/process/bugmail.html.tmpl
@@ -27,10 +27,10 @@
 [% USE Bugzilla %]
 [% PROCESS global/variables.none.tmpl %]
 
-<div id="bugmail_summary_[% mailing_bugid FILTER none %]_short">
-  [% IF recipient_count > 0 %]
-    Email sent to [% recipient_count FILTER html %] recipient[% 's' UNLESS recipient_count == 1 %].
-  [% ELSE %]
-    No emails were sent.
-  [% END %]
-</div>
+[% IF recipient_count > 1 %]
+  Email sent to [% recipient_count FILTER none %] recipients.
+[% ELSIF recipient_count == 1 %]
+  Email sent to 1 recipient.
+[% ELSE %]
+  No emails sent.
+[% END %]

--- a/template/en/default/bug/process/results.html.tmpl
+++ b/template/en/default/bug/process/results.html.tmpl
@@ -49,7 +49,7 @@
 
 [% Hook.process('title') %]
 
-<dl>
+<dl class="change-summary bug">
   <dt>[% title.$type %]</dt>
   <dd>
     [% PROCESS "bug/process/bugmail.html.tmpl" mailing_bugid = id %]


### PR DESCRIPTION
Hide the change summary displayed after creating/updating a bug/attachment, and instead show a shorter summary as a toast notification just like what you’ll see when clicking the Copy Summary or Follow button. This makes the UI less cluttered, and allows to fix the bug header at the top of the page.

Note: this change actually _hides_ the “email sent to” message, so people really want it can show it using a user stylesheet. Once the bug form submission is replaced with a background API request, it will be completely removed.

## Bugzilla link

[Bug 1556727 - Replace “Email sent to” message with a toast notification](https://bugzilla.mozilla.org/show_bug.cgi?id=1556727)