### PR TITLE
Bug 1621160 - First row of stagger column headers will be hidden when table header becomes sticky

### DIFF
--- a/skins/standard/buglist.css
+++ b/skins/standard/buglist.css
@@ -55,7 +55,7 @@
   box-shadow: var(--primary-region-box-shadow);
 }
 
-.bz_buglist_header {
+.bz_buglist thead {
   position: sticky;
   top: 0;
   background: var(--grid-header-background-color);


### PR DESCRIPTION
Make sure stagger headers on the search results table are displayed properly. `position: sticky` has to be set on `<thead>` instead of `<tr class="bz_buglist_header">` that will double when staggered.

Note 1: stagger headers can be used when you customize the columns via the “Change Columns” link at the bottom of the search results page.

Note 2: this technique works only on Firefox and Safari. It seems Chrome still doesn’t support `position: sticky` within a `<table>`.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1621160