### PR TITLE
Bug 1580998 - Show link to dependency tree in edit mode

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -945,7 +945,6 @@
           name = "dependencytree"
           container = 1
           label = ""
-          hide_on_edit = 1
       %]
         Dependency <a href="[% basepath FILTER none %]showdependencytree.cgi?id=[% bug.bug_id FILTER none %]&amp;hide_resolved=1">tree</a>
         / <a href="[% basepath FILTER none %]showdependencygraph.cgi?id=[% bug.bug_id FILTER none %]">graph</a>


### PR DESCRIPTION
Show the modal UI’s “Dependency tree / graph“ links even in Edit mode, especially for those who are using the “Always Enable Edit Mode” option.

## Bugzilla link

[Bug 1580998 - Show link to dependency tree in edit mode](https://bugzilla.mozilla.org/show_bug.cgi?id=1580998)