### PR TITLE
Bug 1472757 - Comment field empty after clicking "go back page"

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -119,6 +119,11 @@ $(function() {
         localStorage.removeItem(key);
     }
 
+    // Clear saved comment once the bug is successfully updated
+    if (document.querySelector('.change-summary[data-type="bug"]')) {
+        clearSavedBugComment();
+    }
+
     function restoreSavedBugComment() {
         expireSavedComments();
         let key = `bug-modal-saved-comment-${BUGZILLA.bug_id}`;
@@ -701,8 +706,6 @@ $(function() {
                     .toArray()
                     .join(' ')
             );
-
-            clearSavedBugComment();
         })
         .attr('disabled', false);
 

--- a/template/en/default/bug/process/results.html.tmpl
+++ b/template/en/default/bug/process/results.html.tmpl
@@ -49,7 +49,7 @@
 
 [% Hook.process('title') %]
 
-<dl class="change-summary bug">
+<dl class="change-summary bug" data-type="[% type FILTER html %]">
   <dt>[% title.$type %]</dt>
   <dd>
     [% PROCESS "bug/process/bugmail.html.tmpl" mailing_bugid = id %]


### PR DESCRIPTION
Clear any saved comment on the bug page once the bug is successfully updated, not immediately after the Save Changes button is clicked. This prevents the user’s comment from being cleared when a mid-air collision happens.

Note: the test failure should be solved once #1503 is merged.

## Bugzilla link

[Bug 1472757 - Comment field empty after clicking "go back page"](https://bugzilla.mozilla.org/show_bug.cgi?id=1472757)