### PR TITLE
Bug 1565741 - Let users choose defect or enhancement on guided bug entry form

### DIFF
--- a/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
+++ b/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
@@ -478,7 +478,7 @@ explain how to write effective [% terms.bug %] reports.</li>
   <td>
     <label>
       <input type="radio" name="bug_type" value="defect" required>
-      This is an issue report.
+      This is a defect report.
     </label>
   </td>
   <td>

--- a/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
+++ b/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
@@ -326,7 +326,6 @@ Product: <b><span id="dupes_product_name">?</span></b>:
 
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" enctype="multipart/form-data" onsubmit="return bugForm.validate()">
 <input type="hidden" name="token" value="[% token FILTER html %]">
-<input type="hidden" name="bug_type" value="defect">
 <input type="hidden" name="product" id="product" value="">
 <input type="hidden" name="component" id="component" value="">
 <input type="hidden" name="bug_severity" value="normal">
@@ -472,6 +471,28 @@ explain how to write effective [% terms.bug %] reports.</li>
   <td class="label">File Description:</td>
   <td colspan="2"><input type="text" name="description" id="data_description" class="textInput" disabled></td>
   <td>&nbsp;</td>
+</tr>
+
+<tr>
+  <td class="label">Bug Type:</td>
+  <td>
+    <label>
+      <input type="radio" name="bug_type" value="defect" required>
+      This is an issue report.
+    </label>
+  </td>
+  <td>
+    <label>
+      <input type="radio" name="bug_type" value="enhancement" required>
+      This is a request for enhancement.
+    </label>
+  </td>
+  <td>
+    [% PROCESS help id="type_help" %]
+    <div id="type_help" class="hidden help">
+      Please select what kind of bug you’re about to submit.
+    </div>
+  </td>
 </tr>
 
 <tr>

--- a/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
+++ b/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
@@ -474,7 +474,7 @@ explain how to write effective [% terms.bug %] reports.</li>
 </tr>
 
 <tr>
-  <td class="label">Bug Type:</td>
+  <td class="label">[% terms.Bug %] Type:</td>
   <td>
     <label>
       <input type="radio" name="bug_type" value="defect" required>
@@ -490,7 +490,7 @@ explain how to write effective [% terms.bug %] reports.</li>
   <td>
     [% PROCESS help id="type_help" %]
     <div id="type_help" class="hidden help">
-      Please select what kind of bug you’re about to submit.
+      Please select what kind of [% terms.bug %] you’re about to submit.
     </div>
   </td>
 </tr>


### PR DESCRIPTION
Add required radio buttons on the guided bug entry form to ask if the bug is defect or enhancement, rather than using the defect type for all new bugs.

![image](https://user-images.githubusercontent.com/2929505/61164583-91f8a100-a4e4-11e9-8f50-891db61a427c.png)

## Bugzilla link

[Bug 1565741 - Let users choose defect or enhancement on guided bug entry form](https://bugzilla.mozilla.org/show_bug.cgi?id=1565741)