### PR TITLE
Bug 1597524 - vagrant up failed, saying table 'bugs_bmo.profiles' doesn't exist

### DIFF
--- a/vagrant_support/apache.yml
+++ b/vagrant_support/apache.yml
@@ -10,6 +10,9 @@
   service: name=httpd enabled=no
   when: LAZY == 0
 
+- name: create logs directory
+  file: path=/vagrant/logs state=directory owner=vagrant group=apache mode=770
+
 - name: ensure bugzilla.log has right permissions
   file: path=/vagrant/logs/bugzilla.log state=touch owner=vagrant group=apache mode=0660
 

--- a/vagrant_support/checksetup_answers.j2
+++ b/vagrant_support/checksetup_answers.j2
@@ -6,6 +6,7 @@ $answer{'ADMIN_REALNAME'}       = 'Vagrant User';
 $answer{'NO_PAUSE'}             = 1;
 $answer{'size_limit'}           = 750000;
 $answer{'bugzilla_version'}     = '1';
+$answer{'canonical_urlbase'}    = "http://{{WEB_HOSTNAME}}/";
 $answer{'create_htaccess'}      = '1';
 $answer{'db_check'}             = 1;
 $answer{'db_driver'}            = 'mysql';

--- a/vagrant_support/devtools.yml
+++ b/vagrant_support/devtools.yml
@@ -18,7 +18,10 @@
 - name: copy re.pl
   copy: src=re.pl dest=/usr/local/bin/re.pl mode=0755
 
-- name: copy start_morbo
+- name: fix start_morbo perms
+  file: path=/vagrant/scripts/start_morbo mode=0755
+
+- name: link start_morbo
   file: path=/usr/local/bin/start_morbo src=/vagrant/scripts/start_morbo state=link force=true
 
 - name: copy use-nytprof

--- a/vagrant_support/jobqueue.yml
+++ b/vagrant_support/jobqueue.yml
@@ -1,3 +1,8 @@
+- name: fix jobqueue perms
+  file:
+    path: /vagrant/jobqueue.pl
+    mode: 0750
+
 - name: install job queue
   command: /vagrant/jobqueue.pl install chdir=/vagrant creates=/etc/init.d/bugzilla-queue
 
@@ -9,13 +14,8 @@
       BUGZILLA=/vagrant
       USER=vagrant
 
-- name: fix jobqueue perms
-  file:
-    path: /vagrant/jobqueue.pl
-    mode: 0750
-
 - name: enable jobqueue
   service: name=bugzilla-queue enabled=yes
 
 - name: restart jobqueue
-  service: name=bugzilla-queue state=restarted
+  command: service bugzilla-queue restart

--- a/vagrant_support/playbook.yml
+++ b/vagrant_support/playbook.yml
@@ -20,7 +20,7 @@
         - python2-ndg_httpsclient
 
     - name: link sphinx
-      command: ln -s /usr/bin/sphinx-1.0-{{ item }} /usr/bin/sphinx-{{ item }} creates=/usr/bin/sphinx-{{ item }}
+      file: src=/usr/bin/sphinx-1.0-{{ item }} dest=/usr/bin/sphinx-{{ item }} state=link force=true
       with_items:
         - autogen
         - build
@@ -129,7 +129,7 @@
       shell: |-
         mysqladmin -u root create bugs_bmo
         mysql -u root -e 'GRANT ALL ON bugs_bmo.* TO bugs@"{{WEB_IP}}" IDENTIFIED BY "bugs"'
-      when: bugs_bmo|failed
+      when: bugs_bmo is failed
 
 - hosts: web
   become: true


### PR DESCRIPTION
* canonical_urlbase was missing from checksetup_answers and was causing checksetup.pl to bail before creating the database.
* other cleanups and changes needed