### PR TITLE
Bug 1565872 - Fix miscellaneous typos and spelling inconsistencies

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -57,7 +57,7 @@ severity = 2
 
 # This is not a good policy.
 # Non-explicit return is often easier to read.
-# think of javascript arrow functions.
+# think of JavaScript arrow functions.
 [-Subroutines::RequireFinalReturn]
 
 # This test is technically correct but I do not care.

--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -895,7 +895,7 @@ Note that items accessible via this object are demand-loaded when requested.
 
 For something to be added to this object, it should either be able to benefit
 from persistence when run under mod_perl (such as the a C<template> object),
-or should be something which is globally required by a large ammount of code
+or should be something which is globally required by a large amount of code
 (such as the current C<user> object).
 
 =head1 METHODS
@@ -1022,7 +1022,7 @@ If false (or not specified), this method will return an arrayref of
 the requested fields.
 
 If true, this method will return a hashref of fields, where the keys
-are field names and the valules are L<Bugzilla::Field> objects.
+are field names and the values are L<Bugzilla::Field> objects.
 
 =item C<type>
 
@@ -1123,7 +1123,7 @@ of features, see C<OPTIONAL_MODULES> in C<Bugzilla::Install::Requirements>.
 
 =item C<audit>
 
-Feeds the provided message into our centralised auditing system.
+Feeds the provided message into our centralized auditing system.
 
 =item C<markdown>
 

--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -80,9 +80,9 @@ sub init_page {
     Bugzilla::Logging->fields->{remote_ip} = remote_ip();
   }
 
-  # Because this function is run live from perl "use" commands of
+  # Because this function is run live from Perl "use" commands of
   # other scripts, we're skipping the rest of this function if we get here
-  # during a perl syntax check (perl -c, like we do during the
+  # during a Perl syntax check (perl -c, like we do during the
   # 001compile.t test).
   return if $^C;
 
@@ -717,7 +717,7 @@ sub local_timezone {
     ||= DateTime::TimeZone->new(name => 'local');
 }
 
