### PR TITLE
Bump version to 20190808.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20190725.1';
+our $VERSION = '20190808.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1555508" target="_blank">1555508</a>] Cursor does not change to hand (cursor: pointer) when mouse is over "Edit Bug" or "Save Changes" buttons</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1569194" target="_blank">1569194</a>] My Dashboard shows Unexpected Error dialog when request is aborted while loading</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1568592" target="_blank">1568592</a>] Custom fields are lost when using Edit Search</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1568704" target="_blank">1568704</a>] Allow to use --- as empty Resolution field value in Custom Search</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1569130" target="_blank">1569130</a>] Explain in the API doc that Bugzilla returns a 302 redirect when the query string is &gt; 10 KB</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1545331" target="_blank">1545331</a>] I can't see which of defect/enhancment/task is currently selected during editing</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1430375" target="_blank">1430375</a>] Drop Cookie.js</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1570285" target="_blank">1570285</a>] cannot correctly enter date for 'Search By Change History' on Advanced Search page, gets autocompleted too early leaving no space for last digit</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1565403" target="_blank">1565403</a>] Log how a bug was filed (via standard, guided, custom bug form or API)</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1568695" target="_blank">1568695</a>] Allow to use merge date pronouns with changed before/after operator</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1571129" target="_blank">1571129</a>] Allow attaching font/* content types</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1571572" target="_blank">1571572</a>] Allow to prefill needinfo field on the Enter Bug page</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1562364" target="_blank">1562364</a>] Enforce setting bug type when creating bug through API</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1529406" target="_blank">1529406</a>] Record user’s logged-in/out status and track insiders with Google Analytics</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1567299" target="_blank">1567299</a>] STMO report_ping command should store last ran timestamp in database and automatically run from last time if present</li>
</ul>