### PR TITLE
Bug 1370492 - Assigned to you shows bugs priority in My dashboard

### DIFF
--- a/extensions/MyDashboard/lib/Queries.pm
+++ b/extensions/MyDashboard/lib/Queries.pm
@@ -42,6 +42,7 @@ use constant SELECT_COLUMNS => qw(
   bug_id
   bug_type
   bug_status
+  priority
   short_desc
   changeddate
 );

--- a/extensions/MyDashboard/web/js/query.js
+++ b/extensions/MyDashboard/web/js/query.js
@@ -106,6 +106,7 @@ $(function() {
                 { key: "bug_id", label: "Bug", sortable: true, allowHTML: true, formatter: link_formatter },
                 { key: "changeddate", label: "Updated", formatter: updatedFormatter,
                 allowHTML: true, sortable: true },
+                { key: "priority", label: "Pri", sortable: true, allowHTML: true},
                 { key: "bug_status", label: "Status", sortable: true },
                 { key: "short_desc", label: "Summary", sortable: true, allowHTML: true, formatter: link_formatter },
             ],


### PR DESCRIPTION
As an Outreachy applicant, I made the enhancement Bug1370492 - "Assigned to you" in My dashboard should show bugs priority. I placed the priority column next to the update column.
@dklawren @emceeaich
![priorityColumn](https://user-images.githubusercontent.com/13342992/77975268-d5837d00-72b6-11ea-9293-659469f44ae2.png)
