### PR TITLE
Bug 1585048 - "X new comments since last visit" text doesn't have click affordance

### DIFF
--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -650,6 +650,7 @@ td.flag-requestee {
   opacity: 1;
   font-size: var(--font-size-small);
   text-align: center;
+  cursor: pointer;
   transition: all .2s 2s;
   will-change: transform; /* for performance */
 }


### PR DESCRIPTION
A one-liner fix. Just change the cursor on the blue “X new comments since last visit” banner.

## Bugzilla link

[Bug 1585048 - "X new comments since last visit" text doesn't have click affordance](https://bugzilla.mozilla.org/show_bug.cgi?id=1585048)