### PR TITLE
Bug 1569130 - Explain in the API doc that Bugzilla returns a 302 redirect when the query string is > 10 KB

### DIFF
--- a/docs/en/rst/api/core/v1/general.rst
+++ b/docs/en/rst/api/core/v1/general.rst
@@ -52,6 +52,13 @@ The error contents look similar to:
      "code": 123
    }
 
+To protect the application from excessively large requests, Bugzilla also
+returns a 302 redirect to the homepage when your request URL becomes too long.
+The current limit is 10 KB, which can accept roughly 1,000 bug IDs in the ``id``
+parameter for the ``/rest/bug`` method, but it could be smaller or may lead to a
+414 URI Too Long HTTP error depending on the server configuration. Try to split
+your query into multiple requests if you encounter the issue.
+
 Common Data Types
 -----------------
 

--- a/docs/en/rst/api/core/v1/general.rst
+++ b/docs/en/rst/api/core/v1/general.rst
@@ -52,12 +52,12 @@ The error contents look similar to:
      "code": 123
    }
 
-To protect the application from excessively large requests, Bugzilla also
-returns a 302 redirect to the homepage when your request URL becomes too long.
-The current limit is 10 KB, which can accept roughly 1,000 bug IDs in the ``id``
-parameter for the ``/rest/bug`` method, but it could be smaller or may lead to a
-414 URI Too Long HTTP error depending on the server configuration. Try to split
-your query into multiple requests if you encounter the issue.
+To protect the application from large requests, Bugzilla returns a 302 redirect
+to the homepage when your query string is too long. The current limit is 10 KB,
+which can accept roughly 1,000 bug IDs in the ``id`` parameter for the
+``/rest/bug`` method, but it could be smaller or may lead to a 414 URI Too Long
+HTTP error depending on the server configuration. Split your query into multiple
+requests if you encounter the issue.
 
 Common Data Types
 -----------------


### PR DESCRIPTION
Update the [API document](https://bmo.readthedocs.io/en/latest/api/core/v1/general.html) to clarify what happens when a too long URL is given.

## Bugzilla link

[Bug 1569130 - Explain in the API doc that Bugzilla returns a 302 redirect when the query string is > 10 KB](https://bugzilla.mozilla.org/show_bug.cgi?id=1569130)