### PR TITLE
Bug 1617358 - Remove extra slash in mydashboard.html.tmpl

### DIFF
--- a/extensions/MyDashboard/template/en/default/pages/mydashboard.html.tmpl
+++ b/extensions/MyDashboard/template/en/default/pages/mydashboard.html.tmpl
@@ -129,7 +129,7 @@
 
       [% IF Param('phabricator_enabled') %]
         <h2 class="query_heading requests">
-          <a href="[% Param('phabricator_base_uri') %]/differential">Phabricator Review Requests</a>
+          <a href="[% Param('phabricator_base_uri') %]differential">Phabricator Review Requests</a>
         </h2>
       [% END %]
 


### PR DESCRIPTION
The "phabricator review requests" link had an extra slash in the url. This patch removes it.