### PR TITLE
Bug 1576236 - Arrow beside "CC" does not have any affordance to indicate it's clickable

### DIFF
--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -383,7 +383,7 @@ input[type="number"] {
 
 #cc-latch,
 #cc-summary {
-  cursor: default;
+  cursor: pointer;
 }
 
 #cc-list {


### PR DESCRIPTION
Use the pointer (hand) cursor for the CC field expander, so it looks clickable.

## Bugzilla link

[Bug 1576236 - Arrow beside "CC" does not have any affordance to indicate it's clickable](https://bugzilla.mozilla.org/show_bug.cgi?id=1576236)