### PR TITLE
Bumped version to 20200117.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20191212.1';
+our $VERSION = '20200117.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1569274" target="_blank">1569274</a>] Updated Dockerfile and circleci configuration to build dependencies into a new bmo-slim image based on Perl 5.30</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1604738" target="_blank">1604738</a>] crash graph doesn't handle signatures with "+" character</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1592410" target="_blank">1592410</a>] different bug count with and without count_only=1 parameter</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1607030" target="_blank">1607030</a>] Selecting a most-used component goes into a loop when switching from guided bug entry form</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1608781" target="_blank">1608781</a>] Etiquette page should stop sending people to IRC</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1605179" target="_blank">1605179</a>] Abandoning a revision assigns the commit author to the unassigned bug.</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1608491" target="_blank">1608491</a>] Improve docker environment for developers wanting to work on bmo code</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1608960" target="_blank">1608960</a>] 2018 is not last year</li>
</ul>