### PR TITLE
Bumped version to 20190821.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20190819.1';
+our $VERSION = '20190821.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1344091" target="_blank">1344091</a>] Reorganize the header and modules on modal bug UI</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1574792" target="_blank">1574792</a>] Bugzilla has suffered an internal error:  Bugzilla cannot log you into an external site via GitHub.</li>
</ul>