### PR TITLE
Bug 1587982 - Extraneous comma in history due to wrong join of added field in Bug 1368555

### DIFF
--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -4769,6 +4769,9 @@ sub _join_activity_entries {
 
   # Buglists and see_also need the comma restored
   if ($field =~ /^(?:dependson|blocked|regress(?:ed_by|es)|see_also)$/) {
+    if ($new_change eq '') {
+      return $current_change;
+    }
     if (substr($new_change, 0, 1) eq ',' || substr($new_change, 0, 1) eq ' ') {
       return $current_change . $new_change;
     }


### PR DESCRIPTION
A See Also change can be stored in multiple rows in the `bugs_activity` table and needs to be joined wisely. If the second row is empty, just return the first row, so no extra comma will be included.

## Bugzilla link

[Bug 1587982 - Extraneous comma in history due to wrong join of added field in Bug 1368555](https://bugzilla.mozilla.org/show_bug.cgi?id=1587982)