### PR TITLE
Bug 1565403 - Log how a bug was filed (via standard, guided, custom bug form or API)

### DIFF
--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -91,6 +91,7 @@ sub DB_COLUMNS {
       delta_ts
       estimated_time
       everconfirmed
+      filed_via
       lastdiffed
       op_sys
       priority
@@ -130,6 +131,7 @@ sub VALIDATORS {
     dup_id            => \&_check_dup_id,
     estimated_time    => \&_check_time_field,
     everconfirmed     => \&Bugzilla::Object::check_boolean,
+    filed_via         => \&_check_filed_via,
     groups            => \&_check_groups,
     keywords          => \&_check_keywords,
     op_sys            => \&_check_select_field,
@@ -310,6 +312,15 @@ use constant REQUIRED_FIELD_MAP =>
 # mandatory groups get set on bugs.
 use constant EXTRA_REQUIRED_FIELDS =>
   qw(creation_ts target_milestone cc qa_contact groups);
+
+sub BUG_FILE_METHODS {
+  my @methods = qw(advanced_form custom_form api);
+
+  # Allow extensions to add other methods, e.g. `guided_form`
+  Bugzilla::Hook::process('bug_file_methods', {methods => \@methods});
+
+  return @methods;
+}
 
 with 'Bugzilla::Elastic::Role::Object';
 
@@ -873,6 +884,7 @@ sub possible_duplicates {
 # C<status_whiteboard> - A string.
 # C<bug_status>   - The initial status of the bug, a string.
 # C<bug_file_loc> - The URL field.
+# C<filed_via>    - How this bug is being filed.
 #
 # C<assigned_to> - The full login name of the user who the bug is
 #                  initially assigned to.
@@ -1948,6 +1960,13 @@ sub _check_component {
   return $object;
 }
 
+sub _check_filed_via {
+  my ($invocant, $method) = @_;
+
+  return $method if defined $method && grep(/^$method$/, BUG_FILE_METHODS());
+  return 'unknown';
+}
+
 sub _check_creation_ts {
   return Bugzilla->dbh->selectrow_array('SELECT LOCALTIMESTAMP(0)');
 }
@@ -2633,7 +2652,7 @@ sub fields {
 
     # Standard Fields
     # Keep this ordering in sync with bugzilla.dtd.
-    qw(bug_id alias creation_ts short_desc delta_ts
+    qw(bug_id alias filed_via creation_ts short_desc delta_ts
       reporter_accessible cclist_accessible
       classification_id classification
       product component version rep_platform op_sys
@@ -3675,6 +3694,7 @@ sub deadline            { return $_[0]->{deadline} }
 sub delta_ts            { return $_[0]->{delta_ts} }
 sub error               { return $_[0]->{error} }
 sub everconfirmed       { return $_[0]->{everconfirmed} }
+sub filed_via           { return $_[0]->{filed_via} }
 sub lastdiffed          { return $_[0]->{lastdiffed} }
 sub op_sys              { return $_[0]->{op_sys} }
 sub priority            { return $_[0]->{priority} }

--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -314,7 +314,7 @@ use constant EXTRA_REQUIRED_FIELDS =>
   qw(creation_ts target_milestone cc qa_contact groups);
 
 sub BUG_FILE_METHODS {
-  my @methods = qw(advanced_form custom_form api);
+  my @methods = qw(standard_form custom_form api);
 
   # Allow extensions to add other methods, e.g. `guided_form`
   Bugzilla::Hook::process('bug_file_methods', {methods => \@methods});

--- a/Bugzilla/DB/Schema.pm
+++ b/Bugzilla/DB/Schema.pm
@@ -247,6 +247,7 @@ use constant ABSTRACT_SCHEMA => {
       bug_severity => {TYPE => 'varchar(64)',  NOTNULL => 1},
       bug_status   => {TYPE => 'varchar(64)',  NOTNULL => 1},
       bug_type     => {TYPE => 'varchar(20)',  NOTNULL => 1},
+      filed_via    => {TYPE => 'varchar(40)',  NOTNULL => 1, DEFAULT => "'unknown'"},
       creation_ts  => {TYPE => 'DATETIME'},
       delta_ts     => {TYPE => 'DATETIME',     NOTNULL => 1},
       short_desc   => {TYPE => 'varchar(255)', NOTNULL => 1},

--- a/Bugzilla/Field.pm
+++ b/Bugzilla/Field.pm
@@ -423,6 +423,7 @@ use constant DEFAULT_FIELDS => (
   },
 
   {name => 'target_milestone',    desc => 'Target Milestone',   buglist    => 1},
+  {name => 'filed_via', desc => 'Filed via', buglist => 1,},
   {
     name    => 'creation_ts',
     desc    => 'Opened',

--- a/Bugzilla/Hook.pm
+++ b/Bugzilla/Hook.pm
@@ -400,6 +400,20 @@ User is not a sufficiently empowered user, so B<deny>.
 
 =back
 
+=head2 bug_file_methods
+
+This happens in L<Bugzilla::Bug/BUG_FILE_METHODS>, and allows you to add one or
+more valid file methods stored with bugs.
+
+Params:
+
+=over
+
+=item C<method> - A arrayref containing an array of method names. Push your
+method name(s) onto the array.
+
+=back
+
 =head2 bug_fields
 
 Allows the addition of database fields from the bugs table to the standard

--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -798,6 +798,10 @@ sub update_table_definitions {
 
   _add_oauth2_jwt_support();
 
+  # Bug 1565403 - kohei.yoshino@gmail.com
+  $dbh->bz_add_column('bugs', 'filed_via',
+    {TYPE => 'varchar(40)', NOTNULL => 1, DEFAULT => "'unknown'"});
+
   ################################################################
   # New --TABLE-- changes should go *** A B O V E *** this point #
   ################################################################

--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -2876,7 +2876,7 @@ in the return value.
 
 =item C<filed_via>
 
-How the bug was filed, e.g. C<advanced_form>.
+How the bug was filed, e.g. C<standard_form>.
 
 This is an B<extra> field returned only by specifying C<filed_via> or
 C<_extra> in C<include_fields>.

--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -878,6 +878,9 @@ sub create {
 
   $params = Bugzilla::Bug::map_fields($params);
 
+  # Define the bug file method if missing
+  $params->{filed_via} //= 'api';
+
   my $flags = delete $params->{flags};
 
   # We start a nested transaction in case flag setting fails
@@ -1525,6 +1528,9 @@ sub _bug_to_hash {
   }
   if (filter_wants $params, 'duplicates') {
     $item{'duplicates'} = [map { $self->type('int', $_->id) } @{$bug->duplicates}];
+  }
+  if (filter_wants $params, 'filed_via', ['extra']) {
+    $item{'filed_via'} = $self->type('string', $bug->filed_via);
   }
   if (filter_wants $params, 'groups') {
     my @groups = map { $self->type('string', $_->name) } @{$bug->groups_in};
@@ -2868,6 +2874,13 @@ take.
 If you are not in the time-tracking group, this field will not be included
 in the return value.
 
+=item C<filed_via>
+
+How the bug was filed, e.g. C<advanced_form>.
+
+This is an B<extra> field returned only by specifying C<filed_via> or
+C<_extra> in C<include_fields>.
+
 =item C<flags>
 
 An array of hashes containing the information about flags currently set
@@ -3218,8 +3231,9 @@ and all custom fields.
 in Bugzilla B<4.4>.
 
 =item The C<attachments>, C<comment_count>, C<comments>, C<counts>,
-C<description>, C<duplicates>, C<history>, C<regressed_by>, C<regressions>,
-C<triage_owner> and C<type> fields were added in Bugzilla B<6.0>.
+C<description>, C<duplicates>, C<filed_via>, C<history>, C<regressed_by>,
+C<regressions>, C<triage_owner> and C<type> fields were added in Bugzilla
+B<6.0>.
 
 =back
 
@@ -3497,6 +3511,10 @@ backwards compatibility with older Bugzillas.
 
 C<string> The description (initial comment) of the bug.
 
+=item C<filed_via>
+
+C<string> Searches for bugs that were created with this method.
+
 =item C<id>
 
 C<int> The numeric id of the bug.
@@ -3725,6 +3743,9 @@ the version the bug was found in.
 
 =item C<description> (string) B<Defaulted> - The description (initial comment)
 of the bug. Some Bugzilla installations require this to not be blank.
+
+=item C<filed_via> (string) B<Defaulted> - How the bug is being filed.
+It will be C<api> by default when filing through the API.
 
 =item C<op_sys> (string) B<Defaulted> - The operating system the bug was
 discovered on.

--- a/bugzilla.dtd
+++ b/bugzilla.dtd
@@ -5,7 +5,7 @@
           maintainer CDATA #REQUIRED
           exporter CDATA #IMPLIED
 >
-<!ELEMENT bug (bug_id, (alias?, creation_ts, short_desc, delta_ts, reporter_accessible,
+<!ELEMENT bug (bug_id, (alias?, filed_via, creation_ts, short_desc, delta_ts, reporter_accessible,
     cclist_accessible, classification_id, classification, product, component,
     version, rep_platform, op_sys, bug_status, resolution?, dup_id?, duplicates*, see_also*,
     bug_file_loc?, status_whiteboard?, keywords*, bug_type, priority, bug_severity,

--- a/docs/en/rst/api/core/v1/bug.rst
+++ b/docs/en/rst/api/core/v1/bug.rst
@@ -262,7 +262,7 @@ counts               object  An object containing the numbers of the items in th
                              ``depends_on``, ``regressed_by``, ``regressions``
                              and ``duplicates``.
 description          string  The description (initial comment) of the bug.
-filed_via            string  How the bug was filed, e.g. ``advanced_form``.
+filed_via            string  How the bug was filed, e.g. ``standard_form``.
 history              array   Each array item is a History object. See
                              :ref:`rest_history` for details of the object.
 tags                 array   Each array item is a tag name. Note that tags are

--- a/docs/en/rst/api/core/v1/bug.rst
+++ b/docs/en/rst/api/core/v1/bug.rst
@@ -262,6 +262,7 @@ counts               object  An object containing the numbers of the items in th
                              ``depends_on``, ``regressed_by``, ``regressions``
                              and ``duplicates``.
 description          string  The description (initial comment) of the bug.
+filed_via            string  How the bug was filed, e.g. ``advanced_form``.
 history              array   Each array item is a History object. See
                              :ref:`rest_history` for details of the object.
 tags                 array   Each array item is a tag name. Note that tags are
@@ -504,6 +505,7 @@ creator           string    The login name of the user who created the bug. You
                             ``reporter``, for backwards compatibility with
                             older Bugzillas.
 description       string    The description (initial comment) of the bug.
+filed_via         string    Searches for bugs that were created with this method.
 id                int       The numeric ID of the bug.
 last_change_time  datetime  Searches for bugs that were modified at this time
                             or later. May not be an array.
@@ -645,6 +647,8 @@ name                type     description
 description         string   (defaulted) The description (initial comment) of the
                              bug. Some Bugzilla installations require this to not
                              be blank.
+filed_via           string   (defaulted) How the bug is being filed. It will be
+                             ``api`` by default when filing through the API.
 op_sys              string   (defaulted) The operating system the bug was
                              discovered on.
 platform            string   (defaulted) What type of hardware the bug was

--- a/extensions/BMO/template/en/default/bug/create/create-automative.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-automative.html.tmpl
@@ -80,6 +80,7 @@ function validateAndSubmit() {
 
 <form id="automative_form" method="post" action="[% basepath FILTER none %]post_bug.cgi"
   enctype="multipart/form-data" onSubmit="return validateAndSubmit();">
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" name="format" value="automative">
   <input type="hidden" name="product" value="Testing">
   <input type="hidden" name="component" value="General">

--- a/extensions/BMO/template/en/default/bug/create/create-blocklist.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-blocklist.html.tmpl
@@ -131,6 +131,7 @@ window.addEventListener("DOMContentLoaded", function() {
 [% cgi = Bugzilla.cgi %]
 
 <form id="blocklist_form" method="post" action="[% basepath FILTER none %]post_bug.cgi" enctype="multipart/form-data" class="noscript" onSubmit="return validateAndSubmit()">
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" name="product" value="Toolkit">
   <input type="hidden" name="component" value="Blocklist Policy Requests">
   <input type="hidden" name="rep_platform" value="All">

--- a/extensions/BMO/template/en/default/bug/create/create-client-bounty.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-client-bounty.html.tmpl
@@ -112,6 +112,7 @@ function validateAndSubmit() {
 
 <form id="client_bounty_form" method="post" action="[% basepath FILTER none %]post_bug.cgi" enctype="multipart/form-data"
       onSubmit="return validateAndSubmit();">
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" name="product" value="Firefox">
   <input type="hidden" name="component" value="Security">
   <input type="hidden" name="rep_platform" value="unspecified">

--- a/extensions/BMO/template/en/default/bug/create/create-comm-newsletter.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-comm-newsletter.html.tmpl
@@ -81,6 +81,7 @@ function toggleAreaOther() {
 
 <form id="newsletter_form" method="post" action="[% basepath FILTER none %]post_bug.cgi" enctype="multipart/form-data"
       onSubmit="return validateAndSubmit();">
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" name="format" value="comm-newsletter">
   <input type="hidden" name="product" value="Marketing">
   <input type="hidden" name="component" value="Community">

--- a/extensions/BMO/template/en/default/bug/create/create-costume.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-costume.html.tmpl
@@ -143,6 +143,7 @@ YAHOO.util.Event.onDOMReady(function() {
 
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" enctype="multipart/form-data"
       onSubmit="return validateAndSubmit();">
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" name="format" value="costume">
   <input type="hidden" name="product" value="Marketing">
   <input type="hidden" name="component" value="General">

--- a/extensions/BMO/template/en/default/bug/create/create-creative.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-creative.html.tmpl
@@ -115,6 +115,7 @@ function toggleTypeOther(element) {
 
 <form id="creative_form" method="post" action="[% basepath FILTER none %]post_bug.cgi" enctype="multipart/form-data"
       onSubmit="return validateAndSubmit();">
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" name="format" value="creative">
   <input type="hidden" name="product" value="Marketing">
   <input type="hidden" name="component" value="Design">

--- a/extensions/BMO/template/en/default/bug/create/create-crm.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-crm.html.tmpl
@@ -85,6 +85,7 @@ $(document).ready(function() {
     the invite details once you submit the [% terms.bug %]):</p>
 
   <form method="post" action="[% basepath FILTER none %]post_bug.cgi" id="crmForm">
+    <input type="hidden" name="filed_via" value="custom_form">
     <input type="hidden" id="short_desc" name="short_desc" value="CRM/Email Marketing Request">
     <input type="hidden" name="product" value="Marketing">
     <input type="hidden" name="component" value="Email">

--- a/extensions/BMO/template/en/default/bug/create/create-data-compliance.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-data-compliance.html.tmpl
@@ -75,6 +75,7 @@
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" id="data_comp_form"
       class="enter_bug_form" enctype="multipart/form-data"
       onSubmit="return validateAndSubmit();">
+<input type="hidden" name="filed_via" value="custom_form">
 <input type="hidden" name="format" value="data-compliance">
 <input type="hidden" name="product" value="Data Compliance">
 <input type="hidden" name="component" value="General">

--- a/extensions/BMO/template/en/default/bug/create/create-finance.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-finance.html.tmpl
@@ -77,6 +77,7 @@
 
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" id="bug_form" class="enter_bug_form"
       enctype="multipart/form-data" onsubmit="return onSubmit();">
+<input type="hidden" name="filed_via" value="custom_form">
 <input type="hidden" name="format" value="finance">
 <input type="hidden" name="product" value="Finance">
 <input type="hidden" name="rep_platform" value="All">

--- a/extensions/BMO/template/en/default/bug/create/create-fsa-budget.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-fsa-budget.html.tmpl
@@ -84,6 +84,7 @@ function validateAndSubmit() {
 
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" id="fsa_form" enctype="multipart/form-data"
       onSubmit="return validateAndSubmit();">
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" name="format" value="fsa-budget">
   <input type="hidden" name="product" value="FSA">
   <input type="hidden" name="component" value="Budget Requests">

--- a/extensions/BMO/template/en/default/bug/create/create-intern.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-intern.html.tmpl
@@ -107,6 +107,7 @@ $(document).ready(function() {
   </p>
 
   <form method="post" action="[% basepath FILTER none %]post_bug.cgi" id="internForm">
+    <input type="hidden" name="filed_via" value="custom_form">
     <input type="hidden" id="short_desc" name="short_desc" value="">
     <input type="hidden" name="product" value="Recruiting">
     <input type="hidden" name="component" value="Intern">

--- a/extensions/BMO/template/en/default/bug/create/create-ipp.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-ipp.html.tmpl
@@ -65,6 +65,7 @@ function validateAndSubmit() {
 
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" enctype="multipart/form-data"
       onSubmit="return validateAndSubmit();">
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" name="format" value="ipp">
   <input type="hidden" name="product" value="Internet Public Policy">
   <input type="hidden" name="rep_platform" value="All">

--- a/extensions/BMO/template/en/default/bug/create/create-itrequest.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-itrequest.html.tmpl
@@ -93,6 +93,7 @@
 
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" id="itRequestForm" enctype="multipart/form-data"
       onsubmit="return on_submit()">
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" id="product" name="product" value="Infrastructure & Operations">
   <input type="hidden" name="rep_platform" value="All">
   <input type="hidden" name="op_sys" value="Other">

--- a/extensions/BMO/template/en/default/bug/create/create-legal.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-legal.html.tmpl
@@ -76,6 +76,7 @@ label.required:before {
 <p>[ <span class="required_star">*</span> Required Field ]</p>
 
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" id="legalRequestForm" enctype="multipart/form-data">
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" name="product" value="Legal">
   <input type="hidden" name="rep_platform" value="All">
   <input type="hidden" name="op_sys" value="Other">

--- a/extensions/BMO/template/en/default/bug/create/create-mdn.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-mdn.html.tmpl
@@ -178,6 +178,7 @@ strong.required:before {
 
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" enctype="multipart/form-data"
       onSubmit="return mdn.validateAndSubmit();">
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" name="format" value="mdn">
   <input type="hidden" name="product" value="developer.mozilla.org">
   <input type="hidden" name="rep_platform" value="All">

--- a/extensions/BMO/template/en/default/bug/create/create-mobile-compat.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-mobile-compat.html.tmpl
@@ -77,6 +77,7 @@ function validateAndSubmit() {
 
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" enctype="multipart/form-data"
       onSubmit="return validateAndSubmit();">
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" name="format"       value="mobile-compat">
   <input type="hidden" name="product"      value="Tech Evangelism">
   <input type="hidden" name="component"    value="Mobile">

--- a/extensions/BMO/template/en/default/bug/create/create-mozlist.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-mozlist.html.tmpl
@@ -62,6 +62,7 @@
 
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" id="mozListRequestForm"
       enctype="multipart/form-data" onSubmit="return trySubmit();">
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" id="format" name="format" value="mozlist">
   <input type="hidden" id="product" name="product" value="mozilla.org">
   <input type="hidden" id="rep_platform" name="rep_platform" value="All">

--- a/extensions/BMO/template/en/default/bug/create/create-mozpr.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-mozpr.html.tmpl
@@ -284,6 +284,7 @@ function validate_form() {
 
 <form id="pr_form" name="pr_form" method="post" action="[% basepath FILTER none %]post_bug.cgi"
       enctype="multipart/form-data" onSubmit="return validate_form()">
+<input type="hidden" name="filed_via" value="custom_form">
 <input type="hidden" name="format" value="mozpr">
 <input type="hidden" name="product" value="Mozilla PR">
 <input type="hidden" name="component" value="Projects">

--- a/extensions/BMO/template/en/default/bug/create/create-name-clearance.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-name-clearance.html.tmpl
@@ -72,6 +72,7 @@ $(function() {
 <p>[ <span class="required_star">*</span> <span class="required_explanation">Required Field</span> ]</p>
 
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" id="nameForm">
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" id="short_desc" name="short_desc" value="New Name Clearance Request">
   <input type="hidden" name="product" value="Legal">
   <input type="hidden" name="component" value="Name Clearance (Trademark Search)">

--- a/extensions/BMO/template/en/default/bug/create/create-nda.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-nda.html.tmpl
@@ -63,6 +63,7 @@ $(function() {
   of the ticket.</p>
 
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" id="ndaForm">
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" id="short_desc" name="short_desc" value="New NDA Request">
   <input type="hidden" name="product" value="Legal">
   <input type="hidden" name="component" value="NDA">

--- a/extensions/BMO/template/en/default/bug/create/create-recoverykey.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-recoverykey.html.tmpl
@@ -34,6 +34,7 @@
 </ul>
 
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" id="recoveryKeyForm" enctype="multipart/form-data">
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" name="product" value="mozilla.org">
   <input type="hidden" name="component" value="Server Operations: Desktop Issues">
   <input type="hidden" name="rep_platform" value="All">

--- a/extensions/BMO/template/en/default/bug/create/create-recruiting.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-recruiting.html.tmpl
@@ -72,6 +72,7 @@ function jobDescToggle(what) {
   </p>
 
   <form method="post" action="[% basepath FILTER none %]post_bug.cgi" id="recruitingForm" enctype="multipart/form-data">
+    <input type="hidden" name="filed_via" value="custom_form">
     <input type="hidden" name="product" value="Recruiting">
     <input type="hidden" name="component" value="General">
     <input type="hidden" name="rep_platform" value="All">

--- a/extensions/BMO/template/en/default/bug/create/create-screen-share-whitelist.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-screen-share-whitelist.html.tmpl
@@ -90,6 +90,7 @@ function fieldValue(elem_id) {
 
 <form id="whitelist_form" method="post" action="[% basepath FILTER none %]post_bug.cgi" enctype="multipart/form-data"
       onSubmit="return validateAndSubmit();">
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" name="format" value="screen-share-whitelist">
   <input type="hidden" name="product" value="Firefox">
   <input type="hidden" name="component" value="Screen Sharing Whitelist">

--- a/extensions/BMO/template/en/default/bug/create/create-shield-studies.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-shield-studies.html.tmpl
@@ -43,6 +43,7 @@
 </p>
 
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" id="shieldStudies" class="enter_bug_form" enctype="multipart/form-data">
+<input type="hidden" name="filed_via" value="custom_form">
 <input type="hidden" name="format" id="format" value="shield-studies">
 <input type="hidden" name="product" id="product" value="Shield">
 <input type="hidden" name="component" id="component" value="Shield Study">

--- a/extensions/BMO/template/en/default/bug/create/create-swag.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-swag.html.tmpl
@@ -535,6 +535,7 @@ function showGear() {
 
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" id="swagRequestForm" enctype="multipart/form-data"
       onSubmit="return validateAndSubmit();">
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" name="format" value="swag">
   <input type="hidden" name="product" value="Marketing">
   <input type="hidden" name="component" value="Swag Requests">

--- a/extensions/BMO/template/en/default/bug/create/create-trademark.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-trademark.html.tmpl
@@ -40,6 +40,7 @@
 
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" id="tmRequestForm">
 
+        <input type="hidden" name="filed_via" value="custom_form">
         <input type="hidden" name="product" value="Marketing">
         <input type="hidden" name="component" value="Trademark Permissions">
         <input type="hidden" name="bug_type" value="task">

--- a/extensions/BMO/template/en/default/bug/create/create-user-engagement.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-user-engagement.html.tmpl
@@ -81,6 +81,7 @@ function toggleGoalOther() {
 
 <form id="engagement_form" method="post" action="[% basepath FILTER none %]post_bug.cgi" enctype="multipart/form-data"
       onSubmit="return validateAndSubmit();">
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" name="format" value="user-engagement">
   <input type="hidden" name="product" value="Marketing">
   <input type="hidden" name="component" value="User Engagement">

--- a/extensions/BMO/template/en/default/bug/create/create-web-bounty.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-web-bounty.html.tmpl
@@ -68,6 +68,7 @@ function validateAndSubmit() {
 
 <form id="web_bounty_form" method="post" action="[% basepath FILTER none %]post_bug.cgi" enctype="multipart/form-data"
       onSubmit="return validateAndSubmit();">
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" name="product" value="Websites">
   <input type="hidden" name="component" value="Other">
   <input type="hidden" name="rep_platform" value="All">

--- a/extensions/GuidedBugEntry/Extension.pm
+++ b/extensions/GuidedBugEntry/Extension.pm
@@ -22,6 +22,12 @@ use Bugzilla::Extension::BMO::Data;
 
 our $VERSION = '1';
 
+sub bug_file_methods {
+  my ($self, $args) = @_;
+
+  push(@{$args->{methods}}, 'guided_form');
+}
+
 sub enter_bug_start {
   my ($self, $args) = @_;
   my $vars     = $args->{vars};

--- a/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
+++ b/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
@@ -26,7 +26,7 @@
 
 <noscript>
 You require JavaScript to use this [% terms.bug %] entry form.<br><br>
-Please use the <a href="[% basepath FILTER none %]enter_bug.cgi?format=__default__">advanced [% terms.bug %] entry form</a>.
+Please use the <a href="[% basepath FILTER none %]enter_bug.cgi?format=__default__">standard [% terms.bug %] entry form</a>.
 </noscript>
 
 <div id="loading" class="hidden">
@@ -47,7 +47,7 @@ YAHOO.util.Dom.removeClass('loading', 'hidden');
 <div id="advanced">
   <a id="advanced_img" href="[% basepath FILTER none %]enter_bug.cgi?format=__default__"><img
   src="[% basepath FILTER none %]extensions/GuidedBugEntry/web/images/advanced.png" width="16" height="16" border="0"></a>
-  <a id="advanced_link" href="[% basepath FILTER none %]enter_bug.cgi?format=__default__">Switch to the advanced [% terms.bug %] entry form</a>
+  <a id="advanced_link" href="[% basepath FILTER none %]enter_bug.cgi?format=__default__">Switch to the standard [% terms.bug %] entry form</a>
 </div>
 
 <script [% script_nonce FILTER none %]>

--- a/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
+++ b/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
@@ -325,6 +325,7 @@ Product: <b><span id="dupes_product_name">?</span></b>:
 [% INCLUDE page_title %]
 
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" enctype="multipart/form-data" onsubmit="return bugForm.validate()">
+<input type="hidden" name="filed_via" value="guided_form">
 <input type="hidden" name="token" value="[% token FILTER html %]">
 <input type="hidden" name="product" id="product" value="">
 <input type="hidden" name="component" id="component" value="">

--- a/extensions/MozProjectReview/template/en/default/bug/create/create-moz-project-review.html.tmpl
+++ b/extensions/MozProjectReview/template/en/default/bug/create/create-moz-project-review.html.tmpl
@@ -48,6 +48,7 @@
 </p>
 
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" id="mozProjectForm" enctype="multipart/form-data">
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" id="bug_type" name="bug_type" value="task">
   <input type="hidden" id="product" name="product" value="Legal">
   <input type="hidden" id="component" name="component" value="General">

--- a/extensions/REMO/template/en/default/bug/create/create-csa-discourse.html.tmpl
+++ b/extensions/REMO/template/en/default/bug/create/create-csa-discourse.html.tmpl
@@ -23,6 +23,7 @@
 <h1>Community IT Discourse Request</h1>
 
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" id="tmRequestForm" name="f">
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" name="bug_type" value="task">
   <input type="hidden" name="product" value="Infrastructure & Operations">
   <input type="hidden" name="component" value="Community IT: Discourse">

--- a/extensions/REMO/template/en/default/bug/create/create-mozreps.html.tmpl
+++ b/extensions/REMO/template/en/default/bug/create/create-mozreps.html.tmpl
@@ -39,6 +39,7 @@
 </p>
 
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" id="tmRequestForm">
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" name="bug_type" value="task">
   <input type="hidden" name="product" value="Mozilla Reps">
   <input type="hidden" name="component" value="Mentorship">

--- a/extensions/REMO/template/en/default/bug/create/create-remo-budget.html.tmpl
+++ b/extensions/REMO/template/en/default/bug/create/create-remo-budget.html.tmpl
@@ -77,6 +77,7 @@ function validateAndSubmit() {
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" id="swagRequestForm" enctype="multipart/form-data"
       onSubmit="return validateAndSubmit();">
 
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" name="format" value="remo-budget">
   <input type="hidden" name="created-format" value="remo-budget">
   <input type="hidden" name="bug_type" value="task">

--- a/extensions/REMO/template/en/default/bug/create/create-remo-swag.html.tmpl
+++ b/extensions/REMO/template/en/default/bug/create/create-remo-swag.html.tmpl
@@ -70,6 +70,7 @@ function validateAndSubmit() {
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" id="swagRequestForm" enctype="multipart/form-data"
       onSubmit="return validateAndSubmit();">
 
+  <input type="hidden" name="filed_via" value="custom_form">
   <input type="hidden" name="format" value="remo-swag">
   <input type="hidden" name="bug_type" value="task">
   <input type="hidden" name="product" value="Mozilla Reps">

--- a/post_bug.cgi
+++ b/post_bug.cgi
@@ -117,6 +117,7 @@ push(
     bug_status
     bug_type
     dependson
+    filed_via
     keywords
     short_desc
     op_sys

--- a/qa/t/lib/QA/Util.pm
+++ b/qa/t/lib/QA/Util.pm
@@ -227,8 +227,8 @@ sub file_bug_in_product {
   $sel->wait_for_page_to_load(WAIT_TIME);
 
   # Use normal bug form instead of helper
-  if ($sel->is_text_present('Switch to the advanced bug entry form')) {
-    $sel->click_ok('//a[@id="advanced_link"]', undef, 'Switch to the advanced bug entry form');
+  if ($sel->is_text_present('Switch to the standard bug entry form')) {
+    $sel->click_ok('//a[@id="advanced_link"]', undef, 'Switch to the standard bug entry form');
   }
 
   my $title = $sel->get_title();

--- a/template/en/default/bug/create/create.html.tmpl
+++ b/template/en/default/bug/create/create.html.tmpl
@@ -223,6 +223,7 @@ TUI_hide_default('expert_fields');
 <form name="Create" id="Create" method="post" action="[% basepath FILTER none %]post_bug.cgi"
       class="enter_bug_form" enctype="multipart/form-data"
       onsubmit="return validateEnterBug(this)">
+<input type="hidden" name="filed_via" value="advanced_form">
 <input type="hidden" name="product" value="[% product.name FILTER html %]">
 <input type="hidden" name="token" value="[% token FILTER html %]">
 <input type="hidden" name="bug_ignored" value="[% bug_ignored ? "1" : "0" %]">

--- a/template/en/default/bug/create/create.html.tmpl
+++ b/template/en/default/bug/create/create.html.tmpl
@@ -223,7 +223,7 @@ TUI_hide_default('expert_fields');
 <form name="Create" id="Create" method="post" action="[% basepath FILTER none %]post_bug.cgi"
       class="enter_bug_form" enctype="multipart/form-data"
       onsubmit="return validateEnterBug(this)">
-<input type="hidden" name="filed_via" value="advanced_form">
+<input type="hidden" name="filed_via" value="standard_form">
 <input type="hidden" name="product" value="[% product.name FILTER html %]">
 <input type="hidden" name="token" value="[% token FILTER html %]">
 <input type="hidden" name="bug_ignored" value="[% bug_ignored ? "1" : "0" %]">

--- a/template/en/default/global/field-descs.none.tmpl
+++ b/template/en/default/global/field-descs.none.tmpl
@@ -135,6 +135,7 @@ if ( $stash->get("in_template_var") ) {
         "duplicates"              => "Duplicates",
         "estimated_time"          => "Orig. Est.",
         "everconfirmed"           => "Ever confirmed",
+        "filed_via"               => "Filed via",
         "flagtypes.name"          => "Flags",
         "keywords"                => "Keywords",
         "keywords.count"          => "Number of Keywords",

--- a/template/en/default/pages/bugzilla.dtd.tmpl
+++ b/template/en/default/pages/bugzilla.dtd.tmpl
@@ -37,6 +37,7 @@
 >
 <!ELEMENT [% "bug" %] (bug_id,
                (alias?,
+                filed_via,
                 creation_ts,
                 short_desc,
                 delta_ts,


### PR DESCRIPTION
Add a new field called `filed_via` to each bug that records the bug’s file method: `standard_form`, `guided_form `, `custom_form ` or `api`. All the existing bugs will use `unknown`. It won’t be displayed on the bug, but can be retrieved via the API (`/rest/bug/####?include_fields=filed_via`) as well as bug lists.

## Bugzilla link

[Bug 1565403 - Log how a bug was filed (via standard, guided, custom bug form or API)](https://bugzilla.mozilla.org/show_bug.cgi?id=1565403)