### PR TITLE
Bug 1584583 - Reports are unreadable in dark mode

### DIFF
--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -842,6 +842,10 @@ input[type="radio"]:checked {
   text-shadow: none !important;
 }
 
+.yui-skin-sam .yui-dt th a {
+  color: inherit !important;
+}
+
 .yui-skin-sam .yui-dt table tr,
 .yui3-skin-sam .yui3-datatable-table tr {
   border-bottom: 1px solid var(--grid-border-color) !important;

--- a/template/en/default/reports/report.html.tmpl
+++ b/template/en/default/reports/report.html.tmpl
@@ -75,6 +75,7 @@
     .t3     { background-color: #dddddd } /* grey        */
     .t4     { background-color: #c3d3ed } /* darker blue */
     .ttotal, .ttotal td { background-color: #cfffdf } /* light green */
+    .t1, .t2, .t3, .t4, .ttotal, .ttotal td { color: #333; }
   "
 %]
 


### PR DESCRIPTION
Make the YUI table headers readable in dark mode by overriding the default theme colour.

## Bugzilla link

[Bug 1584583 - Reports are unreadable in dark mode](https://bugzilla.mozilla.org/show_bug.cgi?id=1584583)