### PR TITLE
Bug 1575885 - Triage Owner field cannot be found in reorganized bug UI

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -813,7 +813,7 @@
         field_type = constants.FIELD_TYPE_USER
         value = bug.component_obj.triage_owner
         view_only = 1
-        hide_on_view = bug.triage_owner == ""
+        hide_on_view = bug.component_obj.triage_owner.login == ""
         hide_on_edit = 1
         help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#triage_owner"
     %]


### PR DESCRIPTION
Fix a wrong value check to hide the field. I should have noticed this earlier.

## Bugzilla link

[Bug 1575885 - Triage Owner field cannot be found in reorganized bug UI](https://bugzilla.mozilla.org/show_bug.cgi?id=1575885)