### PR TITLE
Revert "Bug 1588221 - Update current s3 storage controller to only upload attachments over a certain size (schema only)"

### DIFF
--- a/Bugzilla/DB/Schema.pm
+++ b/Bugzilla/DB/Schema.pm
@@ -337,7 +337,7 @@ use constant ABSTRACT_SCHEMA => {
         REFERENCES => {TABLE => 'bugs', COLUMN => 'bug_id', DELETE => 'CASCADE'}
       },
       attach_id => {
-        TYPE => 'INT5',
+        TYPE => 'INT3',
         REFERENCES =>
           {TABLE => 'attachments', COLUMN => 'attach_id', DELETE => 'CASCADE'}
       },
@@ -509,7 +509,7 @@ use constant ABSTRACT_SCHEMA => {
 
   attachments => {
     FIELDS => [
-      attach_id => {TYPE => 'BIGSERIAL', NOTNULL => 1, PRIMARYKEY => 1},
+      attach_id => {TYPE => 'MEDIUMSERIAL', NOTNULL => 1, PRIMARYKEY => 1},
       bug_id    => {
         TYPE       => 'INT3',
         NOTNULL    => 1,
@@ -538,31 +538,16 @@ use constant ABSTRACT_SCHEMA => {
       attachments_ispatch_idx           => ['ispatch'],
     ],
   },
-
   attach_data => {
     FIELDS => [
       id => {
-        TYPE       => 'INT5',
+        TYPE       => 'INT3',
         NOTNULL    => 1,
         PRIMARYKEY => 1,
         REFERENCES =>
           {TABLE => 'attachments', COLUMN => 'attach_id', DELETE => 'CASCADE'}
       },
       thedata => {TYPE => 'LONGBLOB', NOTNULL => 1},
-    ],
-  },
-
-  attachment_storage_class => {
-    FIELDS => [
-      id => {
-        TYPE       => 'INT5',
-        NOTNULL    => 1,
-        PRIMARYKEY => 1,
-        REFERENCES =>
-          {TABLE => 'attachments', COLUMN => 'attach_id', DELETE => 'CASCADE'}
-      },
-      storage_class => {TYPE => 'varchar(64)', NOTNULL => 1},
-      extra_data    => {TYPE => 'MEDIUMTEXT'}
     ],
   },
 
@@ -669,7 +654,7 @@ use constant ABSTRACT_SCHEMA => {
         REFERENCES => {TABLE => 'bugs', COLUMN => 'bug_id', DELETE => 'CASCADE'}
       },
       attach_id => {
-        TYPE => 'INT5',
+        TYPE => 'INT3',
         REFERENCES =>
           {TABLE => 'attachments', COLUMN => 'attach_id', DELETE => 'CASCADE'}
       },
@@ -1824,7 +1809,7 @@ use constant ABSTRACT_SCHEMA => {
       user_agent  => {TYPE => 'TINYTEXT',    NOTNULL => 1},
       timestamp   => {TYPE => 'DATETIME',    NOTNULL => 1},
       bug_id      => {TYPE => 'INT3',        NOTNULL => 0},
-      attach_id   => {TYPE => 'INT5',        NOTNULL => 0},
+      attach_id   => {TYPE => 'INT4',        NOTNULL => 0},
       request_url => {TYPE => 'TINYTEXT',    NOTNULL => 1},
       method      => {TYPE => 'TINYTEXT',    NOTNULL => 1},
       action      => {TYPE => 'varchar(20)', NOTNULL => 1},

--- a/Bugzilla/DB/Schema/Mysql.pm
+++ b/Bugzilla/DB/Schema/Mysql.pm
@@ -103,12 +103,10 @@ sub _initialize {
     INT2 => 'smallint',
     INT3 => 'mediumint',
     INT4 => 'integer',
-    INT5 => 'bigint(20)',
 
     SMALLSERIAL  => 'smallint auto_increment',
     MEDIUMSERIAL => 'mediumint auto_increment',
     INTSERIAL    => 'integer auto_increment',
-    BIGSERIAL    => 'bigint(20) auto_increment',
 
     TINYTEXT   => 'tinytext',
     MEDIUMTEXT => 'mediumtext',

--- a/Bugzilla/DB/Schema/Oracle.pm
+++ b/Bugzilla/DB/Schema/Oracle.pm
@@ -46,12 +46,10 @@ sub _initialize {
     INT2 => 'integer',
     INT3 => 'integer',
     INT4 => 'integer',
-    INT5 => 'integer',
 
     SMALLSERIAL  => 'integer',
     MEDIUMSERIAL => 'integer',
     INTSERIAL    => 'integer',
-    BIGSERIAL    => 'integer',
 
     TINYTEXT   => 'varchar(255)',
     MEDIUMTEXT => 'varchar(4000)',

--- a/Bugzilla/DB/Schema/Pg.pm
+++ b/Bugzilla/DB/Schema/Pg.pm
@@ -55,12 +55,10 @@ sub _initialize {
     INT2 => 'integer',
     INT3 => 'integer',
     INT4 => 'integer',
-    INT5 => 'integer',
 
     SMALLSERIAL  => 'serial unique',
     MEDIUMSERIAL => 'serial unique',
     INTSERIAL    => 'serial unique',
-    BIGSERIAL    => 'serial unique',
 
     TINYTEXT   => 'varchar(255)',
     MEDIUMTEXT => 'text',

--- a/Bugzilla/DB/Schema/Sqlite.pm
+++ b/Bugzilla/DB/Schema/Sqlite.pm
@@ -35,12 +35,10 @@ sub _initialize {
     INT2 => 'integer',
     INT3 => 'integer',
     INT4 => 'integer',
-    INT5 => 'integer',
 
     SMALLSERIAL  => 'SERIAL',
     MEDIUMSERIAL => 'SERIAL',
     INTSERIAL    => 'SERIAL',
-    BIGSERIAL    => 'SERIAL',
 
     TINYTEXT   => 'text',
     MEDIUMTEXT => 'text',

--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -805,17 +805,6 @@ sub update_table_definitions {
   # Bug 1576667 - dkl@mozilla.com
   _populate_api_keys_creation_ts();
 
-  # Bug 1588221 - dkl@mozilla.com
-  $dbh->bz_alter_column('bugs_activity', 'attach_id', {TYPE => 'INT5'});
-  $dbh->bz_alter_column('attachments', 'attach_id',
-    {TYPE => 'BIGSERIAL', NOTNULL => 1, PRIMARYKEY => 1});
-  $dbh->bz_alter_column('attach_data', 'id',
-    {TYPE => 'INT5', NOTNULL => 1, PRIMARYKEY => 1});
-  $dbh->bz_alter_column('flags',            'attach_id', {TYPE => 'INT5'});
-  $dbh->bz_alter_column('user_request_log', 'attach_id', {TYPE => 'INT5'});
-  _populate_attachment_storage_class();
-
-
   ################################################################
   # New --TABLE-- changes should go *** A B O V E *** this point #
   ################################################################
@@ -4335,25 +4324,6 @@ sub _populate_api_keys_creation_ts {
 
   $dbh->bz_alter_column('user_api_keys', 'creation_ts',
     {TYPE => 'DATETIME', NOTNULL => 1});
-}
-
-sub _populate_attachment_storage_class {
-  my $dbh = Bugzilla->dbh;
-
-  my $attach_count
-    = $dbh->selectrow_array('SELECT COUNT(attach_id) FROM attachments');
-  my $class_count
-    = $dbh->selectrow_array('SELECT COUNT(id) FROM attachment_storage_class');
-
-  # Return if we have already made these changes
-  if ($attach_count != $class_count) {
-    print "Populating attachments_storage_class table...\n";
-    $dbh->do("
-       INSERT INTO attachment_storage_class (id, storage_class)
-       SELECT attachments.attach_id, 'database' FROM attachments
-       WHERE NOT EXISTS (SELECT 1 FROM attachment_storage_class WHERE id = attachments.attach_id)
-    ");
-  }
 }
 
 1;

--- a/extensions/Review/Extension.pm
+++ b/extensions/Review/Extension.pm
@@ -874,7 +874,7 @@ sub db_schema_abstract_schema {
       },
 
       attachment_id => {
-        TYPE => 'INT5',
+        TYPE => 'INT3',
         REFERENCES =>
           {TABLE => 'attachments', COLUMN => 'attach_id', DELETE => 'CASCADE'}
       },


### PR DESCRIPTION
Will need to hold on this a little longer as it may require BMO outage to do the table upgrades. There is also a chance we can do this online using Percona toolkit or Ghost.