### PR TITLE
Bug 1576149 - 'Save changes' button disabled after submitting changes which get rejected and using Back button (e.g. bug summary too long)

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -701,6 +701,12 @@ $(function() {
         })
         .attr('disabled', false);
 
+    // re-enable the save buttons when the user goes back to the page due to any
+    // field error or mid-air collision
+    $(window).on('pageshow', function() {
+        $('.save-btn').attr('disabled', false);
+    });
+
     // cc toggle (follow/stop following)
     $('#cc-btn')
         .click(async event => {


### PR DESCRIPTION
Re-enable the Save buttons when the user goes back to the modal bug page due to any field error or mid-air collision.

## Bugzilla link

[Bug 1576149 - 'Save changes' button disabled after submitting changes which get rejected and using Back button (e.g. bug summary too long)](https://bugzilla.mozilla.org/show_bug.cgi?id=1576149)