### PR TITLE
Bump version to 20191016.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20190926.1';
+our $VERSION = '20191016.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1573227" target="_blank">1573227</a>] Various UI text and code comments assume male gender</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1586698" target="_blank">1586698</a>] Add proper autocomplete attributes for password change fields</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1587133" target="_blank">1587133</a>] Crash panel sizing incorrect when first opened</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1461358" target="_blank">1461358</a>] Add a dev server link to the account creation process.</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1584191" target="_blank">1584191</a>] Cloning a bug doesn't copy the regressed by / regressions field</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1580980" target="_blank">1580980</a>] Including "patch" in attachment description automatically flags the attachment as a patch</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1580998" target="_blank">1580998</a>] Show link to dependency tree in edit mode</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1587982" target="_blank">1587982</a>] Extraneous comma in history due to wrong join of added field in Bug 1368555</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1584332" target="_blank">1584332</a>] older comment edits/changes returned by API call with history restricted by new_since=YYYY-MM-DD</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1587849" target="_blank">1587849</a>] Cannot create markdown comments via the REST API</li>
</ul>