### PR TITLE
Bumped version to 20190906.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20190829.2';
+our $VERSION = '20190906.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1576667" target="_blank">1576667</a>] Add creation timestamp to the user_api_keys table to show when an api key was first generated</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1578481" target="_blank">1578481</a>] Update tracking flags admin UI to use special edittrackingflags group instead of admin and add relman to the new group</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1579236" target="_blank">1579236</a>] Push connector for Phabricator should add security and bmo groups to revision if revision is private</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1578805" target="_blank">1578805</a>] When changing password or enabling 2fa, previous sessions should be revoked in Bugzila</li>
</ul>