### PR TITLE
Bug 1574792 - Bugzilla has suffered an internal error:  Bugzilla cannot log you into an external site via GitHub.

### DIFF
--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -123,21 +123,6 @@ sub new {
   return $self;
 }
 
-sub target_uri {
-  my ($self) = @_;
-
-  my $base = Bugzilla->localconfig->urlbase;
-  if (my $request_uri = $self->request_uri) {
-    my $base_uri = URI->new($base);
-    $base_uri->path('');
-    $base_uri->query(undef);
-    return $base_uri . $request_uri;
-  }
-  else {
-    return $base . ($self->url(-relative => 1, -query => 1) || 'index.cgi');
-  }
-}
-
 # We want this sorted plus the ability to exclude certain params
 sub canonicalize_query {
   my ($self, @exclude) = @_;

--- a/extensions/GitHubAuth/lib/Client.pm
+++ b/extensions/GitHubAuth/lib/Client.pm
@@ -37,14 +37,6 @@ sub new {
   return $self;
 }
 
-sub login_uri {
-  my ($class, $target_uri) = @_;
-
-  my $uri = URI->new(Bugzilla->localconfig->urlbase . "github.cgi");
-  $uri->query_form(target_uri => $target_uri);
-  return $uri;
-}
-
 sub authorize_uri {
   my ($class, $state) = @_;
 

--- a/extensions/GitHubAuth/template/en/default/hook/account/auth/login-additional_methods.html.tmpl
+++ b/extensions/GitHubAuth/template/en/default/hook/account/auth/login-additional_methods.html.tmpl
@@ -9,7 +9,7 @@
 [% IF Param('user_info_class').split(',').contains('GitHubAuth') %]
   <form method="post" action="[% basepath FILTER html %]github.cgi">
     <input type="hidden" name="github_secret" value="[% Bugzilla.github_secret FILTER html %]">
-    <input type="hidden" name="target_uri" value="[% Bugzilla.cgi.target_uri FILTER html %]">
+    <input type="hidden" name="target_uri" value="[% basepath FILTER html %]github.cgi">
     <input type="image" src="[% basepath FILTER none %]extensions/GitHubAuth/web/images/github_sign_in.png"
            alt="Sign in with GitHub"
            title="Sign in with GitHub"

--- a/extensions/GitHubAuth/template/en/default/hook/account/auth/login-additional_methods.html.tmpl
+++ b/extensions/GitHubAuth/template/en/default/hook/account/auth/login-additional_methods.html.tmpl
@@ -9,7 +9,7 @@
 [% IF Param('user_info_class').split(',').contains('GitHubAuth') %]
   <form method="post" action="[% basepath FILTER html %]github.cgi">
     <input type="hidden" name="github_secret" value="[% Bugzilla.github_secret FILTER html %]">
-    <input type="hidden" name="target_uri" value="[% basepath FILTER html %]github.cgi">
+    <input type="hidden" name="target_uri" value="[% urlbase FILTER html %]index.cgi">
     <input type="image" src="[% basepath FILTER none %]extensions/GitHubAuth/web/images/github_sign_in.png"
            alt="Sign in with GitHub"
            title="Sign in with GitHub"

--- a/extensions/GitHubAuth/template/en/default/hook/account/auth/login-small-additional_methods.html.tmpl
+++ b/extensions/GitHubAuth/template/en/default/hook/account/auth/login-small-additional_methods.html.tmpl
@@ -11,7 +11,7 @@
   <span id="github_mini_login[% qs_suffix FILTER html %]" class="mini_login[% qs_suffix FILTER html %]">
     <form method="post" action="[% basepath FILTER html %]github.cgi">
       <input type="hidden" name="github_secret" value="[% Bugzilla.github_secret FILTER html %]">
-      <input type="hidden" name="target_uri" value="[% Bugzilla.cgi.target_uri FILTER html %]">
+      <input type="hidden" name="target_uri" value="[% basepath FILTER html %]github.cgi">
       <input type="image" src="[% basepath FILTER none %]extensions/GitHubAuth/web/images/sign_in.png" height="22" width="75" align="absmiddle"
              alt="Sign in with GitHub"
              title="Sign in with GitHub"> or

--- a/extensions/GitHubAuth/template/en/default/hook/account/auth/login-small-additional_methods.html.tmpl
+++ b/extensions/GitHubAuth/template/en/default/hook/account/auth/login-small-additional_methods.html.tmpl
@@ -11,7 +11,7 @@
   <span id="github_mini_login[% qs_suffix FILTER html %]" class="mini_login[% qs_suffix FILTER html %]">
     <form method="post" action="[% basepath FILTER html %]github.cgi">
       <input type="hidden" name="github_secret" value="[% Bugzilla.github_secret FILTER html %]">
-      <input type="hidden" name="target_uri" value="[% basepath FILTER html %]github.cgi">
+      <input type="hidden" name="target_uri" value="[% urlbase FILTER html %]index.cgi">
       <input type="image" src="[% basepath FILTER none %]extensions/GitHubAuth/web/images/sign_in.png" height="22" width="75" align="absmiddle"
              alt="Sign in with GitHub"
              title="Sign in with GitHub"> or


### PR DESCRIPTION
- Remove request_uri from Bugzilla/CGI.pm as GitHub login was only thing using.
- Change GitHub target_uri to always redirect back to index.cgi
- Remove login_uri method from GitHub extension as no code was using it.
- Internal error occurring due to no [% urlbase %] in the login templates. github.cgi looks for the urlbase before sending off to GitHub for auth.