### PR TITLE
Bug 1586698 - Add proper autocomplete attributes for password change fields

### DIFF
--- a/template/en/default/account/password/set-forgotten-password.html.tmpl
+++ b/template/en/default/account/password/set-forgotten-password.html.tmpl
@@ -40,14 +40,14 @@
         <tr>
           <th align="right">New Password:</th>
           <td>
-            <input type="password" name="password" id="new_password1" required>
+            <input autocomplete="new-password" type="password" name="password" id="new_password1" required>
           </td>
         </tr>
 
         <tr>
           <th align="right">New Password Again:</th>
           <td>
-            <input type="password" name="matchpassword" id="new_password2" required>
+            <input autocomplete="new-password" type="password" name="matchpassword" id="new_password2" required>
           </td>
         </tr>
 

--- a/template/en/default/account/prefs/account.html.tmpl
+++ b/template/en/default/account/prefs/account.html.tmpl
@@ -65,7 +65,7 @@
           <th align="right">Current password:</th>
           <td>
             <input type="hidden" name="old_login" value="[% user.login FILTER html %]">
-            <input type="password" name="old_password" id="old_password">
+            <input autocomplete="current-password" type="password" name="old_password" id="old_password">
             <a href="#" id="forgot-password">I forgot my password</a>
           </td>
         </tr>
@@ -86,14 +86,14 @@
           <tr>
             <th align="right">New password:</th>
             <td>
-              <input type="password" name="new_password1" id="new_password1">
+              <input autocomplete="new-password" type="password" name="new_password1" id="new_password1">
               [% INCLUDE "mfa/protected.html.tmpl" %]
             </td>
           </tr>
           <tr>
             <th align="right">Confirm new password:</th>
             <td>
-              <input type="password" name="new_password2" id="new_password2">
+              <input autocomplete="new-password" type="password" name="new_password2" id="new_password2">
             </td>
           </tr>
         [% END %]

--- a/template/en/default/account/reset-password.html.tmpl
+++ b/template/en/default/account/reset-password.html.tmpl
@@ -111,7 +111,7 @@ $(function() {
     <div class="field-row">
       <div class="field-name">Current Password</div>
       <div class="field-value">
-        <input type="password" name="old_password" id="old_password" size="30" required>
+        <input autocomplete="current-password" type="password" name="old_password" id="old_password" size="30" required>
       </div>
     </div>
     <div class="field-hr">&nbsp;</div>
@@ -119,13 +119,13 @@ $(function() {
     <div class="field-row">
       <div class="field-name">New Password</div>
       <div class="field-value">
-        <input type="password" name="new_password1" id="new_password1" size="30" required>
+        <input autocomplete="new-password" type="password" name="new_password1" id="new_password1" size="30" required>
       </div>
     </div>
     <div class="field-row">
       <div class="field-name">New Password</div>
       <div class="field-value">
-        <input type="password" name="new_password2" id="new_password2" size="30" required>
+        <input autocomplete="new-password" type="password" name="new_password2" id="new_password2" size="30" required>
         (again)
       </div>
     </div>


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#Values

autocomplete="current-password"

autocomplete="new-password"

can be used to provide the correct semantics.

The latter also allows integration with the password generation feature in Chrome and Firefox.

