### PR TITLE
Bump version to 20200211.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20200123.1';
+our $VERSION = '20200211.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1613686" target="_blank">1613686</a>] Improper encoding of content-type, content-transfer-encoding for security reports causes content to not be displayed properly</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1556727" target="_blank">1556727</a>] Replace “Email sent to” message with a toast notification</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1611281" target="_blank">1611281</a>] Double-escaping of '&lt;' in code areas</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1611494" target="_blank">1611494</a>] Bugzilla custom email headers are getting mashed together</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1612287" target="_blank">1612287</a>] Issue with negation operator in query search</li>
</ul>