### PR TITLE
Bug 1576667 - Add creation timestamp to the user_api_keys table to show when an api key was first generated (Schema Fix)

### DIFF
--- a/Bugzilla/User/APIKey.pm
+++ b/Bugzilla/User/APIKey.pm
@@ -29,6 +29,7 @@ use constant DB_COLUMNS => qw(
   app_id
   description
   revoked
+  creation_ts
   last_used
   last_used_ip
   sticky
@@ -60,6 +61,7 @@ sub api_key      { return $_[0]->{api_key} }
 sub app_id       { return $_[0]->{app_id} }
 sub description  { return $_[0]->{description} }
 sub revoked      { return $_[0]->{revoked} }
+sub creation_ts  { return $_[0]->{creation_ts} }
 sub last_used    { return $_[0]->{last_used} }
 sub last_used_ip { return $_[0]->{last_used_ip} }
 sub sticky       { return $_[0]->{sticky} }
@@ -85,6 +87,14 @@ sub set_revoked     { $_[0]->set('revoked',     $_[1]); }
 sub set_sticky      { $_[0]->set('sticky',      $_[1]); }
 
 # Validators
+sub run_create_validators {
+  my ($class, $params) = @_;
+  $params = $class->SUPER::run_create_validators($params);
+  $params->{creation_ts}
+    ||= Bugzilla->dbh->selectrow_array('SELECT LOCALTIMESTAMP(0)');
+  return $params;
+}
+
 sub _check_api_key { return generate_random_password(40); }
 sub _check_description { return trim($_[1]) || ''; }
 


### PR DESCRIPTION
- This fixes the not null error for creation_ts