### PR TITLE
Bug 1575005 - Do not send email announcement upon automated creation of API keys by auth.cgi

### DIFF
--- a/auth.cgi
+++ b/auth.cgi
@@ -92,13 +92,6 @@ if ($confirmed || $skip_confirmation) {
       = Bugzilla::User::APIKey->create({
       user_id => $user->id, description => $description, app_id => $app_id,
       });
-    my $template = Bugzilla->template_inner($user->setting('lang'));
-    my $vars = {user => $user, new_key => $api_key};
-    my $message;
-    $template->process('email/new-api-key.txt.tmpl', $vars, \$message)
-      or ThrowTemplateError($template->error());
-
-    MessageToMTA($message);
   }
 
   my $ua = LWP::UserAgent->new();

--- a/extensions/PhabBugz/Extension.pm
+++ b/extensions/PhabBugz/Extension.pm
@@ -51,7 +51,6 @@ sub config_add_panels {
 
 sub auth_delegation_confirm {
   my ($self, $args) = @_;
-  return;
   my $phab_enabled      = Bugzilla->params->{phabricator_enabled};
   my $phab_callback_url = Bugzilla->params->{phabricator_auth_callback_url};
   my $phab_app_id       = Bugzilla->params->{phabricator_app_id};

--- a/extensions/PhabBugz/Extension.pm
+++ b/extensions/PhabBugz/Extension.pm
@@ -51,6 +51,7 @@ sub config_add_panels {
 
 sub auth_delegation_confirm {
   my ($self, $args) = @_;
+  return;
   my $phab_enabled      = Bugzilla->params->{phabricator_enabled};
   my $phab_callback_url = Bugzilla->params->{phabricator_auth_callback_url};
   my $phab_app_id       = Bugzilla->params->{phabricator_app_id};

--- a/template/en/default/account/auth/delegation.html.tmpl
+++ b/template/en/default/account/auth/delegation.html.tmpl
@@ -21,7 +21,8 @@
 
 <p>A new [% terms.Bugzilla %] API key[% IF description %], with the description
   '[% description FILTER truncate(10) %]'[% END %] will also be created. You can
-  view or update the key in <a href="[% basepath %]userprefs.cgi?tab=apikey">your preferences</a>.</p>
+  view or update the key in <a href="[% basepath FILTER html %]userprefs.cgi?tab=apikey">
+  your preferences</a>.</p>
 
 <p>Do you want this website to have <strong>complete</strong> access to your [% terms.Bugzilla %]
   account?</p>

--- a/template/en/default/account/auth/delegation.html.tmpl
+++ b/template/en/default/account/auth/delegation.html.tmpl
@@ -10,16 +10,18 @@
    title = "Auth Delegation Request" %]
 
 <h1>[% title FILTER html %] </h1>
-<p>
-  A third-party website (<a href="[% callback_base FILTER html %]">[% callback_base FILTER html %]</a>)
-    would like to have <strong>complete</strong> access to your [% terms.Bugzilla %] account.
-</p>
+
+<p>A third-party website (<a href="[% callback_base FILTER html %]">[% callback_base FILTER html %]</a>)
+  would like to have <strong>complete</strong> access to your [% terms.Bugzilla %] account.</p>
 
 <p>The description of the site reads:
   <blockquote>
     [% description FILTER html %]
-  </blockquote>
-</p>
+  </blockquote></p>
+
+<p>A new [% terms.Bugzilla %] API key[% IF description %], with the description
+  '[% description FILTER truncate(10) %]'[% END %] will also be created. You can
+  view or update the key in <a href="[% basepath %]userprefs.cgi?tab=apikey">your preferences</a>.</p>
 
 <p>Do you want this website to have <strong>complete</strong> access to your [% terms.Bugzilla %]
   account?</p>

--- a/template/en/default/account/auth/delegation.html.tmpl
+++ b/template/en/default/account/auth/delegation.html.tmpl
@@ -20,7 +20,7 @@
   </blockquote></p>
 
 <p>A new [% terms.Bugzilla %] API key[% IF description %], with the description
-  '[% description FILTER truncate(10) %]'[% END %] will also be created. You can
+  '[% description FILTER truncate(10) FILTER html %]'[% END %] will also be created. You can
   view or update the key in <a href="[% basepath FILTER html %]userprefs.cgi?tab=apikey">
   your preferences</a>.</p>
 


### PR DESCRIPTION
- Display a confirmation of the new key being created on the auth delegation verification page. Do this instead of sending an email for those types of new keys.