### PR TITLE
Bumped version to 20190829.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20190821.1';
+our $VERSION = '20190829.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1575885" target="_blank">1575885</a>] Triage Owner field cannot be found in reorganized bug UI</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1576236" target="_blank">1576236</a>] Arrow beside "CC" does not have any affordance to indicate it's clickable</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1576149" target="_blank">1576149</a>] 'Save changes' button disabled after submitting changes which get rejected and using Back button (e.g. bug summary too long)</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1575805" target="_blank">1575805</a>] Manually expanded section will be collapsed again after visiting a bug that hides the section by default</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1575881" target="_blank">1575881</a>] Bug open/updated/closed date, reporter and triage owner should be visible in Edit mode</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1417229" target="_blank">1417229</a>] Enable Triage Lead on a component to see security bugs in that component</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1575003" target="_blank">1575003</a>] Can't link to gitlab issues in the "see also" field</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1576667" target="_blank">1576667</a>] Add creation timestamp to the user_api_keys table to show when an api key was first generated</li>
</ul>