### PR TITLE
Bug 1568695 - Allow to use merge date pronouns with changed before/after operator

### DIFF
--- a/Bugzilla/Hook.pm
+++ b/Bugzilla/Hook.pm
@@ -597,19 +597,18 @@ Params:
 
 =back
 
-=head2 search_timestamp_translate
+=head2 search_date_pronoun
 
-This happens in L<Bugzilla::Search/_timestamp_translate> and allows you to
-support pronouns for specific dates, such as a product release date. Check the
-`value` argument and replace it with actual date where needed.
+This happens in L<Bugzilla::Search/SqlifyDate> and allows you to support
+pronouns for specific dates, such as a product release date. Pronouns must be
+quoted with percent signs like C<%LAST_RELEASE_DATE%>.
 
 Params:
 
 =over
 
-=item C<search> - The L<Bugzilla::Search> object.
-
-=item C<args> - The original arguments including C<value>.
+=item C<pronoun> - A capitalized pronoun without percent signs can be found in
+the C<name>. Add an actual date back to the C<date> if it's a supported pronoun.
 
 =back
 

--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -2254,11 +2254,7 @@ sub _timestamp_translate {
   my $value = $args->{value};
   my $dbh   = Bugzilla->dbh;
 
-  # Allow to support custom date pronouns
-  Bugzilla::Hook::process('search_timestamp_translate',
-    {search => $self, args => $args});
-
-  return if $value !~ /^(?:[\+\-]?\d+[hdwmy]s?|now)$/i;
+  return if $value !~ /^(?:[\+\-]?\d+[hdwmy]s?|now)$/i && $value !~ /^%\w+%$/;
 
   $value = SqlifyDate($value);
 
@@ -2301,6 +2297,16 @@ sub SqlifyDate {
   if ($str eq "") {
     my ($sec, $min, $hour, $mday, $month, $year, $wday) = localtime(time());
     return sprintf("%4d-%02d-%02d 00:00:00", $year + 1900, $month + 1, $mday);
+  }
+
+  # Allow to support custom date pronouns
+  if ($str =~ /^%(\w+)%$/) {
+    my $pronoun = {name => uc($1)};
+    Bugzilla::Hook::process('search_date_pronoun', {pronoun => $pronoun});
+    unless ($pronoun->{date}) {
+      ThrowUserError('illegal_date_pronoun', {pronoun => $str});
+    }
+    return $pronoun->{date};
   }
 
   if ($str =~ /^(-|\+)?(\d+)([hdwmy])(s?)$/i) {    # relative date

--- a/Bugzilla/WebService/Constants.pm
+++ b/Bugzilla/WebService/Constants.pm
@@ -70,6 +70,7 @@ use constant WS_ERROR_CODE => {
   number_too_large      => 54,
   number_too_small      => 55,
   illegal_date          => 56,
+  illegal_date_pronoun  => 57,
 
   # Bug errors usually occupy the 100-200 range.
   improper_bug_id_field_value => 100,

--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -2738,18 +2738,16 @@ sub search_params_to_data_structure {
 
 # Allow to use Firefox release date pronouns, including `%LAST_MERGE_DATE%`,
 # `%LAST_RELEASE_DATE%` and `%LAST_SOFTFREEZE_DATE%`.
-sub search_timestamp_translate {
+sub search_date_pronoun {
   my ($self, $args) = @_;
-  $args = $args->{args};
-  my $key = uc($args->{value});
-  $key =~ s/^%([A-Z_]+)%$/$1/;
+  my $pronoun = $args->{pronoun};
+  my $key = $pronoun->{name};
   my $keys = ['LAST_MERGE_DATE', 'LAST_RELEASE_DATE', 'LAST_SOFTFREEZE_DATE'];
   return unless grep(/^$key$/, @$keys);
 
   my $date = _fetch_product_version_file('firefox')->{$key};
   ThrowUserError('product_date_pronouns_unavailable') unless $date;
-  $args->{value}  = $date;
-  $args->{quoted} = Bugzilla->dbh->quote($date);
+  $pronoun->{date} = $date;
 }
 
 sub tf_buglist_columns {

--- a/template/en/default/global/user-error.html.tmpl
+++ b/template/en/default/global/user-error.html.tmpl
@@ -977,6 +977,10 @@
       Please use the format '<tt>[% format FILTER html %]</tt>'.
     [% END %]
 
+  [% ELSIF error == "illegal_date_pronoun" %]
+    [% title = "Illegal Date Pronoun" %]
+    '<code>[% pronoun FILTER html %]</code>' is not a legal date pronoun.
+
   [% ELSIF error == "illegal_email_address" %]
     [% title = "Invalid Email Address" %]
     The e-mail address you entered (<b>[% addr FILTER html %]</b>)


### PR DESCRIPTION
The current date pronoun support is incomplete because pronouns can be used only for certain date fields. This allows to use a pronoun for any other field in conjunction with the changed before/after operator, and shows a proper error if it’s not a valid pronoun.

## Bugzilla link

[Bug 1568695 - Allow to use merge date pronouns with changed before/after operator](https://bugzilla.mozilla.org/show_bug.cgi?id=1568695)