-# Send messages to syslog for the auditing systems (eg. mozdef) to pick up.
+# Send messages to syslog for the auditing systems (e.g. mozdef) to pick up.
 sub audit {
   my (undef, $message) = @_;
   state $logger = Log::Log4perl->get_logger("audit");
@@ -885,7 +885,7 @@ all passed from the caller, and the caller's caller, and....
 
 =item *
 
-We can reuse objects across requests using mod_perl where appropriate (eg
+We can reuse objects across requests using mod_perl where appropriate (e.g.
 templates), whilst destroying those which are only valid for a single request
 (such as the current user)
 
@@ -1102,7 +1102,7 @@ Change the database object to refer to the main database.
 
 The current Parameters of Bugzilla, as a hashref. If C<data/params>
 does not exist, then we return an empty hashref. If C<data/params>
-is unreadable or is not valid perl, we C<die>.
+is unreadable or is not valid Perl, we C<die>.
 
 =item C<local_timezone>
 
@@ -1143,7 +1143,7 @@ collisions.
 
 =item B<Request Cache>
 
-The request cache is a hashref which supports caching any perl variable for the
+The request cache is a hashref which supports caching any Perl variable for the
 duration of the current request. At the end of the current request the contents
 of this cache are cleared.
 
@@ -1155,7 +1155,7 @@ Bugzilla.
 
 =item C<request_cache>
 
-Returns a hashref which can be checked and modified to store any perl variable
+Returns a hashref which can be checked and modified to store any Perl variable
 for the duration of the current request.
 
 =item C<clear_request_cache>
@@ -1166,7 +1166,7 @@ Removes all entries from the C<request_cache>.
 
 =item B<Process Cache>
 
-The process cache is a hashref which support caching of any perl variable. If
+The process cache is a hashref which support caching of any Perl variable. If
 Bugzilla is configured to run using Apache mod_perl, the contents of this cache
 are persisted across requests for the lifetime of the Apache worker process
 (which varies depending on the SizeLimit configuration in mod_perl.pl).
@@ -1181,7 +1181,7 @@ is running (for example the path where Bugzilla is installed).
 
 =item C<process_cache>
 
-Returns a hashref which can be checked and modified to store any perl variable
+Returns a hashref which can be checked and modified to store any Perl variable
 for the duration of the current process (mod_perl) or request (mod_cgi).
 
 =back

--- a/Bugzilla/App/Command/report_ping.pm
+++ b/Bugzilla/App/Command/report_ping.pm
@@ -17,7 +17,7 @@ use Mojo::Util 'getopt';
 use PerlX::Maybe 'maybe';
 use Try::Tiny;
 
-has description => 'send a report ping to a url';
+has description => 'send a report ping to a URL';
 has usage       => sub { shift->extract_usage };
 
 sub run {
@@ -130,7 +130,7 @@ __END__
 
 =head1 NAME
 
-Bugzilla::App::Command::report_ping - descriptionsend a report ping to a url';
+Bugzilla::App::Command::report_ping - descriptionsend a report ping to a URL';
 
 =head1 SYNOPSIS
 
@@ -140,17 +140,17 @@ Bugzilla::App::Command::report_ping - descriptionsend a report ping to a url';
 
   Options:
     -h, --help               Print a brief help message and exits.
-    -u, --base-url           URL to send the json documents to.
+    -u, --base-url           URL to send the JSON documents to.
     -r, --rows num           (Optional) Number of requests to send at once. Default: 10.
     -p, --page num           (Optional) Page to start on. Default: 1
     --since str              (Optional) Typically the date of the last run.
     --class word             (Optional) Report class to use. Default: Simple
-    --test                   Validate the json documents against the json schema.
-    --dump-schema            Print the json schema.
+    --test                   Validate the JSON documents against the JSON schema.
+    --dump-schema            Print the JSON schema.
 
 =head1 DESCRIPTION
 
-send a report ping to a url.
+send a report ping to a URL.
 
 =head1 ATTRIBUTES
 

--- a/Bugzilla/App/Command/report_ping.pm
+++ b/Bugzilla/App/Command/report_ping.pm
@@ -130,7 +130,7 @@ __END__
 
 =head1 NAME
 
-Bugzilla::App::Command::report_ping - descriptionsend a report ping to a URL';
+Bugzilla::App::Command::report_ping - Send a report ping to a URL';
 
 =head1 SYNOPSIS
 

--- a/Bugzilla/Attachment/PatchReader.pm
+++ b/Bugzilla/Attachment/PatchReader.pm
@@ -83,8 +83,8 @@ sub process_diff {
 
     setup_template_patch_reader($last_reader, $format, $context, $vars);
 
-    # The patch is going to be displayed in a HTML page and if the utf8
-    # param is enabled, we have to encode attachment data as utf8.
+    # The patch is going to be displayed in a HTML page and if the UTF-8
+    # param is enabled, we have to encode attachment data as UTF-8.
     if (Bugzilla->params->{'utf8'}) {
       $attachment->data;    # Populate ->{data}
       utf8::decode($attachment->{data});
@@ -106,7 +106,7 @@ sub process_interdiff {
     }
   }
 
-  # Encode attachment data as utf8 if it's going to be displayed in a HTML
+  # Encode attachment data as UTF-8 if it's going to be displayed in a HTML
   # page using the UTF-8 encoding.
   if ($format ne 'raw' && Bugzilla->params->{'utf8'}) {
     $old_attachment->data;    # Populate ->{data}

--- a/Bugzilla/Auth.pm
+++ b/Bugzilla/Auth.pm
@@ -518,7 +518,7 @@ password.
 
 If an Info Getter returns only a C<user_id> and no username/password,
 then it MUST NOT require verification. If an Info Getter requires
-verfication, then it MUST return at least a C<username>.
+verification, then it MUST return at least a C<username>.
 
 =head2 The Verifier
 

--- a/Bugzilla/Auth.pm
+++ b/Bugzilla/Auth.pm
@@ -396,7 +396,7 @@ on what constant you pass into it:
 =head2 C<LOGIN_OPTIONAL>
 
 A login is never required to access this data. Attempting to login is
-still useful, because this allows the page to be personalised. Note that
+still useful, because this allows the page to be personalized. Note that
 an incorrect login will still trigger an error, even though the lack of
 a login will be OK.
 

--- a/Bugzilla/Auth/Login/APIKey.pm
+++ b/Bugzilla/Auth/Login/APIKey.pm
@@ -52,7 +52,7 @@ sub get_login_info {
 
   if (!$api_key or $api_key->api_key ne $api_key_text) {
 
-    # The second part checks the correct capitalisation. Silly MySQL
+    # The second part checks the correct capitalization. Silly MySQL
     ThrowUserError("api_key_not_valid");
   }
   elsif ( $api_key->sticky

--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -889,7 +889,7 @@ sub create {
   my $dbh = Bugzilla->dbh;
 
   # BMO - allow parameter alteration before creation.  also add support for
-  # fields which are not bug columns (eg bug_mentors). extensions should move
+  # fields which are not bug columns (e.g. bug_mentors). extensions should move
   # fields from $params to $stash, then use the bug_end_of_create hook to
   # update the database
   my $stash = {};
@@ -4314,7 +4314,7 @@ sub groups {
   }
 
   # BMO: if required, hack in groups exposed by -visible membership
-  # (eg mozilla-employee-confidential-visible), so reporters can add the
+  # (e.g. mozilla-employee-confidential-visible), so reporters can add the
   # bug to a group on show_bug.
   # if the bug is already in the group, the user will not be able to remove
   # it unless they are a true group member.

--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -3553,7 +3553,7 @@ sub remove_see_also {
       {field => 'see_also', oldvalue => $url, privs => $privs});
   }
 
-  # Since we remove also the url from the referenced bug,
+  # Since we remove also the URL from the referenced bug,
   # we need to notify changes for that bug too.
   $removed_bug_url = $removed_bug_url->[0];
   if ( !$skip_recursion
@@ -4746,7 +4746,7 @@ sub _join_activity_entries {
     }
   }
 
-  # Assume bug_file_loc contain a single url, don't insert a delimiter
+  # Assume bug_file_loc contain a single URL, don't insert a delimiter
   if ($field eq 'bug_file_loc') {
     return $current_change . $new_change;
   }

--- a/Bugzilla/BugMail.pm
+++ b/Bugzilla/BugMail.pm
@@ -616,8 +616,8 @@ sub _get_new_bugmail_fields {
   my @diffs;
 
   # Show fields in the same order as the DEFAULT_FIELDS list, which mirrors
-  # 4.0's behavour and provides sane grouping of similar fields.
-  # Any additional fields are sorted by descrsiption
+  # 4.0's behavior and provides sane grouping of similar fields.
+  # Any additional fields are sorted by description
   my @prepend;
   foreach my $name (map { $_->{name} } Bugzilla::Field::DEFAULT_FIELDS) {
     my $idx = firstidx { $_->name eq $name } @fields;

--- a/Bugzilla/BugUrl.pm
+++ b/Bugzilla/BugUrl.pm
@@ -50,7 +50,7 @@ use constant VALIDATORS => {
 };
 
 # This is the order we go through all of subclasses and
-# pick the first one that should handle the url. New
+# pick the first one that should handle the URL. New
 # subclasses should be added at the end of the list.
 use constant SUB_CLASSES => qw(
   Bugzilla::BugUrl::Bugzilla::Local

--- a/Bugzilla/BugUrl/Bugzilla/Local.pm
+++ b/Bugzilla/BugUrl/Bugzilla/Local.pm
@@ -47,7 +47,7 @@ sub should_handle {
 
   # Check if it is a local Bugzilla uri and call
   # Bugzilla::BugUrl::Bugzilla to check if it's a valid Bugzilla
-  # see also url.
+  # See Also URL.
   my $canonical_local = URI->new($class->local_uri)->canonical;
   if (  $canonical_local->authority eq $uri->canonical->authority
     and $canonical_local->path eq $uri->canonical->path)
@@ -69,7 +69,7 @@ sub _check_value {
   }
   else {
     # It's not a word, then we have to check
-    # if it's a valid Bugzilla url.
+    # if it's a valid Bugzilla URL.
     $uri = $class->SUPER::_check_value($uri);
   }
 

--- a/Bugzilla/BugUserLastVisit.pm
+++ b/Bugzilla/BugUserLastVisit.pm
@@ -14,7 +14,7 @@ use warnings;
 use parent qw(Bugzilla::Object);
 
 #####################################################################
-# Overriden Constants that are used as methods
+# Overridden Constants that are used as methods
 #####################################################################
 
 use constant DB_TABLE       => 'bug_user_last_visit';

--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -73,7 +73,7 @@ sub new {
     if (!grep($_ eq $script, @whitelist)) {
 
       # apache collapses // to / in $ENV{PATH_INFO} but not in $self->path_info.
-      # url() requires the full path in ENV in order to generate the correct url.
+      # url() requires the full path in ENV in order to generate the correct URL.
       $ENV{PATH_INFO} = $path;
       DEBUG("redirecting because we see PATH_INFO and don't like it");
       print $self->redirect($self->url(-path => 0, -query => 1));
@@ -88,7 +88,7 @@ sub new {
   if (my $C = $Bugzilla::App::CGI::C) {
     if ($C->url_is_attachment_base and $script ne 'attachment.cgi') {
       DEBUG(
-        "Redirecting to urlbase because the url is in the attachment base and not attachment.cgi"
+        "Redirecting to urlbase because the URL is in the attachment base and not attachment.cgi"
       );
       $self->redirect_to_urlbase();
     }
@@ -113,7 +113,7 @@ sub new {
     # ends up here, and calls ThrowCodeError, and then recurses forever.
     # So don't use it.
     # In fact, we can't use templates at all, because we need a CGI object
-    # to determine the template lang as well as the current url (from the
+    # to determine the template lang as well as the current URL (from the
     # template)
     # Since this is an internal error which indicates a severe browser bug,
     # just die.
@@ -327,7 +327,7 @@ sub _prevent_unsafe_response {
   if (Bugzilla->usage_mode == USAGE_MODE_BROWSER) {
 
     # Safe content types are ones that aren't images.
-    # For now let's assume plain text and html are not valid images.
+    # For now let's assume plain text and HTML are not valid images.
     my $content_type = $headers->{'-type'} // $headers->{'-content_type'}
       // 'text/html';
     my $is_safe_content_type = $content_type =~ $safe_content_type_re;
@@ -388,7 +388,7 @@ sub header {
   }
 
   # We generate a cookie and store it in the request cache
-  # To initiate github login, a form POSTs to github.cgi with the
+  # To initiate GitHub login, a form POSTs to github.cgi with the
   # github_secret as a parameter. It must match the github_secret cookie.
   # this prevents some types of redirection attacks.
   unless ($user->id || $self->{bz_redirecting}) {
@@ -514,7 +514,7 @@ sub param {
 sub _fix_utf8 {
   my $input = shift;
 
-  # The is_utf8 is here in case CGI gets smart about utf8 someday.
+  # The is_utf8 is here in case CGI gets smart about UTF-8 someday.
   utf8::decode($input) if defined $input && !ref $input && !utf8::is_utf8($input);
   return $input;
 }
@@ -626,7 +626,7 @@ sub redirect_search_url {
   # are only redirected if they're under the CGI_URI_LIMIT though.
   my $self_url = $self->self_url();
   if ($self->request_method() ne 'POST' or length($self_url) < CGI_URI_LIMIT) {
-    DEBUG("Redirecting search url");
+    DEBUG("Redirecting search URL");
     print $self->redirect(-url => $self_url);
     exit;
   }
@@ -761,7 +761,7 @@ I<Bugzilla::CGI> also includes additional functions.
 =item C<canonicalize_query(@exclude)>
 
 This returns a sorted string of the parameters whose values are non-empty,
-suitable for use in a url.
+suitable for use in a URL.
 
 Values in C<@exclude> are not included in the result.
 

--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -139,7 +139,7 @@ sub target_uri {
 }
 
 # We want this sorted plus the ability to exclude certain params
-sub canonicalise_query {
+sub canonicalize_query {
   my ($self, @exclude) = @_;
 
   # Reconstruct the URL by concatenating the sorted param=value pairs
@@ -326,7 +326,7 @@ sub _prevent_unsafe_response {
 
   if (Bugzilla->usage_mode == USAGE_MODE_BROWSER) {
 
-    # Safe content types are ones that arn't images.
+    # Safe content types are ones that aren't images.
     # For now let's assume plain text and html are not valid images.
     my $content_type = $headers->{'-type'} // $headers->{'-content_type'}
       // 'text/html';
@@ -737,7 +737,7 @@ Bugzilla::CGI - CGI handling for Bugzilla
 
 This package inherits from the standard CGI module, to provide additional
 Bugzilla-specific functionality. In general, see L<the CGI.pm docs|CGI> for
-documention.
+documentation.
 
 =head1 CHANGES FROM L<CGI.PM|CGI>
 
@@ -758,7 +758,7 @@ I<Bugzilla::CGI> also includes additional functions.
 
 =over 4
 
-=item C<canonicalise_query(@exclude)>
+=item C<canonicalize_query(@exclude)>
 
 This returns a sorted string of the parameters whose values are non-empty,
 suitable for use in a url.

--- a/Bugzilla/CGI/ContentSecurityPolicy.pm
+++ b/Bugzilla/CGI/ContentSecurityPolicy.pm
@@ -292,9 +292,9 @@ style attributes are disabled unless you specify 'unsafe-inline'.
 =head2 upgrade_insecure_requests
 
 The upgrade-insecure-requests directive instructs user agents to treat all of a
-site's unsecure URL's (those serverd over HTTP) as though they have been
+site's insecure URL's (those served over HTTP) as though they have been
 replaced with secure URL's (those served over HTTPS). This directive is intended
-for web sites with large numbers of unsecure legacy URL's that need to be
+for web sites with large numbers of insecure legacy URL's that need to be
 rewritten.
 
 =head1 METHODS

--- a/Bugzilla/CPAN.pm
+++ b/Bugzilla/CPAN.pm
@@ -155,7 +155,7 @@ are installed.
 
 =head2 C<cpan_meta>
 
-Returns a L<CPAN::Meta> from the contents of MYMETA.json in the bugzilla directory.
+Returns a L<CPAN::Meta> from the contents of MYMETA.json in the Bugzilla directory.
 
 =head2 C<preload_features()>
 

--- a/Bugzilla/Config.pm
+++ b/Bugzilla/Config.pm
@@ -25,7 +25,7 @@ use Module::Runtime qw(require_module);
   = (admin => [qw(update_params SetParam write_params)],);
 Exporter::export_ok_tags('admin');
 
-# INITIALISATION CODE
+# INITIALIZATION CODE
 # Perl throws a warning if we use bz_locations() directly after do.
 our %params;
 

--- a/Bugzilla/Config/Admin.pm
+++ b/Bugzilla/Config/Admin.pm
@@ -66,7 +66,7 @@ sub check_rate_limit_rules {
   my $rules = shift;
 
   my $val = eval { decode_json($rules) };
-  return "failed to parse json" unless defined $val;
+  return "failed to parse JSON" unless defined $val;
   return "value is not HASH"    unless ref $val && ref($val) eq 'HASH';
   return "rules are invalid"    unless all {
     ref($_) eq 'ARRAY' && looks_like_number($_->[0]) && looks_like_number($_->[1])

--- a/Bugzilla/Config/Attachment.pm
+++ b/Bugzilla/Config/Attachment.pm
@@ -62,7 +62,7 @@ sub check_storage {
   if ($value eq 's3') {
     return Bugzilla->feature('s3')
       ? ''
-      : 'The perl modules required for S3 support are not installed';
+      : 'The Perl modules required for S3 support are not installed';
   }
   else {
     return '';

--- a/Bugzilla/Config/BugChange.pm
+++ b/Bugzilla/Config/BugChange.pm
@@ -22,7 +22,7 @@ sub get_param_list {
   # Hardcoded bug statuses which existed before Bugzilla 3.1.
   my @closed_bug_statuses = ('RESOLVED', 'VERIFIED', 'CLOSED');
 
-  # If we are upgrading from 3.0 or older, bug statuses are not customisable
+  # If we are upgrading from 3.0 or older, bug statuses are not customizable
   # and bug_status.is_open is not yet defined (hence the eval), so we use
   # the bug statuses above as they are still hardcoded.
   eval {

--- a/Bugzilla/Config/Common.pm
+++ b/Bugzilla/Config/Common.pm
@@ -434,7 +434,7 @@ in the relevant F<Bugzilla::Config::*> package.
 =item C<check_multi>
 
 Checks that a multi-valued parameter (ie types C<s>, C<o> or C<m>) satisfies
-its contraints.
+its constraints.
 
 =item C<check_numeric>
 

--- a/Bugzilla/Config/Common.pm
+++ b/Bugzilla/Config/Common.pm
@@ -337,7 +337,7 @@ sub check_theschwartz_available {
 sub check_comment_taggers_group {
   my $group_name = shift;
   if ($group_name && !Bugzilla->feature('jsonrpc')) {
-    return "Comment tagging requires installation of the JSONRPC feature";
+    return "Comment tagging requires installation of the JSON-RPC feature";
   }
   return check_group($group_name);
 }

--- a/Bugzilla/Config/Common.pm
+++ b/Bugzilla/Config/Common.pm
@@ -433,7 +433,7 @@ in the relevant F<Bugzilla::Config::*> package.
 
 =item C<check_multi>
 
-Checks that a multi-valued parameter (ie types C<s>, C<o> or C<m>) satisfies
+Checks that a multi-valued parameter (i.e. types C<s>, C<o> or C<m>) satisfies
 its constraints.
 
 =item C<check_numeric>

--- a/Bugzilla/Constants.pm
+++ b/Bugzilla/Constants.pm
@@ -654,7 +654,7 @@ use constant AUDIT_CREATE => '__create__';
 use constant AUDIT_REMOVE => '__remove__';
 
 # The maximum number of emails per minute and hour a recipient can receive.
-# Email will be queued/backlogged to avoid exceeeding these limits.
+# Email will be queued/backlogged to avoid exceeding these limits.
 # Setting a limit to 0 will disable this feature.
 use constant EMAIL_LIMIT_PER_MINUTE => 1000;
 use constant EMAIL_LIMIT_PER_HOUR   => 2500;

--- a/Bugzilla/Constants.pm
+++ b/Bugzilla/Constants.pm
@@ -210,7 +210,7 @@ use Memoize;
 # CONSTANTS
 #
 # Bugzilla version
-# BMO: we don't map exactly to a specific bugzilla version, so override our
+# BMO: we don't map exactly to a specific Bugzilla version, so override our
 # reported version with a parameter.
 sub BUGZILLA_VERSION {
   my $bugzilla_version = '4.2';
@@ -726,7 +726,7 @@ sub _bz_locations {
 
     # $webdotdir must be in the web server's tree somewhere. Even if you use a
     # local dot, we output images to there. Also, if $webdotdir is
-    # not relative to the bugzilla root directory, you'll need to
+    # not relative to the Bugzilla root directory, you'll need to
     # change showdependencygraph.cgi to set image_url to the correct
     # location.
     # The script should really generate these graphs directly...

--- a/Bugzilla/DB.pm
+++ b/Bugzilla/DB.pm
@@ -41,7 +41,7 @@ around 'attrs' => sub {
   my $class = ref $self;
 
   # This is only used by the DBIx::Class code DBIx::Connector does something
-  # different because the old bugzilla code has its own ideas about
+  # different because the old Bugzilla code has its own ideas about
   # transactions.
   $attrs->{Callbacks}{connected} = sub {
     my ($dbh, $dsn) = @_;

--- a/Bugzilla/DB.pm
+++ b/Bugzilla/DB.pm
@@ -1973,7 +1973,7 @@ Formatted SQL for negative regular expression search (e.g. NOT REGEXP)
 =item B<Description>
 
 Returns SQL syntax for limiting results to some number of rows
-with optional offset if not starting from the begining.
+with optional offset if not starting from the beginning.
 
 Abstract method, should be overridden by database specific code.
 

--- a/Bugzilla/DB.pm
+++ b/Bugzilla/DB.pm
@@ -1374,7 +1374,7 @@ sub _build_connector {
   $attributes->{Callbacks} = {
     connected => sub {
       my ($dbh, $dsn) = @_;
-      TRACE("$PROGRAM_NAME connected mysql $dsn");
+      TRACE("$PROGRAM_NAME connected MySQL $dsn");
       ThrowCodeError('not_in_transaction') if $self && $self->bz_in_transaction;
       $class->on_dbi_connected(@_) if $class->can('on_dbi_connected');
       return;

--- a/Bugzilla/DB.pm
+++ b/Bugzilla/DB.pm
@@ -1682,7 +1682,7 @@ should use the L<Bugzilla> module to access the current C<dbh> instead.
 This module also contains methods extending the returned handle with
 functionality which is different between databases allowing for easy
 customization for particular database via inheritance. These methods
-should be always preffered over hard-coding SQL commands.
+should be always preferred over hard-coding SQL commands.
 
 =head1 CONSTANTS
 
@@ -2228,7 +2228,7 @@ specified text on a given column.
 
 If one value is returned, it is a numeric expression that indicates
 a match with a positive value and a non-match with zero. In this case,
-the DB must support casting numeric expresions to booleans.
+the DB must support casting numeric expressions to booleans.
 
 If two values are returned, then the first value is a boolean expression
 that indicates the presence of a match, and the second value is a numeric
@@ -2372,7 +2372,7 @@ Returns the last serial number, usually from a previous INSERT.
 
 Must be executed directly following the relevant INSERT.
 This base implementation uses L<DBI/last_insert_id>. If the
-DBD supports it, it is the preffered way to obtain the last
+DBD supports it, it is the preferred way to obtain the last
 serial index. If it is not supported, the DB-specific code
 needs to override this function.
 
@@ -2582,7 +2582,7 @@ the function returns without changing anything.
 =item C<$name> - the name of the column you want to change
 
 =item C<\%new_def> - An abstract column definition for the new
-data type of the columm
+data type of the column
 
 =item C<$set_nulls_to> (Optional) - If you are changing the column
 to be NOT NULL, you probably also want to set any existing NULL columns
@@ -2767,7 +2767,7 @@ Returns nothing and takes no parameters.
 
 =item C<bz_commit_transaction>
 
-Ends a transaction, commiting all changes. Returns nothing and takes
+Ends a transaction, committing all changes. Returns nothing and takes
 no parameters.
 
 =item C<bz_rollback_transaction>

--- a/Bugzilla/DB/Mysql.pm
+++ b/Bugzilla/DB/Mysql.pm
@@ -562,9 +562,9 @@ sub bz_setup_database {
     }    # foreach table
   }    # if old-name indexes
 
-  # If there are no tables, but the DB isn't utf8 and it should be,
-  # then we should alter the database to be utf8. We know it should be
-  # if the utf8 parameter is true or there are no params at all.
+  # If there are no tables, but the DB isn't UTF-8 and it should be,
+  # then we should alter the database to be UTF-8. We know it should be
+  # if the UTF-8 parameter is true or there are no params at all.
   # This kind of situation happens when people create the database
   # themselves, and if we don't do this they will get the big
   # scary WARNING statement about conversion to UTF8.
@@ -599,10 +599,10 @@ sub bz_setup_database {
     );
   }
 
-  # Convert the database to UTF-8 if the utf8 parameter is on.
-  # We check if any table isn't utf8, because lots of crazy
+  # Convert the database to UTF-8 if the UTF-8 parameter is on.
+  # We check if any table isn't UTF-8, because lots of crazy
   # partial-conversion situations can happen, and this handles anything
-  # that could come up (including having the DB charset be utf8 but not
+  # that could come up (including having the DB charset be UTF-8 but not
   # the table charsets.
   #
   # TABLE_COLLATION IS NOT NULL prevents us from trying to convert views.
@@ -640,7 +640,7 @@ sub bz_setup_database {
         # all go away later in checksetup anyway.
         next if $column->{Type} =~ /enum/i;
 
-        # If this particular column isn't stored in utf-8
+        # If this particular column isn't stored in UTF-8
         if ( $column->{Collation}
           && $column->{Collation} ne 'NULL'
           && $column->{Collation} ne $collate)
@@ -705,7 +705,7 @@ sub bz_setup_database {
     }    # foreach my $table (@tables)
   }
 
-  # Sometimes you can have a situation where all the tables are utf8,
+  # Sometimes you can have a situation where all the tables are UTF-8,
   # but the database isn't. (This tends to happen when you've done
   # a mysqldump.) So we have this change outside of the above block,
   # so that it just happens silently if no actual *table* conversion

--- a/Bugzilla/DB/Schema/Mysql.pm
+++ b/Bugzilla/DB/Schema/Mysql.pm
@@ -165,7 +165,7 @@ sub _get_create_index_ddl {
 sub get_create_database_sql {
   my ($self, $name) = @_;
 
-  # We only create as utf8 if we have no params (meaning we're doing
+  # We only create as UTF-8 if we have no params (meaning we're doing
   # a new installation) or if the utf8 param is on.
   my $charset = Bugzilla::DB::Mysql->utf8_charset;
   my $collate = Bugzilla::DB::Mysql->utf8_collate;

--- a/Bugzilla/DB/Schema/Mysql.pm
+++ b/Bugzilla/DB/Schema/Mysql.pm
@@ -322,7 +322,7 @@ sub column_info_to_column {
   if (defined $column_info->{COLUMN_DEF}) {
 
     # The defaults that MySQL inputs automatically are usually
-    # something that would be considered "false" by perl, either
+    # something that would be considered "false" by Perl, either
     # a 0 or an empty string. (Except for datetime and decimal
     # fields, which have their own special auto-defaults.)
     #

--- a/Bugzilla/DB/Schema/Mysql.pm
+++ b/Bugzilla/DB/Schema/Mysql.pm
@@ -284,7 +284,7 @@ sub get_set_serial_sql {
 }
 
 # Converts a DBI column_info output to an abstract column definition.
-# Expects to only be called by Bugzila::DB::Mysql::_bz_build_schema_from_disk,
+# Expects to only be called by Bugzilla::DB::Mysql::_bz_build_schema_from_disk,
 # although there's a chance that it will also work properly if called
 # elsewhere.
 sub column_info_to_column {

--- a/Bugzilla/DB/Schema/Pg.pm
+++ b/Bugzilla/DB/Schema/Pg.pm
@@ -81,7 +81,7 @@ sub _initialize {
 sub get_create_database_sql {
   my ($self, $name) = @_;
 
-  # We only create as utf8 if we have no params (meaning we're doing
+  # We only create as UTF-8 if we have no params (meaning we're doing
   # a new installation) or if the utf8 param is on.
   my $create_utf8
     = Bugzilla->params->{'utf8'} || !defined Bugzilla->params->{'utf8'};

--- a/Bugzilla/DB/Sqlite.pm
+++ b/Bugzilla/DB/Sqlite.pm
@@ -72,7 +72,7 @@ sub BUILDARGS {
   my ($class, $params) = @_;
   my $db_name = $params->{db_name};
 
-  # Let people specify paths intead of data/ for the DB.
+  # Let people specify paths instead of data/ for the DB.
   if ($db_name && $db_name ne ':memory:' && $db_name !~ m{[\\/]}) {
 
     # When the DB is first created, there's a chance that the

--- a/Bugzilla/DB/Sqlite.pm
+++ b/Bugzilla/DB/Sqlite.pm
@@ -106,7 +106,7 @@ sub on_dbi_connected {
 
   my %pragmas = (
 
-    # Make sure that the sqlite file doesn't grow without bound.
+    # Make sure that the SQLite file doesn't grow without bound.
     auto_vacuum  => 1,
     encoding     => "'UTF-8'",
     foreign_keys => 'ON',

--- a/Bugzilla/DaemonControl.pm
+++ b/Bugzilla/DaemonControl.pm
@@ -295,7 +295,7 @@ check for running services (L<assert_httpd()>, L<assert_database()>, L<assert_se
 or help build more functions like the above (L<on_exception()>, L<on_finish()>).
 
 The C<run_> and C<assert_> functions return Futures, see L<Future> for details
-on that. But if you've used Promises in the javascript, Futures are the same concept.
+on that. But if you've used Promises in the JavaScript, Futures are the same concept.
 
 =head1 FUNCTIONS
 

--- a/Bugzilla/Elastic/Search.pm
+++ b/Bugzilla/Elastic/Search.pm
@@ -76,7 +76,7 @@ sub _arrayref_of_fields {
 
 
 # Future maintainer: Maybe consider removing "changeddate" from the codebase entirely.
-# At some point, bugzilla tried to rename some fields
+# At some point, Bugzilla tried to rename some fields
 # one of these is "delta_ts" to changeddate.
 # But the DB column stayed the same... and elasticsearch uses the db name
 # However search likes to use the "new" name.

--- a/Bugzilla/Elastic/Search/FakeCGI.pm
+++ b/Bugzilla/Elastic/Search/FakeCGI.pm
@@ -12,8 +12,8 @@ use namespace::clean;
 has 'params' => (is => 'ro', default => sub { {} });
 
 # we pretend to be Bugzilla::CGI at times.
-sub canonicalise_query {
-  return Bugzilla::CGI::canonicalise_query(@_);
+sub canonicalize_query {
+  return Bugzilla::CGI::canonicalize_query(@_);
 }
 
 sub delete {

--- a/Bugzilla/Error.pm
+++ b/Bugzilla/Error.pm
@@ -256,7 +256,7 @@ END
 
 sub ThrowErrorPage {
 
-  # BMO customisation for bug 659231
+  # BMO customization for bug 659231
   my ($template_name, $message) = @_;
 
   my $dbh = Bugzilla->dbh;
@@ -339,7 +339,7 @@ This function is used when an internal check detects an error of some sort.
 This usually indicates a bug in Bugzilla, although it can occur if the user
 manually constructs urls without correct parameters.
 
-This function's behaviour is similar to C<ThrowUserError>, except that the
+This function's behavior is similar to C<ThrowUserError>, except that the
 template used to display errors is I<global/code-error.html.tmpl>. In addition
 if the hashref used as the optional second argument contains a key I<variables>
 then the contents of the hashref (which is expected to be another hashref) will

--- a/Bugzilla/Error.pm
+++ b/Bugzilla/Error.pm
@@ -113,7 +113,7 @@ sub _throw_error {
     }
 
     if (Bugzilla->error_mode == ERROR_MODE_DIE_SOAP_FAULT) {
-      $logfunc->("XMLRPC error: $error ($code)");
+      $logfunc->("XML-RPC error: $error ($code)");
       die SOAP::Fault->faultcode($code)->faultstring($message);
     }
     else {
@@ -127,7 +127,7 @@ sub _throw_error {
       }
       else {
         my $fake_code = 100000 + $code;
-        $logfunc->("JSONRPC error: $error ($fake_code)");
+        $logfunc->("JSON-RPC error: $error ($fake_code)");
       }
 
       # Technically JSON-RPC isn't allowed to have error numbers

--- a/Bugzilla/Extension.pm
+++ b/Bugzilla/Extension.pm
@@ -718,7 +718,7 @@ override this method in F<Config.pm>.
 
 =head3 C<web_dir>
 
-The directory that your package's web related files are in, such as css and javascript.
+The directory that your package's web related files are in, such as CSS and JavaScript.
 
 This defaults to the C<web> subdirectory of the L</package_dir>.
 

--- a/Bugzilla/Extension.pm
+++ b/Bugzilla/Extension.pm
@@ -209,7 +209,7 @@ L<wiki page|https://wiki.mozilla.org/Bugzilla:Extension_Notes> with additional H
 
 There is a script, L<extensions::create>, that will set up the framework
 of a new extension for you. To use it, pick a name for your extension
-and, in the base bugzilla directory, do:
+and, in the base Bugzilla directory, do:
 
 C<extensions/create.pl NAME>
 

--- a/Bugzilla/Field.pm
+++ b/Bugzilla/Field.pm
@@ -1262,7 +1262,7 @@ sub remove_from_db {
 
     my $type = $self->type;
 
-    # the values for multi-select are stored in a seperate table
+    # the values for multi-select are stored in a separate table
     if ($type != FIELD_TYPE_MULTI_SELECT) {
       $dbh->bz_drop_column('bugs', $name);
     }

--- a/Bugzilla/Flag.pm
+++ b/Bugzilla/Flag.pm
@@ -645,8 +645,8 @@ sub force_retarget {
 
     # $bug is undefined when e.g. editing inclusion and exclusion lists.
     my $obj = $flag->attachment || $bug || $flag->bug;
-    my $is_retargetted = $flag->retarget($obj);
-    if ($is_retargetted) {
+    my $is_retargeted = $flag->retarget($obj);
+    if ($is_retargeted) {
       $dbh->do('UPDATE flags SET type_id = ? WHERE id = ?',
         undef, ($flag->type_id, $flag->id));
       Bugzilla->memcached->clear({table => 'flags', id => $flag->id});
@@ -720,7 +720,7 @@ sub _check_requestee {
     ThrowCodeError('flag_type_requestee_disabled', {type => $self->type})
       if !$self->type->is_requesteeble;
 
-    # BMO customisation:
+    # BMO customization:
     # You can't ask a disabled account, as they don't have the ability to
     # set the flag.
     ThrowUserError('flag_requestee_disabled', {requestee => $requestee})
@@ -813,7 +813,7 @@ sub _check_setter {
     unless $setter->can_change_flag($self->type, $self->{_old_status} || 'X',
     $status);
 
-  # If the request is being retargetted, we don't update
+  # If the request is being retargeted, we don't update
   # the setter, so that the setter gets the notification.
   if ($status eq '?' && $self->{_old_status} eq '?') {
     return $self->setter;

--- a/Bugzilla/Hook.pm
+++ b/Bugzilla/Hook.pm
@@ -1746,7 +1746,7 @@ they have been obtained from the URL or body of the request.
 
 =item C<rpc>
 
-The current JSONRPC, XMLRPC, or REST object.
+The current JSON-RPC, XML-RPC, or REST object.
 
 =back
 
@@ -1767,7 +1767,7 @@ which code handler to use based on a regex match of the CGI path.
 
 =item C<rpc>
 
-The current JSONRPC, XMLRPC, or REST object.
+The current JSON-RPC, XML-RPC, or REST object.
 
 =back
 
@@ -1791,7 +1791,7 @@ A reference to a hash that contains the result data.
 
 =item C<rpc>
 
-The current JSONRPC, XMLRPC, or REST object.
+The current JSON-RPC, XML-RPC, or REST object.
 
 =back
 

--- a/Bugzilla/Hook.pm
+++ b/Bugzilla/Hook.pm
@@ -1732,7 +1732,7 @@ they have been obtained from the URL or body of the request.
 =head2 webservice_rest_request
 
 This hook allows for altering any of the parameters provided by the client
-after authentication has occured. You are able to change things like renaming
+after authentication has occurred. You are able to change things like renaming
 of keys, removing values, or adding additional information.
 
 Params:
@@ -1795,7 +1795,7 @@ The current JSONRPC, XMLRPC, or REST object.
 
 =back
 
-=head2 wevservice_status_code_map
+=head2 webservice_status_code_map
 
 This hook allows an extension to change the status codes returned by
 specific webservice errors. The valid internal error codes that Bugzilla

--- a/Bugzilla/Install.pm
+++ b/Bugzilla/Install.pm
@@ -272,7 +272,7 @@ use constant DEFAULT_PRODUCT => {
   name        => 'TestProduct',
   description => 'This is a test product.'
     . ' This ought to be blown away and replaced with real stuff in a'
-    . ' finished installation of bugzilla.',
+    . ' finished installation of Bugzilla.',
   version          => Bugzilla::Version::DEFAULT_VERSION,
   classification   => 'Unclassified',
   defaultmilestone => DEFAULT_MILESTONE,

--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -560,7 +560,7 @@ sub update_table_definitions {
   # 2008-09-07 LpSolit@gmail.com - Bug 452893
   _fix_illegal_flag_modification_dates();
 
-  _add_visiblity_value_to_value_tables();
+  _add_visibility_value_to_value_tables();
 
   # 2009-03-02 arbingersys@gmail.com - Bug 423613
   _add_extern_id_index();
@@ -3627,7 +3627,7 @@ sub _fix_illegal_flag_modification_dates {
     if ($rows =~ /^\d+$/);
 }
 
-sub _add_visiblity_value_to_value_tables {
+sub _add_visibility_value_to_value_tables {
   my $dbh = Bugzilla->dbh;
   my @standard_fields
     = qw(bug_status resolution priority bug_severity op_sys rep_platform);
@@ -4276,7 +4276,7 @@ sub _add_oauth2_jwt_support {
   $dbh->bz_alter_column('oauth2_scope', 'id',
     {TYPE => 'INTSERIAL', NOTNULL => 1, PRIMARYKEY => 1});
 
-  # oauth2_client_scope.allowed is unncessary so we drop it
+  # oauth2_client_scope.allowed is unnecessary so we drop it
   $dbh->bz_drop_column('oauth2_client_scope', 'allowed');
 
   # Update old non-id string columns to new id column

--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -1302,13 +1302,13 @@ sub _recrypt_plaintext_passwords {
   my $dbh = Bugzilla->dbh;
 
   # 2001-06-12; myk@mozilla.org; bugs 74032, 77473:
-  # Recrypt passwords using Perl &crypt instead of the mysql equivalent
+  # Recrypt passwords using Perl &crypt instead of the MySQL equivalent
   # and delete plaintext passwords from the database.
   if ($dbh->bz_column_info('profiles', 'password')) {
 
     print <<ENDTEXT;
 Your current installation of Bugzilla stores passwords in plaintext
-in the database and uses mysql's encrypt function instead of Perl's
+in the database and uses MySQL's encrypt function instead of Perl's
 crypt function to crypt passwords.  Passwords are now going to be
 re-crypted with the Perl function, and plaintext passwords will be
 deleted from the database.  This could take a while if your
@@ -1442,7 +1442,7 @@ sub _delete_logincookies_cryptpassword_and_handle_invalid_cookies {
     # column
     print "Removing invalid login cookies...\n";
 
-    # mysql doesn't support DELETE with multi-table queries, so we have
+    # MySQL doesn't support DELETE with multi-table queries, so we have
     # to iterate
     my $sth
       = $dbh->prepare("SELECT cookie FROM logincookies, profiles "
@@ -1676,7 +1676,7 @@ sub _convert_groups_system_from_groupset {
   # The groups system needs to be converted if groupset exists
   if ($dbh->bz_column_info("profiles", "groupset")) {
 
-    # Some mysql versions will promote any unique key to primary key
+    # Some MySQL versions will promote any unique key to primary key
     # so all unique keys are removed first and then added back in
     $dbh->bz_drop_index('groups', 'groups_bit_idx');
     $dbh->bz_drop_index('groups', 'groups_name_idx');

--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -1465,7 +1465,7 @@ sub _use_ip_instead_of_hostname_in_logincookies {
   # 2002-05-13 preed@sigkill.com - bug 129446 patch backported to the
   #  BUGZILLA-2_14_1-BRANCH as a security blocker for the 2.14.2 release
   #
-  # Use the ip, not the hostname, in the logincookies table
+  # Use the IP, not the hostname, in the logincookies table
   if ($dbh->bz_column_info("logincookies", "hostname")) {
     print "Clearing the logincookies table...\n";
 
@@ -3592,7 +3592,7 @@ sub _populate_bugs_fulltext {
     }
 
     # As recommended by Monty Widenius for GNOME's upgrade.
-    # mkanat and justdave concur it'll be helpful for bmo, too.
+    # mkanat and justdave concur it'll be helpful for BMO, too.
     $dbh->do('SET SESSION myisam_sort_buffer_size = 3221225472');
 
     my $newline = $dbh->quote("\n");

--- a/Bugzilla/Install/Filesystem.pm
+++ b/Bugzilla/Install/Filesystem.pm
@@ -197,7 +197,7 @@ sub FILESYSTEM {
     "$extensionsdir/*/*.pl"        => {perms => WS_EXECUTE},
     "$extensionsdir/*/bin/*"       => {perms => WS_EXECUTE},
 
-    # google webmaster tools verification files
+    # Google Webmaster Tools verification files
     'google*.html'    => {perms => WS_SERVE},
     'contribute.json' => {perms => WS_SERVE},
   );

--- a/Bugzilla/Install/Filesystem.pm
+++ b/Bugzilla/Install/Filesystem.pm
@@ -491,7 +491,7 @@ sub _remove_empty_css {
   }
 }
 
-# We used to allow a single css file in the skins/contrib/ directory
+# We used to allow a single CSS file in the skins/contrib/ directory
 # to be a whole skin.
 sub _convert_single_file_skins {
   my $skinsdir = bz_locations()->{'skinsdir'};
@@ -795,7 +795,7 @@ sub _check_web_server_group {
     ThrowCodeError('invalid_webservergroup', {group => $group})
       unless defined $group_id;
 
-    # If on unix, see if we need to print a warning about a webservergroup
+    # If on Unix, see if we need to print a warning about a webservergroup
     # that we can't chgrp to
     if ($output && $< != 0 && !grep($_ eq $group_id, split(" ", $)))) {
       print "\n\n" . get_text('install_webservergroup_not_in') . "\n\n";

--- a/Bugzilla/Install/Requirements.pm
+++ b/Bugzilla/Install/Requirements.pm
@@ -8,7 +8,7 @@
 package Bugzilla::Install::Requirements;
 
 # NOTE: This package MUST NOT "use" any Bugzilla modules other than
-# Bugzilla::Constants, anywhere. We may "use" standard perl modules.
+# Bugzilla::Constants, anywhere. We may "use" standard Perl modules.
 #
 # Subroutines may "require" and "import" from modules, but they
 # MUST NOT "use."
@@ -331,7 +331,7 @@ Bugzilla::Install::Requirements - Functions and variables dealing
 
 This module is used primarily by C<checksetup.pl> to determine whether
 or not all of Bugzilla's prerequisites are installed. (That is, all the
-perl modules it requires.)
+Perl modules it requires.)
 
 =head1 CONSTANTS
 
@@ -355,7 +355,7 @@ of file names (which are passed to C<glob>, so shell patterns work).
 
 =item B<Description>
 
-This checks what required perl modules are installed, like
+This checks what required Perl modules are installed, like
 C<checksetup.pl> does.
 
 =item B<Params>

--- a/Bugzilla/Install/Util.pm
+++ b/Bugzilla/Install/Util.pm
@@ -9,7 +9,7 @@ package Bugzilla::Install::Util;
 
 # The difference between this module and Bugzilla::Util is that this
 # module may require *only* Bugzilla::Constants and built-in
-# perl modules.
+# Perl modules.
 
 use 5.10.1;
 use strict;
@@ -356,7 +356,7 @@ sub template_include_path {
 }
 
 # This is taken straight from Sort::Versions 1.5, which is not included
-# with perl by default.
+# with Perl by default.
 sub vers_cmp {
   my ($a, $b) = @_;
 
@@ -615,7 +615,7 @@ non-installation code, so they have been split out into this module.
 
 The difference between this module and L<Bugzilla::Util> is that this
 module is safe to C<use> anywhere in Bugzilla, even during installation,
-because it depends only on L<Bugzilla::Constants> and built-in perl modules.
+because it depends only on L<Bugzilla::Constants> and built-in Perl modules.
 
 None of the subroutines are exported by default--you must explicitly
 export them.
@@ -632,7 +632,7 @@ binary, if the binary is in the C<PATH>.
 =item C<get_version_and_os>
 
 Returns a hash containing information about what version of Bugzilla we're
-running, what perl version we're using, and what OS we're running on.
+running, what Perl version we're using, and what OS we're running on.
 
 =item C<get_console_locale>
 

--- a/Bugzilla/JobQueue/Runner.pm
+++ b/Bugzilla/JobQueue/Runner.pm
@@ -224,7 +224,7 @@ sub gd_run {
 }
 
 # This executes the script "jobqueue-worker.pl"
-# $EXECUTABLE_NAME is the name of the perl interpreter.
+# $EXECUTABLE_NAME is the name of the Perl interpreter.
 sub run_worker {
   my ($self) = @_;
 

--- a/Bugzilla/MFA.pm
+++ b/Bugzilla/MFA.pm
@@ -54,7 +54,7 @@ sub prompt { }
 # throws errors if code is invalid
 sub check { }
 
-# if true verifcation can happen inline (during enrollment/pref changes)
+# if true verification can happen inline (during enrollment/pref changes)
 # if false then the mfa provider requires an intermediate verification page
 sub can_verify_inline {0}
 

--- a/Bugzilla/Mailer.pm
+++ b/Bugzilla/Mailer.pm
@@ -218,14 +218,14 @@ sub MessageToMTA {
     $content_type =~ /charset=['"](.+)['"]/;
 
     # If no charset is defined or is the default us-ascii,
-    # then we encode the email to UTF-8 if Bugzilla has utf8 enabled.
+    # then we encode the email to UTF-8 if Bugzilla has UTF-8 enabled.
     # XXX - This is a hack to workaround bug 723944.
     if (!$1 || $1 eq 'us-ascii') {
       my $body = $part->body;
       if (Bugzilla->params->{'utf8'}) {
         $part->charset_set('UTF-8');
 
-        # encoding_set works only with bytes, not with utf8 strings.
+        # encoding_set works only with bytes, not with UTF-8 strings.
         my $raw = $part->body_raw;
         if (utf8::is_utf8($raw)) {
           utf8::encode($raw);

--- a/Bugzilla/Markdown.pm
+++ b/Bugzilla/Markdown.pm
@@ -65,7 +65,7 @@ sub render_html {
     return $html;
   }
 
-  no warnings 'utf8'; # this is needed because our perl is so old.
+  no warnings 'utf8'; # this is needed because our Perl is so old.
   # This is a bit faster since it doesn't engage the regex engine.
   # Replace < with \x{FDD4}, and remove \x{FDD4}.
   $markdown =~ tr/\x{FDD4}//d;

--- a/Bugzilla/Markdown/GFM.pm
+++ b/Bugzilla/Markdown/GFM.pm
@@ -89,4 +89,4 @@ Bugzilla::Markdown::GFM - Sets up the FFI to libcmark_gfm.
 =head1 DESCRIPTION
 
 This modules mainly just does setup work. See L<Bugzilla::Markdown::GFM::Parser>
-to actually render markdown to html.
+to actually render markdown to HTML.

--- a/Bugzilla/Memcached.pm
+++ b/Bugzilla/Memcached.pm
@@ -603,7 +603,7 @@ C<$object-E<gt>update()>), then it's possible for the data in the cache to be
 out of sync with the database.
 
 As an example let's consider an extension which adds a timestamp field
-C<last_activitiy_ts> to the profiles table and user object which contains the
+C<last_activity_ts> to the profiles table and user object which contains the
 user's last activity.  If the extension were to call C<$user-E<gt>update()>,
 then an audit entry would be created for each change to the C<last_activity_ts>
 field, which is undesirable.

--- a/Bugzilla/Object.pm
+++ b/Bugzilla/Object.pm
@@ -36,7 +36,7 @@ use constant AUDIT_CREATES         => 1;
 use constant AUDIT_UPDATES         => 1;
 use constant AUDIT_REMOVES         => 1;
 
-# When USE_MEMCACHED is true, the class is suitable for serialisation to
+# When USE_MEMCACHED is true, the class is suitable for serialization to
 # Memcached.  See documentation in Bugzilla::Memcached for more information.
 use constant USE_MEMCACHED => 1;
 
@@ -206,7 +206,7 @@ sub new_from_hash {
   my $invocant    = shift;
   my $class       = ref($invocant) || $invocant;
   my $object_data = shift || return;
-  $class->_serialisation_keys($object_data);
+  $class->_serialization_keys($object_data);
   bless($object_data, $class);
   $object_data->initialize();
   return $object_data;
@@ -275,11 +275,11 @@ sub object_cache_clearall {
   }
 }
 
-# To support serialisation, we need to capture the keys in an object's default
+# To support serialization, we need to capture the keys in an object's default
 # hashref.
-sub _serialisation_keys {
+sub _serialization_keys {
   my ($class, $object) = @_;
-  my $cache = Bugzilla->request_cache->{serialisation_keys} ||= {};
+  my $cache = Bugzilla->request_cache->{serialization_keys} ||= {};
   $cache->{$class} = [keys %$object] if $object && !exists $cache->{$class};
   return @{$cache->{$class}};
 }
@@ -425,7 +425,7 @@ sub _do_list_select {
     # they're only used in placeholders here.
     my @untainted = @{$values || []};
     $objects = $dbh->selectall_arrayref($sql, {Slice => {}}, @untainted);
-    $class->_serialisation_keys($objects->[0]) if @$objects;
+    $class->_serialization_keys($objects->[0]) if @$objects;
   }
 
   if ($objects && $set_memcached) {
@@ -640,7 +640,7 @@ sub audit_log {
 sub flatten_to_hash {
   my $self  = shift;
   my $class = blessed($self);
-  my %hash  = map { $_ => $self->{$_} } $class->_serialisation_keys;
+  my %hash  = map { $_ => $self->{$_} } $class->_serialization_keys;
   return \%hash;
 }
 

--- a/Bugzilla/PatchReader.pm
+++ b/Bugzilla/PatchReader.pm
@@ -39,7 +39,7 @@ PatchReader - Utilities to read and manipulate patches and CVS
 
 =head1 ABSTRACT
 
-This perl library allows you to manipulate patches programmatically by
+This Perl library allows you to manipulate patches programmatically by
 chaining together a variety of objects that read, manipulate, and output
 patch information:
 

--- a/Bugzilla/Product.pm
+++ b/Bugzilla/Product.pm
@@ -1053,7 +1053,7 @@ currently-logged-in user. Returns an arrayref of C<Bugzilla::Group> objects.
 Tells you whether or not the currently-logged-in user can set a group
 on a bug (whether or not they match the MemberControl/OtherControl
 settings for a group in this product). Groups that are C<Mandatory> for
-the currently-loggeed-in user are also acceptable since from Bugzilla's
+the currently-logged-in user are also acceptable since from Bugzilla's
 perspective, there's no problem with "setting" a Mandatory group on
 a bug. (In fact, the user I<must> set the Mandatory group on the bug.)
 

--- a/Bugzilla/Report/Ping/Simple.pm
+++ b/Bugzilla/Report/Ping/Simple.pm
@@ -18,8 +18,8 @@ with 'Bugzilla::Report::Ping';
 sub _build_validator {
   my ($self) = @_;
 
-  # For prototyping we use joi, but after protyping
-  # $schema should be set to the file path or url of a json schema file.
+  # For prototyping we use joi, but after prototyping
+  # $schema should be set to the file path or URL of a JSON schema file.
   my $schema = joi->object->strict->props({
     reporter    => joi->integer->required,
     assigned_to => joi->integer->required,

--- a/Bugzilla/Report/SecurityRisk.pm
+++ b/Bugzilla/Report/SecurityRisk.pm
@@ -314,7 +314,7 @@ sub _build_events {
   } @$result;
 
   # We sort by reverse chronological order instead of ORDER BY
-  # since values %hash doesn't guareentee any order.
+  # since values %hash doesn't guarantee any order.
   @events = sort { $b->{bug_when} cmp $a->{bug_when} } @events;
   return \@events;
 }
@@ -334,7 +334,7 @@ sub _build_results {
     )
   {
 
-# We rewind events while there are still events existing which occured after the start
+# We rewind events while there are still events existing which occurred after the start
 # of the report week. The bugs will reflect a snapshot of how they were at the start of the week.
 # $self->events is ordered reverse chronologically, so the end of the array is the earliest event.
     while ($e < @{$self->events}

--- a/Bugzilla/S3/Bucket.pm
+++ b/Bugzilla/S3/Bucket.pm
@@ -228,7 +228,7 @@ Bugzilla::S3::Bucket - A container class for a S3 bucket and its contents.
 
 =head2 new
 
-Instaniates a new bucket object.
+Instantiates a new bucket object.
 
 Requires a hash containing two arguments:
 
@@ -246,7 +246,7 @@ bucket is associated with.
 =back
 
 NOTE: This method does not check if a bucket actually
-exists. It simply instaniates the bucket.
+exists. It simply instantiates the bucket.
 
 Typically a developer will not call this method directly,
 but work through the interface in L<S3::Amazon> that will
@@ -275,9 +275,9 @@ Adding them to the configuration hash will override what the
 library would send and add headers that are not typically
 required for S3 interactions.
 
-In addition to additional and overriden HTTP headers, this
+In addition to additional and overridden HTTP headers, this
 HASHREF can have a C<acl_short> key to set the permissions
-(access) of the resource without a seperate call via
+(access) of the resource without a separate call via
 C<add_acl> or in the form of an XML document.  See the
 documentation in C<add_acl> for the values and usage.
 

--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -1979,7 +1979,7 @@ sub _handle_chart {
 
   $search_args{quoted} = $self->_quote_unless_numeric(\%search_args);
 
-  # This should add a "term" selement to %search_args.
+  # This should add a "term" element to %search_args.
   $self->do_search_function(\%search_args);
 
   # If term is left empty, then this means the criteria

--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -3700,7 +3700,7 @@ sub _empty_value {
 sub IsValidQueryType {
   my ($queryType) = @_;
 
-  # BMO: Added google and instant
+  # BMO: Added Google and instant
   if (grep { $_ eq $queryType } qw(specific advanced google instant)) {
     return 1;
   }

--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -802,7 +802,7 @@ sub data {
   my %tf_map = map { $_ => 1 } Bugzilla->tracking_flag_names;
   my @tf_selected = grep { exists $tf_map{$_} } @orig_fields;
 
-  # mysql has a limit of 61 joins, and we want to avoid massive amounts of joins
+  # MySQL has a limit of 61 joins, and we want to avoid massive amounts of joins
   # 30 ensures we won't hit the limit, nor generate too many joins
   if (scalar @tf_selected > 30) {
     foreach my $column (@tf_selected) {

--- a/Bugzilla/Search/Quicksearch.pm
+++ b/Bugzilla/Search/Quicksearch.pm
@@ -292,7 +292,7 @@ sub quicksearch {
 
   # List of quicksearch-specific CGI parameters to get rid of.
   my @params_to_strip = ('quicksearch', 'load', 'run');
-  my $modified_query_string = $cgi->canonicalise_query(@params_to_strip);
+  my $modified_query_string = $cgi->canonicalize_query(@params_to_strip);
 
   if ($cgi->param('load')) {
     # Param 'load' asks us to display the query in the advanced search form.
@@ -315,7 +315,7 @@ sub _parse_line {
   return () unless defined $line;
 
   # parse_line always treats ' as a quote character, making it impossible
-  # to sanely search for contractions. As this behavour isn't
+  # to sanely search for contractions. As this behavior isn't
   # configurable, we replace ' with a placeholder to hide it from the
   # parser.
 

--- a/Bugzilla/Search/Saved.pm
+++ b/Bugzilla/Search/Saved.pm
@@ -231,7 +231,7 @@ sub edit_link {
   {
     $cgi->param('query_type', 'advanced');
   }
-  $self->{edit_link} = $cgi->canonicalise_query;
+  $self->{edit_link} = $cgi->canonicalize_query;
   return $self->{edit_link};
 }
 

--- a/Bugzilla/Search/Saved.pm
+++ b/Bugzilla/Search/Saved.pm
@@ -369,7 +369,7 @@ These return data about the object, without modifying the object.
 
 =item C<edit_link>
 
-A url with which you can edit the search.
+A URL with which you can edit the search.
 
 =item C<url>
 

--- a/Bugzilla/Series.pm
+++ b/Bugzilla/Series.pm
@@ -154,7 +154,7 @@ sub initFromCGI {
   $self->{'frequency'} = $cgi->param('frequency');
   detaint_natural($self->{'frequency'}) || ThrowUserError("missing_frequency");
 
-  $self->{'query'} = $cgi->canonicalise_query(
+  $self->{'query'} = $cgi->canonicalize_query(
     "format",      "ctype", "action",    "category",
     "subcategory", "name",  "frequency", "public",
     "query_format"

--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -210,7 +210,7 @@ sub quoteUrls {
                ("\x{FDD2}" . ($count-1) . "\x{FDD3}")
               ~egox;
 
-  # We have to quote now, otherwise the html itself is escaped
+  # We have to quote now, otherwise the HTML itself is escaped
   # THIS MEANS THAT A LITERAL ", <, >, ' MUST BE ESCAPED FOR A MATCH
 
   $text = html_quote($text);
@@ -393,7 +393,7 @@ sub version_filter {
 #  2. standard/global.css
 #  3. Standard Bugzilla stylesheet set
 #  4. Third-party "skin" stylesheet set, per user prefs
-#  5. Inline css passed to global/header.html.tmpl
+#  5. Inline CSS passed to global/header.html.tmpl
 #  6. Custom Bugzilla stylesheet set
 
 sub css_files {
@@ -677,8 +677,8 @@ sub create {
       strip_control_chars => sub {
         my ($data) = @_;
 
-        # Only run for utf8 to avoid issues with other multibyte encodings
-        # that may be reassigning meaning to ascii characters.
+        # Only run for UTF-8 to avoid issues with other multibyte encodings
+        # that may be reassigning meaning to ASCII characters.
         if (Bugzilla->params->{'utf8'}) {
           $data =~ s/(?![\t\r\n])[[:cntrl:]]//g;
         }
@@ -686,7 +686,7 @@ sub create {
       },
 
       # HTML collapses newlines in element attributes to a single space,
-      # so form elements which may have whitespace (ie comments) need
+      # so form elements which may have whitespace (i.e. comments) need
       # to be encoded using &#013;
       # See bugs 4928, 22983 and 32000 for more details
       html_linebreak => sub {
@@ -875,7 +875,7 @@ sub create {
         # Trivial HTML tag remover
         $var =~ s/<[^>]*>//g;
 
-        # And this basically reverses the html filter.
+        # And this basically reverses the HTML filter.
         $var =~ s/\&#64;/@/g;
         $var =~ s/\&lt;/</g;
         $var =~ s/\&gt;/>/g;
@@ -990,7 +990,7 @@ sub create {
       # Allow templates to get the absolute path of the URLBase value
       'basepath' => sub { return Bugzilla->localconfig->basepath; },
 
-      # Allow templates to access docs url with users' preferred language
+      # Allow templates to access docs URL with users' preferred language
       'docs_urlbase' => sub {
         my $language     = Bugzilla->current_language;
         my $docs_urlbase = Bugzilla->params->{'docs_urlbase'};

--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -106,7 +106,7 @@ sub get_format {
   $template .= ".$ctype.tmpl";
 
   # Now check that the template actually exists. We only want to check
-  # if the template exists; any other errors (eg parse errors) will
+  # if the template exists; any other errors (e.g. parse errors) will
   # end up being detected later.
   eval { $self->context->template($template); };
 

--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -972,7 +972,7 @@ sub create {
       # If an sudo session is in progress, this is the user we're faking
       'user' => sub { return Bugzilla->user; },
 
-      # Currenly active language
+      # Currently active language
       'current_language' => sub { return Bugzilla->current_language; },
 
       'script_nonce' => sub {
@@ -984,7 +984,7 @@ sub create {
       # started the session.
       'sudoer' => sub { return Bugzilla->sudoer; },
 
-      # Allow templates to access the "corect" URLBase value
+      # Allow templates to access the "correct" URLBase value
       'urlbase' => sub { return Bugzilla->localconfig->urlbase; },
 
       # Allow templates to get the absolute path of the URLBase value

--- a/Bugzilla/Template/Context.pm
+++ b/Bugzilla/Template/Context.pm
@@ -67,7 +67,7 @@ sub stash {
   # templates, because if somebody calls Throw*Error globally inside of
   # template_before_process, that causes an infinite recursion into
   # the PRE_PROCESS templates (because Bugzilla, while inside
-  # global/intialize.none.tmpl, loads the template again to create the
+  # global/initialize.none.tmpl, loads the template again to create the
   # template object for Throw*Error).
   #
   # Checking Bugzilla::Hook::in prevents infinite recursion on this hook.

--- a/Bugzilla/User.pm
+++ b/Bugzilla/User.pm
@@ -2493,7 +2493,7 @@ sub wants_mail {
 
   # Don't send any mail, ever, if account is disabled
   # XXX Temporary Compatibility Change 1 of 2:
-  # This code is disabled for the moment to make the behaviour like the old
+  # This code is disabled for the moment to make the behavior like the old
   # system, which sent bugmail to disabled accounts.
   # return 0 if $self->{'disabledtext'};
 
@@ -3027,7 +3027,7 @@ containing the user's recent searches.
 =item C<recent_search_containing(bug_id)>
 
 Returns a L<Bugzilla::Search::Recent> object that contains the most recent
-search by the user for the specified bug id. Retuns undef if no match is found.
+search by the user for the specified bug id. Returns undef if no match is found.
 
 =item C<recent_search_for(bug)>
 

--- a/Bugzilla/User/APIKey.pm
+++ b/Bugzilla/User/APIKey.pm
@@ -18,7 +18,7 @@ use Bugzilla::Util qw(generate_random_password trim);
 use Bugzilla::Error;
 
 #####################################################################
-# Overriden Constants that are used as methods
+# Overridden Constants that are used as methods
 #####################################################################
 
 use constant DB_TABLE   => 'user_api_keys';

--- a/Bugzilla/User/Session.pm
+++ b/Bugzilla/User/Session.pm
@@ -14,7 +14,7 @@ use warnings;
 use base qw(Bugzilla::Object);
 
 #####################################################################
-# Overriden Constants that are used as methods
+# Overridden Constants that are used as methods
 #####################################################################
 
 use constant DB_TABLE   => 'logincookies';

--- a/Bugzilla/Util.pm
+++ b/Bugzilla/Util.pm
@@ -96,7 +96,7 @@ my %html_quote = (
   q{@} => '&#64;',    # Obscure '@'.
 );
 
-# Bug 120030: Override html filter to obscure the '@' in user
+# Bug 120030: Override HTML filter to obscure the '@' in user
 #             visible strings.
 # Bug 319331: Handle BiDi disruptions.
 sub html_quote {
@@ -108,8 +108,8 @@ sub html_quote {
 
   if ($use_utf8) {
 
-    # Remove control characters if the encoding is utf8.
-    # Other multibyte encodings may be using this range; so ignore if not utf8.
+    # Remove control characters if the encoding is UTF-8.
+    # Other multibyte encodings may be using this range; so ignore if not UTF-8.
     $var =~ s/(?![\t\r\n])[[:cntrl:]]//g;
 
     # Remove the following characters because they're
@@ -956,7 +956,7 @@ sub extract_nicks {
             :
             # try tp capture a "word", plus some symbols
             # this covers most everything people use for ircnicks
-            # in bmo.
+            # in BMO.
             ([\p{IsAlnum}|._-]+)
             # require a word terminator, which
             # can be the end of the string or some punctuation.
@@ -974,7 +974,7 @@ __END__
 
 =head1 NAME
 
-Bugzilla::Util - Generic utility functions for bugzilla
+Bugzilla::Util - Generic utility functions for Bugzilla
 
 =head1 SYNOPSIS
 
@@ -1078,7 +1078,7 @@ escaped (if HTML::Scrubber is not installed) or removed.
 
 =item C<url_quote($val)>
 
-Quotes characters so that they may be included as part of a url.
+Quotes characters so that they may be included as part of a URL.
 
 =item C<css_class_quote($val)>
 
@@ -1194,7 +1194,7 @@ ASCII 10 (LineFeed) and ASCII 13 (Carrage Return).
 
 =item C<disable_utf8()>
 
-Disable utf8 on STDOUT (and display raw data instead).
+Disable UTF-8 on STDOUT (and display raw data instead).
 
 =item C<detect_encoding($str)>
 

--- a/Bugzilla/Util.pm
+++ b/Bugzilla/Util.pm
@@ -1059,7 +1059,7 @@ B<MUST> check the result of this routine to avoid security holes.
 
 =head2 Quoting
 
-Some values may need to be quoted from perl. However, this should in general
+Some values may need to be quoted from Perl. However, this should in general
 be done in the template where possible.
 
 =over 4
@@ -1269,7 +1269,7 @@ the Bugzilla server's local timezone if there isn't a logged-in user.
 
 =item C<time_ago($datetime_object)>, C<time_ago($seconds)>
 
-Returns a concise representation of the time passed.  eg. "11 months ago".
+Returns a concise representation of the time passed. e.g. "11 months ago".
 
 Accepts either a DateTime object, which is assumed to be in the past, or
 seconds.
@@ -1284,7 +1284,7 @@ seconds.
 =item C<file_mod_time($filename)>
 
 Takes a filename and returns the modification time. It returns it in the format
-of the "mtime" parameter of the perl "stat" function.
+of the "mtime" parameter of the Perl "stat" function.
 
 =back
 
@@ -1297,7 +1297,7 @@ of the "mtime" parameter of the perl "stat" function.
 Takes a string and returns a hashed (encrypted) value for it, using a
 random salt. An optional salt string may also be passed in.
 
-Please always use this function instead of the built-in perl C<crypt>
+Please always use this function instead of the built-in Perl C<crypt>
 function, when checking or setting a password. Bugzilla does not use
 C<crypt>.
 

--- a/Bugzilla/Util.pm
+++ b/Bugzilla/Util.pm
@@ -1114,7 +1114,7 @@ in a command-line script.
 =item C<i_am_webservice()>
 
 Tells you whether or not the current usage mode is WebServices related
-such as JSONRPC or XMLRPC.
+such as JSON-RPC or XML-RPC.
 
 =item C<is_webserver_group()>
 

--- a/Bugzilla/Util.pm
+++ b/Bugzilla/Util.pm
@@ -955,7 +955,7 @@ sub extract_nicks {
             (?<!\d)
             :
             # try tp capture a "word", plus some symbols
-            # this covers most everything people use for ircnicks
+            # this covers most everything people use for IRC nicks
             # in BMO.
             ([\p{IsAlnum}|._-]+)
             # require a word terminator, which
@@ -1190,7 +1190,7 @@ The search starts at $maxpos and goes back to the beginning of the string.
 =item C<is_7bit_clean($str)>
 
 Returns true is the string contains only 7-bit characters (ASCII 32 through 126,
-ASCII 10 (LineFeed) and ASCII 13 (Carrage Return).
+ASCII 10 (LineFeed) and ASCII 13 (Carriage Return).
 
 =item C<disable_utf8()>
 

--- a/Bugzilla/Version.pm
+++ b/Bugzilla/Version.pm
@@ -194,7 +194,7 @@ sub _check_product {
 ###############################
 
 # This is taken straight from Sort::Versions 1.5, which is not included
-# with perl by default.
+# with Perl by default.
 sub vers_cmp {
   my ($a, $b) = @_;
 

--- a/Bugzilla/WebService.pm
+++ b/Bugzilla/WebService.pm
@@ -17,7 +17,7 @@ use Bugzilla::WebService::Server;
 use Bugzilla::WebService::Wants;
 use PerlX::Maybe qw(maybe);
 
-# Used by the JSON-RPC server to convert incoming date fields apprpriately.
+# Used by the JSON-RPC server to convert incoming date fields appropriately.
 use constant DATE_FIELDS => {};
 
 # Used by the JSON-RPC server to convert incoming base64 fields appropriately.
@@ -214,7 +214,7 @@ convenience.
 
 =back
 
-There are also two deprecreated methods of authentications. This will be
+There are also two deprecated methods of authentications. This will be
 removed in the version after Bugzilla 5.0.
 
 =over

--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -1867,7 +1867,7 @@ or get information about bugs that have already been filed.
 See L<Bugzilla::WebService> for a description of how parameters are passed,
 and what B<STABLE>, B<UNSTABLE>, and B<EXPERIMENTAL> mean.
 
-Although the data input and output is the same for JSONRPC, XMLRPC and REST,
+Although the data input and output is the same for JSON-RPC, XML-RPC and REST,
 the directions for how to access the data via REST is noted in each method
 where applicable.
 

--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -1076,7 +1076,7 @@ sub update_attachment {
     }
     elsif (scalar @$update_flags && !scalar(@$new_flags) && !scalar keys %$params) {
 
-      # Requestees can set flags targetted to them, even if they cannot
+      # Requestees can set flags targeted to them, even if they cannot
       # edit the attachment. Flag setters can edit their own flags too.
       my %flag_list = map { $_->{id} => $_ } @$update_flags;
       my $flag_objs = Bugzilla::Flag->new_from_list([keys %flag_list]);

--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -2689,7 +2689,7 @@ B<STABLE>
 
 Gets information about particular bugs in the database.
 
-Note: Can also be called as "get_bugs" for compatibilty with Bugzilla 3.0 API.
+Note: Can also be called as "get_bugs" for compatibility with Bugzilla 3.0 API.
 
 =item B<REST>
 

--- a/Bugzilla/WebService/BugUserLastVisit.pm
+++ b/Bugzilla/WebService/BugUserLastVisit.pm
@@ -111,7 +111,7 @@ visited a bug.
 See L<Bugzilla::WebService> for a description of how parameters are passed,
 and what B<STABLE>, B<UNSTABLE>, and B<EXPERIMENTAL> mean.
 
-Although the data input and output is the same for JSONRPC, XMLRPC and REST,
+Although the data input and output is the same for JSON-RPC, XML-RPC and REST,
 the directions for how to access the data via REST is noted in each method
 where applicable.
 

--- a/Bugzilla/WebService/Bugzilla.pm
+++ b/Bugzilla/WebService/Bugzilla.pm
@@ -135,7 +135,7 @@ This provides functions that tell you about Bugzilla in general.
 See L<Bugzilla::WebService> for a description of how parameters are passed,
 and what B<STABLE>, B<UNSTABLE>, and B<EXPERIMENTAL> mean.
 
-Although the data input and output is the same for JSONRPC, XMLRPC and REST,
+Although the data input and output is the same for JSON-RPC, XML-RPC and REST,
 the directions for how to access the data via REST is noted in each method
 where applicable.
 

--- a/Bugzilla/WebService/Classification.pm
+++ b/Bugzilla/WebService/Classification.pm
@@ -171,7 +171,7 @@ C<string> The name of the classification.
 
 =item C<description>
 
-C<string> The description of the classificaion.
+C<string> The description of the classification.
 
 =item C<sort_key>
 

--- a/Bugzilla/WebService/Classification.pm
+++ b/Bugzilla/WebService/Classification.pm
@@ -108,7 +108,7 @@ You will be able to get information about them as well as manipulate them.
 See L<Bugzilla::WebService> for a description of how parameters are passed,
 and what B<STABLE>, B<UNSTABLE>, and B<EXPERIMENTAL> mean.
 
-Although the data input and output is the same for JSONRPC, XMLRPC and REST,
+Although the data input and output is the same for JSON-RPC, XML-RPC and REST,
 the directions for how to access the data via REST is noted in each method
 where applicable.
 

--- a/Bugzilla/WebService/Constants.pm
+++ b/Bugzilla/WebService/Constants.pm
@@ -233,7 +233,7 @@ use constant WS_ERROR_CODE => {
   rest_invalid_resource         => 32614,
 };
 
-# RESTful webservices use the http status code
+# RESTful webservices use the HTTP status code
 # to describe whether a call was successful or
 # to describe the type of error that occurred.
 use constant STATUS_OK               => 200;
@@ -248,7 +248,7 @@ use constant STATUS_GONE             => 410;
 
 # The integer value is the error code above returned by
 # the related webvservice call. We choose the appropriate
-# http status code based on the error code or use the
+# HTTP status code based on the error code or use the
 # default STATUS_BAD_REQUEST.
 sub REST_STATUS_CODE_MAP {
   my $status_code_map = {

--- a/Bugzilla/WebService/Group.pm
+++ b/Bugzilla/WebService/Group.pm
@@ -243,7 +243,7 @@ get information about them.
 See L<Bugzilla::WebService> for a description of how parameters are passed,
 and what B<STABLE>, B<UNSTABLE>, and B<EXPERIMENTAL> mean.
 
-Although the data input and output is the same for JSONRPC, XMLRPC and REST,
+Although the data input and output is the same for JSON-RPC, XML-RPC and REST,
 the directions for how to access the data via REST is noted in each method
 where applicable.
 

--- a/Bugzilla/WebService/Group.pm
+++ b/Bugzilla/WebService/Group.pm
@@ -567,7 +567,7 @@ different than their email.
 
 =item can_login
 
-C<boolean> A boolean value to indicate if the user can login into bugzilla.
+C<boolean> A boolean value to indicate if the user can login into Bugzilla.
 
 =item email_enabled
 
@@ -577,7 +577,7 @@ to the user or not.
 =item disabled_text
 
 C<string> A text field that holds the reason for disabling a user from logging
-into bugzilla, if empty then the user account is enabled otherwise it is
+into Bugzilla, if empty then the user account is enabled otherwise it is
 disabled/closed.
 
 =back
@@ -595,8 +595,8 @@ group object existed for that invalid name.
 
 =item 805 (Cannot view groups)
 
-Logged-in users are not authorized to edit bugzilla groups as they are not
-members of the creategroups group in bugzilla, or they are not authorized to
+Logged-in users are not authorized to edit Bugzilla groups as they are not
+members of the creategroups group in Bugzilla, or they are not authorized to
 access group member's information as they are not members of the "editusers"
 group or can bless the group.
 

--- a/Bugzilla/WebService/Group.pm
+++ b/Bugzilla/WebService/Group.pm
@@ -384,7 +384,7 @@ as the name of the groups.
 
 C<string> A new regular expression for email. Will automatically grant
 membership to these groups to anyone with an email address that matches
-this perl regular expression.
+this Perl regular expression.
 
 =item C<is_active>
 

--- a/Bugzilla/WebService/Product.pm
+++ b/Bugzilla/WebService/Product.pm
@@ -302,7 +302,7 @@ get information about them.
 See L<Bugzilla::WebService> for a description of how parameters are passed,
 and what B<STABLE>, B<UNSTABLE>, and B<EXPERIMENTAL> mean.
 
-Although the data input and output is the same for JSONRPC, XMLRPC and REST,
+Although the data input and output is the same for JSON-RPC, XML-RPC and REST,
 the directions for how to access the data via REST is noted in each method
 where applicable.
 

--- a/Bugzilla/WebService/Product.pm
+++ b/Bugzilla/WebService/Product.pm
@@ -425,7 +425,7 @@ B<EXPERIMENTAL>
 
 Returns a list of information about the products passed to it.
 
-Note: Can also be called as "get_products" for compatibilty with Bugzilla 3.0 API.
+Note: Can also be called as "get_products" for compatibility with Bugzilla 3.0 API.
 
 =item B<REST>
 

--- a/Bugzilla/WebService/Server.pm
+++ b/Bugzilla/WebService/Server.pm
@@ -101,7 +101,7 @@ sub bz_etag {
     # Append content_type to the end of the data
     # string as we want the etag to be unique to
     # the content_type. We do not need this for
-    # XMLRPC as text/xml is always returned.
+    # XML-RPC as text/xml is always returned.
     if (blessed($self) && $self->can('content_type')) {
       $data .= $self->content_type if $self->content_type;
     }
@@ -120,7 +120,7 @@ Bugzilla::WebService::Server - Base server class for the WebService API
 =head1 DESCRIPTION
 
 Bugzilla::WebService::Server is the base class for the individual WebService API
-servers such as XMLRPC, JSONRPC, and REST. You never actually create a
+servers such as XML-RPC, JSON-RPC, and REST. You never actually create a
 Bugzilla::WebService::Server directly, you only make subclasses of it.
 
 =head1 FUNCTIONS
@@ -130,7 +130,7 @@ Bugzilla::WebService::Server directly, you only make subclasses of it.
 =item C<bz_etag>
 
 This function is used to store an ETag value that will be used when returning
-the data by the different API server modules such as XMLRPC, or REST. The individual
+the data by the different API server modules such as XML-RPC, or REST. The individual
 webservice methods can also set the value earlier in the process if needed such as
 before a unique update token is added. If a value is not set earlier, an etag will
 automatically be created using the returned data except in some cases when an error

--- a/Bugzilla/WebService/Server/JSONRPC.pm
+++ b/Bugzilla/WebService/Server/JSONRPC.pm
@@ -55,8 +55,8 @@ sub create_json_coder {
   $json->allow_nonref(1);
 
   # This may seem a little backwards, but what this really means is
-  # "don't convert our utf8 into byte strings, just leave it as a
-  # utf8 string."
+  # "don't convert our UTF-8 into byte strings, just leave it as a
+  # UTF-8 string."
   $json->utf8(0) if Bugzilla->params->{'utf8'};
   return $json;
 }
@@ -74,7 +74,7 @@ sub response_header {
     utf8::encode($_[1]);
 
     # Since we're going to just be sending raw bytes, we need to
-    # set STDOUT to not expect utf8.
+    # set STDOUT to not expect UTF-8.
     disable_utf8();
   }
   return $self->SUPER::response_header(@_);
@@ -522,7 +522,7 @@ Here's a call to C<User.get>, with several parameters:
 
  jsonrpc.cgi?method=User.get&params=[ { "ids": [1,2], "names": ["user@domain.com"] } ]
 
-Although in reality you would url-encode the C<params> argument, so it would
+Although in reality you would URL-encode the C<params> argument, so it would
 look more like this:
 
  jsonrpc.cgi?method=User.get&params=%5B+%7B+%22ids%22%3A+%5B1%2C2%5D%2C+%22names%22%3A+%5B%22user%40domain.com%22%5D+%7D+%5D

--- a/Bugzilla/WebService/Server/REST.pm
+++ b/Bugzilla/WebService/Server/REST.pm
@@ -112,7 +112,7 @@ sub response {
   my ($self, $response) = @_;
 
   # If we have thrown an error, the 'error' key will exist
-  # otherwise we use 'result'. JSONRPC returns other data
+  # otherwise we use 'result'. JSON-RPC returns other data
   # along with the result/error such as version and id which
   # we will strip off for REST calls.
   my $content = $response->content;
@@ -547,7 +547,7 @@ looks cleaner.
 
 The REST API only supports JSON input, and either JSON and JSONP output.
 So objects sent and received must be in JSON format. Basically since
-the REST API is a sub class of the JSONRPC API, you can refer to
+the REST API is a sub class of the JSON-RPC API, you can refer to
 L<JSONRPC|Bugzilla::WebService::Server::JSONRPC> for more information
 on data types that are valid for REST.
 
@@ -602,14 +602,14 @@ the JSON-RPC library that Bugzilla uses, not by Bugzilla.
 
 =item B<handle>
 
-This method overrides the handle method provided by JSONRPC so that certain
+This method overrides the handle method provided by JSON-RPC so that certain
 actions related to REST such as determining the proper resource to use,
 loading query parameters, etc. can be done before the proper WebService
 method is executed.
 
 =item B<response>
 
-This method overrides the response method provided by JSONRPC so that
+This method overrides the response method provided by JSON-RPC so that
 the response content can be altered for REST before being returned to
 the client.
 

--- a/Bugzilla/WebService/Server/REST.pm
+++ b/Bugzilla/WebService/Server/REST.pm
@@ -121,7 +121,7 @@ sub response {
   if ($content) {
 
     # Content is in bytes at this point and needs to be converted
-    # back to utf8 string.
+    # back to UTF-8 string.
     enable_utf8();
     utf8::decode($content) if !utf8::is_utf8($content);
     $json_data = $self->json->decode($content);
@@ -352,7 +352,7 @@ sub _retrieve_json_params {
   }
 
   # Any parameters passed in in the body of a non-GET request will override
-  # any parameters pull from the url path. Otherwise non-unique keys are
+  # any parameters pull from the URL path. Otherwise non-unique keys are
   # combined.
   if ($self->request->method ne 'GET') {
     my $extra_params = {};

--- a/Bugzilla/WebService/Server/XMLRPC.pm
+++ b/Bugzilla/WebService/Server/XMLRPC.pm
@@ -141,7 +141,7 @@ use Scalar::Util qw(tainted);
 sub new {
   my $self = shift->SUPER::new(@_);
 
-  # Initialise XML::Parser to not expand references to entities, to prevent DoS
+  # Initialize XML::Parser to not expand references to entities, to prevent DoS
   require XML::Parser;
   my $parser = XML::Parser->new(
     NoExpand => 1,

--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -814,7 +814,7 @@ C<string> The new name of the user.
 
 =item C<email>
 
-C<string> The email of the user. Note that email used to login to bugzilla.
+C<string> The email of the user. Note that email used to login to Bugzilla.
 Also note that you can only update one user at a time when changing the
 login name / email. (An error will be thrown if you try to update this field
 for multiple users at once.)
@@ -830,7 +830,7 @@ C<boolean> A boolean value to enable/disable sending bug-related mail to the use
 =item C<login_denied_text>
 
 C<string> A text field that holds the reason for disabling a user from logging
-into bugzilla, if empty then the user account is enabled otherwise it is
+into Bugzilla, if empty then the user account is enabled otherwise it is
 disabled/closed.
 
 =item C<groups>
@@ -1042,7 +1042,7 @@ different than their email.
 
 =item can_login
 
-C<boolean> A boolean value to indicate if the user can login into bugzilla.
+C<boolean> A boolean value to indicate if the user can login into Bugzilla.
 
 =item email_enabled
 
@@ -1052,7 +1052,7 @@ to the user or not.
 =item login_denied_text
 
 C<string> A text field that holds the reason for disabling a user from logging
-into bugzilla, if empty then the user account is enabled. Otherwise it is
+into Bugzilla, if empty then the user account is enabled. Otherwise it is
 disabled/closed.
 
 =item groups

--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -564,7 +564,7 @@ management of cookies across sessions.
 
 On success, a hash containing two items, C<id>, the numeric id of the
 user that was logged in, and a C<token> which can be passed in
-the parameters as authentication in other calls. A set of http cookies
+the parameters as authentication in other calls. A set of HTTP cookies
 is also sent with the response. These cookies *or* the token can be sent
 along with any future requests to the webservice, for the duration of the
 session. Note that cookies are not accepted for GET requests for JSON-RPC

--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -520,7 +520,7 @@ log in/out using an existing account.
 See L<Bugzilla::WebService> for a description of how parameters are passed,
 and what B<STABLE>, B<UNSTABLE>, and B<EXPERIMENTAL> mean.
 
-Although the data input and output is the same for JSONRPC, XMLRPC and REST,
+Although the data input and output is the same for JSON-RPC, XML-RPC and REST,
 the directions for how to access the data via REST is noted in each method
 where applicable.
 
@@ -567,7 +567,7 @@ user that was logged in, and a C<token> which can be passed in
 the parameters as authentication in other calls. A set of http cookies
 is also sent with the response. These cookies *or* the token can be sent
 along with any future requests to the webservice, for the duration of the
-session. Note that cookies are not accepted for GET requests for JSONRPC
+session. Note that cookies are not accepted for GET requests for JSON-RPC
 and REST for security reasons. You may, however, use the token or valid
 login parameters for those requests.
 

--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -555,7 +555,7 @@ call to login should expire with the session or not.  In order for
 this option to have effect the Bugzilla server must be configured to
 allow the user to set this option - the Bugzilla parameter
 I<rememberlogin> must be set to "defaulton" or
-"defaultoff". Addionally, the client application must implement
+"defaultoff". Additionally, the client application must implement
 management of cookies across sessions.
 
 =back
@@ -601,7 +601,7 @@ A login or password parameter was not provided.
 
 =item C<token> was added in Bugzilla B<4.4.3>.
 
-=item This function will be removed in the release after Bugzilla 5.0, in favour of API keys.
+=item This function will be removed in the release after Bugzilla 5.0, in favor of API keys.
 
 =back
 
@@ -665,7 +665,7 @@ for the provided username.
 
 =item Added in Bugzilla B<5.0>.
 
-=item This function will be removed in the release after Bugzilla 5.0, in favour of API keys.
+=item This function will be removed in the release after Bugzilla 5.0, in favor of API keys.
 
 =back
 
@@ -1171,7 +1171,7 @@ illegal to pass a group name you don't belong to.
 =item B<Description>
 
 Allows for validating a user's API key, token, or username and password.
-If sucessfully authenticated, it returns simple information about the
+If successfully authenticated, it returns simple information about the
 logged in user.
 
 =item B<Params> (none)

--- a/Log/Log4perl/Layout/Mozilla.pm
+++ b/Log/Log4perl/Layout/Mozilla.pm
@@ -82,7 +82,7 @@ __END__
 
 =head1 NAME
 
-Log::Log4perl::Layout::Mozilla - Implement the mozilla-services json log format
+Log::Log4perl::Layout::Mozilla - Implement the mozilla-services JSON log format
 
 =head1 SYNOPSIS
 
@@ -95,7 +95,7 @@ Example configuration:
 =head1 DESCRIPTION
 
 This class implements a C<Log::Log4perl> layout format
-that implements the recommend json format using in Mozilla services.
+that implements the recommend JSON format using in Mozilla services.
 L<https://wiki.mozilla.org/Firefox/Services/Logging#MozLog_JSON_schema>.
 
 The JSON hash is ASCII encoded, with no newlines or other whitespace, and is

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -377,7 +377,7 @@ my %test_requires = (
 my @bmo_features = grep { is_bmo_feature($_) } keys %optional_features;
 
 $optional_features{bmo} = {
-  description => 'features that bmo needs',
+  description => 'features that BMO needs',
   prereqs     => {
     runtime => {
       requires => {

--- a/README.rst
+++ b/README.rst
@@ -118,7 +118,7 @@ Technical Details
 
 This Vagrant environment is a very complete but scaled-down version of
 production BMO.  It uses roughly the same RPMs (from CentOS 6, versus RHEL 6
-in production) and the same perl dependencies (via
+in production) and the same Perl dependencies (via
 https://github.com/mozilla-bteam/carton-bundles).
 
 It includes a couple example products, some fake users, and some of BMO's
@@ -137,7 +137,7 @@ Perl Shell (re.pl, repl)
 
 Installed on the vagrant vm is also a program called re.pl.
 
-re.pl an interactive perl shell (sometimes called a REPL (short for Read-Eval-Print-Loop)).
+re.pl an interactive Perl shell (sometimes called a REPL (short for Read-Eval-Print-Loop)).
 It loads Bugzilla.pm and you can call Bugzilla internal API methods from it, an example session is reproduced below:
 
 .. code-block:: plain

--- a/README.rst
+++ b/README.rst
@@ -137,7 +137,7 @@ Perl Shell (re.pl, repl)
 
 Installed on the vagrant vm is also a program called re.pl.
 
-re.pl an interactive perl shell (somtimes called a REPL (short for Read-Eval-Print-Loop)).
+re.pl an interactive perl shell (sometimes called a REPL (short for Read-Eval-Print-Loop)).
 It loads Bugzilla.pm and you can call Bugzilla internal API methods from it, an example session is reproduced below:
 
 .. code-block:: plain
@@ -188,7 +188,7 @@ Using Docker (For Development)
 While not yet as featureful or complete as the vagrant setup, this repository now contains a
 docker-compose file that will create a local bugzilla for testing.
 
-To use docker-compose, ensure you have the latest Docker install for your environemnt
+To use docker-compose, ensure you have the latest Docker install for your environment
 (Linux, Windows, or Mac OS). If you are using Ubuntu, then you can read the next section
 to ensure that you have the correct docker setup.
 
@@ -199,7 +199,7 @@ to ensure that you have the correct docker setup.
 
 Then, you must configure your browser to use http://localhost:1091 as an HTTP proxy.
 For setting a proxy in Firefox, see `Firefox Connection Settings`_.
-The procecure should be similar for other browsers.
+The procedure should be similar for other browsers.
 
 .. _`Firefox Connection Settings`: https://support.mozilla.org/en-US/kb/connection-settings-firefox
 
@@ -408,7 +408,7 @@ NYTPROF_DIR
 LOG4PERL_CONFIG_FILE
   Filename of `Log::Log4perl`_ config file.
   It defaults to log4perl-syslog.conf.
-  If the file is given as a relative path, it will belative to the /app/conf/ directory.
+  If the file is given as a relative path, it will relative to the /app/conf/ directory.
 
 .. _`Devel::NYTProf`: https://metacpan.org/pod/Devel::NYTProf
 
@@ -418,7 +418,7 @@ LOG4PERL_STDERR_DISABLE
   Boolean. By default log messages are logged as plain text to `STDERR`.
   Setting this to a true value disables this behavior.
 
-  Note: For programs that run using the `cereal` log aggregator, this environemnt
+  Note: For programs that run using the `cereal` log aggregator, this environment
   variable will be ignored.
 
 
@@ -466,7 +466,7 @@ changing the mail_delivery_method to either 'Test' or 'Sendmail'. Afterwards res
 With this option, all mail will be appended to a ``mailer.testfile``.
 
 - Using docker, run ``docker-compose run bmo-web.vm cat /app/data/mailer.testfile``.
-- Using vagrant, run ``vagrant ssh web`` and then naviage to ``/vagrant/data/mailer.testfile``.
+- Using vagrant, run ``vagrant ssh web`` and then navigate to ``/vagrant/data/mailer.testfile``.
 
 'Sendmail' option (Default for Vagrant)
 ~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -302,15 +302,15 @@ BUGZILLA_ALLOW_INSECURE_HTTP
   This should never be set in production. It allows auth delegation and oauth over http.
 
 BMO_urlbase
-  The public url for this instance. Note that if this begins with https://
+  The public URL for this instance. Note that if this begins with https://
   and BMO_inbound_proxies is set to '*' Bugzilla will believe the connection to it
   is using SSL.
 
 BMO_canonical_urlbase
-  The public url for the production instance, if different from urlbase above.
+  The public URL for the production instance, if different from urlbase above.
 
 BMO_attachment_base
-  This is the url for attachments.
+  This is the URL for attachments.
   When the allow_attachment_display parameter is on, it is possible for a
   malicious attachment to steal your cookies or perform an attack on Bugzilla
   using your credentials.
@@ -367,19 +367,19 @@ BMO_memcached_namespace
   The global namespace for the memcached servers.
 
 BMO_memcached_servers
-  A list of memcached servers (ip addresses or host names). Can be empty.
+  A list of memcached servers (IP addresses or host names). Can be empty.
 
 BMO_shadowdb
   The database name of the read-only database.
 
 BMO_shadowdbhost
-  The hotname or ip address of the read-only database.
+  The hotname or IP address of the read-only database.
 
 BMO_shadowdbport
    The port of the read-only database.
 
 BMO_setrlimit
-    This is a json object and can set any limit described in https://metacpan.org/pod/BSD::Resource.
+    This is a JSON object and can set any limit described in https://metacpan.org/pod/BSD::Resource.
     Typically it used for setting RLIMIT_AS, and the default value is ``{ "RLIMIT_AS": 2000000000 }``.
 
 BMO_size_limit

--- a/README.rst
+++ b/README.rst
@@ -186,7 +186,7 @@ Using Docker (For Development)
 ==============================
 
 While not yet as featureful or complete as the vagrant setup, this repository now contains a
-docker-compose file that will create a local bugzilla for testing.
+docker-compose file that will create a local Bugzilla for testing.
 
 To use docker-compose, ensure you have the latest Docker install for your environment
 (Linux, Windows, or Mac OS). If you are using Ubuntu, then you can read the next section
@@ -455,9 +455,9 @@ Development Tips
 Testing Emails
 --------------
 
-With vagrant have two options to test emails sent by a local bugzilla instance. You can configure
+With vagrant have two options to test emails sent by a local Bugzilla instance. You can configure
 which setting you want to use by going to http://bmo-web.vm/editparams.cgi?section=mta and
-changing the mail_delivery_method to either 'Test' or 'Sendmail'. Afterwards restart bmo with
+changing the mail_delivery_method to either 'Test' or 'Sendmail'. Afterwards restart BMO with
 ``vagrant reload``. With docker, only the default 'Test' option is supported.
 
 'Test' option (Default for Docker)
@@ -490,6 +490,6 @@ mail (SMTP, which bmo-web.vm doesn't provide). To work around this, using a regu
 account to first setup, then modify the settings of that account: Right Click the account in
 the left side bar > Settings > Server Settings. Update the server settings to match those
 listed above. Afterwards, you may update the account name to be vagrant@bmo-web.vm. Thunderbird
-will now pull email from bmo. You can try it out by commenting on a bug.
+will now pull email from BMO. You can try it out by commenting on a bug.
 
 .. _`Thunderbird's`: https://www.mozilla.org/en-US/thunderbird/

--- a/attachment.cgi
+++ b/attachment.cgi
@@ -381,7 +381,7 @@ sub view {
   # Return the appropriate HTTP response headers.
   $attachment->datasize || ThrowUserError("attachment_removed");
 
-  # BMO add a hook for github url redirection
+  # BMO add a hook for GitHub URL redirection
   Bugzilla::Hook::process('attachment_view', {attachment => $attachment});
 
   my $do_redirect = 0;
@@ -569,7 +569,7 @@ sub insert {
 
   if ($attach_text) {
 
-    # Convert to unix line-endings if pasting a patch
+    # Convert to Unix line-endings if pasting a patch
     if (scalar($cgi->param('ispatch'))) {
       $attach_text =~ s/[\012\015]{1,2}/\012/g;
     }

--- a/attachment.cgi
+++ b/attachment.cgi
@@ -238,7 +238,7 @@ sub get_attachment {
       $attachments{$field_name} = $attachment;
     }
     my @args = map { $_ . '=' . $attachments{$_}->id } @field_names;
-    my $cgi_params = $cgi->canonicalise_query(@field_names, 't', 'Bugzilla_login',
+    my $cgi_params = $cgi->canonicalize_query(@field_names, 't', 'Bugzilla_login',
       'Bugzilla_password');
     push(@args, $cgi_params) if $cgi_params;
     my $path = 'attachment.cgi?' . join('&', @args);
@@ -791,7 +791,7 @@ sub update {
     $attachment->set_flags($flags, $new_flags);
   }
 
-  # Requestees can set flags targetted to them, even if they cannot
+  # Requestees can set flags targeted to them, even if they cannot
   # edit the attachment. Flag setters can edit their own flags too.
   elsif (scalar @$flags) {
     my @flag_ids  = map { $_->{id} } @$flags;

--- a/buglist.cgi
+++ b/buglist.cgi
@@ -423,7 +423,7 @@ elsif (($cmdtype eq "doit") && defined $cgi->param('remtype')) {
     $user = Bugzilla->login(LOGIN_REQUIRED);
     my $token = $cgi->param('token');
     check_hash_token($token, ['searchknob']);
-    $buffer = $params->canonicalise_query('cmdtype', 'remtype', 'query_based_on',
+    $buffer = $params->canonicalize_query('cmdtype', 'remtype', 'query_based_on',
       'token');
     InsertNamedQuery(DEFAULT_QUERY_NAME, $buffer);
     $vars->{'message'} = "buglist_new_default_query";
@@ -439,7 +439,7 @@ elsif (($cmdtype eq "doit") && defined $cgi->param('remtype')) {
     # individual bugs.
     if ($cgi->param('list_of_bugs')) {
 
-      # We add/remove tags based on the action choosen.
+      # We add/remove tags based on the action chosen.
       my $action = trim($cgi->param('action') || '');
       $action =~ /^(add|remove)$/
         || ThrowUserError('unknown_action', {action => $action});
@@ -1116,7 +1116,7 @@ else {
 
 # Set 'urlquerypart' once the buglist ID is known.
 $vars->{'urlquerypart'}
-  = $params->canonicalise_query('order', 'cmdtype', 'query_based_on', 'token');
+  = $params->canonicalize_query('order', 'cmdtype', 'query_based_on', 'token');
 
 if ($format->{'extension'} eq "csv") {
 

--- a/chart.cgi
+++ b/chart.cgi
@@ -20,7 +20,7 @@
 #
 # JS-less chart creation - hard.
 # Broken image on error or no data - need to do much better.
-# Centralise permission checking, so Bugzilla->user->in_group('editbugs')
+# Centralize permission checking, so Bugzilla->user->in_group('editbugs')
 #   not scattered everywhere.
 # User documentation :-)
 #
@@ -61,7 +61,7 @@ if (!Bugzilla->feature('new_charts')) {
 
 # Go back to query.cgi if we are adding a boolean chart parameter.
 if (grep(/^cmd-/, $cgi->param())) {
-  my $params = $cgi->canonicalise_query("format", "ctype", "action");
+  my $params = $cgi->canonicalize_query("format", "ctype", "action");
   $cgi->base_redirect("query.cgi?format="
       . $cgi->param('query_format') . ($params ? "&$params" : ''));
 }
@@ -84,7 +84,7 @@ $action ||= "assemble";
 
 # Go to buglist.cgi if we are doing a search.
 if ($action eq "search") {
-  my $params = $cgi->canonicalise_query("format", "ctype", "action");
+  my $params = $cgi->canonicalize_query("format", "ctype", "action");
   $cgi->base_redirect('buglist.cgi' . ($params ? "?$params" : ""));
 }
 
@@ -221,7 +221,7 @@ elsif ($action eq "convert_search") {
     my $params = new Bugzilla::CGI($query->edit_link);
 
     # These two parameters conflict with the one below.
-    $url = '&' . $params->canonicalise_query('format', 'query_format');
+    $url = '&' . $params->canonicalize_query('format', 'query_format');
   }
   $cgi->base_redirect("query.cgi?format=create-series$url");
 }
@@ -340,7 +340,7 @@ sub wrap {
   $vars->{'time'} = localtime(time());
 
   $vars->{'imagebase'}
-    = $cgi->canonicalise_query("action", "action-wrap", "ctype", "format",
+    = $cgi->canonicalize_query("action", "action-wrap", "ctype", "format",
     "width", "height");
 
   print $cgi->header();

--- a/checksetup.pl
+++ b/checksetup.pl
@@ -132,7 +132,7 @@ exit 0 if $switch{'check-modules'};
 # It's never safe to "use" a Bugzilla module in checksetup. If a module
 # prerequisite is missing, and you "use" a module that requires it,
 # then instead of our nice normal checksetup message, the user would
-# get a cryptic perl error about the missing module.
+# get a cryptic Perl error about the missing module.
 
 require Bugzilla;
 require Bugzilla::User;
@@ -421,7 +421,7 @@ F<checksetup.pl> runs through several stages during installation:
 
 =item 1
 
-Checks if the required and optional perl modules are installed,
+Checks if the required and optional Perl modules are installed,
 using L<Bugzilla::Install::Requirements/check_requirements>.
 
 =item 2

--- a/collectstats.pl
+++ b/collectstats.pl
@@ -460,7 +460,7 @@ sub delta_time {
 
 sub CollectSeriesData {
 
-  # We need some way of randomising the distribution of series, such that
+  # We need some way of randomizing the distribution of series, such that
   # all of the series which are to be run every 7 days don't run on the same
   # day. This is because this might put the server under severe load if a
   # particular frequency, such as once a week, is very common. We achieve

--- a/conf/log4perl-json.conf
+++ b/conf/log4perl-json.conf
@@ -4,7 +4,7 @@ log4perl.appender.Cereal.PeerAddr=127.0.0.1
 log4perl.appender.Cereal.PeerPort=5880
 log4perl.appender.Cereal.defer_connection=1
 
-# This class is currently bundled with bugzilla
+# This class is currently bundled with Bugzilla
 log4perl.appender.Cereal.layout = Log::Log4perl::Layout::Mozilla
 
 # lines longer than this will not be logged in detail.

--- a/contribute.json
+++ b/contribute.json
@@ -12,7 +12,7 @@
         "CSS",
         "HTML",
         "JSON",
-        "Javascript",
+        "JavaScript",
         "Perl",
         "jQuery"
     ],

--- a/docs/en/images/bzLifecycle.xml
+++ b/docs/en/images/bzLifecycle.xml
@@ -1055,7 +1055,7 @@ work on bug#</dia:string>
         <dia:composite type="text">
           <dia:attribute name="string">
             <dia:string>#Bug is not fixable
-(e.g because it is invalid)#</dia:string>
+(e.g. because it is invalid)#</dia:string>
           </dia:attribute>
           <dia:attribute name="font">
             <dia:font family="sans" style="0" name="Helvetica"/>

--- a/docs/en/rst/administering/flags.rst
+++ b/docs/en/rst/administering/flags.rst
@@ -33,10 +33,10 @@ Category
     You can set a flag to be visible or not visible on any combination of
     products and components.
 
-    Default behaviour for a newly created flag is to appear on all
+    Default behavior for a newly created flag is to appear on all
     products and all components, which is why ``__Any__:__Any__``
     is already entered in the :guilabel:`Inclusions` box.
-    If this is not your desired behaviour, you must either set some
+    If this is not your desired behavior, you must either set some
     exclusions (for products on which you don't want the flag to appear),
     or you must remove ``__Any__:__Any__`` from the :guilabel:`Inclusions` box
     and define products/components specifically for this flag.

--- a/docs/en/rst/administering/keywords.rst
+++ b/docs/en/rst/administering/keywords.rst
@@ -4,7 +4,7 @@ Keywords
 ########
 
 The administrator can define keywords which can be used to tag and
-categorise bugs. For example, the keyword "regression" is commonly used.
+categorize bugs. For example, the keyword "regression" is commonly used.
 A company might have a policy stating all regressions
 must be fixed by the next release—this keyword can make tracking those
 bugs much easier. Keywords are global, rather than per product.

--- a/docs/en/rst/administering/parameters.rst
+++ b/docs/en/rst/administering/parameters.rst
@@ -389,7 +389,7 @@ necessary to configure Bugzilla for use with LDAP authentication.
 The existing authentication
 scheme for Bugzilla uses email addresses as the primary user ID and a
 password to authenticate that user. All places within Bugzilla that
-require a user ID (e.g assigning a bug) use the email
+require a user ID (e.g. assigning a bug) use the email
 address. The LDAP authentication builds on top of this scheme, rather
 than replacing it. The initial log-in is done with a username and
 password for the LDAP directory. Bugzilla tries to bind to LDAP using

--- a/docs/en/rst/api/core/v1/attachment.rst
+++ b/docs/en/rst/api/core/v1/attachment.rst
@@ -97,7 +97,7 @@ creator_detail    object    An object containing detailed user information for
                             detail object, see :ref:`rest_single_bug`.
 flags             array     Array of objects, each containing the information
                             about the flag currently set for each attachment.
-                            Each flag object contains items descibed in the
+                            Each flag object contains items described in the
                             Flag object below.
 ================  ========  =====================================================
 

--- a/docs/en/rst/api/core/v1/bug.rst
+++ b/docs/en/rst/api/core/v1/bug.rst
@@ -933,9 +933,9 @@ product                string   The name of the product that the bug is in. If
                                 valid on a bug depends on the product. Groups
                                 that are not valid in the new product will be
                                 automatically removed, and groups which are
-                                mandatory in the new product will be automaticaly
-                                added, but no other automatic group changes will
-                                be done.
+                                mandatory in the new product will be
+                                automatically added, but no other automatic group
+                                changes will be done.
 
                                 .. note::
                                    Users can only move a bug into a product if

--- a/docs/en/rst/api/core/v1/classification.rst
+++ b/docs/en/rst/api/core/v1/classification.rst
@@ -61,7 +61,7 @@ name         type    description
 ===========  ======  ============================================================
 id           int     The ID of the classification.
 name         string  The name of the classification.
-description  string  The description of the classificaion.
+description  string  The description of the classification.
 sort_key     int     The value which determines the order the classification is
                      sorted.
 products     array   Products the user is authorized to access within the

--- a/docs/en/rst/api/core/v1/comment.rst
+++ b/docs/en/rst/api/core/v1/comment.rst
@@ -220,13 +220,13 @@ Example:
 
    GET /rest/bug/comment/tags/spa
 
-=========  ======  ====================================================
+=========  ======  =====================================================
 name       type    description
-=========  ======  ====================================================
-**query**  string  Only tags containg this substring will be returned.
+=========  ======  =====================================================
+**query**  string  Only tags containing this substring will be returned.
 limit      int     If provided will return no more than ``limit`` tags.
                    Defaults to ``10``.
-=========  ======  ====================================================
+=========  ======  =====================================================
 
 **Response**
 

--- a/docs/en/rst/api/core/v1/comment.rst
+++ b/docs/en/rst/api/core/v1/comment.rst
@@ -295,7 +295,7 @@ This method can throw all of the errors that :ref:`rest_single_bug` throws, plus
 * 125 (Comment Tagging Disabled)
   Comment tagging support is not available or enabled.
 * 126 (Invalid Comment Tag)
-  The comment tag provided was not valid (eg. contains invalid characters).
+  The comment tag provided was not valid (e.g. contains invalid characters).
 * 127 (Comment Tag Too Short)
   The comment tag provided is shorter than the minimum length.
 * 128 (Comment Tag Too Long)

--- a/docs/en/rst/api/core/v1/field.rst
+++ b/docs/en/rst/api/core/v1/field.rst
@@ -223,7 +223,7 @@ product_id  int     If you're picking a product-specific field, you have to
                     specify the ID of the product you want the values for.
 ==========  ======  =============================================================
 
-**Resppnse**
+**Response**
 
 .. code-block:: js
 

--- a/docs/en/rst/api/core/v1/group.rst
+++ b/docs/en/rst/api/core/v1/group.rst
@@ -124,7 +124,7 @@ description  string   A new description for the groups. This is what will appear
                       in the UI as the name of the groups.
 user_regexp  string   A new regular expression for email. Will automatically
                       grant membership to these groups to anyone with an email
-                      address that matches this perl regular expression.
+                      address that matches this Perl regular expression.
 is_active    boolean  Set if groups are active and eligible to be used for bugs.
                       ``true`` if bugs can be restricted to this group, ``false``
                       otherwise.

--- a/docs/en/rst/api/core/v1/group.rst
+++ b/docs/en/rst/api/core/v1/group.rst
@@ -287,7 +287,7 @@ email          string   The email address of the user.
 name           string   The login name of the user. Note that in some situations
                         this is different than their email.
 can_login      boolean  A boolean value to indicate if the user can login into
-                        bugzilla.
+                        Bugzilla.
 email_enabled  boolean  A boolean value to indicate if bug-related mail will
                         be sent to the user or not.
 disabled_text  string   A text field that holds the reason for disabling a user
@@ -301,7 +301,7 @@ disabled_text  string   A text field that holds the reason for disabling a user
   A non existing group name was passed to the function, as a result no
   group object existed for that invalid name.
 * 805 (Cannot view groups)
-  Logged-in users are not authorized to edit bugzilla groups as they are not
-  members of the creategroups group in bugzilla, or they are not authorized to
+  Logged-in users are not authorized to edit Bugzilla groups as they are not
+  members of the creategroups group in Bugzilla, or they are not authorized to
   access group member's information as they are not members of the "editusers"
   group or can bless the group.

--- a/docs/en/rst/api/core/v1/user.rst
+++ b/docs/en/rst/api/core/v1/user.rst
@@ -12,7 +12,7 @@ Login
 Logging in with a username and password is required for many Bugzilla
 installations, in order to search for private bugs, post new bugs, etc. This
 method allows you to retrieve a token that can be used as authentication for
-subsequent API calls. Otherwise yuou will need to pass your ``login`` and
+subsequent API calls. Otherwise you will need to pass your ``login`` and
 ``password`` with each call.
 
 This method will be going away in the future in favor of using *API keys*.
@@ -159,7 +159,7 @@ password    string  The password for the new user account, in plain text. It
    }
 
 ====  ====  ============================================
-name  type  desciption
+name  type  description
 ====  ====  ============================================
 id    int   The numeric ID of the user that was created.
 ====  ====  ============================================
@@ -427,7 +427,7 @@ Who Am I
 --------
 
 Allows for validating a user's API key, token, or username and password.
-If sucessfully authenticated, it returns simple information about the
+If successfully authenticated, it returns simple information about the
 logged in user.
 
 **Request**
@@ -442,7 +442,7 @@ logged in user.
 
    {
      "id" : "1234",
-     "name" : "user@bugzulla.org",
+     "name" : "user@bugzilla.org",
      "real_name" : "Test User",
      "nick" : "user"
    }

--- a/docs/en/rst/api/core/v1/user.rst
+++ b/docs/en/rst/api/core/v1/user.rst
@@ -197,7 +197,7 @@ login names using the ``ids`` or ``names`` parameters respectively.
 **names**          array    Additional login names of users to update.
 full_name          string   The new name of the user.
 email              string   The email of the user. Note that email used to
-                            login to bugzilla. Also note that you can only
+                            login to Bugzilla. Also note that you can only
                             update one user at a time when changing the login
                             name / email. (An error will be thrown if you try to
                             update this field for multiple users at once.)
@@ -355,7 +355,7 @@ email              string   The email address of the user.
 name               string   The login name of the user. Note that in some
                             situations this is different than their email.
 can_login          boolean  A boolean value to indicate if the user can login
-                            into bugzilla.
+                            into Bugzilla.
 email_enabled      boolean  A boolean value to indicate if bug-related mail will
                             be sent to the user or not.
 login_denied_text  string   A text field that holds the reason for disabling a

--- a/docs/en/rst/integrating/apis.rst
+++ b/docs/en/rst/integrating/apis.rst
@@ -15,7 +15,7 @@ The APIs currently available are as follows:
 Ad-Hoc APIs
 ===========
 
-Various pages on Bugzilla are available in machine-parseable formats as well
+Various pages on Bugzilla are available in machine-parsable formats as well
 as HTML. For example, bugs can be downloaded as XML, and buglists as CSV.
 CSV is useful for spreadsheet import. There should be links on the HTML page
 to alternate data formats where they are available.

--- a/docs/en/rst/integrating/auth-delegation.rst
+++ b/docs/en/rst/integrating/auth-delegation.rst
@@ -20,7 +20,7 @@ and the Bugzilla site is `http://bugzilla.mozilla.org`.
      with a the request body data being a JSON object with keys `client_api_key` and `client_api_login`.
   2. The callback, when responding to the POST request must return a JSON object with a key `result`. This result
      is intended to be a unique token used to identify this transaction.
-  3. Bugzilla will then cause the useragent to redirect (using a GET request) to `http://app.example.org/callback`
+  3. Bugzilla will then cause the user agent to redirect (using a GET request) to `http://app.example.org/callback`
      with additional query string parameters `client_api_login` and `callback_result`.
   4. At this point, the consumer now has the api key and login information. Be sure to compare the `callback_result` to whatever result was initially sent back
      to Bugzilla.

--- a/docs/en/rst/integrating/auth-delegation.rst
+++ b/docs/en/rst/integrating/auth-delegation.rst
@@ -28,7 +28,7 @@ and the Bugzilla site is `http://bugzilla.mozilla.org`.
    resource.
 
 Your application should take measures to ensure when receiving a user at your
-callback URL that you previously redirected them to Bugzilla. The simplest method would be ensuring the callback url always has the
+callback URL that you previously redirected them to Bugzilla. The simplest method would be ensuring the callback URL always has the
 hostname and path you specified, with only the query string parameters varying.
 
 The description should include the name of your application, in a form that will be recognizable to users.

--- a/docs/en/rst/integrating/auth0.rst
+++ b/docs/en/rst/integrating/auth0.rst
@@ -11,7 +11,7 @@ Parameter             Example(s)                                        Notes
 Name                  BMO-Stage                                         Whatever makes you happy
 Client ID             aaaaaaaaaaaaaaaaaaaa                              Ask your Bugzilla admin to create one for you.
 Client Secret         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa          Same as above.
-Authorization URL     https://bugzilla.allizom.org/oauth/authorize      Note the http client must use the correct HOST header.
+Authorization URL     https://bugzilla.allizom.org/oauth/authorize      Note the HTTP client must use the correct HOST header.
 Token URL             https://bugzilla.allizom.org/oauth/access_token   (none)
 Scope                 user:read                                         As of this writing, this is the only scope available.
 Fetch User Profile    (see below)                                       (none)

--- a/docs/en/rst/integrating/extensions.rst
+++ b/docs/en/rst/integrating/extensions.rst
@@ -156,7 +156,7 @@ To add a new user preference:
   :file:`hook/global/setting-descs-settings.none.tmpl`. Your code can see the
   hash variable; just set more members in it.
 
-* To change behaviour based on the setting, reference it in templates using
+* To change behavior based on the setting, reference it in templates using
   ``[% user.settings.setting_name.value %]``. Reference it in code using
   ``$user->settings->{'setting_name'}->{'value'}``. The value will be one of
   the option tag names (e.g. some_option).

--- a/docs/en/rst/integrating/faq.rst
+++ b/docs/en/rst/integrating/faq.rst
@@ -8,7 +8,7 @@ How do I...
 
 ...add a new field on a bug?
   Use :ref:`custom-fields` or, if you just want new form fields on bug entry
-  but don't need Bugzilla to track the field seperately thereafter, you can
+  but don't need Bugzilla to track the field separately thereafter, you can
   use a :ref:`custom bug entry form <custom-bug-entry>`.
 
 ...change the name of a built-in bug field?

--- a/docs/en/rst/integrating/templates.rst
+++ b/docs/en/rst/integrating/templates.rst
@@ -6,7 +6,7 @@ Templates
 Bugzilla uses a system of templates to define its user interface. The standard
 templates can be modified, replaced or overridden. You can also use template
 hooks in an :ref:`extension <extensions>` to add or modify the
-behaviour of templates using a stable interface.
+behavior of templates using a stable interface.
 
 .. _template-directory:
 
@@ -199,9 +199,9 @@ customizing for your installation.
   This template controls the appearance of the bug lists created
   by Bugzilla. Editing this template allows per-column control of
   the width and title of a column, the maximum display length of
-  each entry, and the wrap behaviour of long entries.
+  each entry, and the wrap behavior of long entries.
   For long bug lists, Bugzilla inserts a 'break' every 100 bugs by
-  default; this behaviour is also controlled by this template, and
+  default; this behavior is also controlled by this template, and
   that value can be modified here.
 
 :file:`bug/create/user-message.html.tmpl`:

--- a/docs/en/rst/using/finding.rst
+++ b/docs/en/rst/using/finding.rst
@@ -89,7 +89,7 @@ There are three fields in each row (known as a "term") of a custom search:
   the value to which the field is being compared
 
 The list of available *fields* contains all the fields defined for a bug,
-including any custom fields, and then also some pseudofields like
+including any custom fields, and then also some pseudo-fields like
 :guilabel:`Assignee Real Name`, :guilabel:`Days Since Bug Changed`,
 :guilabel:`Time Since Assignee Touched` and other things it may be useful to
 search on.
@@ -217,7 +217,7 @@ to list the bugs restricted to `groupname`.
 Searching on Relative Dates
 ---------------------------
 
-In order to conduct searches over a window of time, you can use *relative dates* in query values. 
+In order to conduct searches over a window of time, you can use *relative dates* in query values.
 
 The relative date values are of the form `nnV` where `nn` is a positive or negative integer and `V` is one of:
 
@@ -227,7 +227,7 @@ The relative date values are of the form `nnV` where `nn` is a positive or negat
 * `m` – for months
 * `y` – for years
 
-A value of `1d` means 24 hours in the future from the time of the search. 
+A value of `1d` means 24 hours in the future from the time of the search.
 
 A value of `-1d` means 24 hours in the past from the time of the search.
 
@@ -243,11 +243,11 @@ and the field compared is a Datetime type.
 To find bugs opened in the last 24 hours, you could search on:
 
     Opened   is less than   "-1d"
-    
+
 To find bugs opened during the current day (UTC),
 
     Opened   is less than   "-0ds"
-    
+
 Appending `s` to a relative date means *start of*.
 
 You may also use relative dates for when a field changed. In the :guilabel:`Custom Search` operator that would be
@@ -319,5 +319,5 @@ Edit Search:
 
 Remember Search As:
     You can give a search a name and remember it; the name will appear
-    as an auto-completion in the search field in the header of Bugzilla 
+    as an auto-completion in the search field in the header of Bugzilla
     pages giving you quick access to run it again later.

--- a/docs/en/rst/using/reports-and-charts.rst
+++ b/docs/en/rst/using/reports-and-charts.rst
@@ -59,7 +59,7 @@ can define as a search.
    they have done so.
 
 An individual line on a chart is called a data set.
-All data sets are organised into categories and subcategories. The
+All data sets are organized into categories and subcategories. The
 data sets that Bugzilla defines automatically use the Product name
 as a :guilabel:`Category` and Component names as :guilabel:`Subcategories`,
 but there is no need for you to follow that naming scheme with your own

--- a/docs/en/rst/using/tips.rst
+++ b/docs/en/rst/using/tips.rst
@@ -55,7 +55,7 @@ where someone just adds themselves to the CC field of a bug
 and add a comment saying "Adding self to CC", then that person
 gets a pointless piece of mail they would otherwise have avoided.
 
-Don't use sigs in comments. Signing your name ("Bill") is acceptable,
+Don't use signs in comments. Signing your name ("Bill") is acceptable,
 if you do it out of habit, but full mail/news-style
 four line ASCII art creations are not.
 

--- a/docs/en/rst/using/understanding.rst
+++ b/docs/en/rst/using/understanding.rst
@@ -69,7 +69,7 @@ installation of Bugzilla.
 
 *Keywords:*
    The administrator can define keywords which you can use to tag and
-   categorise bugs—e.g. ``crash`` or ``regression``.
+   categorize bugs—e.g. ``crash`` or ``regression``.
 
 *Personal Tags:*
    Unlike Keywords which are global and visible by all users, Personal Tags

--- a/email_in.pl
+++ b/email_in.pl
@@ -357,7 +357,7 @@ sub html_strip {
   # Trivial HTML tag remover (this is just for error messages, really.)
   $var =~ s/<[^>]*>//g;
 
-  # And this basically reverses the Template-Toolkit html filter.
+  # And this basically reverses the Template-Toolkit HTML filter.
   $var =~ s/\&amp;/\&/g;
   $var =~ s/\&lt;/</g;
   $var =~ s/\&gt;/>/g;

--- a/errors/401.html
+++ b/errors/401.html
@@ -30,7 +30,7 @@
         <div id="content">
             <h1>Authentication Required</h1>
             <p>This server could not verify that you are authorized to access
-            that url. you either supplied the wrong credentials (e.g., bad
+            that URL. you either supplied the wrong credentials (e.g., bad
             password), or your browser doesn't understand how to supply the
             credentials required.</p>
             <h3>Error 401</h3>

--- a/extensions/AntiSpam/Extension.pm
+++ b/extensions/AntiSpam/Extension.pm
@@ -95,7 +95,7 @@ sub _domain_blocking {
 }
 
 #
-# ip blocking
+# IP blocking
 #
 
 sub _ip_blocking {

--- a/extensions/AntiSpam/Extension.pm
+++ b/extensions/AntiSpam/Extension.pm
@@ -154,7 +154,7 @@ sub bug_set_flags {
   my $flag_count = @{$args->{new_flags}};
   if ($flag_count > Bugzilla->params->{antispam_multi_user_limit_count}) {
     Bugzilla->audit(sprintf(
-      "blocked <%s> from flaging %s users",
+      "blocked <%s> from flagging %s users",
       Bugzilla->user->login, $flag_count
     ));
 

--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -458,7 +458,7 @@ sub active_custom_fields {
 sub cf_hidden_in_product {
   my ($field_name, $product_name, $component_name, $bug) = @_;
 
-  # check bugzilla's built-in visibility controls first
+  # check Bugzilla's built-in visibility controls first
   if ($bug) {
     my $field = Bugzilla::Field->new({name => $field_name, cache => 1});
     return 1 if $field && !$field->is_visible_on_bug($bug);

--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -1212,7 +1212,7 @@ sub object_start_of_update {
   }
 }
 
-# detect github pull requests and reviewboard reviews, set the content-type
+# detect GitHub pull requests and Review Board reviews, set the content-type
 sub attachment_process_data {
   my ($self, $args) = @_;
   my $attributes = $args->{attributes};
@@ -1245,7 +1245,7 @@ sub attachment_process_data {
 sub _detect_attached_url {
   my ($url) = @_;
 
-  # trim and check for the pull request url
+  # trim and check for the pull request URL
   return unless defined $url;
   return if length($url) > 256;
   $url = trim($url);
@@ -1322,7 +1322,7 @@ sub attachment_view {
   # don't redirect if the content-type is specified explicitly
   return if defined $cgi->param('content_type');
 
-  # must be a valid redirection url
+  # must be a valid redirection URL
   return unless defined $attachment->external_redirect;
 
   # redirect
@@ -1824,7 +1824,7 @@ sub _inject_headers_into_body {
       # text/plain|html only
       return unless $part->content_type =~ /^text\/(?:html|plain)/;
 
-      # hide in html content
+      # hide in HTML content
       if ($replacement && $part->content_type =~ /^text\/html/) {
         $replacement
           = '<pre style="font-size: 0pt; color: #fff">' . $replacement . '</pre>';
@@ -2279,7 +2279,7 @@ sub _add_attachment {
 # Note: you must call $bug->update($bug->creation_ts) after adding all attachments
 }
 
-# bugzilla's content_type detection makes assumptions about form fields, which
+# Bugzilla's content_type detection makes assumptions about form fields, which
 # means we can't use it here.  this code is lifted from
 # Bugzilla::Attachment::get_content_type and the TypeSniffer extension.
 sub _detect_content_type {

--- a/extensions/BMO/lib/Reports/Triage.pm
+++ b/extensions/BMO/lib/Reports/Triage.pm
@@ -366,7 +366,7 @@ sub owners {
           @{$input->{component}}
           );
         $selected = 1
-          if (!ref $input->{componet} && $input->{component} eq $component->name);
+          if (!ref $input->{component} && $input->{component} eq $component->name);
       }
       my $comp_data = {name => $component->name, selected => $selected};
       push(@{$prod_data->{components}}, $comp_data);

--- a/extensions/BMO/template/en/default/bug/create/comment-costume.txt.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/comment-costume.txt.tmpl
@@ -20,7 +20,7 @@ Email:
 Mozillian Profile:
 [%+ cgi.param("requester_profile") %]
 
-Responsibile for the Costume:
+Responsible for the Costume:
 [%+ cgi.param("responsible") == "Yes" ? "Requester" : cgi.param("responsible_other") %]
 
 :: Event Information

--- a/extensions/BMO/template/en/default/bug/create/comment-shield-studies-legal.txt.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/comment-shield-studies-legal.txt.tmpl
@@ -9,7 +9,7 @@
 [% USE Bugzilla %]
 [% cgi = Bugzilla.cgi %]a
 
-> Pleasese include a link to the consent form.
+> Please include a link to the consent form.
 [%+ cgi.param('consent_form') %]
 
 > Please include a link to debrief survey.

--- a/extensions/BMO/template/en/default/bug/create/comment-shield-studies-shipping-status.txt.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/comment-shield-studies-shipping-status.txt.tmpl
@@ -10,7 +10,7 @@
 [% cgi = Bugzilla.cgi %]
 
 > Targeted locales
-[%+ cgi.param('targetted_locales') %]
+[%+ cgi.param('targeted_locales') %]
 
 > Sampling rates
 [%+ cgi.param('sampling_rates') %]

--- a/extensions/BMO/template/en/default/bug/create/comment-shield-studies.txt.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/comment-shield-studies.txt.tmpl
@@ -34,7 +34,7 @@
 [%+ cgi.param('study_length') %]
 
 > Targeted locales
-[%+ cgi.param('targetted_locales') %]
+[%+ cgi.param('targeted_locales') %]
 
 > Sampling rates
 [%+ cgi.param('sampling_rates') %]
@@ -57,7 +57,7 @@
 > Does your data analyst have an analysis plan?
 [%+ cgi.param('analysis_plan') %]
 
-> Pleasese include a link to the consent form.
+> Please include a link to the consent form.
 [%+ cgi.param('consent_form') %]
 
 > Please include a link to debrief survey.

--- a/extensions/BMO/template/en/default/bug/create/create-blocklist.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-blocklist.html.tmpl
@@ -168,7 +168,7 @@ window.addEventListener("DOMContentLoaded", function() {
     </label>
     <div class="field_desc">
       The name of the extension to be blocked. If multiple extensions are to be blocked, please
-      mention a common trait (for example, Multiple Youtube downloaders).
+      mention a common trait (for example, Multiple YouTube downloaders).
     </div>
     <input type="text" name="blocklist_name" id="blocklist_name" size="80" required>
   </div>

--- a/extensions/BMO/template/en/default/bug/create/create-comm-newsletter.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-comm-newsletter.html.tmpl
@@ -172,7 +172,7 @@ function toggleAreaOther() {
   </label>
   <div class="field_desc">
     What product or functional area does this opportunity relate to? Click
-    multiple areas if they apply (ie both Security and UX)
+    multiple areas if they apply (i.e. both Security and UX)
   </div>
   <input type="checkbox" name="area_coding" id="area_coding" value="Coding">Coding<br>
   <input type="checkbox" name="area_community_building"
@@ -224,7 +224,7 @@ function toggleAreaOther() {
 
 <div class="form_section">
   <label for="background_url" class="field_label">
-    Please provide a url that provides full background and instructions on this
+    Please provide a URL that provides full background and instructions on this
     contribution opportunity.
   </label>
   <div class="field_desc">

--- a/extensions/BMO/template/en/default/bug/create/create-finance.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-finance.html.tmpl
@@ -33,7 +33,7 @@
     if (!isFilledOut('team_priority'))
       alert_text += "Please select a value for team priority.\n";
     if (!isFilledOut('signature_time'))
-      alert_text += "Please enter a value for signture timeframe.\n";
+      alert_text += "Please enter a value for signature timeframe.\n";
     if (!isFilledOut('other_party'))
       alert_text += "Please enter a value for the name of other party.\n";
     if (!isFilledOut('business_obj'))

--- a/extensions/BMO/template/en/default/bug/create/create-fsa-budget.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-fsa-budget.html.tmpl
@@ -60,7 +60,7 @@ function validateAndSubmit() {
     return trySubmit();
   }
 
-  //alert text, stay here on the pagee
+  //alert text, stay here on the page
   alert(alert_text);
   return false;
 }

--- a/extensions/BMO/template/en/default/bug/create/create-recruiting.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-recruiting.html.tmpl
@@ -340,7 +340,7 @@ function jobDescToggle(what) {
             it to your headcount request [% terms.bug %]. To learn more about
             Textio and learn how to create a Textio account,
             <a href="https://mana.mozilla.org/wiki/display/globalstaffing/Diversity+Recruiting+Initiatives">
-              visit this mana page</a>.<br><br>
+              visit this Mana page</a>.<br><br>
             Please upload a draft of the Job Description you would like to be associated with this requisition
             (or <a href="javascript:jobDescToggle('text')">paste text as attachment</a>).</em><br>
           <input type="file" id="data" name="data" size="60"><br>

--- a/extensions/BMO/template/en/default/bug/create/create-screen-share-whitelist.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-screen-share-whitelist.html.tmpl
@@ -73,7 +73,7 @@ function fieldValue(elem_id) {
 [% END %]
 
 [% PROCESS global/header.html.tmpl
-   title = "Firefox Screen Sharing Whitelisti Submission"
+   title = "Firefox Screen Sharing Whitelist Submission"
    style = inline_style
    javascript = inline_javascript
    javascript_urls = [ 'extensions/BMO/web/js/form_validate.js' ]
@@ -122,7 +122,7 @@ function fieldValue(elem_id) {
   <textarea name="site_urls" id="site_urls" cols="80" rows="10"></textarea>
 </div>
 
-<h3>Access Resquest Details</h3>
+<h3>Access Request Details</h3>
 
 <div class="head_desc">
   Please answer the questions below and freely ask for any clarification

--- a/extensions/BMO/template/en/default/bug/create/create-shield-studies.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-shield-studies.html.tmpl
@@ -103,7 +103,7 @@
     If there is prior art or previous results?
   </label>
   <div class="field_desc">
-    I.e.,such as testpilot, usertesting.com, field research, etc. Please list it here.
+    I.e.,such as Test Pilot, UserTesting.com, field research, etc. Please list it here.
   </div>
   <textarea name="prior_art" id="prior_art" rows="10" cols="60"></textarea>
 </div>
@@ -113,7 +113,7 @@
     How do you intend to test your study prior to launch?
   </label>
   <div class="field_desc">
-    Moco wide, team only, etc.
+    MoCo wide, team only, etc.
   </div>
   <input type="text" name="test_method" id="test_method" size="60" required="true">
 </div>
@@ -131,10 +131,10 @@
 <h3>Shipping Status</h3>
 
 <div class="form_section">
-  <label for="targetted_locales" class="field_label required">
+  <label for="targeted_locales" class="field_label required">
     Targeted locales
   </label>
-  <input type="text" name="targetted_locales" id="targetted_locales" size="60" required="true">
+  <input type="text" name="targeted_locales" id="targeted_locales" size="60" required="true">
 </div>
 
 <div class="form_section">
@@ -165,7 +165,7 @@
     Will your study require third-party data collection?
   </label>
   <div class="field_desc">
-    I.e., Google analytics, loggly, any Apache server logs, etc.
+    I.e., Google analytics, Loggly, any Apache server logs, etc.
   </div>
   <input type="text" name="third_party_data" id="third_party_data" size="60" required="true">
 </div>

--- a/extensions/BMO/template/en/default/bug/create/create-shield-studies.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-shield-studies.html.tmpl
@@ -165,7 +165,7 @@
     Will your study require third-party data collection?
   </label>
   <div class="field_desc">
-    I.e., Google analytics, Loggly, any Apache server logs, etc.
+    I.e., Google Analytics, Loggly, any Apache server logs, etc.
   </div>
   <input type="text" name="third_party_data" id="third_party_data" size="60" required="true">
 </div>

--- a/extensions/BMO/template/en/default/bug/create/create-user-engagement.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-user-engagement.html.tmpl
@@ -48,7 +48,7 @@ function validateAndSubmit() {
   if (!isFilledOut('timing_date')) alert_text += 'Please enter a value for project timing.\n';
   if (!isFilledOut('localization')) alert_text += 'Please enter a value for project localization.\n';
   if (!isFilledOut('success')) alert_text += 'Please enter a value for project success\n';
-  if (!isFilledOut('bug_file_loc')) alert_text += 'Please enter a value for project destination url.\n';
+  if (!isFilledOut('bug_file_loc')) alert_text += 'Please enter a value for project destination URL.\n';
   if (!isFilledOut('mozilla_goal')) alert_text += 'Please enter a value for Mozilla goal.\n';
   if (alert_text != '') {
     alert(alert_text);

--- a/extensions/BMO/template/en/default/bug/create/create-web-bounty.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-web-bounty.html.tmpl
@@ -92,7 +92,7 @@ function validateAndSubmit() {
   <label for="short_desc" class="field_label required">Summary / Title</label>
   <div class="field_desc">
     A short description of the issue being reported including the host name
-    for the website on which it exists (example xss in blarg.foo.mozilla.org)
+    for the website on which it exists (example XSS in blarg.foo.mozilla.org)
   </div>
   <input type="text" name="short_desc" id="short_desc" size="80">
 </div>

--- a/extensions/BMO/template/en/default/bug/create/custom_forms.none.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/custom_forms.none.tmpl
@@ -6,7 +6,7 @@
   # defined by the Mozilla Public License, v. 2.0.
   #%]
 
-[%# link  => url (can be relative to bugzilla.mozilla.org, or full url)
+[%# link  => URL (can be relative to bugzilla.mozilla.org, or full URL)
   # title => visible title
   # group => optional group name, if present the form won't be show to
   #          users not in this group

--- a/extensions/BMO/template/en/default/hook/admin/sanitycheck/messages-statuses.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/admin/sanitycheck/messages-statuses.html.tmpl
@@ -7,7 +7,7 @@
   #%]
 
 [% IF san_tag == "bmo_check_cf_visible_in_products" %]
-  Checking $cf_visibile_in_products for missing product names.
+  Checking $cf_visible_in_products for missing product names.
 
 [% ELSIF san_tag == "bmo_check_cf_visible_in_products_missing" %]
   ... there are custom fields for [% cf_product FILTER html %] but it does not exist!

--- a/extensions/BMO/template/en/default/hook/list/list-links.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/list/list-links.html.tmpl
@@ -7,5 +7,5 @@
   #%]
 
 <a href="[% basepath FILTER none %]rest/bug?include_fields=id,summary,status&amp;
-   [%- cgi.new(urlquerypart).canonicalise_query('list_id','query_format') FILTER html %]"
+   [%- cgi.new(urlquerypart).canonicalize_query('list_id','query_format') FILTER html %]"
    title="Query as a REST API request">REST</a> |

--- a/extensions/BMO/template/en/default/pages/query_database.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/query_database.html.tmpl
@@ -14,7 +14,7 @@
 <form method="post" action="[% basepath FILTER none %]page.cgi">
   <input type="hidden" name="id" value="query_database.html">
   <textarea cols="80" rows="10" name="query">[% query FILTER html %]</textarea><br>
-  <input type="checkbox" id="csv" name="csv" value="1"><label for="csv">Ouput as CSV</label><br><br>
+  <input type="checkbox" id="csv" name="csv" value="1"><label for="csv">Output as CSV</label><br><br>
   <input type="submit" value="Execute">
   <input type="hidden" name="token" value="[% issue_hash_token(['query_database']) FILTER html %]">
 </form>

--- a/extensions/BMO/template/en/default/pages/release_tracking_report.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/release_tracking_report.html.tmpl
@@ -41,7 +41,7 @@ var default_query = '[% default_query FILTER js %]';
     </select>
 
     was changed to (and is currently)
-    <select id="flag_value" onchange="serialiseForm()">
+    <select id="flag_value" onchange="serializeForm()">
       <option value="?">?</option>
       <option value="-">-</option>
       <option value="+">+</option>
@@ -49,7 +49,7 @@ var default_query = '[% default_query FILTER js %]';
 
     between
     <span id="fixed_range">
-      <select id="range" onChange="serialiseForm()">
+      <select id="range" onChange="serializeForm()">
         [% FOREACH range = ranges %]
           <option value="[% range.value FILTER html %]">
             [% range.label FILTER html %]
@@ -58,10 +58,10 @@ var default_query = '[% default_query FILTER js %]';
       </select>
     </span>
     <span id="custom_range" style="display:none;">
-      <input class="date_field" name="from" id="from" onChange="serialiseForm()">
+      <input class="date_field" name="from" id="from" onChange="serializeForm()">
       <img class="date_field-img" id="from-img" src="[% basepath FILTER none %]extensions/BugModal/web/calendar.png" width="16" height="16">
       and
-      <input class="date_field" name="to" id="to" onChange="serialiseForm()">
+      <input class="date_field" name="to" id="to" onChange="serializeForm()">
       <img class="date_field-img" id="to-img" src="[% basepath FILTER none %]extensions/BugModal/web/calendar.png" width="16" height="16">
     </span>
     <input type="checkbox" id="is_custom" onchange="selectRangeType()" [% "checked" IF is_custom %]>
@@ -81,7 +81,7 @@ var default_query = '[% default_query FILTER js %]';
 <tr>
   <td>&nbsp;</td>
   <td>
-    <select id="op" onChange="serialiseForm()">
+    <select id="op" onChange="serializeForm()">
       <option value="and">All selected tracking fields (AND)</option>
       <option value="or">Any selected tracking fields (OR)</option>
     </select>

--- a/extensions/BMO/template/en/default/pages/triage_owners.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/triage_owners.html.tmpl
@@ -30,7 +30,7 @@
 %]
 
 <noscript>
-<h2>Javascript is required to use this report.</h2>
+<h2>JavaScript is required to use this report.</h2>
 </noscript>
 
 [% PROCESS "global/field-descs.none.tmpl" %]

--- a/extensions/BMO/template/en/default/pages/triage_reports.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/triage_reports.html.tmpl
@@ -49,7 +49,7 @@ var selected_components = [
 %]
 
 <noscript>
-<h2>Javascript is required to use this report.</h2>
+<h2>JavaScript is required to use this report.</h2>
 </noscript>
 
 [% PROCESS "global/field-descs.none.tmpl" %]

--- a/extensions/BMO/template/en/default/pages/upgrade-3.6.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/upgrade-3.6.html.tmpl
@@ -65,7 +65,7 @@
   from the study.</p>
 
 <p>As a result, you will see many small improvements in [% terms.Bugzilla %]'s
-  usability, such as using Javascript to validate certain forms before
+  usability, such as using JavaScript to validate certain forms before
   they are submitted, standardizing the words that we use in the user interface,
   being clearer about what [% terms.Bugzilla %] needs from the user,
   and other changes, all of which are also listed individually in this New

--- a/extensions/BMO/web/js/dev_engagement.js
+++ b/extensions/BMO/web/js/dev_engagement.js
@@ -96,13 +96,13 @@ var DE = {
 
     if (fieldValue('vouched_mozillian') == 'Yes')
       required_text_fields['mozillian_profile_url']
-        = 'Please enter your mozillian profile url.';
+        = 'Please enter your mozillian profile URL.';
     if (fieldValue('mozilla_attending') == 'Yes')
       required_text_fields['mozilla_attending_list']
         = 'Please enter a list of Mozilla persons attending the event.';
     if (fieldValue('code_of_conduct') == 'Yes')
       required_text_fields['code_of_conduct_url']
-        = 'Please enter a code of conduct url.';
+        = 'Please enter a code of conduct URL.';
     if (fieldValue('previous_event') == 'Yes') {
       required_text_fields['previous_event_year']
         = 'Please select a year for the previous sponsored event.';

--- a/extensions/BMO/web/js/release_tracking_report.js
+++ b/extensions/BMO/web/js/release_tracking_report.js
@@ -21,7 +21,7 @@ function onFieldToggle(cbEl, id) {
     selectedFields['field_' + id] = false;
   }
   $('#field_' + id + '_select').attr('disabled', !cbEl.checked);
-  serialiseForm();
+  serializeForm();
 }
 
 function onProductChange() {
@@ -57,7 +57,7 @@ function onProductChange() {
     html += '</table>';
   }
   trackingEl.innerHTML = html;
-  serialiseForm();
+  serializeForm();
 }
 
 function onFlagChange() {
@@ -88,7 +88,7 @@ function selectAllFields() {
     cb.checked = true;
     onFieldToggle(cb, fields_data[i].id);
   }
-  serialiseForm();
+  serializeForm();
 }
 
 function selectNoFields() {
@@ -98,7 +98,7 @@ function selectNoFields() {
     cb.checked = false;
     onFieldToggle(cb, fields_data[i].id);
   }
-  serialiseForm();
+  serializeForm();
 }
 
 function invertFields() {
@@ -111,7 +111,7 @@ function invertFields() {
       el.options[0].selected = true;
     }
   }
-  serialiseForm();
+  serializeForm();
 }
 
 function onFormSubmit() {
@@ -119,12 +119,12 @@ function onFormSubmit() {
     alert('You must enter both the start and end dates.');
     return false;
   }
-  serialiseForm();
+  serializeForm();
   return true;
 }
 
 function onFormReset() {
-  deserialiseForm('');
+  deserializeForm('');
 }
 
 function selectRangeType() {
@@ -136,10 +136,10 @@ function selectRangeType() {
     $('#custom_range').hide();
     $('#fixed_range').show();
   }
-  serialiseForm();
+  serializeForm();
 }
 
-function serialiseForm() {
+function serializeForm() {
   var q = flagEl.value + ':' +
           $('#flag_value').val() + ':';
   if ($('#is_custom').is(':checked')) {
@@ -165,7 +165,7 @@ function serialiseForm() {
                               `${is_custom}&q=${encodeURIComponent(q)}`);
 }
 
-function deserialiseForm(q) {
+function deserializeForm(q) {
   var parts = q.split(/:/);
   selectValue(flagEl, parts[0]);
   onFlagChange();
@@ -191,7 +191,7 @@ function deserialiseForm(q) {
       selectValue($('#field_' + id + '_select')[0], value);
     }
   }
-  serialiseForm();
+  serializeForm();
 }
 
 // utils
@@ -201,7 +201,7 @@ $().ready(function() {
   productEl = $('#product')[0];
   trackingEl = $('#tracking_span')[0];
   onFlagChange();
-  deserialiseForm(default_query);
+  deserializeForm(default_query);
   selectRangeType();
 });
 

--- a/extensions/BMO/web/js/sorttable.js
+++ b/extensions/BMO/web/js/sorttable.js
@@ -201,7 +201,7 @@ sorttable = {
       return 0;
   },
 
-  /* Visualy mark the cell as sorted.
+  /* Visually mark the cell as sorted.
    *
    * @param cell: the cell being marked
    * @param text: the text being used to mark. you can use html

--- a/extensions/BMO/web/js/sorttable.js
+++ b/extensions/BMO/web/js/sorttable.js
@@ -204,7 +204,7 @@ sorttable = {
   /* Visually mark the cell as sorted.
    *
    * @param cell: the cell being marked
-   * @param text: the text being used to mark. you can use html
+   * @param text: the text being used to mark. you can use HTML
    * @param reversed: whether the column is reversed or not.
    *
    */

--- a/extensions/BMO/web/js/swag.js
+++ b/extensions/BMO/web/js/swag.js
@@ -1,6 +1,6 @@
 /**
  * Swag Request Form Functions
- * Form Interal Swag Request Form
+ * Form Internal Swag Request Form
  * dtran
  * 7/6/09
  **/

--- a/extensions/Bitly/lib/WebService.pm
+++ b/extensions/Bitly/lib/WebService.pm
@@ -34,7 +34,7 @@ use constant PUBLIC_METHODS => qw(
 sub _validate_uri {
   my ($self, $params) = @_;
 
-  # extract url from params
+  # extract URL from params
   if (!defined $params->{url}) {
     ThrowCodeError('param_required', {function => 'Bitly.shorten', param => 'url'});
   }
@@ -79,7 +79,7 @@ sub list {
   );
   my $data = $search->data;
 
-  # form a bug_id only url, sanity check the length
+  # form a bug_id only URL, sanity check the length
   $uri
     = URI->new(Bugzilla->localconfig->urlbase
       . 'buglist.cgi?bug_id='
@@ -96,7 +96,7 @@ sub list {
 sub _bitly {
   my ($self, $uri) = @_;
 
-  # form request url
+  # form request URL
   # http://dev.bitly.com/links.html#v3_shorten
   my $bitly_url = sprintf(
     'https://api-ssl.bitly.com/v3/shorten?access_token=%s&longUrl=%s',
@@ -127,7 +127,7 @@ sub _bitly {
     ThrowUserError('bitly_failure', {message => $result->{status_txt}});
   }
 
-  # return just the short url
+  # return just the short URL
   return {url => $result->{data}->{url}};
 }
 

--- a/extensions/Bitly/lib/WebService.pm
+++ b/extensions/Bitly/lib/WebService.pm
@@ -40,7 +40,7 @@ sub _validate_uri {
   }
   my $url = ref($params->{url}) ? $params->{url}->[0] : $params->{url};
 
-  # only allow buglist queries for this bugzilla install
+  # only allow buglist queries for this Bugzilla install
   my $uri = URI->new($url);
   $uri->query(undef);
   $uri->fragment(undef);

--- a/extensions/Bitly/template/en/default/hook/list/list-links.html.tmpl
+++ b/extensions/Bitly/template/en/default/hook/list/list-links.html.tmpl
@@ -20,6 +20,6 @@
 </div>
 <a id="bitly-shorten" href="#"
    data-url="[% urlbase _ "buglist.cgi?" _
-                cgi.new(urlquerypart).canonicalise_query('list_id','query_format') FILTER html %]"
+                cgi.new(urlquerypart).canonicalize_query('list_id','query_format') FILTER html %]"
 >Short URL</a>
 |&nbsp; [%# using nbsp because tt always trims trailing whitespace from templates %]

--- a/extensions/BugModal/Extension.pm
+++ b/extensions/BugModal/Extension.pm
@@ -113,7 +113,7 @@ sub template_after_create {
   );
 
   # flatten a list of hashrefs to a list of values
-  # eg.  logins = users.pluck("login")
+  # e.g. logins = users.pluck("login")
   $context->define_vmethod(
     list => pluck => sub {
       my ($list, $field) = @_;
@@ -123,7 +123,7 @@ sub template_after_create {
 
   # returns array where the value in $field does not equal $value
   # opposite of "only"
-  # eg.  not_byron = users.skip("name", "Byron")
+  # e.g. not_byron = users.skip("name", "Byron")
   $context->define_vmethod(
     list => skip => sub {
       my ($list, $field, $value) = @_;
@@ -133,7 +133,7 @@ sub template_after_create {
 
   # returns array where the value in $field equals $value
   # opposite of "skip"
-  # eg.  byrons_only = users.only("name", "Byron")
+  # e.g. byrons_only = users.only("name", "Byron")
   $context->define_vmethod(
     list => only => sub {
       my ($list, $field, $value) = @_;
@@ -142,7 +142,7 @@ sub template_after_create {
   );
 
   # returns boolean indicating if the value exists in the list
-  # eg.  has_byron = user_names.exists("byron")
+  # e.g. has_byron = user_names.exists("byron")
   $context->define_vmethod(
     list => exists => sub {
       my ($list, $value) = @_;

--- a/extensions/BugModal/Extension.pm
+++ b/extensions/BugModal/Extension.pm
@@ -292,7 +292,7 @@ sub template_before_process {
   }
   $vars->{tracking_flags_table} = \@tracking_table;
 
-  # for the "view -> hide treeherder comments" menu item
+  # for the "View -> Hide Treeherder Comments" menu item
   my @treeherder_ids = map { $_->id } @{Bugzilla->treeherder_users};
   foreach my $change_set (@{$bug->activity_stream}) {
     if (

--- a/extensions/BugModal/lib/ActivityStream.pm
+++ b/extensions/BugModal/lib/ActivityStream.pm
@@ -204,7 +204,7 @@ sub _add_activities_to_stream {
     : Bugzilla::Bug::GetBugActivity($bug->id);
 
   # allow other extensions to alter history
-  Bugzilla::Hook::process('inline_history_activitiy',
+  Bugzilla::Hook::process('inline_history_activity',
     {activity => $raw_activity});
 
   my %attachment_cache;

--- a/extensions/BugModal/lib/WebService.pm
+++ b/extensions/BugModal/lib/WebService.pm
@@ -248,7 +248,7 @@ sub new_product {
     || $current_version =~ /^Firefox (\d+)$/
     || $current_version =~ /^(\d+)$/)
   {
-    # firefox, with its three version naming schemes
+    # Firefox, with its three version naming schemes
     my $branch = $1;
     foreach my $test_version ("$branch Branch", "Firefox $branch", $branch) {
       if (my $version = first_value { $_->{name} eq $test_version } @$versions) {

--- a/extensions/BugModal/lib/WebService.pm
+++ b/extensions/BugModal/lib/WebService.pm
@@ -56,7 +56,7 @@ sub rest_resources {
       },
     },
 
-    # returns pre-formatted html, enabling reuse of the user template
+    # returns pre-formatted HTML, enabling reuse of the user template
     qr{^/bug_modal/cc/(\d+)$},
     {
       GET => {
@@ -374,7 +374,7 @@ sub new_product {
       };
   }
 
-  # build group selection html
+  # build group selection HTML
   my $template = Bugzilla->template;
   $template->process('bug_modal/new_product_groups.html.tmpl',
     $vars, \$result{groups})

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -1364,7 +1364,7 @@
   [% END %]
 [% END %]
 
-[%# === initialise module visibility === %]
+[%# === initialize module visibility === %]
 
 <script [% script_nonce FILTER none %]>
   init_module_visibility();

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -93,7 +93,7 @@
     END;
   END;
 
-  # build firefox flags subtitle
+  # build Firefox flags subtitle
   firefox_flags = [];
   firefox_fixed_versions = [];
   scores = {firefox => 0, thunderbird => 0, seamonkey => 0};

--- a/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
@@ -26,9 +26,9 @@
   # hide_on_view: (boolean) hide field from read-only view (default: false)
   # hide_on_edit: (boolean) hide content when in edit mode (default: false)
   # append_content: (boolean) when called as a WRAPPER, the content will be appended to the
-  #                 edit html instead of replacing it.  forces edit_only (default: false);
+  #                 edit HTML instead of replacing it.  forces edit_only (default: false);
   # default: (string) default value (eg. used as a placeholder in user fields)
-  # help: (string) optional url that describes the field (requires a label to be defined and visible)
+  # help: (string) optional URL that describes the field (requires a label to be defined and visible)
   # required: (boolean) if the field is required. (At present, only implemented for FIELD_TYPE_FREETEXT)
   # action: (hash) show a button to the right of the edit field (user fields only currently).  keys:
   #   id: (string) optional button id
@@ -122,7 +122,7 @@ END;
     [% aria_labelledby_html = BLOCK %]aria-label="[% aria_label || label FILTER html %]"[% END %]
   [% END %]
 
-  [%# read-only html %]
+  [%# read-only HTML %]
   [% UNLESS edit_only %]
     <div class="[% "value" IF !container %][% " edit-hide" IF editable %][% " container" IF container %]">
       [% IF name %]
@@ -179,7 +179,7 @@ END;
     </div>
   [% END %]
 
-  [%# edit html %]
+  [%# edit HTML %]
   [% IF editable %]
     [% "MISSING NAME" UNLESS name %]
     <div class="value edit edit-show [% " wide" IF full_width %][% " short" IF short_width %]"

--- a/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
@@ -144,7 +144,7 @@ END;
             [% INCLUDE bug_urls values=values edit=0 %]
 
           [% CASE constants.FIELD_TYPE_BUG_LIST %]
-            [%# bug lists (generally dependancies) %]
+            [%# bug lists (generally dependencies) %]
             [% INCLUDE bug_list values=values edit=0 %]
 
           [% CASE constants.FIELD_TYPE_TEXTAREA %]
@@ -401,7 +401,7 @@ END;
   [% END %]
 [% END %]
 
-[%# bug lists, depencancies, blockers %]
+[%# bug lists, dependencies, blockers %]
 [% BLOCK bug_list %]
   [% IF NOT edit %]
     [% FOREACH type IN bug_fields.bug_type.legal_values.pluck('name') %]

--- a/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
@@ -14,7 +14,7 @@
   # aria_label: (string) invisible aria-label attribute
   # view_only: (boolean) don't allow editing (default: determined from bug.check_can_change_field)
   # edit_only: (boolean) always render the edit ui
-  # container: (boolean) output just a label and the content (eg. for multiple fields next to one label)
+  # container: (boolean) output just a label and the content (e.g. for multiple fields next to one label)
   # name: (string) field name (default: field.name)
   # prefix: (string) string to prepend to 'name' and 'id' attributes (default: empty)
   # value: (string) visible value (default: bug.$name)
@@ -27,7 +27,7 @@
   # hide_on_edit: (boolean) hide content when in edit mode (default: false)
   # append_content: (boolean) when called as a WRAPPER, the content will be appended to the
   #                 edit HTML instead of replacing it.  forces edit_only (default: false);
-  # default: (string) default value (eg. used as a placeholder in user fields)
+  # default: (string) default value (e.g. used as a placeholder in user fields)
   # help: (string) optional URL that describes the field (requires a label to be defined and visible)
   # required: (boolean) if the field is required. (At present, only implemented for FIELD_TYPE_FREETEXT)
   # action: (hash) show a button to the right of the edit field (user fields only currently).  keys:

--- a/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
@@ -70,7 +70,7 @@
 %]
 
 [% javascript = BLOCK %]
-  [%# add tracking flags json if available %]
+  [%# add tracking flags JSON if available %]
   [% IF tracking_flags %]
     [% javascript_urls.push("extensions/TrackingFlags/web/js/flags.js") %]
     var tracking_flags_str = "[% tracking_flags_json FILTER js %]";

--- a/extensions/BugModal/template/en/default/bug_modal/tracking_flags.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/tracking_flags.html.tmpl
@@ -7,7 +7,7 @@
   #%]
 
 [%#
-  # type: tracking flag type (eg. "project", "tracking")
+  # type: tracking flag type (e.g. "project", "tracking")
   #%]
 
 [%

--- a/extensions/BugModal/template/en/default/bug_modal/user.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/user.html.tmpl
@@ -8,11 +8,11 @@
 
 [%#
   # u : user object
-  # simple : boolean, if true an unadorned name will be displayed (no gravatar, no menu) (default: false)
-  # gravatar_size : size of the gravator icon (default 0, which disables the gravatar)
-  # gravatar_only : boolean, if true output just the gravatar (not-simple only)
+  # simple : boolean, if true an unadorned name will be displayed (no Gravatar, no menu) (default: false)
+  # gravatar_size : size of the Gravatar icon (default 0, which disables the Gravatar)
+  # gravatar_only : boolean, if true output just the Gravatar (not-simple only)
   # nick_only : boolean, if true, the nickname will be used instead of the full name
-  # id : string, if provided the id of the vcard div
+  # id : string, if provided the id of the vCard div
   #%]
 
 [%

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -149,14 +149,14 @@ $(function() {
         });
     }
 
-    // expand/colapse module
+    // expand/collapse module
     $('.module-latch')
         .click(function(event) {
             event.preventDefault();
             slide_module($(this).parents('.module'));
         })
         .keydown(function(event) {
-            // expand/colapse module with the enter or space key
+            // expand/collapse module with the enter or space key
             if (event.keyCode === 13 || event.keyCode === 32) {
                 event.preventDefault();
                 slide_module($(this).parents('.module'));
@@ -1056,7 +1056,7 @@ $(function() {
         // subtracts time spent from remaining time
         // prevent negative values if work_time > fRemainingTime
         var new_time = Math.max(BUGZILLA.remaining_time - $('#work_time').val(), 0.0);
-        // get upto 2 decimal places
+        // get up to 2 decimal places
         $('#remaining_time').val(Math.round((new_time * 100)/100).toFixed(1));
     });
     $('#remaining_time').change(function() {
@@ -1593,7 +1593,7 @@ $(function() {
 
 (function($) {
     $.extend({
-        // Case insensative $.inArray (http://api.jquery.com/jquery.inarray/)
+        // Case insensitive $.inArray (http://api.jquery.com/jquery.inarray/)
         // $.inArrayIn(value, array [, fromIndex])
         //  value (type: String)
         //    The value to search for

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -171,7 +171,7 @@ $(function() {
             $('#attachments tr.attach-obsolete').toggle();
         });
 
-    // url --> unsafe warning
+    // URL --> unsafe warning
     $('.bug-url')
         .click(function(event) {
             var that = $(this);
@@ -1522,7 +1522,7 @@ async function show_new_changes_indicator() {
     } catch (ex) {}
 }
 
-// fix url after bug creation/update
+// fix URL after bug creation/update
 if (history && history.replaceState) {
     var href = document.location.href;
     if (!href.match(/show_bug\.cgi/)) {
@@ -1624,7 +1624,7 @@ $(function() {
 
         // Bring an element into view, leaving space for the outline. If passed
         // a string, it will be treated as an id - the page will scroll and the
-        // url will be added to the browser's history. If passed an element, no
+        // URL will be added to the browser's history. If passed an element, no
         // entry will be added to the history.
         scrollTo: function(target, complete) {
             let $target;

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -503,7 +503,7 @@ $(function() {
         that.data('preselected', value);
 
         // if the user hasn't touched a field, override the browser's choice
-        // with bugzilla's
+        // with Bugzilla's
         if (!dirty.val())
             that.val(value);
     });

--- a/extensions/BugModal/web/comments.js
+++ b/extensions/BugModal/web/comments.js
@@ -279,7 +279,7 @@ $(function() {
         renderTags(commentNo, tagsFromDom(container));
         updateTagsMenu();
 
-        // update bugzilla
+        // update Bugzilla
         try {
             renderTags(commentNo, await Bugzilla.API.put(`bug/comment/${commentID}/tags`, { remove: [tag] }));
             updateTagsMenu();
@@ -412,7 +412,7 @@ $(function() {
                 tags.sort();
                 renderTags(commentNo, tags);
 
-                // update bugzilla
+                // update Bugzilla
                 try {
                     renderTags(commentNo, await Bugzilla.API.put(`bug/comment/${commentID}/tags`, { add: addTags }));
                     updateTagsMenu();

--- a/extensions/BugmailFilter/Extension.pm
+++ b/extensions/BugmailFilter/Extension.pm
@@ -112,7 +112,7 @@ sub user_preferences {
   my %fields = map { $_->name => $field_descs->{$_->name} }
     @{Bugzilla->fields({obsolete => 0})};
 
-  # remove time trackinger fields
+  # remove time tracking fields
   if (!Bugzilla->user->is_timetracker) {
     foreach my $field (TIMETRACKING_FIELDS) {
       delete $fields{$field};

--- a/extensions/BugmailFilter/Extension.pm
+++ b/extensions/BugmailFilter/Extension.pm
@@ -143,7 +143,7 @@ sub user_preferences {
   }
 
   # some fields are present in the changed-fields x-header but are not real
-  # bugzilla fields
+  # Bugzilla fields
   foreach
     my $field (@{Bugzilla::Extension::BugmailFilter::FakeField->fake_fields()})
   {
@@ -229,7 +229,7 @@ sub user_wants_mail {
   my $fields = [
     map { {
       filter_field => $_->{field_name},    # filter's field_name
-      field_name   => $_->{field_name},    # raw bugzilla field_name
+      field_name   => $_->{field_name},    # raw Bugzilla field_name
     } } grep {
 
       # flags are added later

--- a/extensions/BugmailFilter/template/en/default/hook/global/user-error-errors.html.tmpl
+++ b/extensions/BugmailFilter/template/en/default/hook/global/user-error-errors.html.tmpl
@@ -16,7 +16,7 @@
 
 [% ELSIF error == "bugmail_filter_invalid" %]
   [% title = "Invalid Field Name" %]
-  The field name contains invalid characters (alpha-numeric, underscore,
+  The field name contains invalid characters (alphanumeric, underscore,
   hyphen, and period only).
 
 [% END %]

--- a/extensions/BzAPI/lib/Resources/Bug.pm
+++ b/extensions/BzAPI/lib/Resources/Bug.pm
@@ -375,7 +375,7 @@ sub search_bugs_request {
     $params->{actual_time} = delete $params->{work_time};
   }
 
-  # Other convenience search ariables used by BzAPI
+  # Other convenience search variables used by BzAPI
   my @field_ids = grep(/^f(\d+)$/, keys %$params);
   my $last_field_id = @field_ids ? max @field_ids + 1 : 1;
   foreach my $field (qw(setters.login_name requestees.login_name)) {

--- a/extensions/BzAPI/lib/Resources/Bug.pm
+++ b/extensions/BzAPI/lib/Resources/Bug.pm
@@ -399,7 +399,7 @@ sub create_bug_request {
     }
   }
 
-  # CC should just be a list of bugzilla logins
+  # CC should just be a list of Bugzilla logins
   if (exists $params->{cc}) {
     $params->{cc} = [map { $_->{name} } @{$params->{cc}}];
   }

--- a/extensions/BzAPI/lib/Util.pm
+++ b/extensions/BzAPI/lib/Util.pm
@@ -208,7 +208,7 @@ sub fix_bug {
       next;
     }
 
-    next if $method eq 'Bug.search' && $key eq 'url';    # Return url even if empty
+    next if $method eq 'Bug.search' && $key eq 'url';    # Return URL even if empty
     next if $method eq 'Bug.search' && $key eq 'keywords'; # Return keywords even if empty
     next if $method eq 'Bug.search' && $key eq 'whiteboard'; # Return whiteboard even if empty
     next if $method eq 'Bug.get' && grep($_ eq $key, TIMETRACKING_FIELDS);

--- a/extensions/ComponentWatching/Extension.pm
+++ b/extensions/ComponentWatching/Extension.pm
@@ -209,7 +209,7 @@ sub object_end_of_update {
 sub _generate_watch_user_name {
 
 # this is mirrored in template/en/default/hook/admin/components/edit-common-rows.html.tmpl
-# that javascript needs to be kept in sync with this perl
+# that JavaScript needs to be kept in sync with this perl
   my ($component) = @_;
   return
       _sanitize_name($component->name) . '@'

--- a/extensions/ComponentWatching/Extension.pm
+++ b/extensions/ComponentWatching/Extension.pm
@@ -209,7 +209,7 @@ sub object_end_of_update {
 sub _generate_watch_user_name {
 
 # this is mirrored in template/en/default/hook/admin/components/edit-common-rows.html.tmpl
-# that JavaScript needs to be kept in sync with this perl
+# that JavaScript needs to be kept in sync with this Perl
   my ($component) = @_;
   return
       _sanitize_name($component->name) . '@'

--- a/extensions/ComponentWatching/Extension.pm
+++ b/extensions/ComponentWatching/Extension.pm
@@ -212,11 +212,11 @@ sub _generate_watch_user_name {
 # that javascript needs to be kept in sync with this perl
   my ($component) = @_;
   return
-      _sanitise_name($component->name) . '@'
-    . _sanitise_name($component->product->name) . '.bugs';
+      _sanitize_name($component->name) . '@'
+    . _sanitize_name($component->product->name) . '.bugs';
 }
 
-sub _sanitise_name {
+sub _sanitize_name {
   my ($name) = @_;
   $name = lc($name);
   $name =~ s/[^a-z0-9_]/-/g;

--- a/extensions/ComponentWatching/template/en/default/account/prefs/component_watch.html.tmpl
+++ b/extensions/ComponentWatching/template/en/default/account/prefs/component_watch.html.tmpl
@@ -6,7 +6,7 @@
   # defined by the Mozilla Public License, v. 2.0.
   #%]
 
-[%# initialise product to component mapping #%]
+[%# initialize product to component mapping #%]
 
 [% SET selectable_products = user.get_selectable_products %]
 [% SET dont_show_button = 1 %]

--- a/extensions/ComponentWatching/template/en/default/hook/admin/components/edit-common-rows.html.tmpl
+++ b/extensions/ComponentWatching/template/en/default/hook/admin/components/edit-common-rows.html.tmpl
@@ -28,7 +28,7 @@
 </tr>
 
 <script [% script_nonce FILTER none %]>
-function sanitise_name(name) {
+function sanitize_name(name) {
   return name.toLowerCase()
              .replace(/[^a-z0-9_]/g, '-')
              .replace(/-+/g, '-')
@@ -46,8 +46,8 @@ function update_watch_user() {
       watch = '(no component name)';
     }
     else {
-      watch = sanitise_name(component) +
-              '@' + sanitise_name('[% product.name FILTER js %]') + '.bugs';
+      watch = sanitize_name(component) +
+              '@' + sanitize_name('[% product.name FILTER js %]') + '.bugs';
     }
     Dom.get('watch_user_suggestion').innerHTML = ' : <b>' + watch + '</b>';
     Dom.get('watch_user').value = watch;

--- a/extensions/EditComments/template/en/default/pages/comment-revisions.html.tmpl
+++ b/extensions/EditComments/template/en/default/pages/comment-revisions.html.tmpl
@@ -19,7 +19,7 @@
 
 <p>
   <strong>Note</strong>: The actual edited comment in the [% terms.bug %] view
-  page will always show the original commentor’s name and original timestamp.
+  page will always show the original commenter’s name and original timestamp.
 </p>
 
 [% SET rev_count = 0 %]

--- a/extensions/EditComments/web/js/inline-editor.js
+++ b/extensions/EditComments/web/js/inline-editor.js
@@ -270,7 +270,7 @@ Bugzilla.InlineCommentEditor = class InlineCommentEditor {
   }
 
   /**
-   * Finish editing by restoring the UI, once editing is complete or cancelled. Any unsaved comment will be discarded.
+   * Finish editing by restoring the UI, once editing is complete or canceled. Any unsaved comment will be discarded.
    */
   finish() {
     this.toggle_toolbar_buttons(false);

--- a/extensions/EditComments/web/js/inline-editor.js
+++ b/extensions/EditComments/web/js/inline-editor.js
@@ -281,7 +281,7 @@ Bugzilla.InlineCommentEditor = class InlineCommentEditor {
 
   /**
    * Enable or disable buttons on the comment actions toolbar (not the editor's own toolbar) while editing the comment
-   * to avoid any unexpected behaviour. The Reply button should always be disabled if the comment is empty.
+   * to avoid any unexpected behavior. The Reply button should always be disabled if the comment is empty.
    * @param {Boolean} disabled Whether the buttons should be disabled.
    */
   toggle_toolbar_buttons(disabled) {

--- a/extensions/FlagTypeComment/web/js/ftc.js
+++ b/extensions/FlagTypeComment/web/js/ftc.js
@@ -83,7 +83,7 @@ Bugzilla.FlagTypeComment = class FlagTypeComment {
         $fieldset.className = 'approval-request';
         $fieldset.dataset.flags = $template.dataset.flags;
 
-        // Make the request form dismissable
+        // Make the request form dismissible
         $fieldset.querySelector('header').insertAdjacentHTML('beforeend',
           '<button type="button" class="dismiss" title="Dismiss" aria-label="Dismiss">' +
           '<span class="icon" aria-hidden="true"></span></button>');

--- a/extensions/GitHubAuth/lib/Client.pm
+++ b/extensions/GitHubAuth/lib/Client.pm
@@ -77,7 +77,7 @@ sub _handle_response {
   my $data = eval { decode_json($response->content); };
   if ($@) {
     ThrowCodeError("github_bad_response",
-      {message => "Unable to parse json response"});
+      {message => "Unable to parse JSON response"});
   }
 
   unless ($response->is_success) {

--- a/extensions/GitHubAuth/template/en/default/hook/global/user-error-errors.html.tmpl
+++ b/extensions/GitHubAuth/template/en/default/hook/global/user-error-errors.html.tmpl
@@ -7,9 +7,9 @@
   #%]
 
 [% IF error == "github_no_emails" %]
-  Your GitHub account cannot be used because [% terms.Bugzilla %] cannot see any useable email addresses. Your GitHub account
+  Your GitHub account cannot be used because [% terms.Bugzilla %] cannot see any usable email addresses. Your GitHub account
   may have no verified email addresses, [% terms.Bugzilla %] is not authorized to see them, or you have a non-reply-able email addresses.
-  GitHub's noreply email addresses are not acceptable for [% terms.Bugzilla %] accounts because they cannot recieve email.
+  GitHub's noreply email addresses are not acceptable for [% terms.Bugzilla %] accounts because they cannot receive email.
 
 [% ELSIF error == "github_invalid_email" %]
   Your GitHub account email '[% email FILTER html %]' is not valid.

--- a/extensions/Gravatar/template/en/default/hook/global/setting-descs-settings.none.tmpl
+++ b/extensions/Gravatar/template/en/default/hook/global/setting-descs-settings.none.tmpl
@@ -7,6 +7,6 @@
   #%]
 
 [%
-  setting_descs.show_gravatars   = "Show gravatar images when viewing $terms.bugs"
-  setting_descs.show_my_gravatar = "Show my gravatar image to other users"
+  setting_descs.show_gravatars   = "Show Gravatar images when viewing $terms.bugs"
+  setting_descs.show_my_gravatar = "Show my Gravatar image to other users"
 %]

--- a/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
+++ b/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
@@ -300,7 +300,7 @@ Product: <b><span id="dupes_product_name">?</span></b>:
 
 <div id="dupe_form">
   <p>
-  Please summarise your issue or request in one sentence:
+  Please summarize your issue or request in one sentence:
   </p>
   <input id="dupes_summary" value="Short summary of issue" spellcheck="true" placeholder="Short summary of issue">
   <button id="dupes_search">Find similar issues</button>

--- a/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
+++ b/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
@@ -408,7 +408,7 @@ explain how to write effective [% terms.bug %] reports.</li>
   <td valign="top">
   [% PROCESS help id="steps_help" %]
   <div id="steps_help" class="hidden help">
-  Please be as specific as possible about what what you did
+  Please be as specific as possible about what you did
   to cause the problem.  Providing step-by-step instructions
   would be ideal.<br>
   <br>

--- a/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
+++ b/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
@@ -354,7 +354,7 @@ explain how to write effective [% terms.bug %] reports.</li>
   <td valign="top">
     [% PROCESS help id="summary_help" %]
     <div id="summary_help" class="hidden help">
-    A sentence which summarises the problem. Please be descriptive and use lots of keywords.<br>
+    A sentence which summarizes the problem. Please be descriptive and use lots of keywords.<br>
     <br>
     <span class="help-bad">Bad example</span>: mail crashed<br>
     <span class="help-good">Good example</span>: crash if I close the mail window while checking for new POP mail

--- a/extensions/GuidedBugEntry/web/js/guided.js
+++ b/extensions/GuidedBugEntry/web/js/guided.js
@@ -721,7 +721,7 @@ var bugForm = {
         // standards
         elVersions.add(opt, elVersions.options[0]);
       } catch(ex) {
-        // ie only
+        // IE only
         elVersions.add(opt, 0);
       }
       elVersions.value = '';

--- a/extensions/GuidedBugEntry/web/js/guided.js
+++ b/extensions/GuidedBugEntry/web/js/guided.js
@@ -19,7 +19,7 @@ var guided = {
   updateStep: true,
 
   setStep: function(newStep, noSetHistory) {
-    // initialise new step
+    // initialize new step
     this.updateStep = true;
     switch(newStep) {
       case 'webdev':
@@ -456,7 +456,7 @@ var dupes = {
       return;
     dupes._currentSearchQuery = dupes.getSummary();
 
-    // initialise the datatable as late as possible
+    // initialize the datatable as late as possible
     dupes._initDataTable();
 
     try {

--- a/extensions/GuidedBugEntry/web/js/products.js
+++ b/extensions/GuidedBugEntry/web/js/products.js
@@ -5,13 +5,13 @@
  * This Source Code Form is "Incompatible With Secondary Licenses", as
  * defined by the Mozilla Public License, v. 2.0. */
 
-/* Product-specifc configuration for guided bug entry
+/* Product-specific configuration for guided bug entry
  *
  * related: array of product names which will also be searched for duplicates
- * version: function which returns a version (eg. detected from UserAgent)
+ * version: function which returns a version (e.g. detected from UserAgent)
  * support: string which is displayed at the top of the duplicates page
  * secgroup: the group to place confidential bugs into
- * defaultComponent: the default compoent to select.  Defaults to 'General'
+ * defaultComponent: the default component to select.  Defaults to 'General'
  * noComponentSelection: when true, the default component will always be
  *     used.  Defaults to 'false';
  * detectPlatform: when true the platform and op_sys will be set from the

--- a/extensions/InlineHistory/Extension.pm
+++ b/extensions/InlineHistory/Extension.pm
@@ -68,7 +68,7 @@ sub template_before_process {
   }
 
   # allow other extensions to alter history
-  Bugzilla::Hook::process('inline_history_activtiy', {activity => $activity});
+  Bugzilla::Hook::process('inline_history_activity', {activity => $activity});
 
   my %attachment_cache;
   foreach my $attachment (@{$bug->attachments}) {

--- a/extensions/InlineHistory/Extension.pm
+++ b/extensions/InlineHistory/Extension.pm
@@ -199,7 +199,7 @@ sub _add_duplicates {
 
   my ($bug_id, $activity) = @_;
 
-  # we're ignoring pre-bugzilla 3.0 ".. has been marked as a duplicate .."
+  # we're ignoring pre-Bugzilla 3.0 ".. has been marked as a duplicate .."
   # comments because searching each comment's text is expensive.  these
   # legacy comments will not be visible at all in the bug's comment/activity
   # stream.  bug 928786 deals with migrating those comments to be stored as

--- a/extensions/InlineHistory/README
+++ b/extensions/InlineHistory/README
@@ -6,5 +6,5 @@ and is enabled by a User Preference.
 
 It works with an unmodified install of Bugzilla 4.0 and 4.2.
 
-If you have modified your show_bug template, the javascript in
+If you have modified your show_bug template, the JavaScript in
 web/inline-history.js may need to be updated to suit your installation.

--- a/extensions/InlineHistory/web/inline-history.js
+++ b/extensions/InlineHistory/web/inline-history.js
@@ -35,7 +35,7 @@ var inline_history = {
           // remove the element
           comment.parentNode.removeChild(comment);
           comments[i] = false;
-          // update the html for the history item to include the comment number
+          // update the HTML for the history item to include the comment number
           if (dupeId == 0)
             continue;
           for (var j = 0, jl = ih_activity.length; j < jl; j++) {
@@ -86,8 +86,8 @@ var inline_history = {
       var item = ih_activity[i];
       // item[0] : who
       // item[1] : when
-      // item[2] : change html
-      // item[3] : header html
+      // item[2] : change HTML
+      // item[3] : header HTML
       // item[4] : bool; cc-only
       // item[5] : int; dupe bug id (or 0)
       // item[6] : bool; is flag

--- a/extensions/MozProjectReview/template/en/default/bug/create/comment-moz-project-review.txt.tmpl
+++ b/extensions/MozProjectReview/template/en/default/bug/create/comment-moz-project-review.txt.tmpl
@@ -80,7 +80,7 @@ Vendor Services to be Provided:
 Access to Mozilla Systems Required:
 [%+ cgi.param('sow_vendor_mozilla_systems') %]
 
-[% IF cgi.param('sow_vendow_mozilla_systems') == 'Yes' %]
+[% IF cgi.param('sow_vendor_mozilla_systems') == 'Yes' %]
 Mozilla Systems Access Explanation:
 [%+ cgi.param('sow_vendor_mozilla_systems_explain') %]
 [% END %]

--- a/extensions/MozProjectReview/template/en/default/bug/create/create-moz-project-review.html.tmpl
+++ b/extensions/MozProjectReview/template/en/default/bug/create/create-moz-project-review.html.tmpl
@@ -435,7 +435,7 @@
         <span class="field_label required">Mozilla Systems:</span>
         <span class="field_data">
           <div class="field_description">
-            Will vendor require access to Mozilla systems (e.g. workday, email, google docs, servers)?
+            Will vendor require access to Mozilla systems (e.g. Workday, email, Google Docs, servers)?
           </div>
           <select name="sow_vendor_mozilla_systems" id="sow_vendor_mozilla_systems">
             <option value="">Select One</option>

--- a/extensions/MozProjectReview/web/js/moz_project_review.js
+++ b/extensions/MozProjectReview/web/js/moz_project_review.js
@@ -13,7 +13,7 @@ $(function() {
             "comment": "Please enter a value for description in the initial questions section.",
             "key_initiative": "Please select a value for key initiative in the initial questions section.",
             "contract_type": "Please select a value for contract type in the initial questions section.",
-            "mozilla_data": "Please select a value for mozilla data in the initial questions section.",
+            "mozilla_data": "Please select a value for Mozilla data in the initial questions section.",
             "vendor_cost": "Please select a value for vendor cost in the initial questions section.",
             "timeframe": "Please select a value for timeframe in the initial questions section.",
             "contract_priority": "Please select a value for priority in the initial questions section.",
@@ -23,7 +23,7 @@ $(function() {
             "key_initiative_other": "Please enter a value for other key initiative in the initial questions section."
         },
         "mozilla_data_explain_row": {
-            "mozilla_data_explain": "Please enter a value for mozilla data access explanation in the initial questions section."
+            "mozilla_data_explain": "Please enter a value for Mozilla data access explanation in the initial questions section."
         },
         "contract_type_other": {
             "contract_type_other": "Please enter a value for other contract type in the initial questions section."
@@ -64,7 +64,7 @@ $(function() {
             "sow_vendor_total_max": "Please enter a value for SOW vendor maximum total to be paid.",
         },
         "sow_vendor_mozilla_systems_explain_row": {
-            "sow_vendor_mozilla_systems_explain": "Please enter a value for SOW vendor explanation for use of mozilla systems."
+            "sow_vendor_mozilla_systems_explain": "Please enter a value for SOW vendor explanation for use of Mozilla systems."
         },
         "sow_vendor_onsite_where_row": {
             "sow_vendor_onsite_where": "Please enter a value for SOW vendor onsite where and when."

--- a/extensions/MyDashboard/lib/BugInterest.pm
+++ b/extensions/MyDashboard/lib/BugInterest.pm
@@ -14,7 +14,7 @@ use warnings;
 use parent qw(Bugzilla::Object);
 
 #####################################################################
-# Overriden Constants that are used as methods
+# Overridden Constants that are used as methods
 #####################################################################
 
 use constant DB_TABLE       => 'bug_interest';

--- a/extensions/MyDashboard/lib/Queries.pm
+++ b/extensions/MyDashboard/lib/Queries.pm
@@ -240,7 +240,7 @@ sub query_bugs {
     push(@bugs, $bug);
   }
 
-  return (\@bugs, $params->canonicalise_query());
+  return (\@bugs, $params->canonicalize_query());
 }
 
 sub query_flags {

--- a/extensions/Needinfo/Extension.pm
+++ b/extensions/Needinfo/Extension.pm
@@ -273,7 +273,7 @@ sub object_before_delete {
     unless $object->isa('Bugzilla::Flag') && $object->type->name eq 'needinfo';
   my $user = Bugzilla->user;
 
-  # Require canconfirm to clear requests targetted at someone else
+  # Require canconfirm to clear requests targeted at someone else
   if ( $object->setter_id != $user->id
     && $object->requestee
     && $object->requestee->id != $user->id

--- a/extensions/Needinfo/template/en/default/bug/needinfo.html.tmpl
+++ b/extensions/Needinfo/template/en/default/bug/needinfo.html.tmpl
@@ -157,7 +157,7 @@ $(function() {
           </label>
         </td>
       [% ELSIF user.in_group("canconfirm") || flag.setter_id == user.id %]
-        [%# needinfo targetted at someone else, but the user can clear %]
+        [%# needinfo targeted at someone else, but the user can clear %]
         <td align="center">
           <input type="checkbox" id="needinfo_override_[% flag.id FILTER html %]"
                   name="needinfo_override_[% flag.id FILTER html %]" value="1">

--- a/extensions/OrangeFactor/Extension.pm
+++ b/extensions/OrangeFactor/Extension.pm
@@ -37,7 +37,7 @@ sub template_before_process {
     unless ($user->id && $user->settings->{'orange_factor'}->{'value'} eq 'on');
 
   # in the header we just need to set the var,
-  # to ensure the css and javascript get included
+  # to ensure the CSS and JavaScript get included
   my $bug = exists $vars->{'bugs'} ? $vars->{'bugs'}[0] : $vars->{'bug'};
   if ($bug && grep($_->name eq 'intermittent-failure', @{$bug->keyword_objects}))
   {

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -170,7 +170,7 @@ sub feed_query {
     }
 
     # Skip changes done by phab-bot user
-    # If changer does not exist in bugzilla database
+    # If changer does not exist in Bugzilla database
     # we use the phab-bot account as the changer
     my $author = Bugzilla::Extension::PhabBugz::User->new_from_query(
       {phids => [$author_phid]});
@@ -287,7 +287,7 @@ sub group_query {
     ids => [$lando_bmo_user->id]
     });
 
-  # secure-revision project that will be used for bmo group projects
+  # secure-revision project that will be used for BMO group projects
   my $secure_revision
     = Bugzilla::Extension::PhabBugz::Project->new_from_query({
     name => 'secure-revision'
@@ -419,7 +419,7 @@ sub process_revision_change {
   # else bug is private.
   else {
     # Here we create a new custom policy containing the project
-    # groups that are mapped to bugzilla groups.
+    # groups that are mapped to Bugzilla groups.
     my $set_project_names = [map { "bmo-" . $_->name } @{$bug->groups_in}];
 
     # If current policy projects matches what we want to set, then
@@ -579,11 +579,11 @@ sub process_new_user {
     foreach my $row (@$results) {
       WARN(
         'Possible username squatter: ',
-        'phab user login: ' . $phab_user->name,
-        ' phab user realname: ' . $phab_user->realname,
-        ' bugzilla user id: ' . $row->{userid},
-        ' bugzilla login: ' . $row->{login_name},
-        ' bugzilla realname: ' . $row->{realname}
+        'Phab user login: ' . $phab_user->name,
+        ' Phab user realname: ' . $phab_user->realname,
+        ' Bugzilla user id: ' . $row->{userid},
+        ' Bugzilla login: ' . $row->{login_name},
+        ' Bugzilla realname: ' . $row->{realname}
       );
 
       my $vars = {

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -177,7 +177,7 @@ sub feed_query {
 
     if ($author && $author->bugzilla_id) {
       if ($author->bugzilla_user->login eq PHAB_AUTOMATION_USER) {
-        INFO("SKIPPING: Change made by phabricator user");
+        INFO("SKIPPING: Change made by Phabricator user");
         $self->save_last_id($story_id, 'feed');
         next;
       }
@@ -551,7 +551,7 @@ sub process_new_user {
   my $phab_user = Bugzilla::Extension::PhabBugz::User->new($user_data);
 
   if (!$phab_user->bugzilla_id) {
-    WARN("SKIPPING: No bugzilla id associated with user");
+    WARN("SKIPPING: No Bugzilla ID associated with user");
     return;
   }
 

--- a/extensions/PhabBugz/t/basic.t
+++ b/extensions/PhabBugz/t/basic.t
@@ -233,7 +233,7 @@ JSON
   my $revisions = get_attachment_revisions($bug);
   is(ref($revisions), 'ARRAY', 'it is an array ref');
   isa_ok($revisions->[0], 'Bugzilla::Extension::PhabBugz::Revision');
-  is($revisions->[0]->bug_id, 23, 'Bugzila ID is 23');
+  is($revisions->[0]->bug_id, 23, 'Bugzilla ID is 23');
   ok(try { $revisions->[0]->update }, 'update revision');
 
 };

--- a/extensions/PhabBugz/t/feed-daemon-guts.t
+++ b/extensions/PhabBugz/t/feed-daemon-guts.t
@@ -54,10 +54,10 @@ my $UserAgent = mock 'Mojo::UserAgent' => ();
 }
 
 my @bad_response = (
-  ['http error',   mock_useragent_tx("doesn't matter", sub { $_->code(500) })],
-  ['invalid json', mock_useragent_tx('<xml>foo</xml>')],
+  ['HTTP error',   mock_useragent_tx("doesn't matter", sub { $_->code(500) })],
+  ['invalid JSON', mock_useragent_tx('<xml>foo</xml>')],
   [
-    'json containing error code',
+    'JSON containing error code',
     mock_useragent_tx(encode_json({error_code => 1234}))
   ],
 );

--- a/extensions/PhabBugz/template/en/default/admin/email/squatter-alert.txt.tmpl
+++ b/extensions/PhabBugz/template/en/default/admin/email/squatter-alert.txt.tmpl
@@ -19,16 +19,16 @@ Possible username squatter:
 Phabricator Account
 
 login: [% phab_user_login %]
-realname: [% phab_user_realname %]
+real name: [% phab_user_realname %]
 
 Bugzilla Account Matching Phabricator Account
 
 user id: [% bugzilla_userid %]
 login: [% bugzilla_login %]
-realname: [% bugzilla_realname %]
+real name: [% bugzilla_realname %]
 
 Possible Bugzilla Account Squatting On
 
 user id: [% squat_userid %]
 login: [% squat_login %]
-realname: [% squat_realname %]
+real name: [% squat_realname %]

--- a/extensions/PhabBugz/template/en/default/phabricator/table.html.tmpl
+++ b/extensions/PhabBugz/template/en/default/phabricator/table.html.tmpl
@@ -29,7 +29,7 @@
     <tr>
       <td colspan="4">
         <input id="phabricator-show-abandoned" type="checkbox">
-        <label for="phabricator-show-abandoned">Show Abandoned Revisons</label>
+        <label for="phabricator-show-abandoned">Show Abandoned Revisions</label>
       </td>
     </tr>
   </tbody>

--- a/extensions/ProdCompSearch/lib/WebService.pm
+++ b/extensions/ProdCompSearch/lib/WebService.pm
@@ -117,7 +117,7 @@ sub prod_comp_search {
   }
   return {products => []} if !scalar @terms;
 
-  # To help mozilla staff file bmo administration bugs into the right
+  # To help Mozilla staff file bmo administration bugs into the right
   # component, sort bmo first when searching for 'bugzilla'
   if (
        $search =~ /bugzilla/i

--- a/extensions/ProdCompSearch/lib/WebService.pm
+++ b/extensions/ProdCompSearch/lib/WebService.pm
@@ -117,8 +117,8 @@ sub prod_comp_search {
   }
   return {products => []} if !scalar @terms;
 
-  # To help Mozilla staff file bmo administration bugs into the right
-  # component, sort bmo first when searching for 'bugzilla'
+  # To help Mozilla staff file BMO administration bugs into the right
+  # component, sort BMO first when searching for 'bugzilla'
   if (
        $search =~ /bugzilla/i
     && $search !~ /^bugzilla\s*::/i

--- a/extensions/ProdCompSearch/template/en/default/prodcompsearch/form.html.tmpl
+++ b/extensions/ProdCompSearch/template/en/default/prodcompsearch/form.html.tmpl
@@ -18,7 +18,7 @@
   # new_tab:          open in a new tab
   # anchor_component: append #component to url
   # custom_select:    when true don't manage menu-item selects
-  # hidden:           initialise container as display:none
+  # hidden:           initialize container as display:none
   # throbber:         id of the throbber element
   #%]
 
@@ -42,7 +42,7 @@
       Result limited to [% max_results FILTER html %] components
     </span>
     <span class="pcs-message" id="[% id FILTER html %]-error" style="display:none">
-      An error occured
+      An error occurred
     </span>
   </div>
   <input type="text" class="prod_comp_search" id="[% id FILTER html %]" size="50"

--- a/extensions/ProdCompSearch/template/en/default/prodcompsearch/form.html.tmpl
+++ b/extensions/ProdCompSearch/template/en/default/prodcompsearch/form.html.tmpl
@@ -16,7 +16,7 @@
   # format:           format parameter passed to cgi
   # cloned_bug_id:    cloned_bug_id parameter
   # new_tab:          open in a new tab
-  # anchor_component: append #component to url
+  # anchor_component: append #component to URL
   # custom_select:    when true don't manage menu-item selects
   # hidden:           initialize container as display:none
   # throbber:         id of the throbber element

--- a/extensions/Profanivore/README
+++ b/extensions/Profanivore/README
@@ -9,6 +9,6 @@ the aim here is to prevent people immediately noticing they are being
 censored, and getting 'creative'.
 
 The purpose of Profanivore is to make it a little harder for trolls to
-vandalise public Bugzilla installations.
+vandalize public Bugzilla installations.
 
 It does not currently affect fields other than comments.

--- a/extensions/Push/Extension.pm
+++ b/extensions/Push/Extension.pm
@@ -380,7 +380,7 @@ sub flag_end_of_update {
   delete $args->{changes};
 }
 
-# comments in bugzilla 4.0 doesn't aren't included in the bug_end_of_* hooks,
+# comments in Bugzilla 4.0 doesn't aren't included in the bug_end_of_* hooks,
 # this code uses custom hooks to trigger
 sub bug_comment_create {
   my ($self, $args) = @_;

--- a/extensions/Push/Extension.pm
+++ b/extensions/Push/Extension.pm
@@ -21,7 +21,7 @@ use Bugzilla::Extension::Push::Connectors;
 use Bugzilla::Extension::Push::Logger;
 use Bugzilla::Extension::Push::Message;
 use Bugzilla::Extension::Push::Push;
-use Bugzilla::Extension::Push::Serialise;
+use Bugzilla::Extension::Push::Serialize;
 use Bugzilla::Extension::Push::Util;
 use Bugzilla::Install::Filesystem;
 
@@ -34,7 +34,7 @@ our $VERSION = '1';
 $Carp::CarpInternal{'CGI::Carp'} = 1;
 
 #
-# monkey patch for convience
+# monkey patch for convenience
 #
 
 BEGIN {
@@ -266,26 +266,26 @@ sub _morph_flag_update {
 }
 
 #
-# serialise and insert into the table
+# serialize and insert into the table
 #
 
 sub _push_object {
   my ($self, $message_type, $object, $change_set, $changes) = @_;
   my $rh;
 
-  # serialise the object
+  # serialize the object
   my ($rh_object, $name)
-    = Bugzilla::Extension::Push::Serialise->instance->object_to_hash($object);
+    = Bugzilla::Extension::Push::Serialize->instance->object_to_hash($object);
 
   if (!$rh_object) {
-    warn "empty hash from serialiser ($message_type $object)\n";
+    warn "empty hash from serializer ($message_type $object)\n";
     return;
   }
   $rh->{$name} = $rh_object;
 
   # add in the events hash
   my $rh_event
-    = Bugzilla::Extension::Push::Serialise->instance->changes_to_event($changes);
+    = Bugzilla::Extension::Push::Serialize->instance->changes_to_event($changes);
   return unless $rh_event;
   $rh_event->{'action'}      = $message_type;
   $rh_event->{'target'}      = $name;

--- a/extensions/Push/lib/BacklogMessage.pm
+++ b/extensions/Push/lib/BacklogMessage.pm
@@ -25,7 +25,7 @@ use Bugzilla::Util;
 use Encode;
 
 #
-# initialisation
+# initialization
 #
 
 use constant DB_TABLE   => 'push_backlog';

--- a/extensions/Push/lib/Backoff.pm
+++ b/extensions/Push/lib/Backoff.pm
@@ -23,7 +23,7 @@ use Bugzilla::Logging;
 use Bugzilla::Util;
 
 #
-# initialisation
+# initialization
 #
 
 use constant DB_TABLE   => 'push_backoff';

--- a/extensions/Push/lib/Connector.disabled/ServiceNow.pm
+++ b/extensions/Push/lib/Connector.disabled/ServiceNow.pm
@@ -18,7 +18,7 @@ use Bugzilla::Bug;
 use Bugzilla::Component;
 use Bugzilla::Constants;
 use Bugzilla::Extension::Push::Constants;
-use Bugzilla::Extension::Push::Serialise;
+use Bugzilla::Extension::Push::Serialize;
 use Bugzilla::Extension::Push::Util;
 use Bugzilla::Field;
 use Bugzilla::Mailer;
@@ -155,7 +155,7 @@ sub should_send {
   my $bug_data = $self->_get_bug_data($data) || return 0;
 
   # we don't want to send the initial comment in a separate message
-  # because we inject it into the inital message
+  # because we inject it into the initial message
   if (exists $data->{comment} && $data->{comment}->{number} == 0) {
     return 0;
   }
@@ -191,7 +191,7 @@ sub send {
   my $logger = Bugzilla->push_ext->logger;
   my $config = $self->config;
 
-# should_send intiailises bugzilla_user; make sure we return a useful error message
+# should_send initializes bugzilla_user; make sure we return a useful error message
   if (!$self->{bugzilla_user}) {
     return (PUSH_RESULT_TRANSIENT,
       "Invalid bugzilla-user (" . $self->config->{bugzilla_user} . ")");
@@ -208,7 +208,7 @@ sub send {
     my $comment = shift @{$bug->comments};
     if ($comment->body ne '') {
       $bug_data->{comment}
-        = Bugzilla::Extension::Push::Serialise->instance->object_to_hash($comment, 1);
+        = Bugzilla::Extension::Push::Serialize->instance->object_to_hash($comment, 1);
     }
 
   }

--- a/extensions/Push/lib/Connector.disabled/ServiceNow.pm
+++ b/extensions/Push/lib/Connector.disabled/ServiceNow.pm
@@ -194,7 +194,7 @@ sub send {
 # should_send initializes bugzilla_user; make sure we return a useful error message
   if (!$self->{bugzilla_user}) {
     return (PUSH_RESULT_TRANSIENT,
-      "Invalid bugzilla-user (" . $self->config->{bugzilla_user} . ")");
+      "Invalid Bugzilla-user (" . $self->config->{bugzilla_user} . ")");
   }
 
   # load the bug
@@ -219,10 +219,10 @@ sub send {
     $data->{attachment}->{data} = encode_base64($attachment->data);
   }
 
-  # map bmo login to ldap login and insert into json payload
+  # map BMO login to ldap login and insert into JSON payload
   $self->_add_ldap_logins($data, {});
 
-  # flatten json data
+  # flatten JSON data
   $self->_flatten($data);
 
   # add sysparm_action
@@ -242,7 +242,7 @@ sub send {
   $self->{lwp} ||= LWP::UserAgent->new(agent => Bugzilla->localconfig->urlbase);
   my $result = $self->{lwp}->request($request);
 
-  # http level errors
+  # HTTP level errors
   if (!$result->is_success) {
 
     # treat these as transient
@@ -257,7 +257,7 @@ sub send {
     return (PUSH_RESULT_TRANSIENT, "Empty response");
   }
 
-  # json errors
+  # JSON errors
   my $result_data;
   eval { $result_data = from_json($result->content); };
   if ($@) {
@@ -270,7 +270,7 @@ sub send {
     return (PUSH_RESULT_ERROR, $result_data->{error});
   }
 
-  # malformed/unexpected json response
+  # malformed/unexpected JSON response
   if (!exists $result_data->{records}
     || ref($result_data->{records}) ne 'ARRAY'
     || scalar(@{$result_data->{records}}) == 0)
@@ -313,7 +313,7 @@ sub _get_bug_data {
 
 sub _flatten {
 
-  # service-now expects a flat json object
+  # service-now expects a flat JSON object
   my ($self, $data) = @_;
 
   my $target = $data->{event}->{target};

--- a/extensions/Push/lib/Connector/Base.pm
+++ b/extensions/Push/lib/Connector/Base.pm
@@ -35,7 +35,7 @@ sub init {
   my ($self) = @_;
 
   # abstract
-  # perform any initialisation here
+  # perform any initialization here
   # will be run when created by the web pages or by the daemon
   # and also when the configuration needs to be reloaded
 }

--- a/extensions/Push/lib/Connector/File.pm
+++ b/extensions/Push/lib/Connector/File.pm
@@ -48,7 +48,7 @@ sub should_send {
 sub send {
   my ($self, $message) = @_;
 
-  # pretty-format json payload
+  # pretty-format JSON payload
   my $payload = $message->payload_decoded;
   $payload = to_json($payload, 1);
 

--- a/extensions/Push/lib/LogEntry.pm
+++ b/extensions/Push/lib/LogEntry.pm
@@ -23,7 +23,7 @@ use Bugzilla::Error;
 use Bugzilla::Extension::Push::Constants;
 
 #
-# initialisation
+# initialization
 #
 
 use constant DB_TABLE   => 'push_log';

--- a/extensions/Push/lib/Message.pm
+++ b/extensions/Push/lib/Message.pm
@@ -24,7 +24,7 @@ use Bugzilla::Extension::Push::Util;
 use Encode;
 
 #
-# initialisation
+# initialization
 #
 
 use constant DB_TABLE   => 'push';

--- a/extensions/Push/lib/Option.pm
+++ b/extensions/Push/lib/Option.pm
@@ -18,7 +18,7 @@ use Bugzilla::Error;
 use Bugzilla::Util;
 
 #
-# initialisation
+# initialization
 #
 
 use constant DB_TABLE   => 'push_options';

--- a/extensions/Push/lib/Serialize.pm
+++ b/extensions/Push/lib/Serialize.pm
@@ -112,7 +112,7 @@ sub _select {
   return $value;
 }
 
-# return an object which serializes to a json boolean, but still acts as a perl
+# return an object which serializes to a JSON boolean, but still acts as a perl
 # boolean
 sub _boolean {
   my ($value) = @_;

--- a/extensions/Push/lib/Serialize.pm
+++ b/extensions/Push/lib/Serialize.pm
@@ -112,7 +112,7 @@ sub _select {
   return $value;
 }
 
-# return an object which serializes to a JSON boolean, but still acts as a perl
+# return an object which serializes to a JSON boolean, but still acts as a Perl
 # boolean
 sub _boolean {
   my ($value) = @_;

--- a/extensions/Push/lib/Serialize.pm
+++ b/extensions/Push/lib/Serialize.pm
@@ -104,7 +104,7 @@ sub changes_to_event {
   return $event;
 }
 
-# bugzilla returns '---' or '--' for single-select fields that have no value
+# Bugzilla returns '---' or '--' for single-select fields that have no value
 # selected.  it makes more sense to return an empty string.
 sub _select {
   my ($value) = @_;

--- a/extensions/Push/lib/Serialize.pm
+++ b/extensions/Push/lib/Serialize.pm
@@ -5,7 +5,7 @@
 # This Source Code Form is "Incompatible With Secondary Licenses", as
 # defined by the Mozilla Public License, v. 2.0.
 
-package Bugzilla::Extension::Push::Serialise;
+package Bugzilla::Extension::Push::Serialize;
 
 use 5.10.1;
 use strict;
@@ -21,7 +21,7 @@ use JSON ();
 my $_instance;
 
 sub instance {
-  $_instance ||= Bugzilla::Extension::Push::Serialise->_new();
+  $_instance ||= Bugzilla::Extension::Push::Serialize->_new();
   return $_instance;
 }
 
@@ -32,7 +32,7 @@ sub _new {
   return $self;
 }
 
-# given an object, serliase to a hash
+# given an object, serialize to a hash
 sub object_to_hash {
   my ($self, $object, $is_shallow) = @_;
 
@@ -49,7 +49,7 @@ sub object_to_hash {
     return wantarray ? ($cache->{$cache_id}, $name) : $cache->{$cache_id};
   }
 
-  # call the right method to serialise to a hash
+  # call the right method to serialize to a hash
   my $rh = $self->$method($object, $is_shallow);
 
   # store in cache
@@ -75,14 +75,14 @@ sub changes_to_event {
   foreach my $change (@{$changes->{'changes'}}) {
     if (exists $change->{'field'}) {
 
-      # map undef to emtpy
+      # map undef to empty
       hash_undef_to_empty($change);
 
       # custom_fields change from undef to empty, ignore these changes
       return
         if ($change->{'added'} || "") eq "" && ($change->{'removed'} || "") eq "";
 
-      # use saner field serialisation
+      # use saner field serialization
       my $field = $change->{'field'};
       $change->{'field'} = $field;
 
@@ -112,7 +112,7 @@ sub _select {
   return $value;
 }
 
-# return an object which serialises to a json boolean, but still acts as a perl
+# return an object which serializes to a json boolean, but still acts as a perl
 # boolean
 sub _boolean {
   my ($value) = @_;
@@ -162,7 +162,7 @@ sub _custom_field {
 
 #
 # class mappings
-# automatically derrived from the class name
+# automatically derived from the class name
 # Bugzilla::Bug --> _bug, Bugzilla::User --> _user, etc
 #
 

--- a/extensions/Push/lib/Util.pm
+++ b/extensions/Push/lib/Util.pm
@@ -81,7 +81,7 @@ sub mapr(&$) {
 }
 
 
-# convert datetime string (from db) to a UTC json friendly datetime
+# convert datetime string (from db) to a UTC JSON friendly datetime
 sub datetime_to_timestamp {
   my ($datetime_string) = @_;
   return '' unless $datetime_string;
@@ -146,7 +146,7 @@ sub canon_email {
   return $email;
 }
 
-# json helpers
+# JSON helpers
 sub to_json {
   my ($object, $pretty) = @_;
   if ($pretty) {

--- a/extensions/Push/lib/Util.pm
+++ b/extensions/Push/lib/Util.pm
@@ -137,7 +137,7 @@ sub clean_email {
   return $email;
 }
 
-# resolve to canonised email form
+# resolve to canonical email form
 # eg. glob+bmo@mozilla.com --> glob@mozilla.com
 sub canon_email {
   my $email = shift;

--- a/extensions/Push/lib/Util.pm
+++ b/extensions/Push/lib/Util.pm
@@ -138,7 +138,7 @@ sub clean_email {
 }
 
 # resolve to canonical email form
-# eg. glob+bmo@mozilla.com --> glob@mozilla.com
+# e.g. glob+bmo@mozilla.com --> glob@mozilla.com
 sub canon_email {
   my $email = shift;
   $email = clean_email($email);

--- a/extensions/REMO/template/en/default/bug/create/comment-remo-budget.txt.tmpl
+++ b/extensions/REMO/template/en/default/bug/create/comment-remo-budget.txt.tmpl
@@ -33,7 +33,7 @@ Requester info:
 Requester: [% cgi.param('firstname') %] [%+ cgi.param('lastname') %]
 Profile page: [% cgi.param('profilepage') %]
 Event page: [% cgi.param('eventpage') %]
-Funtional Goals:
+Functional Goals:
 [%+ cgi.param('functional_goals') %]
 Event Goals:
 [%+ cgi.param('event_goals') %]
@@ -41,7 +41,7 @@ Why is budget needed:
 [%+ cgi.param('budget_reason') %]
 Agenda Link: [% cgi.param('agenda_link') %]
 Mentor Email: [% cgi.param('mentoremail') %]
-Paypal Account: [% cgi.param('paypal') %]
+PayPal Account: [% cgi.param('paypal') %]
 Country You Reside: [% cgi.param('country') %]
 Advance payment needed: [% IF cgi.param('advancepayment') %]Yes[% ELSE %]No[% END %]
 

--- a/extensions/REMO/template/en/default/bug/create/create-csa-discourse.html.tmpl
+++ b/extensions/REMO/template/en/default/bug/create/create-csa-discourse.html.tmpl
@@ -17,7 +17,7 @@
 [% USE Bugzilla %]
 
 <noscript>
-  <h1>Javascript is required to use this form.</h1>
+  <h1>JavaScript is required to use this form.</h1>
 </noscript>
 
 <h1>Community IT Discourse Request</h1>

--- a/extensions/REMO/template/en/default/bug/create/create-mozreps.html.tmpl
+++ b/extensions/REMO/template/en/default/bug/create/create-mozreps.html.tmpl
@@ -28,7 +28,7 @@
 %]
 
 <noscript>
-  <h1>Javascript is required to use this form.</h1>
+  <h1>JavaScript is required to use this form.</h1>
 </noscript>
 
 <h1>Mozilla Reps - Application Form</h1>

--- a/extensions/REMO/template/en/default/bug/create/create-remo-budget.html.tmpl
+++ b/extensions/REMO/template/en/default/bug/create/create-remo-budget.html.tmpl
@@ -196,7 +196,7 @@ function validateAndSubmit() {
 </tr>
 
 <tr class="odd">
-  <th class="field_label">Paypal Account Email:</th>
+  <th class="field_label">PayPal Account Email:</th>
   <td>
     <input type="text" name="paypal" id="paypal"
            value="" size="40" placeholder=""><br>

--- a/extensions/REMO/template/en/default/bug/create/create-remo-budget.html.tmpl
+++ b/extensions/REMO/template/en/default/bug/create/create-remo-budget.html.tmpl
@@ -54,7 +54,7 @@ function validateAndSubmit() {
     return trySubmit();
   }
 
-  //alert text, stay here on the pagee
+  //alert text, stay here on the page
   alert(alert_text);
   return false;
 }

--- a/extensions/REMO/template/en/default/bug/create/create-remo-swag.html.tmpl
+++ b/extensions/REMO/template/en/default/bug/create/create-remo-swag.html.tmpl
@@ -55,7 +55,7 @@ function validateAndSubmit() {
     return trySubmit();
   }
 
-  //alert text, stay here on the pagee
+  //alert text, stay here on the page
   alert(alert_text);
   return false;
 }

--- a/extensions/RequestNagger/bin/send-request-nags.pl
+++ b/extensions/RequestNagger/bin/send-request-nags.pl
@@ -222,10 +222,10 @@ sub _send_email {
           # non-public bugs
           if ($request->{bug}->is_private) {
             $has_private_bug = 1;
-            $request->{bug}->{sanitise_bug} = !$securemail || !$has_key;
+            $request->{bug}->{sanitize_bug} = !$securemail || !$has_key;
           }
           else {
-            $request->{bug}->{sanitise_bug} = 0;
+            $request->{bug}->{sanitize_bug} = 0;
           }
         }
       }

--- a/extensions/RequestNagger/lib/Bug.pm
+++ b/extensions/RequestNagger/lib/Bug.pm
@@ -18,7 +18,7 @@ use Bugzilla::User;
 
 sub short_desc {
   my ($self) = @_;
-  return $self->{sanitise_bug} ? '(Secure bug)' : $self->SUPER::short_desc;
+  return $self->{sanitize_bug} ? '(Secure bug)' : $self->SUPER::short_desc;
 }
 
 sub is_private {
@@ -36,7 +36,7 @@ sub tooltip {
   if ($self->bug_status eq 'RESOLVED') {
     $tooltip .= '/' . $self->resolution;
   }
-  if (!$self->{sanitise_bug}) {
+  if (!$self->{sanitize_bug}) {
     $tooltip .= ' ' . $self->product . ' :: ' . $self->component;
   }
   return $tooltip;

--- a/extensions/RequestNagger/template/en/default/account/prefs/request_nagging.html.tmpl
+++ b/extensions/RequestNagger/template/en/default/account/prefs/request_nagging.html.tmpl
@@ -68,5 +68,5 @@
 
 <input type="checkbox" id="no_encryption" name="no_encryption" value="1"
   [%= "checked" IF settings.no_encryption %]>
-<label for="no_encryption">Don't encrypt email (sensitive information will be sanitised)</label><br>
+<label for="no_encryption">Don't encrypt email (sensitive information will be sanitized)</label><br>
 <br>

--- a/extensions/Review/Extension.pm
+++ b/extensions/Review/Extension.pm
@@ -591,7 +591,7 @@ sub _check_review_flag {
       }
 
       # we want to throw an error if the requestee does not have access
-      # to the bug.  bugzilla's default behaviour is to sliently drop the
+      # to the bug.  bugzilla's default behavior is to silently drop the
       # requestee, which results in a confusing 'reviewer required'
       # error.
       # fake it by creating a flag and try to set the requestee.

--- a/extensions/Review/Extension.pm
+++ b/extensions/Review/Extension.pm
@@ -534,7 +534,7 @@ sub _adjust_request_count {
   Bugzilla->memcached->clear({table => 'profiles', id => $requestee_id});
 }
 
-# bugzilla's handling of requestee matching when creating bugs is "if it's
+# Bugzilla's handling of requestee matching when creating bugs is "if it's
 # wrong, or matches too many, default to empty", which breaks mandatory
 # reviewer requirements.  instead we just throw an error.
 sub post_bug_attachment_flags {
@@ -591,11 +591,11 @@ sub _check_review_flag {
       }
 
       # we want to throw an error if the requestee does not have access
-      # to the bug.  bugzilla's default behavior is to silently drop the
+      # to the bug.  Bugzilla's default behavior is to silently drop the
       # requestee, which results in a confusing 'reviewer required'
       # error.
       # fake it by creating a flag and try to set the requestee.
-      # bugzilla's flags don't have a normal constructor or property
+      # Bugzilla's flags don't have a normal constructor or property
       # setters, so we have to bless it directly then call the internal
       # check_requestee method.  urgh.
       my $flag = bless(

--- a/extensions/Review/lib/WebService.pm
+++ b/extensions/Review/lib/WebService.pm
@@ -50,7 +50,7 @@ sub suggestions {
   my @reviewers;
   if ($bug) {
 
-    # we always need to be authentiated to perform user matching
+    # we always need to be authenticated to perform user matching
     my $user = Bugzilla->user;
     if (!$user->id) {
       Bugzilla->set_user(Bugzilla::User->check({name => 'nobody@mozilla.org'}));
@@ -316,7 +316,7 @@ __END__
 =head1 NAME
 
 Bugzilla::Extension::Review::WebService - Functions for the Mozilla specific
-'review' flag optimisations.
+'review' flag optimizations.
 
 =head1 METHODS
 

--- a/extensions/Review/lib/WebService.pm
+++ b/extensions/Review/lib/WebService.pm
@@ -323,7 +323,7 @@ Bugzilla::Extension::Review::WebService - Functions for the Mozilla specific
 See L<Bugzilla::WebService> for a description of how parameters are passed,
 and what B<STABLE>, B<UNSTABLE>, and B<EXPERIMENTAL> mean.
 
-Although the data input and output is the same for JSONRPC, XMLRPC and REST,
+Although the data input and output is the same for JSON-RPC, XML-RPC and REST,
 the directions for how to access the data via REST is noted in each method
 where applicable.
 

--- a/extensions/Review/lib/WebService.pm
+++ b/extensions/Review/lib/WebService.pm
@@ -429,9 +429,9 @@ Use one or more of the following parameters to find specific flag status changes
 
 Note that searching by C<flag_id> is not reliable because when flags are removed, flag_ids cease to exist.
 
-=item C<requestee> (string) - The bugzilla login of the flag's requestee
+=item C<requestee> (string) - The Bugzilla login of the flag's requestee
 
-=item C<setter> (string) - The bugzilla login of the flag's setter
+=item C<setter> (string) - The Bugzilla login of the flag's setter
 
 =item C<type_id> (int) - The flag type id of a change
 
@@ -495,17 +495,17 @@ Boolean flag indicating if the flag type is multiplicable.
 
 =item C<setter> (object)
 
-The setter is the bugzilla user that set the flag. It is represented by an object with the following fields.
+The setter is the Bugzilla user that set the flag. It is represented by an object with the following fields.
 
 =over
 
 =item C<id> (integer)
 
-The id of the bugzilla user. A unique integer value.
+The id of the Bugzilla user. A unique integer value.
 
 =item C<real_name> (string)
 
-The real name of the bugzilla user.
+The real name of the Bugzilla user.
 
 =item C<nick> (string)
 
@@ -514,27 +514,27 @@ email field.
 
 =item C<name> (string)
 
-The bugzilla login of the bugzilla user (typically an email address).
+The Bugzilla login of the Bugzilla user (typically an email address).
 
 =back
 
 =item C<requestee> (object)
 
-The requestee is the bugzilla user that is specified by the flag. Optional - absent if there is no requestee.
+The requestee is the Bugzilla user that is specified by the flag. Optional - absent if there is no requestee.
 
 Requestee has the same keys/values as the setter object.
 
 =item C<bug_id> (integer)
 
-The id of the bugzilla bug that the changed flag belongs to.
+The id of the Bugzilla bug that the changed flag belongs to.
 
 =item C<attachment_id> (integer)
 
-The id of the bugzilla attachment that the changed flag belongs to.
+The id of the Bugzilla attachment that the changed flag belongs to.
 
 =item C<status> (string)
 
-The status of the bugzilla flag that changed. One of C<+ - ? X>.
+The status of the Bugzilla flag that changed. One of C<+ - ? X>.
 
 =back
 

--- a/extensions/Review/web/js/review_history.js
+++ b/extensions/Review/web/js/review_history.js
@@ -174,7 +174,7 @@ $(function () {
                     case '+':
                     case '-':
                         // if we get a + or -, we only accept it if the requestee is the user we're interested in.
-                        // we set is_complete to handle cancelations.
+                        // we set is_complete to handle cancellations.
                         if (stash[flag_id] && stash[flag_id].requestee.name == user) {
                             add_historical_action(history, flag, stash[flag_id], "review" + flag.status);
                             stash[flag_id].is_complete = true;

--- a/extensions/Review/web/js/review_history.js
+++ b/extensions/Review/web/js/review_history.js
@@ -164,7 +164,7 @@ $(function () {
                         if (stash[flag_id]) {
                             // Only process if we did not get a + or a - since
                             if (!stash[flag_id].is_complete) {
-                                add_historical_action(history, flag, stash[flag_id], 'cancelled');
+                                add_historical_action(history, flag, stash[flag_id], 'canceled');
                             }
                             delete stash[flag_id];
                         }

--- a/extensions/SecureMail/Extension.pm
+++ b/extensions/SecureMail/Extension.pm
@@ -360,7 +360,7 @@ sub mailer_before_send {
     }
     elsif ($is_passwordmail) {
 
-      # Mail is made unsecure only if the user does not have a public
+      # Mail is made insecure only if the user does not have a public
       # key and is not in any security groups. So specifying a public
       # key OR being in a security group means the mail is kept secure
       # (but, as noted above, the check is the other way around because

--- a/extensions/SecureMail/Extension.pm
+++ b/extensions/SecureMail/Extension.pm
@@ -412,10 +412,10 @@ sub mailer_before_send {
 sub bugmail_referenced_bugs {
   my ($self, $args) = @_;
 
-  # Sanitise subjects of referenced bugs.
+  # sanitize subjects of referenced bugs.
   my $referenced_bugs = $args->{'referenced_bugs'};
 
-  # No need to sanitise subjects if the entire email will be secured.
+  # No need to sanitize subjects if the entire email will be secured.
   return if _should_secure_bug($args->{'updated_bug'});
 
   # Replace the subject if required
@@ -457,7 +457,7 @@ sub _should_secure_whine {
 }
 
 sub _make_secure {
-  my ($email, $key, $sanitise_subject, $add_new) = @_;
+  my ($email, $key, $sanitize_subject, $add_new) = @_;
 
   # Add header showing this email has been secured
   $email->header_set('X-Bugzilla-Secure-Email', 'Yes');
@@ -495,7 +495,7 @@ sub _make_secure {
 
       $email->walk_parts(sub {
         my ($part) = @_;
-        if ($sanitise_subject) {
+        if ($sanitize_subject) {
           _insert_subject($part, $subject);
         }
         return if $part->parts > 1;    # Top-level
@@ -533,7 +533,7 @@ sub _make_secure {
     }
     else {
       _fix_encoding($email);
-      if ($sanitise_subject) {
+      if ($sanitize_subject) {
         _insert_subject($email, $subject);
       }
       $email->body_set(_tct_encrypt($tct, $email->body, $bug_id));
@@ -547,7 +547,7 @@ sub _make_secure {
 
     $email->walk_parts(\&_fix_encoding);
 
-    if ($sanitise_subject) {
+    if ($sanitize_subject) {
       $email->walk_parts(sub { _insert_subject($_[0], $subject) });
     }
 
@@ -595,7 +595,7 @@ sub _make_secure {
     $email->body_set($message);
   }
 
-  if ($sanitise_subject) {
+  if ($sanitize_subject) {
 
     # This is designed to still work if the admin changes the word
     # 'bug' to something else. However, it could break if they change
@@ -605,7 +605,7 @@ sub _make_secure {
     my $component = $email->header('X-Bugzilla-Component');
 
     # Note: the $bug_id is required within the parentheses in order to keep
-    # gmail's threading algorithm happy.
+    # Gmail's threading algorithm happy.
     $subject
       =~ s/($bug_id\])\s+(.*)$/$1$new (Secure bug $bug_id in $product :: $component)/;
     {
@@ -637,7 +637,7 @@ sub _tct_encrypt {
 }
 
 # Insert the subject into the part's body, as the subject of the message will
-# be sanitised.
+# be sanitized.
 # XXX this incorrectly assumes all parts of the message are the body
 # we should only alter parts whose parent is multipart/alternative
 sub _insert_subject {

--- a/extensions/SecureMail/template/en/default/pages/securemail/help.html.tmpl
+++ b/extensions/SecureMail/template/en/default/pages/securemail/help.html.tmpl
@@ -80,7 +80,7 @@ Then, you need to convert it to a .pem file. Here are two possible ways to do th
 <code>openssl pkcs12 -in certificate.p12 -out certificate.pem -nodes -nokeys</code></p>
 
 <p>
-Open the .pem file in a text editor. You can recognise the public key because
+Open the .pem file in a text editor. You can recognize the public key because
 it starts "BEGIN CERTIFICATE" and ends "END CERTIFICATE" and
 has an appropriate friendly name (e.g. "StartCom Free Certificate Member's StartCom Ltd. ID").</p>
 

--- a/extensions/Splinter/Extension.pm
+++ b/extensions/Splinter/Extension.pm
@@ -76,8 +76,8 @@ sub page_before_template {
         ThrowUserError('bug_attach_id_mismatch');
       }
 
-      # The patch is going to be displayed in a HTML page and if the utf8
-      # param is enabled, we have to encode attachment data as utf8.
+      # The patch is going to be displayed in a HTML page and if the UTF-8
+      # param is enabled, we have to encode attachment data as UTF-8.
       if (Bugzilla->params->{'utf8'}) {
         $attachment->data;    # load data
         utf8::decode($attachment->{data});

--- a/extensions/TrackingFlags/bin/migrate_tracking_flags.pl
+++ b/extensions/TrackingFlags/bin/migrate_tracking_flags.pl
@@ -205,7 +205,7 @@ sub migrate_flag_bugs {
 sub migrate_flag_activity {
   my ($new_flag, $field) = @_;
 
-  print "Migating flag activity...";
+  print "Migrating flag activity...";
 
   my $new_field = Bugzilla::Field->new({name => $new_flag->name});
   $dbh->do("UPDATE bugs_activity SET fieldid = ? WHERE fieldid = ?",

--- a/extensions/TrackingFlags/lib/Admin.pm
+++ b/extensions/TrackingFlags/lib/Admin.pm
@@ -198,7 +198,7 @@ sub _load_from_input {
     $value->{is_active} = $value->{is_active} ? 1 : 0;
   }
 
-  # vibility
+  # visibility
 
   my $visibilities = decode_json($input->{visibility} || '[]');
   foreach my $visibility (@$visibilities) {
@@ -426,7 +426,7 @@ sub _update_db_visibility {
 }
 
 #
-# serialisation
+# serialization
 #
 
 sub _groups_to_json {
@@ -459,7 +459,7 @@ sub _flag_values_to_json {
 sub _flag_visibility_to_json {
   my ($visibilities, $is_copy) = @_;
 
-  # setting is_copy will set the id's to zero, to force new visibilites
+  # setting is_copy will set the id's to zero, to force new visibilities
   # rather than editing existing ones
   my @data;
 

--- a/extensions/TrackingFlags/lib/Flag/Visibility.pm
+++ b/extensions/TrackingFlags/lib/Flag/Visibility.pm
@@ -33,7 +33,7 @@ use constant DB_COLUMNS => qw(
 
 use constant LIST_ORDER => 'id';
 
-use constant UPDATE_COLUMNS => ();    # imutable
+use constant UPDATE_COLUMNS => ();    # immutable
 
 use constant VALIDATORS => {
   tracking_flag_id => \&_check_tracking_flag,

--- a/extensions/TrackingFlags/web/js/admin.js
+++ b/extensions/TrackingFlags/web/js/admin.js
@@ -393,7 +393,7 @@ function delete_confirm(flag) {
 function on_submit() {
     if (Dom.get('delete') && Dom.get('delete').value)
         return;
-    // let perl manage most validation errors, because they are clearly marked
+    // let Perl manage most validation errors, because they are clearly marked
     // the exception is an empty visibility list, so catch that here as well
     if (!flag_visibility.length) {
         alert('You must provide at least one product for visibility.');

--- a/extensions/UserProfile/Extension.pm
+++ b/extensions/UserProfile/Extension.pm
@@ -239,7 +239,7 @@ sub merge_users_before {
   my ($old_id, $new_id) = @$args{qw(old_id new_id)};
 
   # when users are merged, we have to delete all the statistics for both users
-  # we'll recalcuate the stats after the merge
+  # we'll recalculate the stats after the merge
   print "deleting user profile statistics for $old_id and $new_id\n";
   my $dbh = Bugzilla->dbh;
   foreach my $table (

--- a/extensions/UserStory/Extension.pm
+++ b/extensions/UserStory/Extension.pm
@@ -73,7 +73,7 @@ sub bug_update_before_logging {
 }
 
 # stop inline-history from displaying changes to the user story
-sub inline_history_activtiy {
+sub inline_history_activity {
   my ($self, $args) = @_;
   foreach my $activity (@{$args->{activity}}) {
     foreach my $change (@{$activity->{changes}}) {

--- a/extensions/ZPushNotify/Extension.pm
+++ b/extensions/ZPushNotify/Extension.pm
@@ -23,7 +23,7 @@ use Bugzilla;
 sub _notify {
   my ($bug_id, $delta_ts) = @_;
 
-  # beacuse the push_notify table is hot, we defer updating it until the
+  # because the push_notify table is hot, we defer updating it until the
   # request has completed.  this ensures we are outside the scope of any
   # transaction blocks.
 

--- a/heartbeat.cgi
+++ b/heartbeat.cgi
@@ -20,7 +20,7 @@ use Bugzilla::Update;
 
 my $ok = eval {
 
-# Ensure that any Throw*Error calls just use die, rather than trying to return html...
+# Ensure that any Throw*Error calls just use die, rather than trying to return HTML...
   Bugzilla->error_mode(ERROR_MODE_DIE);
   my $memcached    = Bugzilla->memcached;
   my $dbh          = Bugzilla->dbh;

--- a/importxml.pl
+++ b/importxml.pl
@@ -329,7 +329,7 @@ sub init() {
 # one bugs' attachments at a time.
 # The cycle will then repeat for the next <bug>
 #
-# The attach_id is ignored since mysql generates a new one for us.
+# The attach_id is ignored since MySQL generates a new one for us.
 # The submitter_id gets filled in with $exporterid.
 
 sub process_attachment() {

--- a/importxml.pl
+++ b/importxml.pl
@@ -7,7 +7,7 @@
 # defined by the Mozilla Public License, v. 2.0.
 
 # This script reads in xml bug data from standard input and inserts
-# a new bug into bugzilla. Everything before the beginning <?xml line
+# a new bug into Bugzilla. Everything before the beginning <?xml line
 # is removed so you can pipe in email messages.
 
 use 5.10.1;
@@ -16,9 +16,9 @@ use warnings;
 
 #####################################################################
 #
-# This script is used to import bugs from another installation of bugzilla.
+# This script is used to import bugs from another installation of Bugzilla.
 # It can be used in two ways.
-# First using the move function of bugzilla
+# First using the move function of Bugzilla
 # on another system will send mail to an alias provided by
 # the administrator of the target installation (you). Set up an alias
 # similar to the one given below so this mail will be automatically
@@ -29,7 +29,7 @@ use warnings;
 # bugzilla-import: "|/usr/bin/perl /opt/bugzilla/importxml.pl"
 #
 # Second it can be run from the command line with any xml file from
-# STDIN that conforms to the bugzilla DTD. In this case you can pass
+# STDIN that conforms to the Bugzilla DTD. In this case you can pass
 # an argument to set whether you want to send the
 # mail that will be sent to the exporter and maintainer normally.
 #
@@ -289,7 +289,7 @@ sub _to_array {
 # maintainer and URL base are set.
 #
 #    exporter:   email address of the person moving the bugs
-#    maintainer: the maintainer of the bugzilla installation
+#    maintainer: the maintainer of the Bugzilla installation
 #                as set in the parameters file
 #    urlbase:    The urlbase parameter of the installation
 #                bugs are being moved from
@@ -517,7 +517,7 @@ sub process_bug {
 
     # Same goes for bug #'s Since we don't know if the referenced bug
     # is also being moved, lets make sure they know it means a different
-    # bugzilla.
+    # Bugzilla.
     my $url = $urlbase . "show_bug.cgi?id=";
     $data =~ s/([Bb]ugs?\s*\#?\s*(\d+))/$url$2/g;
 
@@ -1338,7 +1338,7 @@ __END__
 
 =head1 NAME
 
-importxml - Import bugzilla bug data from xml.
+importxml - Import Bugzilla bug data from xml.
 
 =head1 SYNOPSIS
 
@@ -1379,9 +1379,9 @@ XML doesn't exist.
 
 =head1 DESCRIPTION
 
-     This script is used to import bugs from another installation of bugzilla.
+     This script is used to import bugs from another installation of Bugzilla.
      It can be used in two ways.
-     First using the move function of bugzilla
+     First using the move function of Bugzilla
      on another system will send mail to an alias provided by
      the administrator of the target installation (you). Set up an alias
      similar to the one given below so this mail will be automatically
@@ -1392,7 +1392,7 @@ XML doesn't exist.
      bugzilla-import: "|/usr/bin/perl /opt/bugzilla/importxml.pl --mail"
 
      Second it can be run from the command line with any xml file from
-     STDIN that conforms to the bugzilla DTD. In this case you can pass
+     STDIN that conforms to the Bugzilla DTD. In this case you can pass
      an argument to set whether you want to send the
      mail that will be sent to the exporter and maintainer normally.
 

--- a/index.cgi
+++ b/index.cgi
@@ -44,7 +44,7 @@ if ($cgi->param('logout')) {
   $cgi->delete('logout');
 }
 
-# our weak etag is based on the bugzilla version parameter (BMO customization) and the announcehtml
+# our weak etag is based on the Bugzilla version parameter (BMO customization) and the announcehtml
 # if either change, the cache will be considered invalid.
 my @etag_parts = (
   Bugzilla->VERSION,

--- a/js/comment-tagging.js
+++ b/js/comment-tagging.js
@@ -238,7 +238,7 @@ YAHOO.bugzilla.commentTagging = {
     },
 
     add : function(comment_id, comment_no, add_tags) {
-        // build list of current tags from html
+        // build list of current tags from HTML
         var tags = new Array();
         var spans = Dom.getElementsByClassName('bz_comment_tag', undefined, 'ct_' + comment_no);
         for (var i = 0, l = spans.length; i < l; i++) {

--- a/js/comments.js
+++ b/js/comments.js
@@ -146,7 +146,7 @@ function goto_add_comments( anchor ){
     document.getElementById('comment').focus();
     setTimeout(function(){
         document.location.hash = anchor;
-        // firefox doesn't seem to keep focus through the anchor change
+        // Firefox doesn't seem to keep focus through the anchor change
         document.getElementById('comment').focus();
     },10);
     return false;

--- a/js/field.js
+++ b/js/field.js
@@ -447,7 +447,7 @@ function showDuplicateItem(e) {
             dup_id.blur();
         }
     }
-    YAHOO.util.Event.preventDefault(e); //prevents the hyperlink from going to the url in the href.
+    YAHOO.util.Event.preventDefault(e); //prevents the hyperlink from going to the URL in the href.
 }
 
 function setResolutionToDuplicate(e, duplicate_or_move_bug_status) {

--- a/js/global.js
+++ b/js/global.js
@@ -155,7 +155,7 @@ function display_value(field, value) {
     return value;
 }
 
-// html encoding
+// HTML encoding
 if (!String.prototype.htmlEncode) {
     (function() {
         String.prototype.htmlEncode = function() {

--- a/js/instant-search.js
+++ b/js/instant-search.js
@@ -99,7 +99,7 @@ YAHOO.bugzilla.instantSearch = {
     YAHOO.bugzilla.instantSearch.currentSearchQuery = query;
     YAHOO.bugzilla.instantSearch.currentSearchProduct = product;
 
-    // initialise the datatable as late as possible
+    // initialize the datatable as late as possible
     YAHOO.bugzilla.instantSearch.initDataTable();
 
     try {

--- a/js/productform.js
+++ b/js/productform.js
@@ -19,7 +19,7 @@
  */
 
 // Functions to update form select elements based on a
-// collection of javascript arrays containing strings.
+// collection of JavaScript arrays containing strings.
 
 /**
  * Reads the selected classifications and updates product, component,

--- a/js/util.js
+++ b/js/util.js
@@ -342,7 +342,7 @@ function bz_toggleClass(anElement, aClass) {
     }
 }
 
-/* Retruns a string representation of a duration.
+/* Returns a string representation of a duration.
  *
  * @param ss   Duration in seconds
  * or

--- a/post_bug.cgi
+++ b/post_bug.cgi
@@ -201,7 +201,7 @@ if ($data_fh || $attach_text || $data_base64) {
 
   if ($attach_text) {
 
-    # Convert to unix line-endings if pasting a patch
+    # Convert to Unix line-endings if pasting a patch
     if (scalar($cgi->param('ispatch'))) {
       $attach_text =~ s/[\012\015]{1,2}/\012/g;
     }

--- a/post_bug.cgi
+++ b/post_bug.cgi
@@ -71,7 +71,7 @@ Bugzilla::Hook::process('bug_user_match_fields',
 Bugzilla::User::match_field($user_match_fields);
 
 if (defined $cgi->param('maketemplate')) {
-  $vars->{'url'}        = $cgi->canonicalise_query('token');
+  $vars->{'url'}        = $cgi->canonicalize_query('token');
   $vars->{'short_desc'} = $cgi->param('short_desc');
 
   print $cgi->header();

--- a/qa/config/generate_test_data.pl
+++ b/qa/config/generate_test_data.pl
@@ -344,7 +344,7 @@ if ($dbh->selectrow_array("SELECT 1 FROM bug_status WHERE value = 'ASSIGNED'"))
 # Create Bugs
 ##########################################################################
 
-# login to bugzilla
+# login to Bugzilla
 my $admin_user = Bugzilla::User->check($config->{admin_user_login});
 Bugzilla->set_user($admin_user);
 

--- a/qa/t/lib/QA/Util.pm
+++ b/qa/t/lib/QA/Util.pm
@@ -110,7 +110,7 @@ sub get_config {
     $config->{browser_ip_url} = "$uri";
   }
   else {
-    die "unable to find ip for $config->{browser_url}\n";
+    die "unable to find IP for $config->{browser_url}\n";
   }
   return $config;
 }

--- a/qa/t/rest_bugzilla.t
+++ b/qa/t/rest_bugzilla.t
@@ -34,7 +34,7 @@ ok($extensions->{QA},
   'The QA extension is enabled, with version ' . $extensions->{QA}->{version});
 
 my $timezone = $rest->call('timezone')->{timezone};
-ok($timezone, "GET /rest/timezone retuns $timezone");
+ok($timezone, "GET /rest/timezone returns $timezone");
 
 my $time = $rest->call('time');
 foreach my $type (qw(db_time web_time)) {

--- a/qa/t/selenium_server_start.t
+++ b/qa/t/selenium_server_start.t
@@ -64,7 +64,7 @@ sub vnc_start {
   if (!$pid) {
     open(STDOUT, ">/dev/null");
     open(STDERR, ">/dev/null");
-    exec(@vnc_cmd) || die "unabled to execute: $!";
+    exec(@vnc_cmd) || die "unable to execute: $!";
   }
   return $pid;
 }

--- a/qa/t/test_bmo_retire_values.t
+++ b/qa/t/test_bmo_retire_values.t
@@ -127,7 +127,7 @@ ok(
   'TempComponent is missing from create'
 );
 
-# try changing compoent of existing bug to TempComponent
+# try changing component of existing bug to TempComponent
 
 go_to_bug($sel, $clean_bug_id);
 ok(

--- a/qa/t/test_create_user_accounts.t
+++ b/qa/t/test_create_user_accounts.t
@@ -15,7 +15,7 @@ use QA::Util;
 
 my ($sel, $config) = get_selenium();
 
-# Set the email regexp for new bugzilla accounts to end with @bugzilla.test.
+# Set the email regexp for new Bugzilla accounts to end with @bugzilla.test.
 
 log_in($sel, $config, 'admin');
 set_parameters(

--- a/qa/t/test_create_user_accounts.t
+++ b/qa/t/test_create_user_accounts.t
@@ -74,7 +74,7 @@ foreach my $account (@accounts) {
   $sel->is_text_present_ok("User account creation has been restricted.");
 }
 
-# These accounts are illegal and should cause a javascript alert.
+# These accounts are illegal and should cause a JavaScript alert.
 @accounts = qw(
   test\bugzilla@bugzilla.test
   testbugzilla.test
@@ -98,7 +98,7 @@ foreach my $account (@accounts) {
   );
 }
 
-# These accounts are illegal but do not cause a javascript alert
+# These accounts are illegal but do not cause a JavaScript alert
 @accounts = ('test@bugzilla.org@bugzilla.test', 'test@bugzilla..test');
 
 # Logins larger than 127 characters must be rejected, for security reasons.

--- a/qa/t/test_edit_products_properties.t
+++ b/qa/t/test_edit_products_properties.t
@@ -324,8 +324,8 @@ $sel->title_is("Milestone Deleted");
 $text = trim($sel->get_text("message"));
 ok(
   $text
-    =~ /Bugs targetted to this milestone have been retargetted to the default milestone/,
-  "Bug retargetted"
+    =~ /Bugs targeted to this milestone have been retargeted to the default milestone/,
+  "Bug retargeted"
 );
 
 # Try deleting the version used by the bug. This action must be rejected.

--- a/qa/t/test_target_milestones.t
+++ b/qa/t/test_target_milestones.t
@@ -113,7 +113,7 @@ $sel->title_is("Delete Milestone of Product 'TestProduct'");
 $text = trim($sel->get_body_text());
 ok(
   $text =~ /There is 1 bug entered for this milestone/,
-  "Warning displayed about 1 bug targetted to TM1"
+  "Warning displayed about 1 bug targeted to TM1"
 );
 $sel->click_ok("delete");
 $sel->wait_for_page_to_load_ok(WAIT_TIME);

--- a/qa/t/webservice_bug_fields.t
+++ b/qa/t/webservice_bug_fields.t
@@ -145,7 +145,7 @@ foreach my $rpc (@clients) {
       '=~', qr/^-?\d+$/, "The first value has a numeric sortkey");
 
     ok(defined $first_value->{visibility_values},
-      "$field has visibilty_values defined on its first value")
+      "$field has visibility_values defined on its first value")
       or diag(Dumper($field_data->{values}));
     my @value_visibility_values
       = map { @{$_->{visibility_values}} } @{$field_data->{values}};

--- a/qa/t/webservice_bug_get.t
+++ b/qa/t/webservice_bug_get.t
@@ -80,7 +80,7 @@ $public_bug->{see_also}         = ["${base_url}show_bug.cgi?id=$private_id"];
 $public_bug->{cf_qa_status}     = [];
 $public_bug->{cf_single_select} = '---';
 
-# Fill in the timetracking fields on the public bug.
+# Fill in the time tracking fields on the public bug.
 $xmlrpc->bz_log_in('admin');
 $xmlrpc->bz_call_success(
   'Bug.update',

--- a/qa/t/webservice_bug_get_bugs.t
+++ b/qa/t/webservice_bug_get_bugs.t
@@ -70,7 +70,7 @@ $public_bug->{see_also}         = ["${base_url}show_bug.cgi?id=$private_id"];
 $public_bug->{cf_qa_status}     = [];
 $public_bug->{cf_single_select} = '---';
 
-# Fill in the timetracking fields on the public bug.
+# Fill in the time tracking fields on the public bug.
 $xmlrpc->bz_log_in('admin');
 $xmlrpc->bz_call_success(
   'Bug.update',

--- a/qa/t/webservice_bugzilla.t
+++ b/qa/t/webservice_bugzilla.t
@@ -23,7 +23,7 @@ foreach my $rpc (@clients) {
 
   my $tz_call = $rpc->bz_call_success('Bugzilla.timezone');
   my $tz      = $tz_call->result->{timezone};
-  ok($tz, "Bugzilla.timezone retuns $tz");
+  ok($tz, "Bugzilla.timezone returns $tz");
 
   my $ext_call   = $rpc->bz_call_success('Bugzilla.extensions');
   my $extensions = $ext_call->result->{extensions};

--- a/qa/t/webservice_user_get.t
+++ b/qa/t/webservice_user_get.t
@@ -188,7 +188,7 @@ sub post_success {
   else {
     ok(
       !exists $item->{saved_searches},
-      "Users cannot get the list of saved searches and reports from someone else's acccount"
+      "Users cannot get the list of saved searches and reports from someone else's account"
     );
   }
 

--- a/report.cgi
+++ b/report.cgi
@@ -29,7 +29,7 @@ $C->content_security_policy(report_only => 0);
 
 # Go straight back to query.cgi if we are adding a boolean chart.
 if (grep(/^cmd-/, $cgi->param())) {
-  my $params = $cgi->canonicalise_query("format", "ctype");
+  my $params = $cgi->canonicalize_query("format", "ctype");
   $cgi->base_redirect('query.cgi?format='
       . $cgi->param('query_format') . ($params ? "&$params" : ''));
 }
@@ -244,15 +244,15 @@ if ($action eq "wrap") {
 
   # We need a number of different variants of the base URL for different
   # URLs in the HTML.
-  $vars->{'buglistbase'} = $cgi->canonicalise_query(
+  $vars->{'buglistbase'} = $cgi->canonicalize_query(
     "x_axis_field", "y_axis_field", "z_axis_field", "ctype",
     "format",       "query_format", @axis_fields
   );
   $vars->{'imagebase'}
-    = $cgi->canonicalise_query($tbl_field, "action", "ctype", "format", "width",
+    = $cgi->canonicalize_query($tbl_field, "action", "ctype", "format", "width",
     "height");
   $vars->{'switchbase'}
-    = $cgi->canonicalise_query("query_format", "action", "ctype", "format",
+    = $cgi->canonicalize_query("query_format", "action", "ctype", "format",
     "width", "height");
   $vars->{'data'} = \%data;
 }

--- a/reports.cgi
+++ b/reports.cgi
@@ -219,7 +219,7 @@ sub generate_chart {
     "grey_background" => "false",
     "colors"          => {
 
-      # default dataset colours are too alike
+      # default dataset colors are too alike
       dataset4 => [0, 0, 0],    # black
     },
   );

--- a/request.cgi
+++ b/request.cgi
@@ -329,7 +329,7 @@ sub queue {
   }
   $vars->{'components'} = [sort { $a cmp $b } keys %components];
 
-  $vars->{'urlquerypart'} = $cgi->canonicalise_query('ctype');
+  $vars->{'urlquerypart'} = $cgi->canonicalize_query('ctype');
 
   # Generate and return the UI (HTML page) from the appropriate template.
   $template->process($format->{'template'}, $vars)

--- a/scripts/block-ip.pl
+++ b/scripts/block-ip.pl
@@ -55,4 +55,4 @@ If passed, the IPs will be unblocked instead of blocked. Use this to remove IPs 
 
 =head1 DESCRIPTION
 
-This is just a simple CLI inteface to L<Bugzilla::App::Plugin::BlockIP>.
+This is just a simple CLI interface to L<Bugzilla::App::Plugin::BlockIP>.

--- a/scripts/block-ip.pl
+++ b/scripts/block-ip.pl
@@ -34,7 +34,7 @@ else {
 
 =head1 NAME
 
-block-ip.pl -- block or unlock ip addresses from Bugzilla's IP block list
+block-ip.pl -- block or unlock IP addresses from Bugzilla's IP block list
 
 =head1 SYNOPSIS
 

--- a/scripts/convert_datetime.pl
+++ b/scripts/convert_datetime.pl
@@ -32,7 +32,7 @@ my $mysql_dbh = Bugzilla::DB::_connect({
   db_pass   => $root_mysql_pw
 });
 
-# Check that the mysql timezones are populated and up to date
+# Check that the MySQL timezones are populated and up to date
 my $mysql_tz_install
   = "Please populate using instuctions at http://dev.mysql.com/doc/refman/5.6/en/time-zone-support.html#time-zone-installation and re-run this script.";
 my $mysql_tz_count

--- a/scripts/delete_comments_csv.pl
+++ b/scripts/delete_comments_csv.pl
@@ -43,7 +43,7 @@ while (my $line = <CSV>) {
   my $comment = Bugzilla::Comment->new($comment_id);
 
   if (!$comment || $comment->bug_id ne $bug_id) {
-    print "... commment '$comment_id' does not exist ... skipping.\n";
+    print "... comment '$comment_id' does not exist ... skipping.\n";
     next;
   }
   $comment->remove_from_db();

--- a/scripts/fix_all_open_status_queries.pl
+++ b/scripts/fix_all_open_status_queries.pl
@@ -96,7 +96,7 @@ sub all_open_states {
   if (scalar @$added == 1 && $added->[0] eq $new_status) {
     push(@query_states, $new_status);
     $cgi->param('bug_status', @query_states);
-    return $cgi->canonicalise_query();
+    return $cgi->canonicalize_query();
   }
 
   return '';

--- a/scripts/group-set-members.pl
+++ b/scripts/group-set-members.pl
@@ -108,7 +108,7 @@ sub usage {
   die <<EOF;
 usage $0 --admin bob\@mozilla.org --users-file users.txt --group pants
 
---users-file  File containing one bugzilla email per line.
+--users-file  File containing one Bugzilla email per line.
 --admin      Admin user capable of adding people to the group.
 --group      Group name to add users from user.txt into.
 --do-adds    Add users in users-file to the group.

--- a/scripts/migrate-attachments.pl
+++ b/scripts/migrate-attachments.pl
@@ -35,7 +35,7 @@ Syntax:
     again. Attachments deleted on the source will be deleted from the
     destination.
 
-    eg. migrate-attachments.pl --mirror database s3
+    e.g. migrate-attachments.pl --mirror database s3
 
 'copy'
     Copies all attachments from the specified source to the destination.
@@ -43,13 +43,13 @@ Syntax:
     again. Unlike 'mirror', attachments deleted from the source will not be
     removed from the destination.
 
-    eg. migrate-attachments.pl --copy database s3
+    e.g. migrate-attachments.pl --copy database s3
 
 'delete'
     Deletes all attachments in the specified location.  This operation cannot
     be undone.
 
-    eg. migrate-attachments.pl --delete database
+    e.g. migrate-attachments.pl --delete database
 
 Valid locations:
     @storage_names

--- a/scripts/migrate_whiteboard_keyword.pl
+++ b/scripts/migrate_whiteboard_keyword.pl
@@ -22,7 +22,7 @@
 #         BUGS:  1279368
 #        NOTES:  None
 #       AUTHOR:  David Lawrence (dkl@mozilla.com),
-#      COMPANY:  Mozilla Corproation
+#      COMPANY:  Mozilla Corporation
 #      VERSION:  1.0
 #      CREATED:  10/31/2012
 #     REVISION:  1

--- a/scripts/nagios_blocker_checker.pl
+++ b/scripts/nagios_blocker_checker.pl
@@ -21,7 +21,7 @@ use English qw(-no_match_vars);
 
 Bugzilla->usage_mode(USAGE_MODE_CMDLINE);
 Bugzilla->error_mode(ERROR_MODE_DIE);
-use Try::Tiny;    # bmo ships with this nowadays
+use Try::Tiny;    # BMO ships with this nowadays
 
 my $config = {
 

--- a/scripts/nagios_push_checker.pl
+++ b/scripts/nagios_push_checker.pl
@@ -30,7 +30,7 @@ DESCRIPTION
 
 SYNTAX
 
-  --connector  (required) connector's name (eg. ReviewBoard)
+  --connector  (required) connector's name (e.g. ReviewBoard)
   --warn       (optional) number of messages that trigger a warning (def: 5)
   --alarm      (optional) number of messages that trigger an alarm (def: 10)
 

--- a/scripts/remove-non-public-data.pl
+++ b/scripts/remove-non-public-data.pl
@@ -194,7 +194,7 @@ getc();
 
 my $dbh = Bugzilla->dbh;
 
-# run sanitiseme.pl
+# run sanitizeme.pl
 
 print "running sanitizeme.pl\n";
 my $sanitizeme = catfile(realpath(dirname(__FILE__)), 'sanitizeme.pl');

--- a/scripts/remove_idle_group_members.pl
+++ b/scripts/remove_idle_group_members.pl
@@ -76,7 +76,7 @@ foreach my $group_id (keys %remove_data) {
 
   $dbh->bz_commit_transaction();
 
-  # nobody@mozilla.org cannot recieve email
+  # nobody@mozilla.org cannot receive email
   next if $group->owner->login eq 'nobody@mozilla.org';
 
   _send_email($group, \@users_removed);

--- a/scripts/resolve_bugs.pl
+++ b/scripts/resolve_bugs.pl
@@ -54,7 +54,7 @@ if ($bug_count == 0) {
   exit 1;
 }
 
-# if running from commmand line
+# if running from command line
 if (-t STDIN) {
   print STDERR <<EOF;
 About to resolve $bug_count bugs as $resolution

--- a/scripts/sanitizeme.pl
+++ b/scripts/sanitizeme.pl
@@ -275,7 +275,7 @@ sub disable_email_delivery {
 
 =head1 NAME
 
-sanitizeme.pl - remove sensitive information from a bugzilla database
+sanitizeme.pl - remove sensitive information from a Bugzilla database
 
 =head1 SYNOPSIS
 

--- a/scripts/syncmsandversions.pl
+++ b/scripts/syncmsandversions.pl
@@ -35,7 +35,7 @@ sub usage() {
 Usage: syncmsandversions.pl <srcproduct> <tgtproduct>
 
 E.g.: syncmsandversions.pl FoodReplicator SeaMonkey
-will copy any versions and milstones in the product "FoodReplicator"
+will copy any versions and milestones in the product "FoodReplicator"
 which do not exist in product "SeaMonkey" into it. This script is normally
 used prior to moving components from srcproduct to tgtproduct.
 USAGE

--- a/showdependencygraph.cgi
+++ b/showdependencygraph.cgi
@@ -127,7 +127,7 @@ my $urlbase = Bugzilla->localconfig->urlbase;
 print $fh "digraph G {";
 print $fh qq(
 graph [URL="${urlbase}query.cgi", rankdir=$rankdir]
-node [URL="${urlbase}show_bug.cgi?id=\\N", style=filled, color=lightgrey]
+node [URL="${urlbase}show_bug.cgi?id=\\N", style=filled, color=lightgray]
 );
 
 my %baselist;

--- a/showdependencygraph.cgi
+++ b/showdependencygraph.cgi
@@ -295,7 +295,7 @@ else {
 
   # Then, generate a imagemap datafile that contains the corner data
   # for drawn bug objects. Pass it on to $CreateImagemap that
-  # turns this monster into html.
+  # turns this monster into HTML.
 
   my ($mapfh, $mapfilename)
     = File::Temp::tempfile("XXXXXXXXXX", SUFFIX => '.map', DIR => $webdotdir);

--- a/showdependencygraph.cgi
+++ b/showdependencygraph.cgi
@@ -316,7 +316,7 @@ else {
 # Cleanup any old .dot files created from previous runs.
 my $since = time() - 24 * 60 * 60;
 
-# Can't use glob, since even calling that fails taint checks for perl < 5.6
+# Can't use glob, since even calling that fails taint checks for Perl < 5.6
 opendir(DIR, $webdotdir);
 my @files = grep { /\.dot$|\.png$|\.map$/ && -f "$webdotdir/$_" } readdir(DIR);
 closedir DIR;

--- a/showdependencytree.cgi
+++ b/showdependencytree.cgi
@@ -128,7 +128,7 @@ sub _generate_tree {
       _generate_tree($dep_id, $relationship, $depth + 1, $bugs, $ids);
     }
 
-    # remove bugs according to visiblity
+    # remove bugs according to visibility
     if (!Bugzilla->user->can_see_bug($dep_id)) {
       delete $ids->{$dep_id};
     }

--- a/t/002goodperl.t
+++ b/t/002goodperl.t
@@ -153,7 +153,7 @@ foreach my $file (@testitems) {
   close(FILE);
 }
 
-# Forbird the { foo => $cgi->param() } syntax, for security reasons.
+# Forbid the { foo => $cgi->param() } syntax, for security reasons.
 foreach my $file (@testitems) {
   $file =~ s/\s.*$//;    # nuke everything after the first space (#comment)
   next unless $file;     # skip null entries

--- a/t/Support/Templates.pm
+++ b/t/Support/Templates.pm
@@ -96,7 +96,7 @@ foreach my $include_path (@include_paths) {
   $num_actual_files += scalar(@{$actual_files{$include_path}});
 }
 
-# Scan Bugzilla's perl code looking for templates used and put them
+# Scan Bugzilla's Perl code looking for templates used and put them
 # in the @referenced_files array to be used by the 004template.t test.
 my %seen;
 

--- a/t/markdown.t
+++ b/t/markdown.t
@@ -40,7 +40,7 @@ is(
 );
 
 SKIP: {
-  skip("currently no raw html is allowed via the safe option", 1);
+  skip("currently no raw HTML is allowed via the safe option", 1);
   is(
     $parser->render_html('<script>hijack()</script>'),
     "&lt;script&gt;hijack()&lt;/script&gt;\n",

--- a/t/mojo-example.t
+++ b/t/mojo-example.t
@@ -22,7 +22,7 @@ BEGIN {
 # Most localconfig options the other Bugzilla::Test::Mock* modules take care for us.
 use Bugzilla::Test::MockLocalconfig (urlbase => 'http://bmo-web.vm');
 
-# This configures an in-memory sqlite database.
+# This configures an in-memory SQLite database.
 use Bugzilla::Test::MockDB;
 
 # This redirects reads and writes from the config file (data/params)

--- a/t/report-ping-simple.t
+++ b/t/report-ping-simple.t
@@ -12,7 +12,7 @@ use lib qw( . lib local/lib/perl5 );
 BEGIN {
   unlink('data/db/report_ping_simple') if -f 'data/db/report_ping_simple';
   $ENV{test_db_name} = 'report_ping_simple';
-  # Our code will store dates in localtime with sqlite.
+  # Our code will store dates in localtime with SQLite.
   # So for these tests to pass, everything should be UTC.
   $ENV{TZ} = 'UTC';
 }
@@ -34,7 +34,7 @@ use ok 'Bugzilla::Report::Ping::Simple';
 Bugzilla->dbh->model->resultset('Keyword')
   ->create({name => 'regression', description => 'the regression keyword'});
 
-# Our code will store dates in localtime with sqlite.
+# Our code will store dates in localtime with SQLite.
 # So for these tests to pass, everything should be UTC.
 my $UTC = DateTime::TimeZone->new(name => 'UTC');
 Bugzilla->local_timezone($UTC);

--- a/t/security-risk.t
+++ b/t/security-risk.t
@@ -127,7 +127,7 @@ try {
       bugs_by_sec_keyword => {
         'sec-critical' => {
 
-          # 2 wasn't a sec-crtical bug and 4 wasn't created yet on the report date.
+          # 2 wasn't a sec-critical bug and 4 wasn't created yet on the report date.
           open            => [],
           closed          => [],
           median_age_open => 0

--- a/template/en/default/account/prefs/settings.html.tmpl
+++ b/template/en/default/account/prefs/settings.html.tmpl
@@ -16,7 +16,7 @@
   #%]
 
 [%# INTERFACE:
-  # settings:      a hash of hashes, keyed by category ame.
+  # settings:      a hash of hashes, keyed by category name.
   #                Each hash value is a list of hashes containing:
   #                 name          - string (name of the setting)
   #                 is_enabled    - boolean

--- a/template/en/default/admin/classifications/edit-common.html.tmpl
+++ b/template/en/default/admin/classifications/edit-common.html.tmpl
@@ -19,7 +19,7 @@
   #%]
 
 [%# INTERFACE:
-  # classification: Bugzilla::Classifiation object.
+  # classification: Bugzilla::Classification object.
   #%]
 
 <tr>

--- a/template/en/default/admin/custom_fields/edit.html.tmpl
+++ b/template/en/default/admin/custom_fields/edit.html.tmpl
@@ -14,7 +14,7 @@
   #%]
 
 [%# INTERFACE:
-  # field: Bugzila::Field; the current field being edited
+  # field: Bugzilla::Field; the current field being edited
   #%]
 
 [% PROCESS "global/field-descs.none.tmpl" %]

--- a/template/en/default/admin/groups/email/idle-member-removal.html.tmpl
+++ b/template/en/default/admin/groups/email/idle-member-removal.html.tmpl
@@ -12,7 +12,7 @@
 <html>
 
 <head>
-  <title>[[% terms.Bugzilla %]] Ilde Group Member Removal Notification</title>
+  <title>[[% terms.Bugzilla %]] Idle Group Member Removal Notification</title>
 </head>
 
 <body bgcolor="#ffffff">

--- a/template/en/default/admin/groups/list.html.tmpl
+++ b/template/en/default/admin/groups/list.html.tmpl
@@ -146,7 +146,7 @@ will be restricted to others in the same group.
 <p>
   <b>User RegExp</b> is optional, and if filled in, will automatically
 grant membership to this group to anyone with an email address
-that matches this perl regular expression. Do not forget
+that matches this Perl regular expression. Do not forget
 the trailing '$'.  Example '@mycompany\.com$'
 </p>
 

--- a/template/en/default/admin/milestones/confirm-delete.html.tmpl
+++ b/template/en/default/admin/milestones/confirm-delete.html.tmpl
@@ -50,7 +50,7 @@
   <td valign="top">[% terms.Bugs %]:</td>
   <td valign="top">
 [% IF milestone.bug_count %]
-  <a title="List of [% terms.bugs %] targetted at milestone '
+  <a title="List of [% terms.bugs %] targeted at milestone '
            [% milestone.name FILTER html %]'"
      href="[% basepath FILTER none %]buglist.cgi?target_milestone=[% milestone.name FILTER uri %]&amp;product=
           [%- product.name FILTER uri %]">

--- a/template/en/default/admin/params/admin.html.tmpl
+++ b/template/en/default/admin/params/admin.html.tmpl
@@ -26,7 +26,7 @@
 [% rate_limit_rules_desc = BLOCK %]
 This parameter is a json object. It has one or more valid keys, whose values are each of an array [MAX_RATE, SECONDS]. MAX_RATE is the maximum
 number of requests that can occur over SECONDS. The default is [75, 60] or 75 requests
-over 60 seconds. Valid keys are <code>get_b[%''%]ug</code> which covers JSONRPC, XMLRPC, REST and BZAPI single
+over 60 seconds. Valid keys are <code>get_b[%''%]ug</code> which covers JSON-RPC, XML-RPC, REST and BzAPI single
 [% terms.bug %] access methods, and <code>show_b[%''%]ug</code> which controls show [% terms.bug %]
 [% END %]
 

--- a/template/en/default/admin/params/admin.html.tmpl
+++ b/template/en/default/admin/params/admin.html.tmpl
@@ -24,7 +24,7 @@
 %]
 
 [% rate_limit_rules_desc = BLOCK %]
-This parameter is a json object. It has one or more valid keys, whose values are each of an array [MAX_RATE, SECONDS]. MAX_RATE is the maximum
+This parameter is a JSON object. It has one or more valid keys, whose values are each of an array [MAX_RATE, SECONDS]. MAX_RATE is the maximum
 number of requests that can occur over SECONDS. The default is [75, 60] or 75 requests
 over 60 seconds. Valid keys are <code>get_b[%''%]ug</code> which covers JSON-RPC, XML-RPC, REST and BzAPI single
 [% terms.bug %] access methods, and <code>show_b[%''%]ug</code> which controls show [% terms.bug %]

--- a/template/en/default/admin/params/attachment.html.tmpl
+++ b/template/en/default/admin/params/attachment.html.tmpl
@@ -44,7 +44,7 @@
 
   attachment_storage =>
     "Where attachment data should be stored.  If this value is changed you " _
-    "must use <tt>scripts/mmigrate-attachments</tt> to migrate existing " _
+    "must use <tt>scripts/migrate-attachments</tt> to migrate existing " _
     "attachments.",
 
   }

--- a/template/en/default/admin/params/auth.html.tmpl
+++ b/template/en/default/admin/params/auth.html.tmpl
@@ -212,7 +212,7 @@
     "Set the complexity required for passwords. In all cases must the passwords " _
     "be at least ${constants.USER_PASSWORD_MIN_LENGTH} characters long." _
     "<ul><li>no_constraints - No complexity required.</li>" _
-    "<li>BMO - Passwords must meet at least three of the following conditions: " _
+    "<li>bmo - Passwords must meet at least three of the following conditions: " _
     "<ul>" _
     "<li>uppercase letters</li>" _
     "<li>lowercase letters</li>" _

--- a/template/en/default/admin/params/auth.html.tmpl
+++ b/template/en/default/admin/params/auth.html.tmpl
@@ -226,7 +226,7 @@
     "If set, $terms.Bugzilla will check that the password meets the current " _
     "complexity rules and minimum length requirements  when the user logs " _
     "into the $terms.Bugzilla web interface. If it doesn't, the user would " _
-    "not be able to log in, and recieve a message to reset their password.",
+    "not be able to log in, and receive a message to reset their password.",
 
   auth_delegation =>
     "If set, $terms.Bugzilla will allow third party applications " _

--- a/template/en/default/admin/params/auth.html.tmpl
+++ b/template/en/default/admin/params/auth.html.tmpl
@@ -212,7 +212,7 @@
     "Set the complexity required for passwords. In all cases must the passwords " _
     "be at least ${constants.USER_PASSWORD_MIN_LENGTH} characters long." _
     "<ul><li>no_constraints - No complexity required.</li>" _
-    "<li>bmo - Passwords must meet at least three of the following conditions: " _
+    "<li>BMO - Passwords must meet at least three of the following conditions: " _
     "<ul>" _
     "<li>uppercase letters</li>" _
     "<li>lowercase letters</li>" _

--- a/template/en/default/admin/params/ldap.html.tmpl
+++ b/template/en/default/admin/params/ldap.html.tmpl
@@ -36,7 +36,7 @@
   LDAPstarttls => "Whether to require encrypted communication once a normal " _
                   "LDAP connection is achieved with the server.",
 
-  LDAPbinddn => "If your LDAP server requires that you use a binddn and password " _
+  LDAPbinddn => "If your LDAP server requires that you use a bindDN and password " _
                 "instead of binding anonymously, enter it here " _
                 "(e.g. cn=default,cn=user:password). " _
                 "Leave this empty for the normal case of an anonymous bind.",

--- a/template/en/default/admin/params/patchviewer.html.tmpl
+++ b/template/en/default/admin/params/patchviewer.html.tmpl
@@ -47,7 +47,7 @@
                 "server containing information about your CVS repository. " _
                 "Patch Viewer will use this information to create links to " _
                 "bonsai's blame for each section of a patch (it will append " _
-                "'/cvsblame.cgi?...' to this url). Leave this blank if you " _
+                "'/cvsblame.cgi?...' to this URL). Leave this blank if you " _
                 "don't understand what this is.",
 
   lxr_url => "The URL to an <a href=\"https://sourceforge.net/projects/lxr/\">LXR</a> server " _

--- a/template/en/default/admin/params/reports.html.tmpl
+++ b/template/en/default/admin/params/reports.html.tmpl
@@ -15,6 +15,6 @@
     report_secbugs_emails =>
       "Comma delimited list of the email addresses that the security $terms.bugs report will be sent to.",
     report_secbugs_teams =>
-      "JSON dictionary of the teams the security $terms.bugs report will report on. e.g {\"Team1\": { \"Product\": { \"all_components\": false, \"prefixed_components\": [\"Prefix\"], \"named_components\": [\"Component1\"]}, \"Team2\": { ... } }",
+      "JSON dictionary of the teams the security $terms.bugs report will report on. e.g. {\"Team1\": { \"Product\": { \"all_components\": false, \"prefixed_components\": [\"Prefix\"], \"named_components\": [\"Component1\"]}, \"Team2\": { ... } }",
   }
 %]

--- a/template/en/default/admin/params/shadowdb.html.tmpl
+++ b/template/en/default/admin/params/shadowdb.html.tmpl
@@ -34,7 +34,7 @@
   shadowdbsock => "The socket used to connect to the shadow database, if the host " _
                   "is the local machine. This setting is required because MySQL " _
                   "ignores the port specified by the client and connects using " _
-                  "its compiled-in socket path (on unix machines) when connecting " _
+                  "its compiled-in socket path (on Unix machines) when connecting " _
                   "from a client to a local server. If you leave this blank, and " _
                   "have the database on localhost, then the <tt>shadowdbport</tt> " _
                   "will be ignored.",

--- a/template/en/default/admin/products/confirm-delete.html.tmpl
+++ b/template/en/default/admin/products/confirm-delete.html.tmpl
@@ -44,7 +44,7 @@
     </tr>
     <tr>
       <td>Classification Description:</td>
-      [%# descriptions are intentionally not filtered to allow html content %]
+      [%# descriptions are intentionally not filtered to allow HTML content %]
       <td>
         [% IF classification.description %]
           [% classification.description FILTER html_light %]
@@ -65,7 +65,7 @@
   </tr>
   <tr>
     <td valign="top">Description:</td>
-    [%# descriptions are intentionally not filtered to allow html content %]
+    [%# descriptions are intentionally not filtered to allow HTML content %]
     <td valign="top">
       [% IF product.description %]
         [% product.description FILTER html_light %]
@@ -118,7 +118,7 @@
           [% FOREACH comp = product.components %]
             <tr>
               <th align="right">[% comp.name FILTER html %]:</th>
-              [%# descriptions are intentionally not filtered to allow html content %]
+              [%# descriptions are intentionally not filtered to allow HTML content %]
               <td>
                 [% IF comp.description %]
                   [% comp.description FILTER html_light %]

--- a/template/en/default/admin/products/edit-common.html.tmpl
+++ b/template/en/default/admin/products/edit-common.html.tmpl
@@ -18,7 +18,7 @@
 [%# INTERFACE:
   # product: Bugzilla::Product object; The product
   #
-  # classification: Bugzilla::Classifiation object; classification product is in.
+  # classification: Bugzilla::Classification object; classification product is in.
   #%]
 
 [% PROCESS "global/field-descs.none.tmpl" %]

--- a/template/en/default/admin/products/list-classifications.html.tmpl
+++ b/template/en/default/admin/products/list-classifications.html.tmpl
@@ -16,7 +16,7 @@
 [%# INTERFACE:
   # classifications: array of hashes having the following properties:
   #   - name: string; The name of the classification
-  #   - description: string; The classification description (html allowed)
+  #   - description: string; The classification description (HTML allowed)
   #   - product_count: number; The number of products in this classification
   #
   #%]

--- a/template/en/default/admin/table.html.tmpl
+++ b/template/en/default/admin/table.html.tmpl
@@ -52,7 +52,7 @@
   # overrides:
   # Example:
   #     overrides {                           # first hash
-  #       column_name_to_be_overwriten => {   # second hash
+  #       column_name_to_be_overwritten => {  # second hash
   #         name_of_row_to_match_against => { # third hash
   #           value_to_match_against => {     # fourth hash
   #             content => "some contents"

--- a/template/en/default/admin/table.html.tmpl
+++ b/template/en/default/admin/table.html.tmpl
@@ -40,7 +40,7 @@
   #                        This content WILL be HTML-filtered in this case.
   #     align: left/center/right. Controls the horizontal alignment of the
   #            text in the column.
-  #     allow_html_content: if defined, then this column allows some html content
+  #     allow_html_content: if defined, then this column allows some HTML content
   #                         and so it will be only partially filtered.
   #     yesno_field: Turn the data from 0/!0 into Yes/No
   #

--- a/template/en/default/admin/users/confirm-delete.html.tmpl
+++ b/template/en/default/admin/users/confirm-delete.html.tmpl
@@ -433,7 +433,7 @@
             The user has performed audited administrative tasks
             that are logged in the database.
             If you delete this user account, the audit log entries
-            will no longer be indentifiable.
+            will no longer be identifiable.
           </li>
         [% END %]
         [% Hook.process('warn_safe') %]

--- a/template/en/default/admin/users/list.html.tmpl
+++ b/template/en/default/admin/users/list.html.tmpl
@@ -77,7 +77,7 @@
   %]
 [% END %]
 
-[%# Disabled users are crossed out. Missing realnames are noticed in red. %]
+[%# Disabled users are crossed out. Missing real names are noticed in red. %]
 [% overrides.login_name = {} %]
 [% overrides.realname = {} %]
 

--- a/template/en/default/admin/users/userdata.html.tmpl
+++ b/template/en/default/admin/users/userdata.html.tmpl
@@ -77,7 +77,7 @@
     <td>
       <input type="password" size="16" name="password" id="password" value="" autocomplete="off">
       [%# if a user's cryptpassword is '*' it means they use an auth provider
-        # such as github, or you can't log in with that account.  in either case
+        # such as GitHub, or you can't log in with that account.  in either case
         # forcing a password reset isn't valid %]
       [% IF otheruser.cryptpassword != '*' && editform %]
         <br>

--- a/template/en/default/admin/versions/confirm-delete.html.tmpl
+++ b/template/en/default/admin/versions/confirm-delete.html.tmpl
@@ -50,7 +50,7 @@
   <td valign="top">[% terms.Bugs %]:</td>
   <td valign="top">
 [% IF version.bug_count %]
-  <a title="List of [% terms.bugs %] targetted at version '
+  <a title="List of [% terms.bugs %] targeted at version '
            [%- version.name FILTER html %]'"
      href="[% basepath FILTER none %]buglist.cgi?version=[% version.name FILTER uri %]&amp;product=
           [%- product.name FILTER uri %]">

--- a/template/en/default/attachment/diff-file.html.tmpl
+++ b/template/en/default/attachment/diff-file.html.tmpl
@@ -21,7 +21,7 @@
 
 [%# This line is really long for a reason: to get rid of any possible textnodes
   # between the elements.  This is necessary because DOM parent-child-sibling
-  # relations can change and screw up the javascript for restoring, collapsing
+  # relations can change and screw up the JavaScript for restoring, collapsing
   # and expanding.  Do not change without testing all three of those.
   # Also, the first empty row is required because 'table-layout: fixed' only
   # considers the first row to determine column widths. If a colspan is found,

--- a/template/en/default/bug/create/create-guided.html.tmpl
+++ b/template/en/default/bug/create/create-guided.html.tmpl
@@ -38,7 +38,7 @@
 
 [% INCLUDE 'bug/create/user-message.html.tmpl' %]
 
-[% tablecolour = "#FFFFCC" %]
+[% tablecolor = "#FFFFCC" %]
 
 [%# This script displays the descriptions for selected components. %]
 <script [% script_nonce FILTER none %]>
@@ -145,7 +145,7 @@ function PutDescription() {
 
 <table valign="top" cellpadding="5" cellspacing="5" border="0">
 
-  <tr bgcolor="[% tablecolour %]">
+  <tr bgcolor="[% tablecolor %]">
     <td align="right" valign="top">
       <b>Product</b>
     </td>
@@ -207,7 +207,7 @@ function PutDescription() {
       are based on which are most common in the b.m.o database %]
   [% rep_platform = [ "x86", "x86_64", "PowerPC", "All", "Other" ] %]
 
-  <tr bgcolor="[% tablecolour %]">
+  <tr bgcolor="[% tablecolor %]">
     <td align="right" valign="top">
       <b>Hardware Platform</b>
     </td>
@@ -240,7 +240,7 @@ function PutDescription() {
    </td>
   </tr>
 
-  <tr bgcolor="[% tablecolour %]">
+  <tr bgcolor="[% tablecolor %]">
     <td align="right" valign="top">
       <b>Summary</b>
     </td>
@@ -294,7 +294,7 @@ function PutDescription() {
     </td>
   </tr>
 
-  <tr bgcolor="[% tablecolour %]">
+  <tr bgcolor="[% tablecolor %]">
     <td align="right" valign="top">
       <b>Reproducibility</b>
     </td>
@@ -334,7 +334,7 @@ function PutDescription() {
     </td>
   </tr>
 
-  <tr bgcolor="[% tablecolour %]">
+  <tr bgcolor="[% tablecolor %]">
     <td valign="top" align="right">
       <b>Actual Results</b>
     </td>
@@ -366,7 +366,7 @@ function PutDescription() {
     </td>
   </tr>
 
-  <tr bgcolor="[% tablecolour %]">
+  <tr bgcolor="[% tablecolor %]">
     <td valign="top" align="right">
       <b>Additional Information</b>
     </td>

--- a/template/en/default/bug/create/create-guided.html.tmpl
+++ b/template/en/default/bug/create/create-guided.html.tmpl
@@ -248,7 +248,7 @@ function PutDescription() {
       <input type="text" size="80" name="short_desc" id="short_desc"
              maxlength="255" spellcheck="true">
       <p>
-        A sentence which summarises the problem.
+        A sentence which summarizes the problem.
         Please be descriptive and use lots of keywords.
       </p>
       <p>

--- a/template/en/default/bug/edit.html.tmpl
+++ b/template/en/default/bug/edit.html.tmpl
@@ -75,7 +75,7 @@
       // prevent negative values if work_time > fRemainingTime
       new_time =
           Math.max(fRemainingTime - document.changeform.work_time.value, 0.0);
-      // get upto 2 decimal places
+      // get up to 2 decimal places
       document.changeform.remaining_time.value =
           Math.round(new_time * 100)/100;
   }

--- a/template/en/default/bug/field-help.none.tmpl
+++ b/template/en/default/bug/field-help.none.tmpl
@@ -67,8 +67,8 @@ cc =>
    are interested in its progress.",
 
 classification =>
-  "$terms.Bugs are categorised into Classifications, Products and"
-  _ " Components. classifications is the top-level categorisation.",
+  "$terms.Bugs are categorized into Classifications, Products and"
+  _ " Components. classifications is the top-level categorization.",
 
 component =>
   "Components are second-level categories; each belongs to a"
@@ -117,7 +117,7 @@ priority =>
 
 # Note that this has extra text added below if useclassification is on.
 product =>
-  "$terms.Bugs are categorised into Products and Components.",
+  "$terms.Bugs are categorized into Products and Components.",
 
 qa_contact =>
   "The person responsible for confirming this $terms.bug if it is"

--- a/template/en/default/bug/process/updates-disabled.html.tmpl
+++ b/template/en/default/bug/process/updates-disabled.html.tmpl
@@ -28,7 +28,7 @@ body {
   margin: 2em;
   background-color: #455372;
   color: #fff;
-  font-family: verdana, sans-serif;
+  font-family: Verdana, sans-serif;
   font-size: small;
 }
 a {

--- a/template/en/default/config.js.tmpl
+++ b/template/en/default/config.js.tmpl
@@ -23,7 +23,7 @@
 // Note: this interface is experimental and under development.
 // We may and probably will make breaking changes to it in the future.
 
-// the global bugzilla url
+// the global Bugzilla URL
 var installation = {
   base_url        : '[% urlbase FILTER js %]',
   install_version : '[% constants.BUGZILLA_VERSION FILTER js %]',

--- a/template/en/default/config.rdf.tmpl
+++ b/template/en/default/config.rdf.tmpl
@@ -19,7 +19,7 @@
   #                 Frédéric Buclin <LpSolit@gmail.com>
   #%]
 
-[%# The url to the installation is going to be displayed many times.
+[%# The URL to the installation is going to be displayed many times.
   # So we cache it here for better performance.
  %]
 [% escaped_urlbase = BLOCK %][% urlbase FILTER xml %][% END %]

--- a/template/en/default/extensions/extension.pm.tmpl
+++ b/template/en/default/extensions/extension.pm.tmpl
@@ -24,7 +24,7 @@ use B[% %]ugzilla::Extension::[% name %]::Util;
 our $VERSION = '0.01';
 
 # See the documentation of B[% %]ugzilla::Hook ("perldoc B[% %]ugzilla::Hook"
-# in the bugzilla directory) for a list of all available hooks.
+# in the Bugzilla directory) for a list of all available hooks.
 sub install_update_db {
     my ($self, $args) = @_;
 

--- a/template/en/default/filterexceptions.pl
+++ b/template/en/default/filterexceptions.pl
@@ -181,7 +181,7 @@
   'bug/create/create.html.tmpl' => ['cloned_bug_id',],
 
   'bug/create/create-guided.html.tmpl' =>
-    ['tablecolour', 'sel', 'productstring',],
+    ['tablecolor', 'sel', 'productstring',],
 
   'bug/activity/table.html.tmpl' => ['change.attachid',],
 

--- a/template/en/default/global/code-error.html.tmpl
+++ b/template/en/default/global/code-error.html.tmpl
@@ -467,7 +467,7 @@
     The data is too large to store in a token.
 
   [% ELSIF error == "cancel_token_does_not_exist" %]
-    The token to be cancelled does not exist.
+    The token to be canceled does not exist.
 
   [% ELSIF error == "template_error" %]
     [% template_error_msg FILTER html %]

--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -213,7 +213,7 @@
       [% PROCESS format_js_link %]
     [% END %]
 
-    [%# this puts the live bookmark up on firefox for the Atom feed %]
+    [%# this puts the live bookmark up on Firefox for the Atom feed %]
     [% IF atomlink %]
        <link rel="alternate"
              type="application/atom+xml" title="Atom feed"

--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -37,7 +37,7 @@
   # atomlink: Atom link URL, May contain HTML
   # generate_api_token: generate a token which can be used to make authenticated webservice calls
   # no_body: if true the body element will not be generated
-  # allow_mobile: allow special CSS and viewport for detected mobile useragents
+  # allow_mobile: allow special CSS and viewport for detected mobile user agents
   # use_login_page: display a link to the full login page, rather than an inline login.
   # robots: index / noindex (default: index)
   #%]
@@ -220,7 +220,7 @@
              href="[% atomlink FILTER html %]">
     [% END %]
 
-    [%# Required for the 'Autodiscovery' feature in Firefox 2 and IE 7. %]
+    [%# Required for the 'Auto-discovery' feature in Firefox 2 and IE 7. %]
     <link rel="search" type="application/opensearchdescription+xml"
                        title="[% terms.BugzillaTitle %]" href="[% basepath FILTER none %]search_plugin.cgi">
     [% IF allow_mobile && is_mobile_browser %]

--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -29,8 +29,8 @@
   # subheader: string. Page subheader.
   # bodyclasses: array of extra CSS classes for the <body>
   # onload: string. JavaScript code to run when the page finishes loading.
-  # javascript: string. Javascript to go in the header.
-  # javascript_urls: list. List of URLs to Javascript.
+  # javascript: string. JavaScript to go in the header.
+  # javascript_urls: list. List of URLs to JavaScript.
   # style: string. CSS style.
   # style_urls: list. List of URLs to CSS style sheets.
   # message: string. A message to display to the user. May contain HTML.

--- a/template/en/default/global/js-products.html.tmpl
+++ b/template/en/default/global/js-products.html.tmpl
@@ -19,7 +19,7 @@
   #                 Frédéric Buclin <LpSolit@gmail.com>
   #%]
 
-[%# The javascript block gets used in header.html.tmpl. %]
+[%# The JavaScript block gets used in header.html.tmpl. %]
 [% javascript = BLOCK %]
   var useclassification = false; // No classification level in use
   var first_load = true; // Is this the first time we load the page?

--- a/template/en/default/global/messages.html.tmpl
+++ b/template/en/default/global/messages.html.tmpl
@@ -368,7 +368,7 @@
 
   [% ELSIF message_tag == "flag_creation_failed" %]
     [% title = "Flag Creation Failure" %]
-    An error occured while validating flags:
+    An error occurred while validating flags:
     [%+ flag_creation_error FILTER none %]
 
   [% ELSIF message_tag == "get_field_desc" %]
@@ -560,7 +560,7 @@
     [% title = "Milestone Deleted" %]
     The milestone <em>[% milestone.name FILTER html %]</em> has been deleted.
     [% IF milestone.bug_count %]
-      [%+ terms.Bugs %] targetted to this milestone have been retargetted to
+      [%+ terms.Bugs %] targeted to this milestone have been retargeted to
       the default milestone <em>[% product.default_milestone FILTER html %]</em>.
     [% END %]
 

--- a/template/en/default/global/user-error.html.tmpl
+++ b/template/en/default/global/user-error.html.tmpl
@@ -732,7 +732,7 @@
     and then paste the URL to this file on the attachment
     creation page in the appropriate text field.
     <br>Alternately, if your attachment is an image, you could convert
-    it to a compressible format like JPG or PNG and try again.
+    it to a compressible format like JPEG or PNG and try again.
 
   [% ELSIF error == "flag_requestee_disabled" %]
     [% title = "Flag Requestee Disabled" %]

--- a/template/en/default/global/userselect.html.tmpl
+++ b/template/en/default/global/userselect.html.tmpl
@@ -21,7 +21,7 @@
   # field_title: optional, extra information to display as a tooltip
   # placeholder: optional, input only; placeholder attribute value
   # mandatory: optional; if true, the field cannot be empty.
-  # aria_labelledby: optiona; extra information to use for arai labels
+  # aria_labelledby: optional; extra information to use for WAI-ARIA labels
   # request_type: optional; one of the request flag types: "review", "feedback" or "needinfo"
   #%]
 

--- a/template/en/default/list/list.atom.tmpl
+++ b/template/en/default/list/list.atom.tmpl
@@ -52,7 +52,7 @@
     </author>
     <updated>[% bug.changedtime FILTER time("%Y-%m-%dT%H:%M:%SZ", "UTC") FILTER xml %]</updated>
     <summary type="html">
-      [%# Filter out the entire block, so that we don't need to escape the html code out %]
+      [%# Filter out the entire block, so that we don't need to escape the HTML code out %]
       [% FILTER xml %]
       <table>
       <tr>

--- a/template/en/default/mfa/duo/verify.html.tmpl
+++ b/template/en/default/mfa/duo/verify.html.tmpl
@@ -57,7 +57,7 @@ $(function() {
 
 <p>
   <b>[% reason FILTER html %]</b> requires verification.<br>
-  [% UNLESS is_enrolment %]
+  [% UNLESS is_enrollment %]
     <a href="#" id="recovery-toggle">Verify using a recovery code</a>.
   [% END %]
 </p>
@@ -70,7 +70,7 @@ $(function() {
   [% FOREACH field IN postback.fields.keys %]
     <input type="hidden" name="[% field FILTER html %]" value="[% postback.fields.item(field) FILTER html %]">
   [% END %]
-  [% UNLESS is_enrolment %]
+  [% UNLESS is_enrollment %]
     <div id="recovery" style="display:none">
       <p>
         Provide a two-factor recovery code:

--- a/template/en/default/mfa/totp/verify.html.tmpl
+++ b/template/en/default/mfa/totp/verify.html.tmpl
@@ -16,7 +16,7 @@
 <p>
   <b>[% reason FILTER html %]</b> requires verification.<br>
   Please enter your verification code from your TOTP application. If your device has been lost or stolen, you
-  may use one of your pregenerated recovery codes.
+  may use one of your pre-generated recovery codes.
 </p>
 <div class="verify-totp">
   <form method="POST" action="[% postback.action FILTER none %]">

--- a/template/en/default/pages/quicksearch.html.tmpl
+++ b/template/en/default/pages/quicksearch.html.tmpl
@@ -53,7 +53,7 @@
 
 <p>This is an overview of how to effectively use search in [% terms.Bugzilla %].
   For more general information about [% terms.Bugzilla %] usage, including the jargon and
-  shorthand that the Mozilla commmunity uses in [% terms.bug %] discussions, please look at
+  shorthand that the Mozilla community uses in [% terms.bug %] discussions, please look at
   <a href="https://wiki.mozilla.org/Introduction_to_B[% %]ugzilla">Introduction to
   [% terms.Bugzilla %]</a> page on <a href="https://wiki.mozilla.org/">Wiki.m.o</a>.</p>
 

--- a/template/en/default/pages/quicksearch.html.tmpl
+++ b/template/en/default/pages/quicksearch.html.tmpl
@@ -54,7 +54,7 @@
 <p>This is an overview of how to effectively use search in [% terms.Bugzilla %].
   For more general information about [% terms.Bugzilla %] usage, including the jargon and
   shorthand that the Mozilla commmunity uses in [% terms.bug %] discussions, please look at
-  <a href="https://wiki.mozilla.org/Introduction_to_B[% %]ugzilla">Introduction to 
+  <a href="https://wiki.mozilla.org/Introduction_to_B[% %]ugzilla">Introduction to
   [% terms.Bugzilla %]</a> page on <a href="https://wiki.mozilla.org/">Wiki.m.o</a>.</p>
 
 <h2 id="basics">The Basics</h2>
@@ -119,7 +119,7 @@
     (no need to mention open [% terms.bugs %], this is the default):<br>
     <kbd>cc:userA@company.com</kbd></li>
   <li>All unconfirmed [% terms.bugs %] in product productA (putting the
-    [%+ terms.bug %] status at the first position make it being automagically
+    [%+ terms.bug %] status at the first position make it being automatically
     considered as [% terms.abug %] status):<br>
     <kbd>UNCONFIRMED product:productA</kbd>
   <li>All open and closed [% terms.bugs %] reported by userB@company.com

--- a/template/en/default/pages/release-notes.html.tmpl
+++ b/template/en/default/pages/release-notes.html.tmpl
@@ -792,7 +792,7 @@
    <li>Autcomplete for users now works even if you are using the
      "emailsuffix" option.
      (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=641519">[% terms.Bug %] 641519</a>)</li>
-   <li>Javascript errors during series creation in New Charts have been
+   <li>JavaScript errors during series creation in New Charts have been
      fixed.
      (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=644285">[% terms.Bug %] 644285</a>)</li>
     <li>The "Show Votes" page now works, for installations using the Voting
@@ -1069,7 +1069,7 @@
   <li><a href="#v40_feat_ws">Major WebService Enhancements</a></li>
   <li><a href="#v40_feat_mandatory">Mandatory Custom Fields</a></li>
   <li><a href="#v40_feat_vot_ext">Voting Is Now An Extension</a></li>
-  <li><a href="#v40_feat_js_css_update">Users Get New CSS and Javascript
+  <li><a href="#v40_feat_js_css_update">Users Get New CSS and JavaScript
     Automatically</a></li>
   <li><a href="#v40_feat_hooks">Many New Hooks</a></li>
   <li><a href="#v40_feat_apache_config">New Apache Configuration</a></li>
@@ -1220,16 +1220,16 @@
   to get addressed is for somebody to step up and offer to maintain the
   system outside of [% terms.Bugzilla %]'s core code.</p>
 
-<h3 id="v40_feat_js_css_update">Users Get New CSS and Javascript
+<h3 id="v40_feat_js_css_update">Users Get New CSS and JavaScript
   Automatically</h3>
 
 <p>In past versions of [% terms.Bugzilla %], if you changed
-  [%+ terms.Bugzilla %]'s CSS or Javascript files, then every user of
+  [%+ terms.Bugzilla %]'s CSS or JavaScript files, then every user of
   [%+ terms.Bugzilla %] would have to clear their cache in order to get
   the updated files. Now, if you are using Apache as your webserver and
   you have the <a href="#v40_req_apache">optional Apache modules</a>
   installed and enabled, users will automatically get every new version of
-  [%+ terms.Bugzilla %]'s Javascript and CSS without having to clear
+  [%+ terms.Bugzilla %]'s JavaScript and CSS without having to clear
   their caches.</p>
 
 <p>This feature also gives a slight performance speedup to

--- a/template/en/default/pages/release-notes.html.tmpl
+++ b/template/en/default/pages/release-notes.html.tmpl
@@ -896,7 +896,7 @@
 
 <h3 id="v40_req_optional_mod">Optional Perl Modules</h3>
 
-<p>The following perl modules, if installed, enable various
+<p>The following Perl modules, if installed, enable various
   features of [% terms.Bugzilla %]:</p>
 
   <table cellspacing="0" cellpadding="0" border="0" class="req_table">

--- a/template/en/default/pages/release-notes.html.tmpl
+++ b/template/en/default/pages/release-notes.html.tmpl
@@ -734,7 +734,7 @@
 <ul>
   <li>The <kbd>B[% %]ug.create</kbd> WebService method now throws an error if you
     pass a group name which doesn't exist. In [% terms.Bugzilla %] 4.0 and 4.0.1,
-    this group name was silently ignored, leaving your [% terms.bug %] unsecure
+    this group name was silently ignored, leaving your [% terms.bug %] insecure
     if no other group applied.
     (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=653341">[% terms.Bug %] 653341</a>)</li>
   <li>Moving several [% terms.bugs %] at once into another product displayed the

--- a/template/en/default/pages/release-notes.html.tmpl
+++ b/template/en/default/pages/release-notes.html.tmpl
@@ -1296,7 +1296,7 @@
     shown as columns in the search results.</li>
   <li><strong>Searches:</strong> When using the Boolean Charts (now called
     "Custom Search"), if you specify both a criterion for an attachment
-    and a criteron for a flag, then only [% terms.bugs %] that have
+    and a criterion for a flag, then only [% terms.bugs %] that have
     attachments with that flag will be found.</li>
   <li><strong>Searches:</strong> If you hover your mouse over the field labels
     on the Advanced Search page, you will get a description of what that

--- a/template/en/default/pages/release-notes3.html.tmpl
+++ b/template/en/default/pages/release-notes3.html.tmpl
@@ -285,7 +285,7 @@
 
 <h3 id="v36_req_optional_mod">Optional Perl Modules</h3>
 
-<p>The following perl modules, if installed, enable various
+<p>The following Perl modules, if installed, enable various
   features of [% terms.Bugzilla %]:</p>
 
 <table class="req_table" border="0" cellspacing="0" cellpadding="0">
@@ -1221,7 +1221,7 @@
 
 <h3 id="v34_req_optional_mod">Optional Perl Modules</h3>
 
-<p>The following perl modules, if installed, enable various
+<p>The following Perl modules, if installed, enable various
   features of [% terms.Bugzilla %]:</p>
 
 <table class="req_table" border="0" cellspacing="0" cellpadding="0">
@@ -1911,7 +1911,7 @@
 
 <h3 id="v32_req_optional_mod">Optional Perl Modules</h3>
 
-<p>The following perl modules, if installed, enable various
+<p>The following Perl modules, if installed, enable various
   features of [% terms.Bugzilla %]:</p>
 
 <table class="req_table" border="0" cellpadding="0" cellspacing="0">
@@ -2722,7 +2722,7 @@
 
 <h3 id="v30_req_optional_mod">Optional Perl Modules</h3>
 
-<p>The following perl modules, if installed, enable various
+<p>The following Perl modules, if installed, enable various
   features of [% terms.Bugzilla %]:</p>
 
 <table class="req_table" border="0" cellspacing="0" cellpadding="0">
@@ -3340,7 +3340,7 @@
 
 <h3 id="v30_code_scope">Cleaned Up Variable Scoping Issues</h3>
 
-<p>In normal perl, you can have code like this:</p>
+<p>In normal Perl, you can have code like this:</p>
 <pre>my $var = 0;
 sub y { $var++ }</pre>
 

--- a/template/en/default/pages/release-notes3.html.tmpl
+++ b/template/en/default/pages/release-notes3.html.tmpl
@@ -1670,7 +1670,7 @@
     file every time it runs, keeping the current values set (if there
     are any), but moving any unexpected variables into a file called
     <kbd>localconfig.old</kbd>. If you want to continue having custom
-    varibles in <kbd>localconfig</kbd>, you will have to add them to
+    variables in <kbd>localconfig</kbd>, you will have to add them to
     the <code>LOCALCONFIG_VARS</code> constant in
     <kbd>Bugzilla::Install::Localconfig</kbd>.</li>
   <li><kbd>Bugzilla::Object-&gt;update()</kbd> now returns something different
@@ -2591,7 +2591,7 @@
     patch by [% terms.Bugzilla %].
     (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=365756">[% terms.Bug %] 365756</a>)</li>
   <li>Dependency Graphs now work correctly on all mod_perl installations.
-    There should now be no remaining signficant problems with running
+    There should now be no remaining significant problems with running
     [%+ terms.Bugzilla %] under mod_perl.
     (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=370398">[% terms.Bug %] 370398</a>)</li>
   <li>If moving [% terms.abug %] between products would remove groups

--- a/template/en/default/pages/release-notes3.html.tmpl
+++ b/template/en/default/pages/release-notes3.html.tmpl
@@ -468,7 +468,7 @@
   from the study.</p>
 
 <p>As a result, you will see many small improvements in [% terms.Bugzilla %]'s
-  usability, such as using Javascript to validate certain forms before
+  usability, such as using JavaScript to validate certain forms before
   they are submitted, standardizing the words that we use in the user interface,
   being clearer about what [% terms.Bugzilla %] needs from the user,
   and other changes, all of which are also listed individually in this New

--- a/template/en/default/reports/components.html.tmpl
+++ b/template/en/default/reports/components.html.tmpl
@@ -23,7 +23,7 @@
 [%# INTERFACE:
   # product: object. The product for which we want to display component
   # descriptions.
-  # component: string. The name of the component to hilight in the browser
+  # component: string. The name of the component to highlight in the browser
   #%]
 
 [% title = BLOCK %]

--- a/template/en/default/search/custom-search.html.tmpl
+++ b/template/en/default/search/custom-search.html.tmpl
@@ -42,7 +42,7 @@ FOREACH type = types;
   _types.push({ value => type, label => search_descs.$type });
 END;
 
-# Use single quotes because some strigs contain variables to be replaced in the code
+# Use single quotes because some strings contain variables to be replaced in the code
 _strings = {
   add_group         => 'Add New Group',
   add_row           => 'Add New Row',

--- a/template/en/default/search/form.html.tmpl
+++ b/template/en/default/search/form.html.tmpl
@@ -106,7 +106,7 @@ function doOnSelectProduct(selectmode) {
 
 // Hide the Advanced Fields by default, unless the user has a cookie
 // that specifies otherwise.
-// &#9656; and &#9662; are both utf8 escaped characters for right
+// &#9656; and &#9662; are both UTF-8 escaped characters for right
 //    and down facing arrows respectively.
 TUI_alternates['history_query'] = '&#9658;';
 TUI_alternates['people_query'] = '&#9658;';

--- a/template/en/default/search/form.html.tmpl
+++ b/template/en/default/search/form.html.tmpl
@@ -107,7 +107,7 @@ function doOnSelectProduct(selectmode) {
 // Hide the Advanced Fields by default, unless the user has a cookie
 // that specifies otherwise.
 // &#9656; and &#9662; are both utf8 escaped characters for right
-//    and down facing arrows respectivly.
+//    and down facing arrows respectively.
 TUI_alternates['history_query'] = '&#9658;';
 TUI_alternates['people_query'] = '&#9658;';
 TUI_alternates['information_query'] = '&#9658;';

--- a/template/en/default/setup/strings.txt.pl
+++ b/template/en/default/setup/strings.txt.pl
@@ -173,7 +173,7 @@ database server is running on. Setting this to 0 means "use the default
 port for my database server."
 END
   localconfig_db_sock => <<'END',
-MySQL Only: Enter a path to the unix socket for MySQL. If this is
+MySQL Only: Enter a path to the Unix socket for MySQL. If this is
 blank, then MySQL's compiled-in default will be used. You probably
 want that.
 END
@@ -239,7 +239,7 @@ The URL that is the common initial leading part of all URLs.
 END
   localconfig_canonical_urlbase => <<'END',
 The URL that is the canonical initial leading part of all URLs.
-This will be the production url for a dev site, for instance.
+This will be the production URL for a dev site, for instance.
 END
   localconfig_use_suexec => <<'END',
 Set this to 1 if Bugzilla runs in an Apache SuexecUserGroup environment.
@@ -277,7 +277,7 @@ If you set this to anything other than "", you will need to run checksetup.pl
 as ##root## or as a user who is a member of the specified group.
 END
   localconfig_setrlimit => <<EOT,
-This a json object whose keys are the named constants for the setrlimit(1) C library
+This a JSON object whose keys are the named constants for the setrlimit(1) C library
 function. The default sets RLIMIT_AS to 2GiB.
 EOT
   localconfig_size_limit => <<EOT,

--- a/template/en/default/setup/strings.txt.pl
+++ b/template/en/default/setup/strings.txt.pl
@@ -82,7 +82,7 @@ the documentation of Bugzilla::Extension for details.
 END
   file_remove => 'Removing ##name##...',
   file_rename => 'Renaming ##from## to ##to##...',
-  header      => "* This is Bugzilla ##bz_ver## on perl ##perl_ver##\n"
+  header      => "* This is Bugzilla ##bz_ver## on Perl ##perl_ver##\n"
     . "* Running on ##os_name## ##os_ver##",
   installation_failed => '*** Installation aborted. Read the messages above. ***',
   install_data_too_long => <<EOT,

--- a/template/en/default/setup/strings.txt.pl
+++ b/template/en/default/setup/strings.txt.pl
@@ -161,7 +161,7 @@ SQLite, this is a name (or path) for the DB file.
 END
   localconfig_db_pass => <<'END',
 Enter your database password here. It's normally advisable to specify
-a password for your bugzilla database user.
+a password for your Bugzilla database user.
 If you use apostrophe (') or a backslash (\) in your password, you'll
 need to escape it by preceding it with a '\' character. (\') or (\)
 (It is far simpler to just not use those characters.)

--- a/vagrant_support/bugzilla-push
+++ b/vagrant_support/bugzilla-push
@@ -2,7 +2,7 @@
 #
 # bugzilla-push This starts, stops, and restarts the Bugzilla push
 #        daemon, which manages syncronising bugzilla.mozilla.org and
-#        third party bugzilla installs.
+#        third party Bugzilla installs.
 #
 # chkconfig: 345 85 15
 # description: Bugzilla push daemon

--- a/vagrant_support/hypnotoad
+++ b/vagrant_support/hypnotoad
@@ -2,7 +2,7 @@
 #
 # bugzilla-push This starts, stops, and restarts the Bugzilla push
 #        daemon, which manages syncronising bugzilla.mozilla.org and
-#        third party bugzilla installs.
+#        third party Bugzilla installs.
 #
 # chkconfig: 345 85 15
 # description: Bugzilla push daemon

--- a/xt/lib/Bugzilla/Test/Search.pm
+++ b/xt/lib/Bugzilla/Test/Search.pm
@@ -979,7 +979,7 @@ sub _setup_dependencies {
   my ($self) = @_;
   my $dbh = Bugzilla->dbh;
 
-  # Set up depedency relationships between the bugs.
+  # Set up dependency relationships between the bugs.
   # Bug 1 + 6 depend on bug 2 and block bug 3.
   my $bug2 = $self->bug(2);
   my $bug3 = $self->bug(3);

--- a/xt/lib/Bugzilla/Test/Search/Constants.pm
+++ b/xt/lib/Bugzilla/Test/Search/Constants.pm
@@ -203,7 +203,7 @@ use constant ALLWORDS_BROKEN => (
   cc => {contains => [1]},
 
   # bug 828344 changed how these searches operate to revert back to the 4.0
-  # behavour, so these tests need to be updated (bug 849117).
+  # behavior, so these tests need to be updated (bug 849117).
   'flagtypes.name' => {contains => [1]},
   longdesc         => {contains => [1]},
 );
@@ -233,7 +233,7 @@ use constant CHANGED_VALUE_BROKEN => (
 
 
 # Any test listed in KNOWN_BROKEN gets marked TODO by Test::More
-# (using some complex code in Bugzilla::Test::Seach::FieldTest).
+# (using some complex code in Bugzilla::Test::Search::FieldTest).
 # This means that if you run the test under "prove -v", these tests will
 # still show up as "not ok", but the test suite results won't show them
 # as a failure.

--- a/xt/lib/Bugzilla/Test/Search/CustomTest.pm
+++ b/xt/lib/Bugzilla/Test/Search/CustomTest.pm
@@ -51,7 +51,7 @@ sub test        { return $_[0]->{raw_test} }
 
 sub operator_test { die "unimplemented" }
 sub field_object  { die "unimplemented" }
-sub main_value    { die "unimplenmented" }
+sub main_value    { die "unimplemented" }
 sub test_value    { die "unimplemented" }
 
 # Custom tests don't use transforms.

--- a/xt/lib/Bugzilla/Test/Search/FieldTest.pm
+++ b/xt/lib/Bugzilla/Test/Search/FieldTest.pm
@@ -147,7 +147,7 @@ sub bug_values {
   return @{$self->_field_values->{$number}};
 }
 
-# The untranslated, non-overriden value--used in the name of the test
+# The untranslated, non-overridden value--used in the name of the test
 # and other places.
 sub main_value { return $_[0]->{raw_test}->{value} }
 


### PR DESCRIPTION
Fix typos in the code and use American English intensively. Mostly in the templates and comments but there are some symbols as well.

## Bugzilla link

[Bug 1565872 - Fix miscellaneous typos and spelling inconsistencies](https://bugzilla.mozilla.org/show_bug.cgi?id=1565872)