### PR TITLE
Bug 1575805 - Manually expanded section will be collapsed again after visiting a bug that hides the section by default

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -20,7 +20,7 @@ function slide_module(module, action, fast) {
             'aria-expanded': is_visible,
             'aria-label': is_visible ? latch.data('label-expanded') : latch.data('label-collapsed'),
         });
-        if (BUGZILLA.user.settings.remember_collapsed)
+        if (BUGZILLA.user.settings.remember_collapsed && module.is(':visible'))
             localStorage.setItem(module.attr('id') + '.visibility', is_visible ? 'show' : 'hide');
     }
 


### PR DESCRIPTION
Workaround the issue by remembering if a module is expanded or collapsed only when the module is visible.

## Bugzilla link

[Bug 1575805 - Manually expanded section will be collapsed again after visiting a bug that hides the section by default](https://bugzilla.mozilla.org/show_bug.cgi?id=1575805)