### PR TITLE
no bug - Add bug_type field to custom Shield Studies form

### DIFF
--- a/extensions/BMO/template/en/default/bug/create/create-shield-studies.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-shield-studies.html.tmpl
@@ -49,6 +49,7 @@
 <input type="hidden" name="component" id="component" value="Shield Study">
 <input type="hidden" name="rep_platform" id="rep_platform" value="All">
 <input type="hidden" name="op_sys" id="op_sys" value="All">
+<input type="hidden" name="bug_type" value="task">
 <input type="hidden" name="priority" id="priority" value="--">
 <input type="hidden" name="version" id="version" value="unspecified">
 <input type="hidden" name="comment" id="comment" value="">


### PR DESCRIPTION
I’ve checked custom forms if they have bug type specified. Other than #1410, only this Shield Studies form doesn’t have it.