### PR TITLE
Bug 1608960 - 2018 is not last year

### DIFF
--- a/Bugzilla/Util.pm
+++ b/Bugzilla/Util.pm
@@ -655,16 +655,16 @@ sub time_ago {
   my $yy = round($mo / 12);
 
   return 'Just now'           if $ss < 10;
-  return $ss . ' seconds ago' if $ss < 45;
-  return '1 minute ago'       if $ss < 90;
-  return $mm . ' minutes ago' if $mm < 45;
-  return 'Last hour'          if $mm < 90;
-  return $hh . ' hours ago'   if $hh < 24;
-  return 'Yesterday'          if $hh < 36;
-  return $dd . ' days ago'    if $dd < 30;
-  return 'Last month'         if $dd < 45;
-  return $mo . ' months ago'  if $mo < 12;
-  return 'Last year'          if $mo < 18;
+  return $ss . ' seconds ago' if $mm < 1;
+  return '1 minute ago'       if $mm < 2;
+  return $mm . ' minutes ago' if $hh < 1;
+  return '1 hour ago'         if $hh < 2;
+  return $hh . ' hours ago'   if $dd < 1;
+  return '1 day ago'          if $dd < 2;
+  return $dd . ' days ago'    if $mo < 1;
+  return '1 month ago'        if $mo < 2;
+  return $mo . ' months ago'  if $yy < 1;
+  return '1 year ago'         if $yy < 2;
   return $yy . ' years ago';
 }
 

--- a/js/util.js
+++ b/js/util.js
@@ -356,16 +356,16 @@ function timeAgo(param) {
         mo = Math.round(dd / 30),
         yy = Math.round(mo / 12);
     if (ss < 10) return 'Just now';
-    if (ss < 45) return ss + ' seconds ago';
-    if (ss < 90) return '1 minute ago';
-    if (mm < 45) return mm + ' minutes ago';
-    if (mm < 90) return 'Last hour';
-    if (hh < 24) return hh + ' hours ago';
-    if (hh < 36) return 'Yesterday';
-    if (dd < 30) return dd + ' days ago';
-    if (dd < 45) return 'Last month';
-    if (mo < 12) return mo + ' months ago';
-    if (mo < 18) return 'Last year';
+    if (mm < 1) return ss + ' seconds ago';
+    if (mm < 2) return '1 minute ago';
+    if (hh < 1) return mm + ' minutes ago';
+    if (hh < 2) return '1 hour ago';
+    if (dd < 1) return hh + ' hours ago';
+    if (dd < 2) return '1 day ago';
+    if (mo < 1) return dd + ' days ago';
+    if (mo < 2) return '1 month ago';
+    if (yy < 1) return mo + ' months ago';
+    if (yy < 2) return '1 year ago';
     return yy + ' years ago';
 }
 


### PR DESCRIPTION
Fix date labels that I changed in #1297 by saying “1 year ago” Instead of “last year.” Also simply the logic. Since the code already uses the math `round` function, 17 months ago will be 1 year ago but 18 months will be 2 years ago, which won’t be changed.

## Bugzilla link

[Bug 1608960 - 2018 is not last year](https://bugzilla.mozilla.org/show_bug.cgi?id=1608960)