### PR TITLE
Bug 1573227 - Various UI text and code comments assume male gender

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -993,7 +993,7 @@ default), LOGOUT_ALL or LOGOUT_KEEP_CURRENT.
 
 =item C<logout_user($user)>
 
-Logs out the specified user (invalidating all his sessions), taking a
+Logs out the specified user (invalidating all their sessions), taking a
 Bugzilla::User instance.
 
 =item C<logout_by_id($id)>

--- a/Bugzilla/Attachment.pm
+++ b/Bugzilla/Attachment.pm
@@ -638,7 +638,7 @@ sub validate_can_edit {
 Description: validates if attachments the user wants to mark as obsolete
              really belong to the given bug and are not already obsolete.
              Moreover, a user cannot mark an attachment as obsolete if
-             he cannot view it (due to restrictions on it).
+             they cannot view it (due to restrictions on it).
 
 Params:      $bug - The bug object obsolete attachments should belong to.
              $attach_ids - The list of attachments to mark as obsolete.

--- a/Bugzilla/Auth.pm
+++ b/Bugzilla/Auth.pm
@@ -58,7 +58,7 @@ sub login {
     return $self->_handle_login_result($login_info, $type);
   }
 
-  # Now verify his username and password against the DB, LDAP, etc.
+  # Now verify their username and password against the DB, LDAP, etc.
   if ($self->{_info_getter}->{successful}->requires_verification) {
     $login_info = $self->{_verifier}->check_credentials($login_info);
     if ($login_info->{failure}) {
@@ -360,7 +360,7 @@ An incorrect username or password was given.
 The hashref may also contain a C<failure_count> element, which specifies
 how many times the account has failed to log in within the lockout
 period (see L</AUTH_LOCKOUT>). This is used to warn the user when
-he is getting close to being locked out.
+they’re getting close to being locked out.
 
 =head2 C<AUTH_NO_SUCH_USER>
 

--- a/Bugzilla/Auth/Verify/LDAP.pm
+++ b/Bugzilla/Auth/Verify/LDAP.pm
@@ -166,7 +166,7 @@ sub _bind_ldap_for_search {
 # We can't just do this in new(), because we're not allowed to throw any
 # error from anywhere under Bugzilla::Auth::new -- otherwise we
 # could create a situation where the admin couldn't get to editparams
-# to fix his mistake. (Because Bugzilla->login always calls
+# to fix their mistake. (Because Bugzilla->login always calls
 # Bugzilla::Auth->new, and almost every page calls Bugzilla->login.)
 sub ldap {
   my ($self) = @_;

--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -2109,10 +2109,10 @@ sub _check_dup_id {
   }
 
   # Should we add the reporter to the CC list of the new bug?
-  # If he can see the bug...
+  # If they can see the bug...
   if ($self->reporter->can_see_bug($dupe_of)) {
 
-    # We only add him if he's not the reporter of the other bug.
+    # We only add them if they’re not the reporter of the other bug.
     $self->{_add_dup_cc} = 1 if $dupe_of_bug->reporter->id != $self->reporter->id;
   }
 
@@ -2128,11 +2128,11 @@ sub _check_dup_id {
       $self->{_add_dup_cc} = $add_confirmed;
     }
     else {
-      # Note that here we don't check if he user is already the reporter
-      # of the dupe_of bug, since we already checked if he can *see*
+      # Note that here we don't check if the user is already the reporter
+      # of the dupe_of bug, since we already checked if they can *see*
       # the bug, above. People might have reporter_accessible turned
       # off, but cclist_accessible turned on, so they might want to
-      # add the reporter even though he's already the reporter of the
+      # add the reporter even though they’re already the reporter of the
       # dup_of bug.
       my $vars     = {};
       my $template = Bugzilla->template;
@@ -2296,7 +2296,7 @@ sub _check_reporter {
   }
   else {
     # On bug creation, the reporter is the logged in user
-    # (meaning that he must be logged in first!).
+    # (meaning that they must be logged in first!).
     Bugzilla->login(LOGIN_REQUIRED);
     $reporter = Bugzilla->user->id;
   }
@@ -3775,7 +3775,7 @@ sub _resolve_ultimate_dup_id {
     # If $dupes{$this_dup} is already set to 1, then a loop
     # already exists which does not involve this bug.
     # As the user is not responsible for this loop, do not
-    # prevent him from marking this bug as a duplicate.
+    # prevent them from marking this bug as a duplicate.
     return $last_dup if exists $dupes{$this_dup};
     $dupes{$this_dup} = 1;
     $last_dup = $this_dup;
@@ -4966,7 +4966,7 @@ sub check_can_change_field {
     return 1;
   }
 
-# If the user isn't allowed to change a field, we must tell him who can.
+# If the user isn't allowed to change a field, we must tell them who can.
 # We store the required permission set into the $PrivilegesRequired
 # variable which gets passed to the error template.
 #
@@ -5020,7 +5020,7 @@ sub check_can_change_field {
   # is not allowed to change.
 
   # The reporter may not:
-  # - reassign bugs, unless the bugs are assigned to him;
+  # - reassign bugs, unless the bugs are assigned to them;
   #   in that case we will have already returned 1 above
   #   when checking for the assignee of the bug.
   if ($field eq 'assigned_to') {
@@ -5040,7 +5040,7 @@ sub check_can_change_field {
     return 0;
   }
 
-  # - change the priority (unless he could have set it originally)
+  # - change the priority (unless they could have set it originally)
   if ($field eq 'priority' && !Bugzilla->params->{'letsubmitterchoosepriority'}) {
     $$PrivilegesRequired = PRIVILEGES_REQUIRED_ASSIGNEE;
     return 0;

--- a/Bugzilla/Constants.pm
+++ b/Bugzilla/Constants.pm
@@ -627,7 +627,7 @@ use constant MAX_WEBDOT_BUGS => 2000;
 # This is the name of the algorithm used to hash passwords before storing
 # them in the database. This can be any string that is valid to pass to
 # Perl's "Digest" module. Note that if you change this, it won't take
-# effect until a user changes his password.
+# effect until a user changes their password.
 use constant PASSWORD_DIGEST_ALGORITHM => 'SHA-256';
 
 # How long of a salt should we use? Note that if you change this, none
@@ -639,7 +639,7 @@ use constant PASSWORD_SALT_LENGTH => 8;
 # can be safely done or not based on the web server's URI length setting.
 use constant CGI_URI_LIMIT => 8000;
 
-# If the user isn't allowed to change a field, we must tell him who can.
+# If the user isn't allowed to change a field, we must tell them who can.
 # We store the required permission set into the $PrivilegesRequired
 # variable which gets passed to the error template.
 

--- a/Bugzilla/Flag.pm
+++ b/Bugzilla/Flag.pm
@@ -716,7 +716,7 @@ sub _check_requestee {
     # Make sure the user didn't specify a requestee unless the flag
     # is specifically requestable. For existing flags, if the requestee
     # was set before the flag became specifically unrequestable, the
-    # user can either remove him or leave him alone.
+    # user can either remove them or leave them alone.
     ThrowCodeError('flag_type_requestee_disabled', {type => $self->type})
       if !$self->type->is_requesteeble;
 

--- a/Bugzilla/Hook.pm
+++ b/Bugzilla/Hook.pm
@@ -681,7 +681,7 @@ about, and the value should always be C<1>. The "relationships"
 are described by the various C<REL_> constants in L<Bugzilla::Constants>.
 
 Here's an example of adding userid C<123> to the recipient list
-as though he were on the CC list:
+as though they were on the CC list:
 
  $recipients->{123}->{+REL_CC} = 1
 

--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -964,8 +964,8 @@ sub _populate_longdescs {
             if (!$who) {
 
               # This username doesn't exist.  Maybe someone
-              # renamed him or something.  Invent a new profile
-              # entry disabled, just to represent him.
+              # renamed them or something.  Invent a new profile
+              # entry disabled, just to represent them.
               $dbh->do(
                 "INSERT INTO profiles (login_name,
                                       cryptpassword, disabledtext)

--- a/Bugzilla/Migrate.pm
+++ b/Bugzilla/Migrate.pm
@@ -774,7 +774,7 @@ sub insert_bugs {
     my $super_user = Bugzilla->user;
     my $reporter   = Bugzilla::User->check($bug->{reporter});
 
-    # Allow the user to file a bug in any product, no matter his current
+    # Allow the user to file a bug in any product, no matter their current
     # permissions.
     $reporter->{groups} = $super_user->groups;
     Bugzilla->set_user($reporter);

--- a/Bugzilla/Product.pm
+++ b/Bugzilla/Product.pm
@@ -311,8 +311,8 @@ sub remove_from_db {
       require Bugzilla::Bug;
       foreach my $bug_id (@{$self->bug_ids}) {
 
-        # Note that we allow the user to delete bugs he can't see,
-        # which is okay, because he's deleting the whole Product.
+        # Note that we allow the user to delete bugs they can't see,
+        # which is okay, because they’re deleting the whole Product.
         my $bug = new Bugzilla::Bug($bug_id);
         $bug->remove_from_db();
       }
@@ -1142,7 +1142,7 @@ a group is valid in a particular product.)
 
  Params:      C<$user> - A Bugzilla::User object.
 
- Returns      C<1> If this user's groups allow him C<entry> access to
+ Returns      C<1> If this user's groups allow them C<entry> access to
               this Product, C<0> otherwise.
 
 =item C<flag_types()>

--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -3848,7 +3848,7 @@ value for this field. At least one search criteria must be defined if the
 
 =item C<sharer>
 
-When a saved search is shared by a user, this is his user ID.
+When a saved search is shared by a user, this is their user ID.
 
 =item C<user>
 

--- a/Bugzilla/Token.pm
+++ b/Bugzilla/Token.pm
@@ -102,7 +102,7 @@ sub issue_new_user_account_token {
   my $vars       = {};
 
   # Is there already a pending request for this login name? If yes, do not throw
-  # an error because the user may have lost his email with the token inside.
+  # an error because the user may have lost their email with the token inside.
   # But to prevent using this way to mailbomb an email address, make sure
   # the last request is at least 10 minutes old before sending a new email.
 
@@ -131,7 +131,7 @@ sub issue_new_user_account_token {
 
   # In 99% of cases, the user getting the confirmation email is the same one
   # who made the request, and so it is reasonable to send the email in the same
-  # language used to view the "Create a New Account" page (we cannot use his
+  # language used to view the "Create a New Account" page (we cannot use their
   # user prefs as the user has no account yet!).
   MessageToMTA($message);
 }
@@ -203,7 +203,7 @@ sub IssuePasswordToken {
   $vars->{'emailaddress'}  = $user->email;
   $vars->{'expiration_ts'} = ctime($token_ts + MAX_TOKEN_AGE * 86400);
 
-  # The user is not logged in (else he wouldn't request a new password).
+  # The user is not logged in (else they wouldn't request a new password).
   # So we have to pass this information to the template.
   $vars->{'timezone'} = $user->timezone;
 
@@ -494,7 +494,7 @@ sub check_token_data {
   {
     # Something is going wrong. Ask confirmation before processing.
     # It is possible that someone tried to trick an administrator.
-    # In this case, we want to know his name!
+    # In this case, we want to know their name!
     require Bugzilla::User;
 
     my $vars = {};
@@ -634,7 +634,7 @@ Bugzilla::Token - Provides different routines to manage tokens.
  Description: Creates and sends a token per email to the email address
               requesting a new user account. It doesn't check whether
               the user account already exists. The user will have to
-              use this token to confirm the creation of his user account.
+              use this token to confirm the creation of their user account.
 
  Params:      $login_name - The new login name requested by the user.
 
@@ -657,7 +657,7 @@ Bugzilla::Token - Provides different routines to manage tokens.
 
  Description: Sends a token per email to the given user. This token
               can be used to change the password (e.g. in case the user
-              cannot remember his password and wishes to enter a new one).
+              cannot remember their password and wishes to enter a new one).
 
  Params:      $user - User object of the user requesting a new password.
 
@@ -687,7 +687,7 @@ Bugzilla::Token - Provides different routines to manage tokens.
 
  Description: Invalidates an existing token, generally when the token is used
               for an action which is not the one expected. An email is sent
-              to the user who originally requested this token to inform him
+              to the user who originally requested this token to inform them
               that this token has been invalidated (e.g. because an hacker
               tried to use this token for some malicious action).
 
@@ -700,7 +700,7 @@ Bugzilla::Token - Provides different routines to manage tokens.
 =item C<DeletePasswordTokens($user_id, $reason)>
 
  Description: Cancels all password tokens for the given user. Emails are sent
-              to the user to inform him about this action.
+              to the user to inform them about this action.
 
  Params:      $user_id: The user ID of the user account whose password tokens
                         are canceled.

--- a/Bugzilla/User.pm
+++ b/Bugzilla/User.pm
@@ -751,7 +751,7 @@ sub name_or_login {
 }
 
 # Generate a string to identify the user by name + login if the user
-# has a name or by login only if she doesn't.
+# has a name or by login only if they don’t.
 sub identity {
   my $self = shift;
 
@@ -1771,7 +1771,7 @@ sub check_can_admin_flagtype {
     my $e         = $flagtype->exclusions_as_hash;
 
     # If there is at least one product for which the user doesn't have
-    # editcomponents privs, then don't allow him to do everything with
+    # editcomponents privs, then don't allow them to do everything with
     # this flagtype, independently of whether this product is in the
     # exclusion list or not.
     my %product_ids;
@@ -2678,7 +2678,7 @@ sub create {
 
   # Add the creation date to the profiles_activity table.
   # $who is the user who created the new user account, i.e. either an
-  # admin or the new user himself.
+  # admin or the new user themselves.
   my $who = Bugzilla->user->id || $user->id;
   my $creation_date_fieldid = get_field_id('creation_ts');
 
@@ -3094,7 +3094,7 @@ Returns the 'real' name for this user, if any.
 
 =item C<showmybugslink>
 
-Returns C<1> if the user has set his preference to show the 'My Bugs' link in
+Returns C<1> if the user has set their preference to show the 'My Bugs' link in
 the page footer, and C<0> otherwise.
 
 =item C<identity>
@@ -3187,7 +3187,7 @@ that you need to be able to see a group in order to bless it.
 =item C<get_products_by_permission($group)>
 
 Returns a list of product objects for which the user has $group privileges
-and which he can access.
+and which they can access.
 $group must be one of the groups defined in PER_PRODUCT_PRIVILEGES.
 
 =item C<can_see_user(user)>
@@ -3299,7 +3299,7 @@ not be aware of the existence of the product.
  Description: Checks whether the user is allowed to edit properties of the flag type.
               If the flag type is also used by some products for which the user
               hasn't editcomponents privs, then the user is only allowed to edit
-              the inclusion and exclusion lists for products he can administrate.
+              the inclusion and exclusion lists for products they can administrate.
 
  Params:      $flagtype_id - a flag type ID.
 
@@ -3437,7 +3437,7 @@ Params: login_name - B<Required> The login name for the new user.
             a plain-text password. If you specify '*', the user will not
             be able to log in using DB authentication.
         disabledtext - The disable-text for the new user. If given, the user
-            will be disabled, meaning he cannot log in. Defaults to an
+            will be disabled, meaning they cannot log in. Defaults to an
             empty string.
         disable_mail - If 1, bug-related mail will not be  sent to this user;
             if 0, mail will be sent depending on the user's  email preferences.
@@ -3468,8 +3468,8 @@ Params: $username (scalar, string) - The full login name of the username
             that you are checking.
         $old_username (scalar, string) - If you are checking an email-change
             token, insert the "old" username that the user is changing from,
-            here. Then, as long as it's the right user for that token, he
-            can change his username to $username. (That is, this function
+            here. Then, as long as it's the right user for that token, they
+            can change their username to $username. (That is, this function
             will return a boolean true value).
 
 =item C<login_to_id($login, $throw_error)>

--- a/Bugzilla/Util.pm
+++ b/Bugzilla/Util.pm
@@ -1253,7 +1253,7 @@ template. Just pass in the name of the variable that you want the value of.
 Takes a time and converts it to the desired format and timezone.
 If no format is given, the routine guesses the correct one and returns
 an empty array if it cannot. If no timezone is given, the user's timezone
-is used, as defined in his preferences.
+is used, as defined in their preferences.
 
 This routine is mainly called from templates to filter dates, see
 "FILTER time" in L<Bugzilla::Template>.

--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -2957,7 +2957,7 @@ C<boolean> True if this bug is open, false if it is closed.
 =item C<is_creator_accessible>
 
 C<boolean> If true, this bug can be accessed by the creator (reporter)
-of the bug, even if he or she is not a member of the groups the bug
+of the bug, even if they’re not a member of the groups the bug
 is restricted to.
 
 =item C<keywords>
@@ -4695,7 +4695,7 @@ C<string> The full login name of the bug's QA Contact.
 =item C<is_creator_accessible>
 
 C<boolean> Whether or not the bug's reporter is allowed to access
-the bug, even if he or she isn't in a group that can normally access
+the bug, even if they aren’t in a group that can normally access
 the bug.
 
 =item C<regressed_by>

--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -245,7 +245,7 @@ sub get {
   my $obj_by_ids;
   $obj_by_ids = Bugzilla::User->new_from_list($params->{ids}) if $params->{ids};
 
-  # obj_by_ids are only visible to the user if he can see
+  # obj_by_ids are only visible to the user if they can see
   # the otheruser, for non visible otheruser throw an error
   foreach my $obj (@$obj_by_ids) {
     if (Bugzilla->user->can_see_user($obj)) {
@@ -587,7 +587,7 @@ error.
 =item 305 (New Password Required)
 
 The current password is correct, but the user is asked to change
-his password.
+their password.
 
 =item 50 (Param Required)
 
@@ -1218,7 +1218,7 @@ error.
 =item 305 (New Password Required)
 
 The current password is correct, but the user is asked to change
-his password.
+their password.
 
 =back
 

--- a/buglist.cgi
+++ b/buglist.cgi
@@ -268,7 +268,7 @@ sub GetGroups {
 
     foreach my $gid (keys %{$product->group_controls}) {
 
-      # The user can only edit groups he belongs to.
+      # The user can only edit groups they belong to.
       next unless $user->in_group_id($gid);
 
       # The user has no control on groups marked as NA or MANDATORY.
@@ -379,7 +379,7 @@ if ($cmdtype eq "dorem") {
       = LookupNamedQuery(scalar $cgi->param("namedcmd"), $user->id);
     if ($query_id) {
 
-      # Make sure the user really wants to delete his saved search.
+      # Make sure the user really wants to delete their saved search.
       my $token = $cgi->param('token');
       check_hash_token($token, [$query_id, $qname]);
 

--- a/describecomponents.cgi
+++ b/describecomponents.cgi
@@ -60,7 +60,7 @@ unless ($product && $user->can_access_product($product->name)) {
   # If there is only one product available but the user entered
   # another product name, we display a list with this single
   # product only, to not confuse the user with components of a
-  # product he didn't request.
+  # product they didn't request.
   elsif (scalar(@products) > 1 || $product_name) {
     $vars->{'classifications'} = [{object => undef, products => \@products}];
     $vars->{'target'} = "describecomponents.cgi";

--- a/docs/en/rst/administering/users.rst
+++ b/docs/en/rst/administering/users.rst
@@ -101,7 +101,7 @@ fields:
   checkboxes will appear here to allow you to add users to, or
   remove them from, these groups. The first checkbox gives the
   user the ability to add and remove other users as members of
-  this group. The second checkbox adds the user himself as a member
+  this group. The second checkbox adds the user themselves as a member
   of the group.
 
 - *canconfirm*:
@@ -193,7 +193,7 @@ can create user accounts for other users:
       addresses which are a mailing list), in general it is
       preferable to log out and use the ``New Account``
       button to create users, as it will pre-populate all the
-      required fields and also notify the user of her account name
+      required fields and also notify the user of their account name
       and password.
 
 .. _user-account-deletion:

--- a/editflagtypes.cgi
+++ b/editflagtypes.cgi
@@ -74,7 +74,7 @@ if (my ($category_action)
   if ($category_action =~ /^(in|ex)clude$/) {
     if (!$user->in_group('editcomponents') && !$product) {
 
-      # The user can only add the flag type to products he can administrate.
+      # The user can only add the flag type to products they can administrate.
       foreach my $prod (@products) {
         push(@categories, $prod->id . ':0');
       }

--- a/extensions/BMO/web/js/sorttable.js
+++ b/extensions/BMO/web/js/sorttable.js
@@ -302,7 +302,7 @@ sorttable = {
       /* and comment out this one */
       //rows.sort(cell.sorttable_sortfunction);
 
-      // Rebuild the table, using he sorted rows.
+      // Rebuild the table, using the sorted rows.
       tb = cell.table.sorttable_bodies[0];
       body_size = cell.table.sorttable_body_size;
       body_index = 0;

--- a/extensions/Example/Extension.pm
+++ b/extensions/Example/Extension.pm
@@ -336,7 +336,7 @@ sub bugmail_recipients {
     # were on the CC list.
     #$recipients->{$user->id}->{+REL_CC} = 1;
 
-    # And this line adds the maintainer as though he had the "REL_EXAMPLE"
+    # And this line adds the maintainer as though they had the "REL_EXAMPLE"
     # relationship from the bugmail_relationships hook below.
     #$recipients->{$user->id}->{+REL_EXAMPLE} = 1;
   }
@@ -418,8 +418,8 @@ sub email_in_after_parse {
   # No other check needed if this is a valid regular user.
   return if login_to_id($reporter);
 
-  # The reporter is not a regular user. We create an account for him,
-  # but he can only comment on existing bugs.
+  # The reporter is not a regular user. We create an account for them,
+  # but they can only comment on existing bugs.
   # This is useful for people who reply by email to bugmails received
   # in mailing-lists.
   if ($args->{fields}->{bug_id}) {

--- a/extensions/MozProjectReview/template/en/default/bug/create/comment-moz-project-review.txt.tmpl
+++ b/extensions/MozProjectReview/template/en/default/bug/create/comment-moz-project-review.txt.tmpl
@@ -39,10 +39,10 @@ If yes, is the person primarily being engaged due to a temporary increase in wor
 [%+ cgi.param('independent_contractor_dupe_services_temp') %]
 [% END %]
 
-Will the person be managing his or her own time?
+Will the person be managing their own time?
 [%+ cgi.param('independent_contractor_self_manage') %]
 
-Will the person be using his or her own equipment?
+Will the person be using their own equipment?
 [%+ cgi.param('independent_contractor_own_equipment') %]
 
 Will the person be regularly working at a Mozilla facility?

--- a/extensions/MozProjectReview/template/en/default/bug/create/create-moz-project-review.html.tmpl
+++ b/extensions/MozProjectReview/template/en/default/bug/create/create-moz-project-review.html.tmpl
@@ -335,7 +335,7 @@
     <div id="independent_contractor_self_manage_row" class="field_row">
       <span class="field_label required"a>Self Managed:</span>
       <span class="field_data">
-        <div class="field_description">Will the person be managing his or her own time?</div>
+        <div class="field_description">Will the person be managing their own time?</div>
         <select name="independent_contractor_self_manage" id="independent_contractor_self_manage">
           <option value="">Select One</option>
           <option value="Yes">Yes</option>
@@ -347,7 +347,7 @@
 -    <div id="independent_contractor_own_equipment_row" class="field_row">
       <span class="field_label required">Own Equipment:</span>
       <span class="field_data">
-        <div class="field_description">Will the person be using his or her own equipment?</div>
+        <div class="field_description">Will the person be using their own equipment?</div>
         <select name="independent_contractor_own_equipment" id="independent_contractor_own_equipment">
           <option value="">Select One</option>
           <option value="Yes">Yes</option>

--- a/extensions/REMO/template/en/default/bug/create/created-mozreps.html.tmpl
+++ b/extensions/REMO/template/en/default/bug/create/created-mozreps.html.tmpl
@@ -37,7 +37,7 @@
 <ul>
   <li>The mozillians who vouched you should comment on the application [% terms.bug %] endorsing your application. Please contact them to make sure they endorse you, this is needed for your application to be complete.</li>
   <li>The application will be reviewed after you are endorsed and if it fits all requirements it will be placed in the mentorship queue.</li>
-  <li>Once a Rep mentor has a free slot, he will be assigned to do the final review.</li>
+  <li>Once a Rep mentor has a free slot, they will be assigned to do the final review.</li>
 </ul>
 
 <p>

--- a/extensions/REMO/template/en/default/bug/create/created-remo-budget.html.tmpl
+++ b/extensions/REMO/template/en/default/bug/create/created-remo-budget.html.tmpl
@@ -16,7 +16,7 @@
 
 <p>
   Your budget request has been successfully submitted. Please make sure to
-  follow-up with your mentor so (s)he can verify your request. CC him/her
+  follow-up with your mentor so they can verify your request. CC them
   on the [% terms.bug %] if needed.
 </p>
 

--- a/importxml.pl
+++ b/importxml.pl
@@ -1217,7 +1217,7 @@ sub process_bug {
     if (!$attacher_id) {
       if ($att->{'attacher'}) {
         $err .= "The original submitter of attachment $att_id was\n   ";
-        $err .= $att->{'attacher'} . ", but he doesn't have an account here.\n";
+        $err .= $att->{'attacher'} . ", but they don’t have an account here.\n";
       }
       else {
         $err .= "The original submitter of attachment $att_id is unknown.\n";

--- a/qa/extensions/QA/Extension.pm
+++ b/qa/extensions/QA/Extension.pm
@@ -27,7 +27,7 @@ sub page_before_template {
   my $cgi      = Bugzilla->cgi;
   print $cgi->header;
 
-  # Needed to make sure he can access and edit bugs.
+  # Needed to make sure they can access and edit bugs.
   my $user = Bugzilla::User->check($cgi->param('sender'));
   Bugzilla->set_user($user);
 

--- a/qa/t/test_bug_edit.t
+++ b/qa/t/test_bug_edit.t
@@ -112,8 +112,8 @@ check_page_load($sel, qq{http://HOSTNAME/show_bug.cgi?id=$bug1_id});
 $sel->is_text_present_ok("Changes submitted for bug $bug1_id");
 logout($sel);
 
-# The admin is not in the mandatory group, but he has been CC'ed,
-# so he can view and edit the bug (as he has editbugs privs by inheritance).
+# The admin is not in the mandatory group, but they have been CC'ed,
+# so they can view and edit the bug (as they have editbugs privs by inheritance).
 
 log_in($sel, $config, 'admin');
 go_to_bug($sel, $bug1_id);
@@ -136,7 +136,7 @@ check_page_load($sel, qq{http://HOSTNAME/show_bug.cgi?id=$bug1_id});
 $sel->is_text_present_ok("Changes submitted for bug $bug1_id");
 logout($sel);
 
-# The powerless user can see the restricted bug, as he has been CC'ed.
+# The powerless user can see the restricted bug, as they have been CC'ed.
 
 log_in($sel, $config, 'unprivileged');
 go_to_bug($sel, $bug1_id);
@@ -269,7 +269,7 @@ $sel->click_ok("submit");
 check_page_load($sel, q{http://HOSTNAME/editproducts.cgi});
 $sel->title_is("Update group access controls for TestProduct");
 
-# The user is in the master group, so he can comment.
+# The user is in the master group, so they can comment.
 
 go_to_bug($sel, $bug1_id);
 $sel->type_ok("comment", "Do nothing except adding a comment...");
@@ -278,7 +278,7 @@ check_page_load($sel, qq{http://HOSTNAME/show_bug.cgi?id=$bug1_id});
 $sel->is_text_present_ok("Changes submitted for bug $bug1_id");
 logout($sel);
 
-# This user is not in the master group, so he cannot comment.
+# This user is not in the master group, so they cannot comment.
 
 log_in($sel, $config, 'QA_Selenium_TEST');
 go_to_bug($sel, $bug1_id);

--- a/qa/t/test_flags.t
+++ b/qa/t/test_flags.t
@@ -399,8 +399,8 @@ $sel->select_ok("flag_type-$aflagtype1_id", "label=?");
 $sel->type_ok("requestee_type-$aflagtype1_id", $config->{admin_user_login});
 $sel->select_ok("flag_type-$aflagtype2_id", "label=?");
 
-# The requestee is not in the Master group, and so he cannot view the bug.
-# He must be silently skipped from the requestee field.
+# The requestee is not in the Master group, and so they cannot view the bug.
+# They must be silently skipped from the requestee field.
 $sel->type_ok("requestee_type-$aflagtype2_id",
   $config->{unprivileged_user_login});
 $sel->type_ok("comment", "second patch, with requestee");
@@ -522,7 +522,7 @@ $sel->is_element_present_ok(
 );
 logout($sel);
 
-# Final tests as an admin. He has editbugs privs, so he can edit
+# Final tests as an admin. They have editbugs privs, so they can edit
 # someone else's patch.
 
 log_in($sel, $config, 'admin');

--- a/qa/t/test_flags2.t
+++ b/qa/t/test_flags2.t
@@ -216,7 +216,7 @@ $sel->is_element_present_ok(
 );
 
 # File a bug in 'Another Product / c2' and assign it
-# to a powerless user, so that he can move it later.
+# to a powerless user, so that they can move it later.
 
 file_bug_in_product($sel, 'Another Product');
 $sel->select_ok("component", "label=c2");

--- a/qa/t/test_private_attachments.t
+++ b/qa/t/test_private_attachments.t
@@ -101,7 +101,7 @@ foreach my $user (undef, 'unprivileged') {
   $sel->is_text_present_ok("this patch is public. Everyone can see it.");
 }
 
-# A powerless user can comment on attachments he doesn't own.
+# A powerless user can comment on attachments they don’t own.
 
 $sel->click_ok('//a[contains(@href,"/attachment.cgi?id='
     . $attachment1_id
@@ -177,7 +177,7 @@ $sel->is_text_present_ok("This is my patch!");
 ok(!$sel->is_text_present("Making the powerless user's patch private"),
   "Private comment not visible to logged out users");
 
-# A powerless user can only see private attachments he owns.
+# A powerless user can only see private attachments they own.
 
 log_in($sel, $config, 'unprivileged');
 go_to_bug($sel, $bug1_id);

--- a/qa/t/test_qa_contact.t
+++ b/qa/t/test_qa_contact.t
@@ -35,8 +35,8 @@ if ($sel->is_element_present(
 }
 
 # Enable the QA contact field and file a new bug restricted to the 'Master' group
-# with a powerless user as the QA contact. He should only be able to access the
-# bug if the QA contact field is enabled, else he looses this privilege.
+# with a powerless user as the QA contact. They should only be able to access the
+# bug if the QA contact field is enabled, else they loose this privilege.
 
 set_parameters($sel, {"Bug Fields" => {"useqacontact-on" => undef}});
 file_bug_in_product($sel, 'TestProduct');
@@ -189,8 +189,8 @@ $sel->value_is(
 $sel->type_ok("qa_contact", " ");
 $sel->click_ok('bottom-save-btn');
 
-# The user is no longer the QA contact, and he has no other role
-# with the bug. He can no longer see it.
+# The user is no longer the QA contact, and they have no other role
+# with the bug. They can no longer see it.
 
 $sel->wait_for_page_to_load_ok(WAIT_TIME);
 $sel->title_is("Access Denied");

--- a/qa/t/test_shared_searches.t
+++ b/qa/t/test_shared_searches.t
@@ -151,7 +151,7 @@ $sel->title_is("User Preferences");
 logout($sel);
 
 # Log in as admin again. The other user is not a blesser for the 'canconfirm'
-# group, and so his shared search must not be displayed by default. But it
+# group, and so their shared search must not be displayed by default. But it
 # must still be available and can be added to the Search Bar, if desired.
 
 log_in($sel, $config, 'admin');
@@ -211,7 +211,7 @@ ok(
 logout($sel);
 
 # Make sure that the 'helpwanted' query is not shared with the QA_Selenium_TEST
-# user as he doesn't belong to the 'canconfirm' group.
+# user as they don’t belong to the 'canconfirm' group.
 
 log_in($sel, $config, 'QA_Selenium_TEST');
 $sel->click_ok("quicksearch_top");

--- a/qa/t/test_show_all_products.t
+++ b/qa/t/test_show_all_products.t
@@ -39,7 +39,7 @@ ok(
 logout($sel);
 
 # Same steps, but for a member of the "QA‑Selenium‑TEST" group.
-# The "QA‑Selenium‑TEST" product must be visible to him.
+# The "QA‑Selenium‑TEST" product must be visible to them.
 
 log_in($sel, $config, 'QA_Selenium_TEST');
 $sel->click_ok('//*[@class="link-file"]//a');

--- a/qa/t/test_sudo_sessions.t
+++ b/qa/t/test_sudo_sessions.t
@@ -22,7 +22,7 @@ set_parameters($sel, {"Group Security" => {"usevisibilitygroups-on" => undef}});
 
 # You can see all users from editusers.cgi, but once you leave this page,
 # usual group visibility restrictions apply and the "powerless" user cannot
-# be sudo'ed as he is in no group.
+# be sudo'ed as they’re in no group.
 
 go_to_admin($sel);
 $sel->click_ok("link=Users");
@@ -90,7 +90,7 @@ ok(
 );
 
 # Make sure this user is not an admin and has no privs at all, and that
-# he cannot access editusers.cgi (despite the sudoer can).
+# they cannot access editusers.cgi (despite the sudoer can).
 
 $sel->click_ok('header-account-menu-button');
 $sel->click_ok("link=Preferences");

--- a/qa/t/test_user_matching.t
+++ b/qa/t/test_user_matching.t
@@ -114,7 +114,7 @@ set_parameters(
 );
 
 # By default, groups are not visible to themselves, so we have to enable this.
-# The tweakparams user has not enough privs to do it himself.
+# The tweakparams user has not enough privs to do it themselves.
 
 logout($sel);
 log_in($sel, $config, 'admin');
@@ -139,7 +139,7 @@ log_in($sel, $config, 'tweakparams');
 go_to_bug($sel, $test_bug_1);
 $sel->click_ok("add-cc-btn");
 
-# We are not in the same groups as the unprivileged user, so we cannot see him.
+# We are not in the same groups as the unprivileged user, so we cannot see them.
 
 $sel->type_ok("add-cc", $config->{unprivileged_user_login_truncated});
 $sel->click_ok('bottom-save-btn');

--- a/qa/t/webservice_bug_update.t
+++ b/qa/t/webservice_bug_update.t
@@ -508,7 +508,7 @@ sub invalid_values {
         test  => 'non-numeric estimated_time fails'
       },
 
-      # We use PRIVATE_BUG_USER because he can modify the bug, but
+      # We use PRIVATE_BUG_USER because they can modify the bug, but
       # can't change time-tracking fields.
       {
         value => '100',
@@ -626,7 +626,7 @@ sub invalid_values {
         test  => 'non-numeric remaining_time fails'
       },
 
-      # We use PRIVATE_BUG_USER because he can modify the bug, but
+      # We use PRIVATE_BUG_USER because they can modify the bug, but
       # can't change time-tracking fields.
       {
         value => '100',
@@ -730,7 +730,7 @@ sub invalid_values {
         test  => 'non-numeric work_time fails'
       },
 
-      # We use PRIVATE_BUG_USER because he can modify the bug, but
+      # We use PRIVATE_BUG_USER because they can modify the bug, but
       # can't change time-tracking fields.
       {
         value => '10',

--- a/qa/t/webservice_user_get.t
+++ b/qa/t/webservice_user_get.t
@@ -46,7 +46,7 @@ my @tests = (
   {
     user => 'unprivileged',
     args => {names => [$get_user]},
-    test => "Unprivileged user can get himself",
+    test => "Unprivileged user can get themselves",
   },
   {
     user => 'unprivileged',
@@ -130,7 +130,7 @@ my @tests = (
   {
     user => 'canconfirm',
     args => {names => [$canconfirm_user]},
-    test => 'Privileged user can get himself',
+    test => 'Privileged user can get themselves',
   },
   {
     user => 'editbugs',
@@ -180,7 +180,7 @@ sub post_success {
 
   # FIXME: We have no way to create a saved search or a saved report from
   #        the WebService, so we cannot test that the correct data is returned
-  #        if the user is accessing his own account.
+  #        if the user is accessing their own account.
   if ($username eq $item->{name}) {
     ok(exists $item->{saved_searches},
       'Users can get the list of saved searches and reports for their own account');
@@ -195,7 +195,7 @@ sub post_success {
   my @groups = map { $_->{name} } @{$item->{groups}};
 
   # Admins can see all groups a user belongs to (assuming they inherited
-  # membership for all groups). Same for a user querying his own account.
+  # membership for all groups). Same for a user querying their own account.
   if ($username eq $item->{name} || $user eq 'admin') {
     if ($username eq $get_user) {
       ok(!scalar @groups, "The unprivileged user doesn't belong to any group");

--- a/request.cgi
+++ b/request.cgi
@@ -45,7 +45,7 @@ print $cgi->header($format->{'ctype'});
 my $fields;
 $fields->{'requester'}->{'type'} = 'single';
 
-# If the user doesn't restrict his search to requests from the wind
+# If the user doesn't restrict their search to requests from the wind
 # (requestee ne '-'), include the requestee for completion.
 unless (defined $cgi->param('requestee') && $cgi->param('requestee') eq '-') {
   $fields->{'requestee'}->{'type'} = 'single';

--- a/show_bug.cgi
+++ b/show_bug.cgi
@@ -66,8 +66,8 @@ if ($format_params->{format} eq 'modal') {
 my @bugs;
 my %marks;
 
-# If the user isn't logged in, we use data from the shadow DB. If he plans
-# to edit the bug(s), he will have to log in first, meaning that the data
+# If the user isn't logged in, we use data from the shadow DB. If they plan
+# to edit the bug(s), they will have to log in first, meaning that the data
 # will be reloaded anyway, from the main DB.
 Bugzilla->switch_to_shadow_db unless $user->id;
 

--- a/template/en/default/admin/confirm-action.html.tmpl
+++ b/template/en/default/admin/confirm-action.html.tmpl
@@ -21,7 +21,7 @@
   # expected_action: the action the user was going to do.
   # script_name: the script generating this warning.
   # alternate_script: the suggested script to redirect the user to
-  #                   if he declines submission.
+  #                   if they decline submission.
   #%]
 
 [% PROCESS "global/field-descs.none.tmpl" %]

--- a/template/en/default/admin/params/auth.html.tmpl
+++ b/template/en/default/admin/params/auth.html.tmpl
@@ -166,7 +166,7 @@
                       </li>
                       <li>
                         defaulton/defaultoff - Default behavior as described
-                        above, but user can choose whether $terms.Bugzilla will remember his
+                        above, but user can choose whether $terms.Bugzilla will remember their
                         login or not.
                       </li>
                     </ul>",

--- a/template/en/default/admin/params/query.html.tmpl
+++ b/template/en/default/admin/params/query.html.tmpl
@@ -56,8 +56,8 @@
     "parameter permits to block the execution of queries with no criteria. " _
     "When turned off, a query must have some criteria specified to limit " _
     "the number of $terms.bugs returned to the user. When turned on, a user " _
-    "is allowed to run a query with no criteria and get all $terms.bugs he can " _
-    "see in his list. Turning this parameter on is not recommended on large " _
+    "is allowed to run a query with no criteria and get all $terms.bugs they can " _
+    "see in their list. Turning this parameter on is not recommended on large " _
     "installations.",
 
   default_search_limit =>

--- a/template/en/default/bug/process/confirm-duplicate.html.tmpl
+++ b/template/en/default/bug/process/confirm-duplicate.html.tmpl
@@ -46,7 +46,7 @@
   [% ELSE %]
     might, in the future,
   [% END %]
-  allow him/her access to view this [% terms.bug %].</b>
+  allow them access to view this [% terms.bug %].</b>
   Do you wish to do this?
 </p>
 

--- a/template/en/default/pages/quicksearch.html.tmpl
+++ b/template/en/default/pages/quicksearch.html.tmpl
@@ -389,7 +389,7 @@
   <a href="[% basepath FILTER none %]query.cgi?format=advanced">Advanced Search</a> form.</p>
 
 <ul class="qs_help">
-  <li>All [% terms.bugs %] reported by userA@company.com or assigned to him
+  <li>All [% terms.bugs %] reported by userA@company.com or assigned to them
     (the initial @ is a shortcut for the assignee, see the
     <a href="#shortcuts">Advanced Shortcuts</a> section above):<br>
     <kbd>ALL @userA@company.com OR reporter:userA@company.com</kbd></li>

--- a/template/en/default/pages/release-notes3.html.tmpl
+++ b/template/en/default/pages/release-notes3.html.tmpl
@@ -2885,9 +2885,9 @@
   &quot;subscribe&quot; to those searches, and have them appear
   in their footer.</p>
 
-<p>If the sharer can &quot;bless&quot; the group he's sharing to,
-  (that is, if he can add users to that group), it's considered
-  that he's a manager of that group, and his queries show up
+<p>If the sharer can &quot;bless&quot; the group they’re sharing to,
+  (that is, if they can add users to that group), it's considered
+  that they’re a manager of that group, and their queries show up
   automatically in that group's footer (although they can
   unsubscribe from any particular search, if they want.)</p>
 

--- a/template/en/default/welcome-admin.html.tmpl
+++ b/template/en/default/welcome-admin.html.tmpl
@@ -55,7 +55,7 @@
 
     <li><a href="[% basepath FILTER none %]editparams.cgi?section=auth#createemailregexp_desc">createemailregexp</a>
     defines which users are allowed to create an account on this installation. If set
-    to ".*" (the default), everybody is free to create his own account. If set to
+    to ".*" (the default), everybody is free to create their own account. If set to
     "@mycompany.com$", only users having an account @mycompany.com will be allowed to
     create an account. If left blank, users will not be able to create accounts themselves;
     only an administrator will be able to create one for them. If you want a private

--- a/token.cgi
+++ b/token.cgi
@@ -428,11 +428,11 @@ sub confirm_create_account {
   # Now delete this token.
   delete_token($token);
 
-  # Let the user know that his user account has been successfully created.
+  # Let the user know that their user account has been successfully created.
   $vars->{'message'}   = 'account_created';
   $vars->{'otheruser'} = $otheruser;
 
-  # Log in the new user using credentials he just gave.
+  # Log in the new user using credentials they just gave.
   $cgi->param('Bugzilla_login',    $otheruser->login);
   $cgi->param('Bugzilla_password', $password1);
   Bugzilla->login(LOGIN_OPTIONAL);

--- a/userprefs.cgi
+++ b/userprefs.cgi
@@ -544,7 +544,7 @@ sub DoPermissions {
     }
   }
 
-  # If the user has product specific privileges, inform him about that.
+  # If the user has product specific privileges, inform them about that.
   foreach my $privs (PER_PRODUCT_PRIVILEGES) {
     next if $user->in_group($privs);
     $vars->{"local_$privs"} = $user->get_products_by_permission($privs);
@@ -621,7 +621,7 @@ sub SaveSavedSearches {
 
     if ($group_id) {
 
-      # Don't allow the user to share queries with groups he's not
+      # Don't allow the user to share queries with groups they’re not
       # allowed to.
       next unless grep($_ eq $group_id, @{$user->queryshare_groups});
 


### PR DESCRIPTION
Use gender-neutral pronouns instead of he/his/she/her, etc. because it’s 2019.

## Bugzilla link

[Bug 1573227 - Various UI text and code comments assume male gender](https://bugzilla.mozilla.org/show_bug.cgi?id=1573227)