### PR TITLE
Bug 1237874 - File size unit always plural: "1 bytes"

### DIFF
--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -807,12 +807,7 @@ sub create {
         my %units = ('KB' => 1024, 'MB' => 1024 * 1024, 'GB' => 1024 * 1024 * 1024,);
 
         if ($data < 1024) {
-          if($data == 1) {
-            return "1 byte";
-          }
-          else {
-            return "$data bytes";
-          }
+          return "$data byte".($data == 1 ? '':'s');
         }
         else {
           my $u;

--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -807,7 +807,12 @@ sub create {
         my %units = ('KB' => 1024, 'MB' => 1024 * 1024, 'GB' => 1024 * 1024 * 1024,);
 
         if ($data < 1024) {
-          return "$data bytes";
+          if($data == 1) {
+            return "1 byte";
+          }
+          else {
+            return "$data bytes";
+          }
         }
         else {
           my $u;


### PR DESCRIPTION
	modified:   Bugzilla/Template.pm to account for 1 byte file size