### PR TITLE
Bug 1572945 - Cannot enter bug through Guided Bug Form if the product’s default platform is auto-detect

### DIFF
--- a/extensions/GuidedBugEntry/web/js/guided.js
+++ b/extensions/GuidedBugEntry/web/js/guided.js
@@ -724,10 +724,21 @@ var bugForm = {
     }
     bugForm.onVersionChange(elVersions.value);
 
-    // set default hw/os/group
-    Dom.get('rep_platform').value = product.details.default_platform;
-    Dom.get('op_sys').value = product.details.default_op_sys;
-    Dom.get('groups').value = product.details.default_security_group;
+    // Set default Platform, OS and Security Group
+    // Skip if the default value is empty = auto-detect
+    const { default_platform, default_op_sys, default_security_group } = product.details;
+
+    if (default_platform) {
+      document.querySelector('#rep_platform').value = default_platform;
+    }
+
+    if (default_op_sys) {
+      document.querySelector('#op_sys').value = default_op_sys;
+    }
+
+    if (default_security_group) {
+      document.querySelector('#groups').value = default_security_group;
+    }
   },
 
   onComponentChange: function(componentName) {


### PR DESCRIPTION
Don’t set the hidden `rep_platform` and `op_sys` fields when the default values are empty = auto-detect. Just use All/All as hardcoded in the guided bug form template.

## Bugzilla link

[Bug 1572945 - Cannot enter bug through Guided Bug Form if the product’s default platform is auto-detect](https://bugzilla.mozilla.org/show_bug.cgi?id=1572945)