### PR TITLE
Bump version to 20200123.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20200117.1';
+our $VERSION = '20200123.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1611257" target="_blank">1611257</a>] Bugmail is being filtered incorrectly since this morning's BMO deployment</li>
</ul>