### PR TITLE
Bug 1512484 - Allow to specify default version per product

### DIFF
--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -2476,9 +2476,10 @@ sub _check_time_field {
 
 sub _check_version {
   my ($invocant, $version, undef, $params) = @_;
-  $version = trim($version);
   my $product  = blessed($invocant) ? $invocant->product_obj : $params->{product};
   my $old_vers = blessed($invocant) ? $invocant->version     : '';
+  $version = trim($version);
+  $version = $product->default_version if !defined $version;
   my $object = Bugzilla::Version->check({product => $product, name => $version});
   if ($object->name ne $old_vers && !$object->is_active) {
     ThrowUserError('value_inactive', {class => ref($object), value => $version});
@@ -3118,7 +3119,7 @@ sub _set_product {
         # already set correctly if they're valid, otherwise they're
         # set to some invalid value which the template will ignore.
         component => $self->component,
-        version   => $self->version,
+        version   => $version_ok ? $self->version : $product->default_version,
         milestone => $milestone_ok
         ? $self->target_milestone
         : $product->default_milestone

--- a/Bugzilla/DB/Schema.pm
+++ b/Bugzilla/DB/Schema.pm
@@ -1422,6 +1422,7 @@ use constant ABSTRACT_SCHEMA => {
       description        => {TYPE => 'MEDIUMTEXT',  NOTNULL => 1},
       isactive           => {TYPE => 'BOOLEAN',     NOTNULL => 1, DEFAULT => 1},
       defaultmilestone   => {TYPE => 'varchar(20)', NOTNULL => 1, DEFAULT => "'---'"},
+      default_version    => {TYPE => 'varchar(20)', NOTNULL => 1, DEFAULT => "'unspecified'"},
       allows_unconfirmed => {TYPE => 'BOOLEAN',     NOTNULL => 1, DEFAULT => 'TRUE'},
       bug_description_template => {TYPE => 'MEDIUMTEXT'},
       default_bug_type  => {TYPE => 'varchar(20)'},

--- a/Bugzilla/Field.pm
+++ b/Bugzilla/Field.pm
@@ -204,7 +204,6 @@ use constant DEFAULT_FIELDS => (
     name           => 'version',
     desc           => 'Version',
     in_new_bugmail => 1,
-    is_mandatory   => 1,
     buglist        => 1
   },
   {

--- a/Bugzilla/Install.pm
+++ b/Bugzilla/Install.pm
@@ -273,7 +273,7 @@ use constant DEFAULT_PRODUCT => {
   description => 'This is a test product.'
     . ' This ought to be blown away and replaced with real stuff in a'
     . ' finished installation of Bugzilla.',
-  version          => Bugzilla::Version::DEFAULT_VERSION,
+  default_version  => Bugzilla::Version::DEFAULT_VERSION,
   classification   => 'Unclassified',
   defaultmilestone => DEFAULT_MILESTONE,
 };

--- a/Bugzilla/Test/MockDB.pm
+++ b/Bugzilla/Test/MockDB.pm
@@ -169,6 +169,7 @@ sub import {
           . '(<a href="https://wiki.mozilla.org/Modules/All#Firefox">more info</a>)',
         versions =>
           ['34 Branch', '35 Branch', '36 Branch', '37 Branch', 'Trunk', 'unspecified'],
+        default_version  => 'unspecified',
         milestones =>
           ['Firefox 36', '---', 'Firefox 37', 'Firefox 38', 'Firefox 39', 'Future'],
         defaultmilestone => '---',
@@ -188,6 +189,7 @@ sub import {
         description    => 'For issues relating to the bugzilla.mozilla.org website, '
           . 'also known as <a href="https://wiki.mozilla.org/BMO">BMO</a>.',
         versions         => ['Development/Staging', 'Production'],
+        default_version  => 'Production',
         milestones       => ['---'],
         defaultmilestone => '---',
         components       => [{
@@ -231,6 +233,9 @@ sub import {
 
         $dbh->do('INSERT INTO milestones (product_id, value) VALUES (?, ?)',
           undef, ($new_product->id, $product->{defaultmilestone}));
+
+        $dbh->do('INSERT INTO versions (product_id, value) VALUES (?, ?)',
+          undef, ($new_product->id, $product->{default_version}));
 
         # Now clear the internal list of accessible products.
         delete Bugzilla->user->{selectable_products};

--- a/Bugzilla/WebService/Constants.pm
+++ b/Bugzilla/WebService/Constants.pm
@@ -209,8 +209,10 @@ use constant WS_ERROR_CODE => {
   product_name_already_in_use          => 702,
   product_name_diff_in_case            => 702,
   product_must_have_description        => 703,
-  product_must_have_version            => 704,
+  # Removed in favour of default value 'unspecified':
+  # product_must_have_version          => 704,
   product_must_define_defaultmilestone => 705,
+  product_must_define_default_version  => 706,
 
   # Group errors are 800-900
   empty_group_name        => 800,

--- a/Bugzilla/WebService/Product.pm
+++ b/Bugzilla/WebService/Product.pm
@@ -153,9 +153,10 @@ sub create {
   my $args = {
     name             => $params->{name},
     description      => $params->{description},
-    version          => $params->{version},
     default_bug_type => $params->{default_bug_type},
     defaultmilestone => $params->{default_milestone},
+    # Accept the old param name `version` for backward compatibility
+    default_version  => $params->{default_version} || $params->{version},
 
     # create_series has no default value.
     create_series => defined $params->{create_series}
@@ -181,6 +182,7 @@ sub _product_to_hash {
     description       => $self->type('string',  $product->description),
     is_active         => $self->type('boolean', $product->is_active),
     default_milestone => $self->type('string',  $product->default_milestone),
+    default_version   => $self->type('string',  $product->default_version),
     has_unconfirmed   => $self->type('boolean', $product->allows_unconfirmed),
     classification    => $self->type('string',  $product->classification->name),
     default_bug_type  => $self->type('string',  $product->default_bug_type),
@@ -503,6 +505,10 @@ C<string> The default type for bugs filed under this product.
 
 C<string> The name of the default milestone for the product.
 
+=item C<default_version>
+
+C<string> The name of the default version for the product.
+
 =item C<has_unconfirmed>
 
 C<boolean> Indicates whether the UNCONFIRMED bug status is available
@@ -661,6 +667,9 @@ been removed.
 =item In Bugzilla B<4.4>, C<flag_types> was added to the fields returned
 by C<get>.
 
+=item In Bugzilla B<6.0>, C<default_version> was added to the fields returned
+by C<get>.
+
 =back
 
 =back
@@ -722,6 +731,10 @@ override this value.
 
 C<string> The default milestone for this product. Default: '---'.
 
+=item C<default_version>
+
+C<string> The default version for this product. Default: 'unspecified'.
+
 =item C<is_open>
 
 C<boolean> True if the product is currently allowing bugs to be entered
@@ -764,10 +777,6 @@ You specified the name of a product that already exists.
 
 You must specify a description for this product.
 
-=item 704 (Product must have version)
-
-You must specify a version for this product.
-
 =back
 
 =item B<History>
@@ -775,6 +784,9 @@ You must specify a version for this product.
 =over
 
 =item REST API call added in Bugzilla B<5.0>.
+
+=item The C<version> field was renamed to C<default_version> in Bugzilla B<6.0>.
+The old name is still accepted for backward compatibility.
 
 =back
 

--- a/docs/en/rst/api/core/v1/product.rst
+++ b/docs/en/rst/api/core/v1/product.rst
@@ -103,6 +103,7 @@ type        string  The group of products to return. Valid values are
          "id": 1,
          "default_bug_type": "defect",
          "default_milestone": "---",
+         "default_version": "unspecified",
          "components": [
            {
              "is_active": true,
@@ -186,6 +187,7 @@ description        string   A description of the product, which may contain HTML
 is_active          boolean  A boolean indicating if the product is active.
 default_bug_type   string   The default type for bugs filed under this product.
 default_milestone  string   The name of the default milestone for the product.
+default_version    string   The name of the default version for the product.
 has_unconfirmed    boolean  Indicates whether the UNCONFIRMED bug status is
                             available for this product.
 classification     string   The classification name for the product.
@@ -287,7 +289,7 @@ This allows you to create a new product in Bugzilla.
      "classification" : "Unclassified",
      "is_open" : false,
      "has_unconfirmed" : false,
-     "version" : "unspecified"
+     "default_version" : "unspecified"
    }
 
 Some params must be set, or an error will be thrown. The required params are
@@ -300,7 +302,6 @@ name               type     description
                             within Bugzilla.
 **description**    string   A description for this product. Allows some simple
                             HTML.
-**version**        string   The default version for this product.
 has_unconfirmed    boolean  Allow the UNCONFIRMED status to be set on bugs in
                             this product. Default: true.
 classification     string   The name of the Classification which contains this
@@ -309,6 +310,9 @@ default_bug_type   string   The default type for bugs filed under this product.
                             Each component can override this value.
 default_milestone  string   The default milestone for this product. Default
                             '---'.
+default_version    string   The default version for this product. Default
+                            'unspecified'. The old name ``version`` is still
+                            accepted for backward compatibility.
 is_open            boolean  ``true`` if the product is currently allowing bugs
                             to be entered into it. Default: ``true``.
 create_series      boolean  ``true`` if you want series for New Charts to be
@@ -345,8 +349,6 @@ id    int   ID of the newly-filed product.
   (Product names must be globally unique in Bugzilla.)
 * 703 (Product must have description)
   You must specify a description for this product.
-* 704 (Product must have version)
-  You must specify a version for this product.
 
 .. _rest_product_update:
 
@@ -397,6 +399,9 @@ default_bug_type   string   The default type for bugs filed under this product.
 default_milestone  string   When a new bug is filed, what milestone does it
                             get by default if the user does not choose one? Must
                             represent a milestone that is valid for this product.
+default_version    string   When a new bug is filed, what version does it
+                            get by default if the user does not choose one? Must
+                            represent a version that is valid for this product.
 description        string   Update the long description for these products to
                             this value.
 has_unconfirmed    boolean  Allow the UNCONFIRMED status to be set on bugs in
@@ -459,3 +464,5 @@ as they are stored as strings in the database currently.
   You must specify a description for this product.
 * 705 (Product must define a default milestone)
   You must define a default milestone.
+* 706 (Product must define a default version)
+  You must define a default version.

--- a/editproducts.cgi
+++ b/editproducts.cgi
@@ -160,8 +160,8 @@ if ($action eq 'new') {
     classification     => $classification_name,
     name               => $product_name,
     description        => scalar $cgi->param('description'),
-    version            => scalar $cgi->param('version'),
     defaultmilestone   => scalar $cgi->param('defaultmilestone'),
+    default_version    => scalar $cgi->param('default_version'),
     isactive           => scalar $cgi->param('is_active'),
     create_series      => scalar $cgi->param('createseries'),
     allows_unconfirmed => scalar $cgi->param('allows_unconfirmed'),
@@ -285,6 +285,7 @@ if ($action eq 'update') {
     is_active          => scalar $cgi->param('is_active'),
     allows_unconfirmed => scalar $cgi->param('allows_unconfirmed'),
     default_milestone  => scalar $cgi->param('defaultmilestone'),
+    default_version    => scalar $cgi->param('default_version'),
     bug_description_template => scalar $cgi->param('bug_description_template'),
     default_bug_type   => scalar $cgi->param('default_bug_type'),
   });

--- a/editversions.cgi
+++ b/editversions.cgi
@@ -131,6 +131,12 @@ if ($action eq 'del') {
     = Bugzilla::Version->check({product => $product, name => $version_name});
   $vars->{'version'} = $version;
   $vars->{'product'} = $product;
+
+  # The default version cannot be deleted.
+  if ($product->default_version eq $version->name) {
+    ThrowUserError("version_is_default", {version => $version});
+  }
+
   $vars->{'token'}   = issue_session_token('delete_version');
   $template->process("admin/versions/confirm-delete.html.tmpl", $vars)
     || ThrowTemplateError($template->error());

--- a/enter_bug.cgi
+++ b/enter_bug.cgi
@@ -372,7 +372,7 @@ elsif (formvalue('version')) {
   $default{'version'} = formvalue('version');
 }
 else {
-  $default{'version'} = $vars->{'version'}->[$#{$vars->{'version'}}]->name;
+  $default{'version'} = $product->default_version;
 }
 
 # Get list of milestones.

--- a/extensions/BugModal/lib/WebService.pm
+++ b/extensions/BugModal/lib/WebService.pm
@@ -270,9 +270,10 @@ sub new_product {
     }
   }
   if (!$selected_version) {
-
-    # default to a blank value
-    unshift @$versions, {name => '', selected => $true,};
+    # use default version
+    my $default_version = $product->default_version;
+    my $version = first_value { $_->{name} eq $default_version } @$versions;
+    $version->{selected} = $true;
   }
   $result{version} = $versions;
 

--- a/importxml.pl
+++ b/importxml.pl
@@ -662,13 +662,12 @@ sub process_bug {
     push(@values, $version->name);
   }
   else {
-    my @versions = @{$product->versions};
-    my $v        = $versions[0];
-    push(@values, $v->name);
+    push(@values, $product->default_version);
     $err .= "Unknown version \"";
     $err .= (defined $bug_fields{'version'}) ? $bug_fields{'version'} : "unknown";
     $err .= " in product " . $product->name . ". \n";
-    $err .= "   Setting version to \"" . $v->name . "\".\n";
+    $err .= "   Setting to default version for this product, ";
+    $err .= "\"" . $product->default_version . "\".\n";
   }
 
   # Milestone

--- a/qa/config/generate_test_data.pl
+++ b/qa/config/generate_test_data.pl
@@ -411,6 +411,7 @@ my @products = (
     product_name     => 'QA-Selenium-TEST',
     description      => "used by Selenium test.. DON'T DELETE",
     versions         => ['unspecified', 'QAVersion'],
+    default_version  => 'unspecified',
     milestones       => ['QAMilestone'],
     defaultmilestone => '---',
     components       => [{
@@ -429,6 +430,7 @@ my @products = (
     product_name     => 'Another Product',
     description      => "Alternate product used by Selenium. <b>Do not edit!</b>",
     versions         => ['unspecified', 'Another1', 'Another2'],
+    default_version  => 'unspecified',
     milestones       => ['AnotherMS1', 'AnotherMS2', 'Milestone'],
     defaultmilestone => '---',
 
@@ -460,6 +462,7 @@ my @products = (
       . 'in all cases! Do not edit!',
     classification   => 'Class2_QA',
     versions         => ['unspecified', 'C2Ver'],
+    default_version  => 'unspecified',
     milestones       => ['C2Mil'],
     defaultmilestone => '---',
     components       => [{
@@ -478,6 +481,7 @@ my @products = (
     product_name     => 'QA Entry Only',
     description      => 'Only the QA group may enter bugs here.',
     versions         => ['unspecified'],
+    default_version  => 'unspecified',
     milestones       => [],
     defaultmilestone => '---',
     components       => [{
@@ -495,6 +499,7 @@ my @products = (
     product_name     => 'QA Search Only',
     description      => 'Only the QA group may search for bugs here.',
     versions         => ['unspecified'],
+    default_version  => 'unspecified',
     milestones       => [],
     defaultmilestone => '---',
     components       => [{
@@ -533,6 +538,9 @@ foreach my $product (@products) {
 
     $dbh->do('INSERT INTO milestones (product_id, value) VALUES (?, ?)',
       undef, ($new_product->id, $product->{defaultmilestone}));
+
+    $dbh->do('INSERT INTO versions (product_id, value) VALUES (?, ?)',
+      undef, ($new_product->id, $product->{default_version}));
 
     # Now clear the internal list of accessible products.
     delete Bugzilla->user->{selectable_products};

--- a/qa/t/webservice_bug_create.t
+++ b/qa/t/webservice_bug_create.t
@@ -13,7 +13,7 @@ use strict;
 use warnings;
 use lib qw(lib ../../lib ../../local/lib/perl5);
 use Storable qw(dclone);
-use Test::More tests => 311;
+use Test::More tests => 305;
 use QA::Util;
 use QA::Tests qw(create_bug_fields PRIVATE_BUG_USER);
 
@@ -49,10 +49,8 @@ my $fields = {
   },
 
   version => {
-    undefined =>
-      {faultstring => 'You must select/enter a version.', value => undef},
     invalid => {
-      faultstring => "There is no version named 'does-not-exist' in the",
+      faultstring => "There is no version named 'does-not-exist'.",
       value       => 'does-not-exist'
     },
   },

--- a/qa/t/webservice_bug_fields.t
+++ b/qa/t/webservice_bug_fields.t
@@ -83,7 +83,7 @@ use constant ALL_SELECT_FIELDS =>
 use constant PRODUCT_FIELDS => qw(version target_milestone component);
 use constant ALL_FIELDS =>
   (GLOBAL_GENERAL_FIELDS, ALL_SELECT_FIELDS, PRODUCT_FIELDS);
-use constant MANDATORY_FIELDS => qw(short_desc product version component);
+use constant MANDATORY_FIELDS => qw(short_desc product component);
 
 use constant PUBLIC_PRODUCT  => 'Another Product';
 use constant PRIVATE_PRODUCT => 'QA-Selenium-TEST';

--- a/qa/t/webservice_product_create.t
+++ b/qa/t/webservice_product_create.t
@@ -12,7 +12,7 @@
 use strict;
 use warnings;
 use lib qw(lib ../../lib ../../local/lib/perl5);
-use Test::More tests => 121;
+use Test::More tests => 109;
 use QA::Util;
 
 use constant DESCRIPTION  => 'Product created by Product.create';
@@ -71,12 +71,6 @@ my @tests = (
   },
   {
     user  => 'admin',
-    args  => {name => random_string(20), description => DESCRIPTION},
-    error => 'You must enter a valid version',
-    test  => 'Missing version to Product.create',
-  },
-  {
-    user  => 'admin',
     args  => {name => '', version => PROD_VERSION, description => DESCRIPTION},
     error => 'You must enter a name',
     test  => 'Name to Product.create cannot be empty',
@@ -86,12 +80,6 @@ my @tests = (
     args => {name => random_string(20), version => PROD_VERSION, description => ''},
     error => 'You must enter a description',
     test  => 'Description to Product.create cannot be empty',
-  },
-  {
-    user  => 'admin',
-    args  => {name => random_string(20), version => '', description => DESCRIPTION},
-    error => 'You must enter a valid version',
-    test  => 'Version to Product.create cannot be empty',
   },
   {
     user => 'admin',
@@ -134,7 +122,7 @@ if (0) {
       user => 'admin',
       args => {
         name              => random_string(20),
-        version           => PROD_VERSION,
+        default_version   => PROD_VERSION,
         description       => DESCRIPTION,
         has_unconfirmed   => 1,
         classification    => '',
@@ -149,7 +137,7 @@ if (0) {
       user => 'admin',
       args => {
         name              => random_string(20),
-        version           => PROD_VERSION,
+        default_version   => PROD_VERSION,
         description       => DESCRIPTION,
         has_unconfirmed   => 1,
         classification    => random_string(10),
@@ -193,7 +181,7 @@ foreach my $rpc ($xmlrpc, $jsonrpc) {
       user => 'admin',
       args => {
         name              => random_string(20),
-        version           => PROD_VERSION,
+        default_version   => PROD_VERSION,
         description       => DESCRIPTION,
         has_unconfirmed   => 1,
         classification    => 'Class2_QA',
@@ -207,7 +195,7 @@ foreach my $rpc ($xmlrpc, $jsonrpc) {
       user => 'admin',
       args => {
         name              => random_string(20),
-        version           => PROD_VERSION,
+        default_version   => PROD_VERSION,
         description       => DESCRIPTION,
         has_unconfirmed   => 0,
         classification    => 'Class2_QA',
@@ -221,7 +209,7 @@ foreach my $rpc ($xmlrpc, $jsonrpc) {
       user => 'admin',
       args => {
         name              => random_string(20),
-        version           => PROD_VERSION,
+        default_version   => PROD_VERSION,
         description       => DESCRIPTION,
         has_unconfirmed   => 1,
         classification    => 'Class2_QA',

--- a/sanitycheck.cgi
+++ b/sanitycheck.cgi
@@ -728,6 +728,12 @@ DoubleCrossCheck(
   ["products", "id",         "defaultmilestone", "name"]
 );
 
+DoubleCrossCheck(
+  "versions", "product_id", "value",
+  ["bugs",     "product_id", "version", "bug_id"],
+  ["products", "id",         "default_version", "name"]
+);
+
 ###########################################################################
 # Perform login checks
 ###########################################################################

--- a/scripts/generate_bmo_data.pl
+++ b/scripts/generate_bmo_data.pl
@@ -225,6 +225,7 @@ my @products = (
       . '(<a href="https://wiki.mozilla.org/Modules/All#Firefox">more info</a>)',
     versions =>
       ['34 Branch', '35 Branch', '36 Branch', '37 Branch', 'Trunk', 'unspecified'],
+    default_version  => 'unspecified',
     milestones =>
       ['Firefox 36', '---', 'Firefox 37', 'Firefox 38', 'Firefox 39', 'Future'],
     defaultmilestone => '---',
@@ -244,6 +245,7 @@ my @products = (
     description    => 'For issues relating to the bugzilla.mozilla.org website, '
       . 'also known as <a href="https://wiki.mozilla.org/BMO">BMO</a>.',
     versions         => ['Development/Staging', 'Production'],
+    default_version  => 'Production',
     milestones       => ['---'],
     defaultmilestone => '---',
     components       => [{
@@ -288,6 +290,9 @@ for my $product (@products) {
 
     $dbh->do('INSERT INTO milestones (product_id, value) VALUES (?, ?)',
       undef, ($new_product->id, $product->{defaultmilestone}));
+
+    $dbh->do('INSERT INTO versions (product_id, value) VALUES (?, ?)',
+      undef, ($new_product->id, $product->{default_version}));
 
     # Now clear the internal list of accessible products.
     delete Bugzilla->user->{selectable_products};

--- a/scripts/remove-non-public-data.pl
+++ b/scripts/remove-non-public-data.pl
@@ -143,6 +143,7 @@ my %whitelist = (
   products => [
     qw(
       id name classification_id description isactive defaultmilestone
+      default_version
       )
   ],
   profiles => [

--- a/template/en/default/admin/products/create.html.tmpl
+++ b/template/en/default/admin/products/create.html.tmpl
@@ -30,8 +30,8 @@
 
 [% DEFAULT
   product.is_active = 1,
-  version = "unspecified",
   product.defaultmilestone = constants.DEFAULT_MILESTONE
+  product.default_version = "unspecified"
   product.allows_unconfirmed = 1
 %]
 
@@ -40,12 +40,6 @@
 
     [% PROCESS "admin/products/edit-common.html.tmpl" %]
 
-    <tr>
-      <th align="right">Version:</th>
-      <td><input size="64" maxlength="255" name="version"
-                value="[% version FILTER html %]">
-      </td>
-    </tr>
     <tr>
       <th align="right">Create chart datasets for this product:</th>
       <td>

--- a/template/en/default/admin/products/edit-common.html.tmpl
+++ b/template/en/default/admin/products/edit-common.html.tmpl
@@ -61,7 +61,7 @@
 
 [% IF Param('usetargetmilestone') -%]
   <tr>
-    <th align="right">Default milestone:</th>
+    <th align="right">Default Milestone:</th>
     <td>
       [% IF product.milestones.size %]
         <select name="defaultmilestone">
@@ -79,6 +79,23 @@
   </tr>
 [% END %]
 
+<tr>
+  <th align="right">Default Version:</th>
+  <td>
+    [% IF product.versions.size %]
+      <select name="default_version">
+        [% FOREACH m = product.versions %]
+          <option value="[% m.name FILTER html %]"
+                  [% " selected=\"selected\"" IF m.name == product.default_version %]>
+            [%- m.name FILTER html -%]</option>
+        [% END %]
+      </select>
+    [% ELSE %]
+      <input type="text" size="20" maxlength="20" name="default_version"
+             value="[% product.default_version FILTER html %]">
+    [% END %]
+  </td>
+</tr>
 <tr>
   <th align="right">Open for [% terms.bug %] entry:</th>
   <td><input type="checkbox" name="is_active" value="1"

--- a/template/en/default/admin/products/updated.html.tmpl
+++ b/template/en/default/admin/products/updated.html.tmpl
@@ -83,6 +83,13 @@
   </p>
 [% END %]
 
+[% IF changes.default_version.defined %]
+  <p>
+  Updated default version from '[% changes.default_version.0 FILTER html %]' to
+  '[% product.default_version FILTER html %]'.
+  </p>
+[% END %]
+
 [% IF changes.allows_unconfirmed.defined %]
   <p>
   [% IF product.allows_unconfirmed %]

--- a/template/en/default/admin/versions/confirm-delete.html.tmpl
+++ b/template/en/default/admin/versions/confirm-delete.html.tmpl
@@ -65,36 +65,33 @@
 <h2>Confirmation</h2>
 
 [% IF version.bug_count %]
-  <p>
-  Sorry, there
-  [% IF version.bug_count > 1 %]
-    are [% version.bug_count FILTER none %] [%+ terms.bugs %]
-  [% ELSE %]
-    is [% version.bug_count FILTER none %] [%+ terms.bug %]
-  [% END %]
 
-  outstanding for this version. You must move
-
-  [% IF version.bug_count > 1 %]
-     those [% terms.bugs %]
-  [% ELSE %]
-     that [% terms.bug %]
-  [% END %]
-  to another version before you can delete this one.
-  </p>
-[% ELSE %]
-
-  <p>Do you really want to delete this version?</p>
-
-  <form method="post" action="[% basepath FILTER none %]editversions.cgi">
-    <input type="submit" id="delete" value="Yes, delete">
-    <input type="hidden" name="action" value="delete">
-    <input type="hidden" name="product" value="[% product.name FILTER html %]">
-    <input type="hidden" name="version" value="[% version.name FILTER html %]">
-    <input type="hidden" name="token" value="[% token FILTER html %]">
-  </form>
+  <table border="0" cellpadding="20" width="70%" bgcolor="red">
+  <tr><td>
+    There
+    [% IF version.bug_count > 1 %]
+      are [% version.bug_count FILTER none %] [%+ terms.bugs %]
+    [% ELSE %]
+      is 1 [% terms.bug %]
+    [% END %]
+    entered for this version! When you delete this version,
+    <b><blink>ALL</blink></b> of these [% terms.bugs %] will be retargeted
+    to [% product.default_version FILTER html %], the default version for
+    the [% product.name FILTER html %] product.
+  </td></tr>
+  </table>
 
 [% END %]
+
+<p>Do you really want to delete this version?</p>
+
+<form method="post" action="[% basepath FILTER none %]editversions.cgi">
+  <input type="submit" id="delete" value="Yes, delete">
+  <input type="hidden" name="action" value="delete">
+  <input type="hidden" name="product" value="[% product.name FILTER html %]">
+  <input type="hidden" name="version" value="[% version.name FILTER html %]">
+  <input type="hidden" name="token" value="[% token FILTER html %]">
+</form>
 
 [% PROCESS admin/versions/footer.html.tmpl %]
 

--- a/template/en/default/admin/versions/list.html.tmpl
+++ b/template/en/default/admin/versions/list.html.tmpl
@@ -67,10 +67,20 @@
 [% END %]
 
 [% columns.push({
+       name => "action"
        heading => "Action"
        content => "Delete"
        contentlink => delete_contentlink
      })
+%]
+
+[%# We want to override the usual 'Delete' link for the default version %]
+[% overrides.action.name.${product.default_version} = {
+     override_content => 1
+     content => "(Default version)"
+     override_contentlink => 1
+     contentlink => undef
+   }
 %]
 
 [% Hook.process('before_table') %]

--- a/template/en/default/global/messages.html.tmpl
+++ b/template/en/default/global/messages.html.tmpl
@@ -924,6 +924,10 @@
     [% title = "Version Deleted" %]
     The version <em>[% version.name FILTER html %]</em> of product
     <em>[% product.name FILTER html %]</em> has been deleted.
+    [% IF version.bug_count %]
+      [%+ terms.Bugs %] targeted to this version have been retargeted to
+      the default version <em>[% product.default_version FILTER html %]</em>.
+    [% END %]
 
   [% ELSIF message_tag == "version_updated" %]
     [% title = "Version Updated" %]

--- a/template/en/default/global/user-error.html.tmpl
+++ b/template/en/default/global/user-error.html.tmpl
@@ -1590,6 +1590,14 @@
     create the milestone '[% milestone FILTER html %]'</a> before
     it can be made the default milestone for product '[% product FILTER html %]'.
 
+  [% ELSIF error == "product_must_define_default_version" %]
+    [% title = "Must define new default version" %]
+    [% admindocslinks = {'products.html' => 'Administering products',
+                         'versions.html' => 'About Versions'} %]
+    You must <a href="[% basepath FILTER none %]editversions.cgi?action=add&amp;product=[% product FILTER uri %]">
+    create the version '[% version FILTER html %]'</a> before
+    it can be made the default version for product '[% product FILTER html %]'.
+
   [% ELSIF error == "product_admin_denied" %]
     [% title = "Product Access Denied" %]
     You are not allowed to edit properties of product '[% product FILTER html %]'.
@@ -1623,12 +1631,6 @@
     [% title = "Product needs Description" %]
     [% admindocslinks = {'products.html' => 'Administering products'} %]
     You must enter a description for this product.
-
-  [% ELSIF error == "product_must_have_version" %]
-    [% title = "Product needs Version" %]
-    [% admindocslinks = {'products.html' => 'Administering products',
-                         'versions.html' => 'Administering versions'} %]
-    You must enter a valid version to create a new product.
 
   [% ELSIF error == "product_unknown_component" %]
     [% title = "Unknown Component" %]
@@ -1871,11 +1873,13 @@
     [% title = "Blank Version Name Not Allowed" %]
     You must enter a name for this version.
 
-  [% ELSIF error == "version_has_bugs" %]
-    [% title = BLOCK %]Version has [% terms.Bugs %][% END %]
-    There are [% nb FILTER html %] [%+ terms.bugs %] associated with this
-    version! You must reassign those [% terms.bugs %] to another version
-    before you can delete this one.
+  [% ELSIF error == "version_is_default" %]
+    [% title = "Default version not deletable" %]
+    [% admindocslinks = {'products.html' => 'Administering products',
+                         'versions.html' => 'About Versions'} %]
+    Sorry, but [% version.name FILTER html %] is the default version
+    for the '[% version.product.name FILTER html %]' product, and so
+    it cannot be deleted.
 
   [% ELSIF error == "users_deletion_disabled" %]
     [% title = "Deletion not activated" %]

--- a/xt/lib/Bugzilla/Test/Search.pm
+++ b/xt/lib/Bugzilla/Test/Search.pm
@@ -415,7 +415,7 @@ sub _create_field_values {
     description        => 'Created by t/search.t',
     defaultmilestone   => $milestone,
     classification     => $classification,
-    version            => $version,
+    default_version    => $version,
     allows_unconfirmed => 1,
   });
   foreach my $item ($group, $self->nobody) {


### PR DESCRIPTION
Add `default_version` to products, and make it editable by admin. The implementation is almost the same as Default Milestone. Also make the field optional when filing a bug (especially via the API.)

## Bugzilla link

[Bug 1512484 - Allow to specify default version per product](https://bugzilla.mozilla.org/show_bug.cgi?id=1512484)