### PR TITLE
Bug 1591549 - Hide bugs in dependencies and regression fields from users without access

### DIFF
--- a/qa/t/lib/QA/RPC.pm
+++ b/qa/t/lib/QA/RPC.pm
@@ -149,13 +149,14 @@ sub _string_array {
 }
 
 sub bz_create_test_bugs {
-  my ($self, $second_private) = @_;
+  my ($self, $second_private, $no_cc) = @_;
   my $config = $self->bz_config;
 
   my @whiteboard_strings = _string_array(3);
   my @summary_strings    = _string_array(3);
 
   my $public_bug = create_bug_fields($config);
+  delete $public_bug->{cc} if $no_cc;
   $public_bug->{alias}      = random_string(40);
   $public_bug->{whiteboard} = join(' ', @whiteboard_strings);
   $public_bug->{summary}    = join(' ', @summary_strings);

--- a/qa/t/test_security.t
+++ b/qa/t/test_security.t
@@ -139,13 +139,15 @@ log_in($sel, $config, 'editbugs');
 go_to_bug($sel, $bug1_id);
 ok(!$sel->is_text_present("secret_qa_bug_$bug2_id"),
   "The alias 'secret_qa_bug_$bug2_id' is not visible for unauthorized users");
-$sel->is_text_present_ok($bug2_id);
+ok(!$sel->is_text_present($bug2_id),
+  "Even the bug ID is not visible for unauthorized users");
 logout($sel);
 
 go_to_bug($sel, $bug1_id, 1);
 ok(!$sel->is_text_present("secret_qa_bug_$bug2_id"),
   "The alias 'secret_qa_bug_$bug2_id' is not visible for logged out users");
-$sel->is_text_present_ok($bug2_id);
+ok(!$sel->is_text_present($bug2_id),
+  "Even the bug ID is not visible for logged out users");
 
 #######################################################################
 # Security bug 472206.

--- a/qa/t/webservice_bug_get.t
+++ b/qa/t/webservice_bug_get.t
@@ -117,7 +117,7 @@ sub post_success {
     cmp_ok($bug->{remaining_time}, '==', '5.0',  'remaining_time is correct');
 
     is_deeply(
-      $bug->{depends_on}->[0],
+      $bug->{depends_on},
       $is_private ? [] : [$private_id],
       $is_private
         ? 'depends_on value is correct'
@@ -131,7 +131,7 @@ sub post_success {
     );
 
     is_deeply(
-      $bug->{depends_on}->[0],
+      $bug->{depends_on},
       [],
       $is_private
         ? 'depends_on value is correct'

--- a/qa/t/webservice_bug_get.t
+++ b/qa/t/webservice_bug_get.t
@@ -107,7 +107,8 @@ sub post_success {
 
   is(scalar @{$call->result->{bugs}}, 1, "Got exactly one bug");
   my $bug = $call->result->{bugs}->[0];
-  my $is_private = $bug->{id} == $private_bug->{id};
+  my $is_private_bug  = $bug->{id} == $private_bug->{id};
+  my $is_private_user = $t->{user} && $t->{user} eq PRIVATE_BUG_USER;
 
   if ($t->{user} && $t->{user} eq 'admin') {
     ok(exists $bug->{estimated_time} && exists $bug->{remaining_time},
@@ -115,29 +116,23 @@ sub post_success {
     is($bug->{deadline}, '2038-01-01', 'deadline is correct');
     cmp_ok($bug->{estimated_time}, '==', '10.0', 'estimated_time is correct');
     cmp_ok($bug->{remaining_time}, '==', '5.0',  'remaining_time is correct');
-
-    is_deeply(
-      $bug->{depends_on},
-      $is_private ? [] : [$private_id],
-      $is_private
-        ? 'depends_on value is correct'
-        : 'Private bug ID in depends_on is returned to privileged users'
-    );
   }
   else {
     ok(
       !exists $bug->{estimated_time} && !exists $bug->{remaining_time},
       'Time-tracking fields are not returned to non-privileged users'
     );
-
-    is_deeply(
-      $bug->{depends_on},
-      [],
-      $is_private
-        ? 'depends_on value is correct'
-        : 'Private bug ID in depends_on is not returned to non-privileged users'
-    );
   }
+
+  is_deeply(
+    $bug->{depends_on},
+    $is_private_bug ? [] : $is_private_user ? [$private_id] : [],
+    $is_private_bug
+      ? 'depends_on value is correct'
+      : $is_private_user
+      ? 'Private bug ID in depends_on is returned to privileged users'
+      : 'Private bug ID in depends_on is not returned to non-privileged users'
+  );
 
   if ($t->{user}) {
     ok($bug->{update_token}, 'Update token returned for logged-in user');
@@ -147,7 +142,7 @@ sub post_success {
       'Update token not returned for logged-out users');
   }
 
-  my $expect = $is_private ? $private_bug : $public_bug;
+  my $expect = $is_private_bug ? $private_bug : $public_bug;
 
   my @fields = sort keys %$expect;
   push(@fields, 'creation_time', 'last_change_time');

--- a/qa/t/webservice_bug_get.t
+++ b/qa/t/webservice_bug_get.t
@@ -16,12 +16,12 @@ use Data::Dumper;
 use DateTime;
 use QA::Util;
 use QA::Tests qw(bug_tests PRIVATE_BUG_USER);
-use Test::More tests => 1036;
+use Test::More tests => 1009;
 my ($config, @clients) = get_rpc_clients();
 
 my $xmlrpc = $clients[0];
 our $creation_time = DateTime->now();
-our ($public_bug, $private_bug) = $xmlrpc->bz_create_test_bugs('private');
+our ($public_bug, $private_bug) = $xmlrpc->bz_create_test_bugs('private', 'no_cc');
 my $private_id = $private_bug->{id};
 my $public_id  = $public_bug->{id};
 

--- a/qa/t/webservice_bug_get.t
+++ b/qa/t/webservice_bug_get.t
@@ -124,15 +124,17 @@ sub post_success {
     );
   }
 
-  is_deeply(
-    $bug->{depends_on},
-    $is_private_bug ? [] : $is_private_user ? [$private_id] : [],
-    $is_private_bug
-      ? 'depends_on value is correct'
-      : $is_private_user
-      ? 'Private bug ID in depends_on is returned to privileged users'
-      : 'Private bug ID in depends_on is not returned to non-privileged users'
-  );
+  if (exists $bug->{depends_on}) {
+    is_deeply(
+      $bug->{depends_on},
+      $is_private_bug ? [] : $is_private_user ? [$private_id] : [],
+      $is_private_bug
+        ? 'depends_on value is correct'
+        : $is_private_user
+        ? 'Private bug ID in depends_on is returned to private bug user'
+        : 'Private bug ID in depends_on is not returned to non-private bug user (' . $t->{user} . ')'
+    );
+  }
 
   if ($t->{user}) {
     ok($bug->{update_token}, 'Update token returned for logged-in user');

--- a/qa/t/webservice_bug_get_bugs.t
+++ b/qa/t/webservice_bug_get_bugs.t
@@ -59,7 +59,6 @@ $private_bug->{see_also}         = ["${base_url}show_bug.cgi?id=$public_id"];
 $private_bug->{cf_qa_status}     = ['in progress', 'verified'];
 $private_bug->{cf_single_select} = 'two';
 
-$public_bug->{depends_on}            = [$private_id];
 $public_bug->{dupe_of}               = undef;
 $public_bug->{resolution}            = '';
 $public_bug->{is_open}               = 1;
@@ -98,6 +97,7 @@ sub post_success {
 
   is(scalar @{$call->result->{bugs}}, 1, "Got exactly one bug");
   my $bug = $call->result->{bugs}->[0];
+  my $is_private = $bug->{id} == $private_bug->{id};
 
   if ($t->{user} && $t->{user} eq 'admin') {
     ok(
@@ -110,6 +110,14 @@ sub post_success {
     is($bug->{deadline}, '2038-01-01', 'deadline is correct');
     cmp_ok($bug->{estimated_time}, '==', '10.0', 'estimated_time is correct');
     cmp_ok($bug->{remaining_time}, '==', '5.0',  'remaining_time is correct');
+
+    is_deeply(
+      $bug->{depends_on}->[0],
+      $is_private ? [] : [$private_id],
+      $is_private
+        ? 'depends_on value is correct'
+        : 'Private bug ID in depends_on is returned to privileged users'
+    );
   }
   else {
     ok(
@@ -117,6 +125,14 @@ sub post_success {
         && !exists $bug->{remaining_time}
         && !exists $bug->{deadline},
       'Time-tracking fields are not returned to non-privileged users'
+    );
+
+    is_deeply(
+      $bug->{depends_on}->[0],
+      [],
+      $is_private
+        ? 'depends_on value is correct'
+        : 'Private bug ID in depends_on is not returned to non-privileged users'
     );
   }
 
@@ -128,7 +144,7 @@ sub post_success {
       'Update token not returned for logged-out users');
   }
 
-  my $expect = $bug->{id} == $private_bug->{id} ? $private_bug : $public_bug;
+  my $expect = $is_private ? $private_bug : $public_bug;
 
   my @fields = sort keys %$expect;
   push(@fields, 'creation_time', 'last_change_time');

--- a/qa/t/webservice_bug_get_bugs.t
+++ b/qa/t/webservice_bug_get_bugs.t
@@ -112,7 +112,7 @@ sub post_success {
     cmp_ok($bug->{remaining_time}, '==', '5.0',  'remaining_time is correct');
 
     is_deeply(
-      $bug->{depends_on}->[0],
+      $bug->{depends_on},
       $is_private ? [] : [$private_id],
       $is_private
         ? 'depends_on value is correct'
@@ -128,7 +128,7 @@ sub post_success {
     );
 
     is_deeply(
-      $bug->{depends_on}->[0],
+      $bug->{depends_on},
       [],
       $is_private
         ? 'depends_on value is correct'

--- a/qa/t/webservice_bug_get_bugs.t
+++ b/qa/t/webservice_bug_get_bugs.t
@@ -121,15 +121,17 @@ sub post_success {
     );
   }
 
-  is_deeply(
-    $bug->{depends_on},
-    $is_private_bug ? [] : $is_private_user ? [$private_id] : [],
-    $is_private_bug
-      ? 'depends_on value is correct'
-      : $is_private_user
-      ? 'Private bug ID in depends_on is returned to privileged users'
-      : 'Private bug ID in depends_on is not returned to non-privileged users'
-  );
+  if (exists $bug->{depends_on}) {
+    is_deeply(
+      $bug->{depends_on},
+      $is_private_bug ? [] : $is_private_user ? [$private_id] : [],
+      $is_private_bug
+        ? 'depends_on value is correct'
+        : $is_private_user
+        ? 'Private bug ID in depends_on is returned to private bug user'
+        : 'Private bug ID in depends_on is not returned to non-private bug user (' . $t->{user} . ')'
+    );
+  }
 
   if ($t->{user}) {
     ok($bug->{update_token}, 'Update token returned for logged-in user');

--- a/qa/t/webservice_bug_get_bugs.t
+++ b/qa/t/webservice_bug_get_bugs.t
@@ -16,12 +16,12 @@ use Data::Dumper;
 use DateTime;
 use QA::Util;
 use QA::Tests qw(bug_tests PRIVATE_BUG_USER);
-use Test::More tests => 1036;
+use Test::More tests => 1009;
 my ($config, @clients) = get_rpc_clients();
 
 my $xmlrpc = $clients[0];
 our $creation_time = DateTime->now();
-our ($public_bug, $private_bug) = $xmlrpc->bz_create_test_bugs('private');
+our ($public_bug, $private_bug) = $xmlrpc->bz_create_test_bugs('private', 'no_cc');
 my $private_id = $private_bug->{id};
 my $public_id  = $public_bug->{id};
 


### PR DESCRIPTION
Use the `Bugzilla->user->visible_bugs` filter to hide security/confidential bugs from people without access. The change applies to the modal bug UI’s References section, inline history and separate history page as well as the API.

## Bugzilla link

[Bug 1591549 - Hide bugs in dependencies and regression fields from users without access](https://bugzilla.mozilla.org/show_bug.cgi?id=1591549)