### PR TITLE
Bug 1549262 - Lack of password confirmation when deleting your account.

### DIFF
--- a/template/en/default/account/prefs/account.html.tmpl
+++ b/template/en/default/account/prefs/account.html.tmpl
@@ -150,6 +150,10 @@
             We are not able to remove your details that are part of comment text.
           </p>
           <p>
+            <em>Warning:</em> You will need to enter your current password above to
+            confirm this action.
+          </p>
+          <p>
             <input type="checkbox" id="account-disable-confirm">
             I acknowledge that my account will not be functional after it has been
             disabled.

--- a/userprefs.cgi
+++ b/userprefs.cgi
@@ -198,6 +198,15 @@ sub MfaAccount {
 
 sub DisableAccount {
   my $user = Bugzilla->user;
+  my $cgi  = Bugzilla->cgi;
+
+  my $oldpassword   = $cgi->param('old_password');
+  my $oldcryptedpwd = $user->cryptpassword;
+  $oldcryptedpwd || ThrowCodeError("unable_to_retrieve_password");
+
+  if (bz_crypt($oldpassword, $oldcryptedpwd) ne $oldcryptedpwd) {
+    ThrowUserError("old_password_incorrect");
+  }
 
   my $new_login = 'u' . $user->id . '@disabled.tld';
 


### PR DESCRIPTION
Testing:

* Create test account
* Go to Preferences -> Account
* Click Disable My Account
* Click checkbox to acknowledge disabling the account.
* Click Disable Account
* Observe error stating that old password was incorrect.
* Go back and enter current password.
* Click Disable Account
* Account should be disabled and test account cannot login.