### PR TITLE
Bug 1344094 - Add a link to a wiki.mozilla.org page describing how to request a keyword

### DIFF
--- a/template/en/default/reports/keywords.html.tmpl
+++ b/template/en/default/reports/keywords.html.tmpl
@@ -103,6 +103,9 @@
   <p>
     <a href="[% basepath FILTER none %]editkeywords.cgi">Edit keywords</a>.
   </p>
+  <p>
+    <a href="https://wiki.mozilla.org/BMO/Requesting_Changes#Keywords">How to request keywords </a>
+  </p>
 [% END %]
 
 [% PROCESS global/footer.html.tmpl %]


### PR DESCRIPTION
Link added to describe keywords page