### PR TITLE
Bug 1536547 add link under poked bugs count

### DIFF
--- a/extensions/UserProfile/template/en/default/pages/user_profile.html.tmpl
+++ b/extensions/UserProfile/template/en/default/pages/user_profile.html.tmpl
@@ -247,7 +247,14 @@
 <tr>
   <td>&nbsp;</td>
   <th>[% terms.Bugs %] poked</th>
-  <td class="numeric">[% stats.touched || 0 FILTER html %]</td>
+  <td class="numeric">
+  [% IF user.id %]
+      <a href="[% basepath FILTER none %]buglist.cgi?query_format=advanced&amp;emailtype1=exact&amp;emailqa_contact1=1&amp;emailassigned_to1=1&amp;emaillongdesc1=1&amp;emailbug_mentor1=1&amp;emailreporter1=1&amp;email1=[% target.login FILTER uri %]"
+        target="_blank">
+  [% END %]
+  [% stats.touched || 0 FILTER html %]
+  [% "</a>" IF user.id %]
+  </td>
 </tr>
 
 <tr>


### PR DESCRIPTION
As an Outreachy applicant, I fixed bug 1536547 - The counter for "Bugs Poked" in User Profile is made a link. I did the query string  according bugzilla advanced search form - option search by authors.