### PR TITLE
Bug 1607030 - Selecting a most-used component goes into a loop when switching from guided bug entry form

### DIFF
--- a/extensions/ProdCompSearch/web/js/prod_comp_search.js
+++ b/extensions/ProdCompSearch/web/js/prod_comp_search.js
@@ -176,8 +176,8 @@ Bugzilla.FrequentComponents = class FrequentComponents {
       const links = (await this.fetch()).map(({ product, component }) => {
         const params = new URLSearchParams(current_params);
 
-        params.append('product', product);
-        params.append('component', component);
+        params.set('product', product);
+        params.set('component', component);
 
         return {
           href: `${BUGZILLA.config.basepath}enter_bug.cgi?${params.toString()}`,


### PR DESCRIPTION
Replace any empty product/component query parameters, so the most-used component links will take you to the advanced bug form as expected.

## Bugzilla link

[Bug 1607030 - Selecting a most-used component goes into a loop when switching from guided bug entry form](https://bugzilla.mozilla.org/show_bug.cgi?id=1607030)