### PR TITLE
Bug 1583153 - Dependency tree view has wrong/confusing indentation

### DIFF
--- a/skins/standard/dependency-tree.css
+++ b/skins/standard/dependency-tree.css
@@ -23,7 +23,7 @@
 
 [role="tree"] {
   display: block;
-  margin: 16px 0;
+  margin: 16px 0 0 22px;
   padding: 0;
 }
 
@@ -45,6 +45,10 @@
   font-size: 18px;
   line-height: 100%;
   vertical-align: top;
+}
+
+[role="treeitem"][aria-expanded] {
+  margin-left: -22px;
 }
 
 [role="treeitem"][aria-expanded="true"] > .expander .icon {


### PR DESCRIPTION
Fix wrong indentations on the dependency tree which confuses people.

## Bugzilla link

[Bug 1583153 - Dependency tree view has wrong/confusing indentation](https://bugzilla.mozilla.org/show_bug.cgi?id=1583153)