### PR TITLE
Bug 1578481 - Update tracking flags admin UI to use special edittrackingflags group instead of admin and add relman to the new group

### DIFF
--- a/extensions/TrackingFlags/Extension.pm
+++ b/extensions/TrackingFlags/Extension.pm
@@ -64,14 +64,14 @@ sub page_before_template {
   my $vars = $args->{'vars'};
 
   if ($page eq 'tracking_flags_admin_list.html') {
-    Bugzilla->user->in_group('admin')
+    Bugzilla->user->in_group('edittrackingflags')
       || ThrowUserError('auth_failure',
       {group => 'admin', action => 'access', object => 'administrative_pages'});
     admin_list($vars);
 
   }
   elsif ($page eq 'tracking_flags_admin_edit.html') {
-    Bugzilla->user->in_group('admin')
+    Bugzilla->user->in_group('edittrackingflags')
       || ThrowUserError('auth_failure',
       {group => 'admin', action => 'access', object => 'administrative_pages'});
     admin_edit($vars);

--- a/extensions/TrackingFlags/template/en/default/hook/admin/admin-end_links_right.html.tmpl
+++ b/extensions/TrackingFlags/template/en/default/hook/admin/admin-end_links_right.html.tmpl
@@ -6,7 +6,7 @@
   # defined by the Mozilla Public License, v. 2.0.
   #%]
 
-[% IF user.in_group('admin') %]
+[% IF user.in_group('edittrackingflags') %]
   <dt id="push">
     <a href="[% basepath FILTER none %]page.cgi?id=tracking_flags_admin_list.html">Release Tracking Flags</a>
   </dt>


### PR DESCRIPTION
The *edittrackingflags* group has been created on BMO already.