### PR TITLE
Bug 1571129 - Allow attaching font/* content types

### DIFF
--- a/Bugzilla/Constants.pm
+++ b/Bugzilla/Constants.pm
@@ -482,8 +482,8 @@ use constant SAFE_PROTOCOLS => (
 
 # Valid MIME types for attachments.
 use constant LEGAL_CONTENT_TYPES => (
-  'application', 'audio',     'image', 'message',
-  'model',       'multipart', 'text',  'video'
+  'application', 'audio',     'font', 'image', 'message',
+  'model',       'multipart', 'text', 'video'
 );
 
 use constant contenttypes => {


### PR DESCRIPTION
Support `font/*` as a legal content type.

## Bugzilla link

[Bug 1571129 - Allow attaching font/* content types](https://bugzilla.mozilla.org/show_bug.cgi?id=1571129)