### PR TITLE
Bump version to 20200225.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20200211.1';
+our $VERSION = '20200225.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1617358" target="_blank">1617358</a>] Extra slash in the "phabricator review requests" link's url on the BMO dashboard</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1591549" target="_blank">1591549</a>] Hide bugs in dependencies and regression fields from users without access</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1612290" target="_blank">1612290</a>] Provide self-service UI for users to reactivate their account after being disabled due to bouncing</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1237874" target="_blank">1237874</a>] File size unit always plural: "1 bytes"</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1599865" target="_blank">1599865</a>] Bug description is erased during page load, leading to dataloss during Firefox session restore</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1472757" target="_blank">1472757</a>] Comment field empty after clicking "go back page"</li>
</ul>