### PR TITLE
Bug 1568259 - Short URL generation isn't working

### DIFF
--- a/extensions/Bitly/web/js/bitly.js
+++ b/extensions/Bitly/web/js/bitly.js
@@ -36,7 +36,7 @@ $(function() {
                 speed: 100,
                 followSpeed: 100,
                 modalColor: '#fff'
-            }, execute);
+            }, function(){ execute(); });
         });
 
     $('#bitly-type')


### PR DESCRIPTION
Fix a shorten URL not generated when the popup comes up. Looks like the callback for the `bPopup()` jQuery plug-in doesn’t accept an `async` function, so use a regular function as a wrapper to work around the issue.

## Bugzilla link

[Bug 1568259 - Short URL generation isn't working](https://bugzilla.mozilla.org/show_bug.cgi?id=1568259)