### PR TITLE
no bug - Fix an error in regex

### DIFF
--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -2947,7 +2947,7 @@ sub _component_nonchanged {
   # Allow to search product/component pairs like "Core::General" with a simple
   # operator. Since product/component names may include spaces, other operators
   # like `anywords` won't work.
-  if ($args->{operator} =~ /^(:?(:?not)?equals)$/
+  if ($args->{operator} =~ /^(?:(?:not)?equals)$/
     && $args->{value} =~ /^(?:(.+)\s*::\s*)?(.+)$/)
   {
     $product = $1;


### PR DESCRIPTION
Oops! This doesn’t throw any exception but is obviously wrong [:?](https://www.urbandictionary.com/define.php?term=%3A%3F)