### PR TITLE
Bug 1568863 - Prefilled comment will be wiped after changing component

### DIFF
--- a/template/en/default/bug/create/create.html.tmpl
+++ b/template/en/default/bug/create/create.html.tmpl
@@ -74,7 +74,7 @@ function initCrashSignatureField() {
 
 const params = new URLSearchParams(location.search);
 let bug_type_specified = params.has('bug_type') || params.has('cloned_bug_id') || params.has('regressed_by');
-let desc_edited = false;
+let desc_edited = params.has('comment') || params.has('cloned_bug_id');
 
 var initialowners = new Array([% product.components.size %]);
 var last_initialowner;


### PR DESCRIPTION
The bug comment is prefilled when the `comment` URL param is given or a bug is cloned. In such cases, the comment should not be replaced by the (empty) description template of the component. Add a proper check to avoid the issue.

## Bugzilla link

[Bug 1568863 - Prefilled comment will be wiped after changing component](https://bugzilla.mozilla.org/show_bug.cgi?id=1568863)