### PR TITLE
Bug 1380437 follow-up - Send API token only if available

### DIFF
--- a/js/util.js
+++ b/js/util.js
@@ -391,6 +391,7 @@ Bugzilla.API = class API {
    */
   static _init(endpoint, method = 'GET', params = {}) {
     const url = new URL(`${BUGZILLA.config.basepath}rest/${endpoint}`, location.origin);
+    const token = BUGZILLA.api_token;
 
     if (method === 'GET') {
       for (const [key, value] of Object.entries(params)) {
@@ -410,7 +411,9 @@ Bugzilla.API = class API {
     }
 
     /** @todo Remove this once Bug 1477163 is solved */
-    url.searchParams.set('Bugzilla_api_token', BUGZILLA.api_token);
+    if (token) {
+      url.searchParams.set('Bugzilla_api_token', token);
+    }
 
     return new Request(url, {
       method,


### PR DESCRIPTION
Forgot to have this in #665. `BUGZILLA.api_token` will be empty for logged-out users, and sending an empty token will lead to a 400 Bad Request. The `Bugzilla_api_token` param should be set only when the token is given. Some features require an API key, and the API will return an error anyway in such cases.