### PR TITLE
Bug 1619361 - Update Reps Application Form

### DIFF
--- a/extensions/REMO/template/en/default/bug/create/comment-mozreps.txt.tmpl
+++ b/extensions/REMO/template/en/default/bug/create/comment-mozreps.txt.tmpl
@@ -18,17 +18,12 @@
   #%]
 [% USE Bugzilla %]
 [% cgi = Bugzilla.cgi %]
+
 First Name:
 [%+ cgi.param('first_name') %]
 
 Last Name:
 [%+ cgi.param('last_name') %]
-
-Under 18 years old:
-[%+ IF cgi.param('underage') %]Yes[% ELSE %]No[% END %]
-
-Gender:
-[%+ cgi.param('gender') %]
 
 City:
 [%+ cgi.param('city') %]
@@ -36,56 +31,38 @@ City:
 Country:
 [%+ cgi.param('country') %]
 
-Local Community:
-[% IF cgi.param('community') %]
-[%+ cgi.param('community') %]
-[% ELSE %]
--
-[% END %]
-
-IM:
-[% IF cgi.param('im') %]
-[%+ cgi.param('im') %]
-[% ELSE %]
--
-[% END %]
-
-Mozillians.org Account URL:
-[% IF cgi.param('mozillian') %]
-[%+ cgi.param('mozillian') %]
-[% ELSE %]
--
-[% END %]
-
-References:
-[% IF cgi.param('cc') %]
-[%+ cgi.param('cc').join(", ") %]
-[% END %]
-
-What are you currently doing at Mozilla?
-[% IF cgi.param('involved') %]
-[%+ cgi.param('involved') %]
-[% END %]
-
-When First Contributed:
-[% IF cgi.param('firstcontribute') %]
-[%+ cgi.param('firstcontribute') %]
-[% ELSE %]
--
-[% END %]
-
-Languages Spoken:
+[% IF cgi.param('languages') %]
+Languages:
 [%+ cgi.param('languages') %]
 
-How did you learn about Mozilla Reps:
+[% END %]
+Mozillians.org Account URL:
+[%+ cgi.param('mozillian') %]
+
+References:
+[%+ cgi.param('cc').join(", ") %]
+
+First contributed to Mozilla:
+[%+ cgi.param('firstcontribute') %]
+
+In which area are you active in Mozilla?
+[%+ cgi.param('involved') %]
+
+How did you learn about Mozilla Reps?
 [%+ cgi.param('learn') %]
 
-What motivates you most about joining Mozilla Reps:
+What motivates you most about joining Mozilla Reps?
 [%+ cgi.param('motivation') %]
 
-Comments:
+[% IF cgi.param('languages') %]
+Mission Driven Mozillians:
+[%+ cgi.param('mdm') %]
+
+[% END %]
+Activity:
+[%+ cgi.param('activity') %]
+
 [% IF cgi.param('comments') %]
+Comments:
 [%+ cgi.param('comments') %]
-[% ELSE %]
--
 [% END %]

--- a/extensions/REMO/template/en/default/bug/create/create-mozreps.html.tmpl
+++ b/extensions/REMO/template/en/default/bug/create/create-mozreps.html.tmpl
@@ -35,7 +35,7 @@
 
 <p>
   If you have questions while completing this form, please contact the
-  <a href="mailto:reps-council@mozilla.org">Reps Council</a> for assistance.
+  <a href="mailto:reps-council@mozilla.com">Reps Council</a> for assistance.
 </p>
 
 <form method="post" action="[% basepath FILTER none %]post_bug.cgi" id="tmRequestForm">
@@ -58,79 +58,116 @@
   <input type="hidden" name="token" value="[% token FILTER html %]">
 
   <table id="reps-form">
-    <tr class="odd">
-      <th><label class="required" for="first_name">First Name:</label></th>
-      <td><input requuired id="first_name" name="first_name" size="40" placeholder="John"></td>
-    </tr>
-
-    <tr class="even">
-      <th><label class="required" for="last_name">Last Name:</label></th>
-      <td><input id="last_name" name="last_name" size="40" placeholder="Doe"></td>
-    </tr>
-
-    <tr class="odd">
-      <th><label for="underage">Are you under 18 years old?:</label></th>
+    <tr>
+      <th><label for="first_time">Is this the first time you have applied for Reps?</label></th>
       <td>
