### PR TITLE
Add JSON to the attachment content types dropdown

### DIFF
--- a/template/en/default/attachment/createformcontents.html.tmpl
+++ b/template/en/default/attachment/createformcontents.html.tmpl
@@ -102,6 +102,7 @@
   [% mimetypes = [{type => "text/plain", desc => "plain text"},
                   {type => "text/html",  desc => "HTML source"},
                   {type => "application/xml", desc => "XML source"},
+                  {type => "application/json", desc => "JSON source"},
                   {type => "image/gif",  desc => "GIF image"},
                   {type => "image/jpeg", desc => "JPEG image"},
                   {type => "image/png",  desc => "PNG image"},


### PR DESCRIPTION
This is useful for about:support JSON files or Firefox Remote Settings data snippets.

Untested patch.