### PR TITLE
Bumped version to 20190819.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20190809.1';
+our $VERSION = '20190819.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1573127" target="_blank">1573127</a>] Blocklist bug form is missing a bug type field</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1572945" target="_blank">1572945</a>] Cannot enter bug through Guided Bug Form if the product’s default platform is auto-detect</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1574792" target="_blank">1574792</a>] Bugzilla has suffered an internal error:  Bugzilla cannot log you into an external site via GitHub.</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1575005" target="_blank">1575005</a>] Do not send email announcement upon automated creation pf API keys by auth.cgi</li>
</ul>