### PR TITLE
Bump version to 20190718.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20190628.1';
+our $VERSION = '20190718.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1524174" target="_blank">1524174</a>] Redirect to show_bug.cgi after creating bug or updating a bug</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1563269" target="_blank">1563269</a>] Stray "from" when redirecting needinfo</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1562804" target="_blank">1562804</a>] status NEW is not present in the status changed section in a bugzilla user profile</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1524175" target="_blank">1524175</a>] Redirect to show_bug.cgi after creating or updating an attachment</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1563312" target="_blank">1563312</a>] Needinfo links at top of bug goes to #c0 rather than relevant comment</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1557799" target="_blank">1557799</a>] Search By Change History: date range is ignored when field is not specified</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1380437" target="_blank">1380437</a>] Implement REST API utility methods in global.js to replace bugzilla_ajax(), eliminate JSON-RPC usage</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1566079" target="_blank">1566079</a>] User autocomplete doesn’t work for requestee for certain flags</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1563868" target="_blank">1563868</a>] Update documentation for searching on bugs by group restriction</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1565741" target="_blank">1565741</a>] Let users choose defect or enhancement on guided bug entry form</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1541898" target="_blank">1541898</a>] Allow to search on product/component pair</li>
</ul>