-        <input type="checkbox" id="underage" name="underage" value="1"><br>
-      </td>
-    </tr>
-
-    <tr id="underage_warning" class="odd" style="display: none">
-      <td colspan="2">
-        Mozilla Reps program is not currently accepting people under 18 years old.
-        Sorry for the inconvenience. In the meantime please check with your local Mozilla
-        group for other contribution opportunities
-      </td>
-    </tr>
-
-    <tr class="even">
-      <th><label class="required" for="gender">Gender:</label></th>
-      <td>
-        <select id="gender" name="gender">
-          <option value=""></option>
-          <option value="Male">Male</option>
-          <option value="Female">Female</option>
-          <option value="Other">Other</option>
+        <select id="first_time">
+          <option value="Yes">Yes</option>
+          <option value="No">No</option>
         </select>
       </td>
     </tr>
 
-    <tr class="odd">
+    <tr id="prior_bug" style="display: none">
+      <th><label for="dependson">Please reference the previous [% terms.bug %] number: </label></th>
+      <td><input id="dependson" name="dependson" type="text" value=""></td>
+    </tr>
+
+    <tr>
+      <th><label class="required" for="first_name">First Name:</label></th>
+      <td><input id="first_name" name="first_name" size="40" placeholder="John"></td>
+    </tr>
+
+    <tr>
+      <th><label class="required" for="last_name">Last Name:</label></th>
+      <td><input id="last_name" name="last_name" size="40" placeholder="Doe"></td>
+    </tr>
+
+    <tr>
+      <th><label for="age">Are you 18 years or older?</label></th>
+      <td>
+        <select id="age">
+          <option value="No">No</option>
+          <option value="Yes">Yes</option>
+        </select>
+      </td>
+    </tr>
+
+    <tr id="age_warning" style="display: none">
+      <td colspan="2">
+        Mozilla Reps program is not currently accepting people under 18 years old.
+        Sorry for the inconvenience. In the meantime please check with your local Mozilla
+        group for other contribution opportunities.
+      </td>
+    </tr>
+
+    <tr>
       <th><label class="required" for="city">City:</label></th>
       <td><input id="city" name="city" size="40" placeholder="Your city"></td>
     </tr>
 
-    <tr class="even">
+    <tr>
       <th><label class="required" for="country">Country:</label></th>
       <td><input id="country" name="country" size="40" placeholder="Your country"></td>
     </tr>
 
-    <tr class="odd">
-      <th><label for="community">Local Community you participate in:</label></th>
-      <td><input id="community" name="community" size="40" placeholder="Name of your community"></td>
+    <tr>
+      <th><label for="languages">Languages spoken:</label></th>
+      <td><input id="languages" name="languages" size="40"></td>
     </tr>
 
-    <tr class="even">
-      <th><label for="im">IM (specify service):</label></th>
-      <td><input id="im" name="im" size="40"></td>
+    <tr>
+      <th><label for="vouched" class="required">Do you have a vouched Mozillian account?</label></th>
+      <td>
+        <select id="vouched">
+          <option value="Yes">Yes</option>
+          <option value="No">No</option>
+        </select>
+      </td>
     </tr>
 
-    <tr class="odd">
+    <tr id="vouched_warning" style="display: none">
+      <td colspan="2">
+        You require a vouched Mozillians account to apply to the Reps Program.
+      </td>
+    </tr>
+
+    <tr>
       <th><label class="required" for="mozillian">Mozillians.org Account URL:</label></th>
       <td>
         <input type="url" id="mozillian" name="mozillian" size="40" placeholder="https://mozillians.org/u/name">
       </td>
     </tr>
 
-    <tr class="even">
+    <tr>
+      <th>
+        <label for="information">
+          Is your Mozillians account filled with the <a href="https://wiki.mozilla.org/Reps/Application_Process/Selection_Criteria" target="_blank">required information</a>?
+        </label>
+      </th>
+      <td>
+        <select id="information">
+          <option value="Yes">Yes</option>
+          <option value="No">No</option>
+        </select>
+      </td>
+    </tr>
+
+    <tr id="information_warning" style="display: none">
+      <td colspan="2">
+        Please fill out your Mozillians account according to the <a href="https://wiki.mozilla.org/Reps/Application_Process/Selection_Criteria" target="_blank">Selection Criteria</a>.
+      </td>
+    </tr>
+
+    <tr>
       <th colspan="2">
         <label class="required" for="cc">
