### PR TITLE
Bug 1571572 - Allow to prefill needinfo field on the Enter Bug page

### DIFF
--- a/extensions/Needinfo/template/en/default/hook/bug/create/create-after_custom_fields.html.tmpl
+++ b/extensions/Needinfo/template/en/default/hook/bug/create/create-after_custom_fields.html.tmpl
@@ -13,7 +13,7 @@
       [% INCLUDE global/userselect.html.tmpl
           id          => "needinfo_from"
           name        => "needinfo_from"
-          value       => ""
+          value       => cgi.param('needinfo_from')
           size        => 30
           multiple    => 5
           field_title => "Enter one or more comma separated users to request more information from"


### PR DESCRIPTION
Use the `needinfo_from` URL param, if exists, to prefill the needinfo field. The string is HTML-filtered in `userselect.html.tmpl` so no filter here.

## Bugzilla link

[Bug 1571572 - Allow to prefill needinfo field on the Enter Bug page](https://bugzilla.mozilla.org/show_bug.cgi?id=1571572)