### PR TITLE
Bug 1580980 - Including "patch" in attachment description automatically flags the attachment as a patch

### DIFF
--- a/js/attachment.js
+++ b/js/attachment.js
@@ -698,7 +698,7 @@ Bugzilla.AttachmentForm = class AttachmentForm {
    * Called whenever the Description is updated. Update the Patch checkbox when needed.
    */
   description_oninput() {
-    const is_patch = this.$description.value.match(/^patch\b/i);
+    const is_patch = !!this.$description.value.match(/^patch\b/i);
     const { checked } = this.$ispatch;
 
     if ((is_patch && !checked) || (!is_patch && checked)) {

--- a/js/attachment.js
+++ b/js/attachment.js
@@ -698,8 +698,11 @@ Bugzilla.AttachmentForm = class AttachmentForm {
    * Called whenever the Description is updated. Update the Patch checkbox when needed.
    */
   description_oninput() {
-    if (this.$description.value.match(/\bpatch\b/i) && !this.$ispatch.checked) {
-      this.update_ispatch(true);
+    const is_patch = this.$description.value.match(/^patch\b/i);
+    const { checked } = this.$ispatch;
+
+    if ((is_patch && !checked) || (!is_patch && checked)) {
+      this.update_ispatch(is_patch);
     }
   }
 

--- a/js/attachment.js
+++ b/js/attachment.js
@@ -699,9 +699,8 @@ Bugzilla.AttachmentForm = class AttachmentForm {
    */
   description_oninput() {
     const is_patch = !!this.$description.value.match(/^patch\b/i);
-    const { checked } = this.$ispatch;
 
-    if ((is_patch && !checked) || (!is_patch && checked)) {
+    if (is_patch !== this.$ispatch.checked) {
       this.update_ispatch(is_patch);
     }
   }


### PR DESCRIPTION
Automatically tick the patch checkbox on the New Attachment page only when the description starts with “patch” so “screenshot of patch” won’t be treated as a patch. Also, toggle the checkbox properly whenever the description is updated by the user.

## Bugzilla link

[Bug 1580980 - Including "patch" in attachment description automatically flags the attachment as a patch](https://bugzilla.mozilla.org/show_bug.cgi?id=1580980)