### PR TITLE
Bug 1567696 - Forms for approval requests should indicate XHR / progress

### DIFF
--- a/extensions/BMO/template/en/default/hook/flag/type_comment-form.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/flag/type_comment-form.html.tmpl
@@ -6,6 +6,9 @@
   # defined by the Mozilla Public License, v. 2.0.
   #%]
 
+[%# These forms are available only when updating an attachment %]
+[% RETURN UNLESS template.name == "attachment/edit.html.tmpl" %]
+
 <meta name="extra-patch-types" content="text/x-phabricator-request">
 
 <template class="approval-request" data-flags="approval-mozilla-beta approval-mozilla-release">

--- a/skins/standard/attachment.css
+++ b/skins/standard/attachment.css
@@ -227,14 +227,16 @@ textarea.bz_private {
   border: 1px solid var(--accent-color-pink-1);
 }
 
-#update {
-  clear: both;
-  display: block;
-}
-
-div#update_container {
+#update_container {
+  display: flex;
+  align-items: center;
   clear: both;
   padding: 1.5em 0;
+}
+
+#update_container [role="status"] {
+  margin-left: 8px;
+  font-style: italic;
 }
 
 #attachment_flags p {

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -315,7 +315,7 @@
     --control-background-color: rgb(35, 36, 37);
     --control-border-color: rgb(60, 61, 62);
     --selected-control-background-color: rgb(60, 61, 62);
-    --disabled-control-foreground-color: rgb(90, 91, 92);
+    --disabled-control-foreground-color: rgb(110, 111, 112);
     --scrollbar-color: rgb(70, 71, 72) var(--application-background-color);
 
     /** Button */

--- a/template/en/default/attachment/edit.html.tmpl
+++ b/template/en/default/attachment/edit.html.tmpl
@@ -290,6 +290,7 @@
   [% IF user.id %]
     <div id="update_container">
       <input type="submit" value="Submit" id="update">
+      <span role="status"></span>
     </div>
   [% END %]
 </form>


### PR DESCRIPTION
Fix a couple of issues on the [uplift request form](https://release.mozilla.org/tooling/bugzilla/2018/10/03/uplift-form):

* Disable the Submit button and show a status message while sending background requests
* Show an error message if something went wrong
* Make the background request process a bit faster by reducing the number of `await`
* Remove the uplift form from the Create New Attachment page, because the form requires only on the Edit Attachment page

## Bugzilla link

[Bug 1567696 - Forms for approval requests should indicate XHR / progress](https://bugzilla.mozilla.org/show_bug.cgi?id=1567696)