### PR TITLE
Bump version to 20191212.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20191121.1';
+our $VERSION = '20191212.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1599002" target="_blank">1599002</a>] Change bug status from NEW to ASSIGNED when setting assignee from Phabricator</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1597524" target="_blank">1597524</a>] vagrant up failed, saying table 'bugs_bmo.profiles' doesn't exist</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1599620" target="_blank">1599620</a>] Don't auto-assign if there are no reviewers specified.</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1599539" target="_blank">1599539</a>] Bugzilla should strip whitespace from the beginning of the "URL" field (because a leading space triggers "This is considered an unsafe URL and could possibly be harmful" dialog)</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1583153" target="_blank">1583153</a>] Dependency tree view has wrong/confusing indentation</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1597800" target="_blank">1597800</a>] Create a "Security Bug Report" report for sec-moderate and sec-low bugs</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1602566" target="_blank">1602566</a>] Update vagrant config and docs to allow using Windows Hyper-V VMs</li>
</ul>