### PR TITLE
Bug 1605761 - It's not clear at all that you need to hit -enter- to save a comment tag.

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -84,11 +84,12 @@
   <div id="ctag" style="display:none">
     <input id="ctag-add" size="10" placeholder="add tag"
       maxlength="[% constants.MAX_COMMENT_TAG_LENGTH FILTER html %]">
-    <button type="button" id="ctag-close" class="minor" aria-label="Close">x</button>
+    <button type="button" id="ctag-save" class="minor">Save</button>
+    <button type="button" id="ctag-cancel" class="minor">Cancel</button>
     <a href="https://wiki.mozilla.org/BMO/comment_tagging" target="_blank" rel="noopener noreferrer" title="About Comment Tagging">Help</a>
   </div>
   <div id="ctag-error" style="display:none">
-    <a href="#" class="close-btn" data-for="ctag-error" aria-label="Close">x</a>
+    <a href="#" class="close-btn" data-for="ctag-error" aria-label="Dismiss">×</a>
     <span id="ctag-error-message"></span>
   </div>
 [% END %]
@@ -174,7 +175,7 @@
         <td colspan="2" class="comment-tags">
           [% FOREACH tag IN comment.tags ~%]
             <span class="comment-tag">
-              [%~ '<a role="button" aria-label="Remove">x</a>' IF user.can_tag_comments %][% tag FILTER html ~%]
+              [%~ '<a role="button" aria-label="Remove" class="remove">×</a>' IF user.can_tag_comments %][% tag FILTER html ~%]
             </span>
           [%~ END %]
         </td>

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -823,6 +823,13 @@ h3.change-name a {
   cursor: pointer;
 }
 
+.comment-tags .remove[role="button"],
+.comment-tags .close-btn {
+  font-size: 1.8em;
+  line-height: .7em;
+  vertical-align: top;
+}
+
 #ctag {
   margin-bottom: 4px;
 }


### PR DESCRIPTION
Add the Save button to the comment tagging UI so people don’t forget to save a new tag by hitting the Enter key. The Enter-to-save keyboard shortcut is still supported. Plus, clean up the code a bit.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1605761