### PR TITLE
Bug 1597235 - Setting the mime type of a pasted attachment doesn't work.

### DIFF
--- a/Bugzilla/Attachment.pm
+++ b/Bugzilla/Attachment.pm
@@ -846,7 +846,7 @@ sub get_content_type {
   my $cgi = Bugzilla->cgi;
 
   return 'application/octet-stream' if ($cgi->param('hide_preview'));
-  return 'text/plain' if ($cgi->param('ispatch') || $cgi->param('attach_text'));
+  return 'text/plain' if ($cgi->param('ispatch'));
 
   my $content_type;
   my $method = $cgi->param('contenttypemethod');


### PR DESCRIPTION
Use a user-defined MIME type for attached text instead of assuming `text/plain`.

## Bugzilla link

[Bug 1597235 - Setting the mime type of a pasted attachment doesn't work.](https://bugzilla.mozilla.org/show_bug.cgi?id=1597235)