### PR TITLE
Bug 1565319 - FF Version selection does not update from client version, shows previous reported version

### DIFF
--- a/enter_bug.cgi
+++ b/enter_bug.cgi
@@ -357,8 +357,6 @@ else {
 #   THEN use the version from the parent bug
 # ELSE IF a version is supplied in the URL
 #   THEN use it
-# ELSE IF there is a version in the cookie
-#   THEN use it (Posting a bug sets a cookie for the current version.)
 # ELSE
 #   The default version is the last one in the list (which, it is
 #   hoped, will be the most recent one).
@@ -367,18 +365,11 @@ else {
 # parameter.
 $vars->{'version'} = $product->versions;
 
-my $version_cookie = $cgi->cookie("VERSION-" . $product->name);
-
 if (($cloned_bug_id) && ($product->name eq $cloned_bug->product)) {
   $default{'version'} = $cloned_bug->version;
 }
 elsif (formvalue('version')) {
   $default{'version'} = formvalue('version');
-}
-elsif (defined $version_cookie
-  and grep { $_->name eq $version_cookie } @{$vars->{'version'}})
-{
-  $default{'version'} = $version_cookie;
 }
 else {
   $default{'version'} = $vars->{'version'}->[$#{$vars->{'version'}}]->name;

--- a/extensions/GuidedBugEntry/web/js/guided.js
+++ b/extensions/GuidedBugEntry/web/js/guided.js
@@ -692,10 +692,6 @@ var bugForm = {
         }
       }
     }
-    if (!defaultVersion) {
-      // load last selected version
-      defaultVersion = YAHOO.util.Cookie.get('VERSION-' + productName);
-    }
 
     if (elVersions.length > 1) {
       // more than one version, show select

--- a/post_bug.cgi
+++ b/post_bug.cgi
@@ -171,16 +171,6 @@ my $timestamp
   = $dbh->selectrow_array('SELECT creation_ts FROM bugs WHERE bug_id = ?',
   undef, $id);
 
-# Set Version cookie, but only if the user actually selected
-# a version on the page.
-if (defined $cgi->param('version')) {
-  $cgi->send_cookie(
-    -name    => "VERSION-" . $bug->product,
-    -value   => $bug->version,
-    -expires => "Fri, 01-Jan-2038 00:00:00 GMT"
-  );
-}
-
 # We don't have to check if the user can see the bug, because a user filing
 # a bug can always see it. You can't change reporter_accessible until
 # after the bug is filed.


### PR DESCRIPTION
Stop storing the Firefox version in a cookie and reusing it on the New Bug page, because it confuses users. With this change, the product’s default version (currently undefined) will be used. The client version won’t be used, because the Version field is almost deprecated in favour of status flags.

## Bugzilla link

[Bug 1565319 - FF Version selection does not update from client version, shows previous reported version](https://bugzilla.mozilla.org/show_bug.cgi?id=1565319)