### PR TITLE
no bug - Update VS Code tasks with Docker commands

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,6 +4,23 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "label": "Docker: Start Web Server",
+      "type": "shell",
+      "command": "docker-compose up --build",
+      "group": "none",
+      "problemMatcher": []
+    },
+    {
+      "label": "Docker: Update Web Server",
+      "type": "shell",
+      "command": "docker-compose exec bmo.test rsync -avz --exclude .git --exclude local /mnt/sync/ /app/",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": []
+    },
+    {
       "label": "Vagrant: Start VM",
       "type": "shell",
       "command": "vagrant up",
@@ -18,20 +35,17 @@
       "problemMatcher": []
     },
     {
-        "label": "Vagrant: Start Web Server",
-        "type": "shell",
-        "command": "vagrant ssh web -c 'start_morbo'",
-        "group": "none",
-        "problemMatcher": []
+      "label": "Vagrant: Start Web Server",
+      "type": "shell",
+      "command": "vagrant ssh web -c 'start_morbo'",
+      "group": "none",
+      "problemMatcher": []
     },
     {
       "label": "Vagrant: Update Web Server",
       "type": "shell",
       "command": "vagrant rsync web",
-      "group": {
-        "kind": "build",
-        "isDefault": true
-      },
+      "group": "build",
       "problemMatcher": []
     },
     {

--- a/README.rst
+++ b/README.rst
@@ -163,14 +163,6 @@ or db is changed, do a full provision:
 
     vagrant rsync && vagrant provision
 
-If you are using Visual Studio Code, these commands will come in handy as the
-editor's `tasks`_ that can be found under the Terminal menu. The update command
-can be executed by simply hitting `Ctrl+Shift+B` on Windows/Linux or
-`Command+Shift+B` on macOS. An `extension bundle`_ for VS Code is also available.
-
-.. _`tasks`: https://code.visualstudio.com/docs/editor/tasks
-.. _`extension bundle`: https://marketplace.visualstudio.com/items?itemName=dylanwh.bugzilla
-
 Testing Auth delegation
 -----------------------
 
@@ -291,6 +283,14 @@ You can run the following command:
 
 The Mojolicious morbo development server, used by the web container, will notice any code changes and
 restart itself.
+
+If you are using Visual Studio Code, these ``docker-compose`` commands will come in handy as the
+editor's `tasks`_ that can be found under the Terminal menu. The update command is assigned to the
+default build task so it can be executed by simply hitting Ctrl+Shift+B on Windows/Linux or
+Command+Shift+B on macOS. An `extension bundle`_ for VS Code is also available.
+
+.. _`tasks`: https://code.visualstudio.com/docs/editor/tasks
+.. _`extension bundle`: https://marketplace.visualstudio.com/items?itemName=dylanwh.bugzilla
 
 
 Ensuring your Docker setup on Ubuntu 16.04


### PR DESCRIPTION
Add `docker-compose` commands to the VS Code tasks file. Make the Docker `rsync` command the default build task instead of Vagrant, so it can be used quickly with the Cmd+Shift+B keyboard shortcut.