-          Mozilla contributors who vouch your application:
+          Mozillians who vouch for your application. They need to add a comment to your application [% terms.bug %] why they endorse your application.
         </label>
       </th>
     </tr>
 
-    <tr class="even">
+    <tr>
       <td colspan="2">
         [% INCLUDE global/userselect.html.tmpl
            id       => "cc"
@@ -143,50 +180,47 @@
       </td>
     </tr>
 
-    <tr class="odd">
-      <th colspan="2">
-        <label class="required" for="involved">
-          What are you currently doing at Mozilla?
-        </label>
-      </th>
-    </tr>
-
-    <tr class="odd">
-      <td colspan="2">
-        <textarea id="involved" name="involved" rows="4" placeholder="Add-ons,  l10n,  SUMO,  QA,  ..."></textarea>
-      </td>
-    </tr>
-
-    <tr class="even">
+    <tr>
       <th>
         <label class="required" for="firstcontribute">
           When did you first start contributing to Mozilla?
         </label>
       </th>
-      <td><input id="firstcontribute" name="firstcontribute" size="40"></td>
+      <td>
+        <input name="firstcontribute" size="20" id="firstcontribute" value=""
+              onchange="updateCalendarFromField(this)">
+        <button type="button" class="calendar_button"
+                id="button_calendar_firstcontribute"
+                onclick="showCalendar('firstcontribute')">
+          <span>Calendar</span>
+        </button>
+        <div id="con_calendar_firstcontribute"></div>
+        <script [% script_nonce FILTER none %]>
+          createCalendar('firstcontribute')
+        </script>
+      </td>
     </tr>
 
-    <tr class="odd">
-      <th><label class="required" for="languages">Languages Spoken:</label></th>
-      <td><input id="languages" name="languages" size="40"></td>
+    <tr>
+      <th colspan="2">
+        <label class="required" for="involved">
+          In which area are you active in Mozilla?
+        </label>
+      </th>
     </tr>
 
-    <tr class="even">
+    <tr>
+      <td colspan="2">
+        <textarea id="involved" name="involved" rows="4" placeholder="Add-ons, Localization,  SUMO, QA, etc."></textarea>
+      </td>
+    </tr>
+
+    <tr>
       <th><label class="required" for="learn">How did you learn about Mozilla Reps?</label></th>
       <td><input id="learn" name="learn" size="40"></td>
     </tr>
 
-    <tr class="odd">
-      <th><label for="first_time">Is this the first time you have applied for Reps?</label></th>
-      <td><input type="checkbox" id="first_time" name="first_time" value="1" checked></td>
-    </tr>
-
-    <tr id="prior_bug" class="odd" style="display: none">
-      <th><label for="dependson">If you have already applied to the program in the past, please reference the [% terms.bug %] number: </label></th>
-      <td><input id="dependson" name="dependson" type="text" value=""></td>
-    </tr>
-
-    <tr class="even">
+    <tr>
       <th colspan="2">
         <label class="required" for="motivation">
           What motivates you most about joining Mozilla Reps?
@@ -194,7 +228,7 @@
       </th>
     </tr>
 
-    <tr class="even">
+    <tr>
       <td colspan="2">
         <textarea id="motivation" name="motivation" rows="4"
                   placeholder="[% INCLUDE motivation_placeholder FILTER html %]"></textarea>
@@ -205,19 +239,52 @@
       Tell us your goals and what you would be able to do as a Rep that you can't do right now
     [%- END %]
 
-    <tr class="odd">
+    <tr>
       <th colspan="2">
-        <label for="comments">
-          Comments:
+        <label for="mdm">
+          What are Mission Driven Mozillans?
         </label>
       </th>
     </tr>
 
-    <tr class="odd">
+    <tr>
+      <td colspan="2">
+        <textarea id="mdm" name="mdm" rows="4"></textarea>
+      </td>
+    </tr>
+
+    <tr>
+      <th colspan="2">
+        <label class="required" for="activity">
+          What have you done in the last 6 months for Mozilla?
+        </label>
+      </th>
+    </tr>
+
+    <tr>
+      <td colspan="2">
+        <textarea id="activity" name="activity" rows="8"
+                  placeholder="[% INCLUDE activity_placeholder FILTER html %]"></textarea>
+      </td>
+    </tr>
+
+    [% BLOCK activity_placeholder -%]
+      List some activities you organized or participated in and support this with links to blogposts/articles/events/etc
+    [%- END %]
+
+    <tr>
+      <th colspan="2">
+        <label for="comments">
+          Do you want to add something we need to know?
+        </label>
+      </th>
+    </tr>
+
+    <tr>
       <td colspan="2"><textarea id="comments" name="comments" rows="4"></textarea></td>
     </tr>
 
-    <tr class="even">
+    <tr>
       <th>
         <label class="required" for="privacy">
           I have read the
@@ -227,7 +294,7 @@
       <td><input id="privacy" name="privacy" type="checkbox" value="1"></td>
     </tr>
 
-    <tr class="odd">
+    <tr>
       <td>&nbsp;</td>
       <td align="right">
         <button id="submit">Submit</button>

--- a/extensions/REMO/template/en/default/bug/create/created-mozreps.html.tmpl
+++ b/extensions/REMO/template/en/default/bug/create/created-mozreps.html.tmpl
@@ -35,9 +35,9 @@
 </p>
 
 <ul>
-  <li>The mozillians who vouched you should comment on the application [% terms.bug %] endorsing your application. Please contact them to make sure they endorse you, this is needed for your application to be complete.</li>
-  <li>The application will be reviewed after you are endorsed and if it fits all requirements it will be placed in the mentorship queue.</li>
-  <li>Once a Rep mentor has a free slot, they will be assigned to do the final review.</li>
+  <li>The Mozillians who vouched you should comment on the application [% terms.bug %] endorsing your application. Please contact them to make sure they endorse you, this is needed for your application to be complete.</li>
+  <li>The application will be reviewed after you are endorsed and all necessary information is provided.</li>
+  <li>The Reps Onboarding team will review your application and report back their decision.</li>
 </ul>
 
 <p>

--- a/extensions/REMO/web/js/moz_reps.js
+++ b/extensions/REMO/web/js/moz_reps.js
@@ -9,9 +9,8 @@ $(document).ready(function() {
     'use strict';
 
     var first_time = $("#first_time");
-    first_time.prop("checked", true);
     first_time.change(function(evt) {
-        if (!this.checked) {
+        if (this.value !== 'Yes') {
             $("#prior_bug").show();
             $("#prior_bug label").addClass("required");
         }
@@ -21,14 +20,36 @@ $(document).ready(function() {
         }
     }).change();
 
-    $("#underage").change(function(evt) {
-        if (this.checked) {
-            $('#underage_warning').show();
-            $('#submit').prop("disabled", true);
+    $("#age").change(function(evt) {
+        if (this.value === 'Yes') {
+            $('#age_warning').hide();
+            $('#submit').prop("disabled", false);
         }
         else {
-            $('#underage_warning').hide();
+            $('#age_warning').show();
+            $('#submit').prop("disabled", true);
+        }
+    }).change();
+
+    $("#vouched").change(function(evt) {
+        if (this.value === 'Yes') {
+            $('#vouched_warning').hide();
             $('#submit').prop("disabled", false);
+        }
+        else {
+            $('#vouched_warning').show();
+            $('#submit').prop("disabled", true);
+        }
+    }).change();
+
+    $("#information").change(function(evt) {
+        if (this.value === 'Yes') {
+            $('#information_warning').hide();
+            $('#submit').prop("disabled", false);
+        }
+        else {
+            $('#information_warning').show();
+            $('#submit').prop("disabled", true);
         }
     }).change();
 

--- a/extensions/REMO/web/styles/moz_reps.css
+++ b/extensions/REMO/web/styles/moz_reps.css
@@ -25,7 +25,7 @@
 }
 
 #reps-form textarea {
-  width: 590px;
+  width: 100%;
 }
 
 #reps-form textarea.small {
@@ -57,4 +57,10 @@ label.required:before {
 
 .yui-calcontainer {
   z-index: 2;
+}
+
+#age_warning,
+#vouched_warning,
+#information_warning {
+  color: var(--error-message-foreground-color);
 }


### PR DESCRIPTION
In the past years we changed the Reps program application criteria several times. Nowadays our application form does not match what we need to know in an application anymore. This leads to an inefficient process where we need to ask back and request information. Due to this [Tim](https://reps.mozilla.org/u/Mad_Maks/) has created a new form, tested it and streamlined our application process. This PR adjusts the form to that variant.

I've tested this locally and Tim has also verified that it behaves as required.