### PR TITLE
Bumped version to 20191121.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20191106.1';
+our $VERSION = '20191121.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1585048" target="_blank">1585048</a>] "X new comments since last visit" text doesn't have click affordance</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1594844" target="_blank">1594844</a>] Automatically set the bug's assignee when they upload a revision to an unassigned bug</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1596628" target="_blank">1596628</a>] The param --since-db is not working for the report_ping script that sends data to STMO</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1584583" target="_blank">1584583</a>] Reports are unreadable in dark mode</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1597235" target="_blank">1597235</a>] Setting the mime type of a pasted attachment doesn't work.</li>
</ul>