### PR TITLE
Open Client Bounty Program link in new tab

### DIFF
--- a/extensions/BMO/template/en/default/bug/create/create-client-bounty.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-client-bounty.html.tmpl
@@ -130,7 +130,7 @@ function validateAndSubmit() {
   <input type="hidden" name="token" value="[% token FILTER html %]">
 
 <div class="head_desc">
-  <a href=" https://www.mozilla.org/en-US/security/client-bug-bounty/">
+  <a href=" https://www.mozilla.org/en-US/security/client-bug-bounty/" target="_blank">
     Details on Client Bounty Program
   </a>
 </div>


### PR DESCRIPTION
leaves bug submission form open when bounty program info is clicked 