### PR TITLE
Bug 1569194 - My Dashboard shows Unexpected Error dialog when request is aborted while loading

### DIFF
--- a/extensions/MyDashboard/web/js/flags.js
+++ b/extensions/MyDashboard/web/js/flags.js
@@ -43,7 +43,7 @@ $(function () {
                 Y.one(`#${type}_loading`).addClass('bz_default_hidden');
                 Y.one(`#${type}_count_refresh`).removeClass('bz_default_hidden');
 
-                alert(`Failed to load requests:\n\n${message}`);
+                dataTable[type].showMessage(`Failed to load requests.`);
             }
         };
 

--- a/extensions/MyDashboard/web/js/query.js
+++ b/extensions/MyDashboard/web/js/query.js
@@ -84,7 +84,7 @@ $(function() {
                 Y.one('#query_loading').addClass('bz_default_hidden');
                 Y.one('#query_count_refresh').removeClass('bz_default_hidden');
 
-                alert(`Failed to load bug list from Bugzilla:\n\n${message}`);
+                bugQueryTable.showMessage(`Failed to load bug list.`);
             }
         };
 
@@ -124,6 +124,8 @@ $(function() {
         bugQueryTable.plug(Y.Plugin.DataTableRowExpansion, {
             uniqueIdKey: 'bug_id',
             template: ({ bug_id, changeddate_api }) => {
+                bugQueryTable.hideMessage();
+
                 // Note: `async` doesn't work for this `template` function, so use an inner `async` function instead
                 if (!lastChangesCache[bug_id]) {
                     try {
@@ -137,7 +139,7 @@ $(function() {
                             Y.one('#last_changes_stub_' + bug_id).setHTML(last_changes_template(last_changes));
                         })();
                     } catch ({ message }) {
-                        alert(`Failed to load last changes from Bugzilla:\n\n${message}`);
+                        bugQueryTable.showMessage(`Failed to load last changes.`);
                     }
 
                     return stub_template({bug_id: bug_id});


### PR DESCRIPTION
Show a simple error message inline instead of using `alert()`. Note: `fetch()` throws a generic `TypeError` instead of an `AbortError` when the user navigates manually, so it’s difficult to know if the request is aborted.

## Bugzilla link

[Bug 1569194 - My Dashboard shows Unexpected Error dialog when request is aborted while loading](https://bugzilla.mozilla.org/show_bug.cgi?id=1569194)