### PR TITLE
Bug 1626543 - Some fields on enter bug page do not have associated labels

### DIFF
--- a/extensions/BMO/template/en/default/hook/bug/create/create-after_custom_fields.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/bug/create/create-after_custom_fields.html.tmpl
@@ -16,7 +16,7 @@
       <td colspan="3">
         <span id="cf_crash_signature_container">
           <span id="cf_crash_signature_nonedit_display"><i>None</i></span>
-          <button type="button" class="minor"
+          <button type="button" class="minor" aria-label="Edit Crash Signature"
                   id="cf_crash_signature_action">Edit</button>
         </span>
         <span id="cf_crash_signature_input">
@@ -27,5 +27,3 @@
     </tr>
   </tbody>
 [% END %]
-
-

--- a/extensions/BMO/template/en/default/hook/bug/create/create-end.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/bug/create/create-end.html.tmpl
@@ -11,7 +11,7 @@
 
 <div id="bug_create_warning">
   <div id="bug_create_warning_image">
-    <img src="[% basepath FILTER none %]extensions/BMO/web/images/sign_warning.png" width="32" height="32">
+    <img src="[% basepath FILTER none %]extensions/BMO/web/images/sign_warning.png" width="32" height="32" alt="">
   </div>
   <div id="bug_create_warning_text">
     <b>Mozilla employees</b><br>

--- a/extensions/Needinfo/template/en/default/hook/bug/create/create-after_custom_fields.html.tmpl
+++ b/extensions/Needinfo/template/en/default/hook/bug/create/create-after_custom_fields.html.tmpl
@@ -7,7 +7,7 @@
   #%]
 
 <tr>
-  <th>Request information from:</th>
+  <th><label for="needinfo_from">Request information from</label>:</th>
   <td colspan="3">
     <span id="needinfo_from_container">
       [% INCLUDE global/userselect.html.tmpl

--- a/extensions/Review/template/en/default/hook/bug/create/create-after_custom_fields.html.tmpl
+++ b/extensions/Review/template/en/default/hook/bug/create/create-after_custom_fields.html.tmpl
@@ -7,7 +7,7 @@
   #%]
 
 <tr class="expert_fields">
-  <th class="field_label">Mentors:</th>
+  <th class="field_label"><label for="bug_mentors">Mentors</label>:</th>
   <td colspan="3" class="field_value">
      [% INCLUDE global/userselect.html.tmpl
         id       = "bug_mentors"

--- a/extensions/UserStory/template/en/default/hook/bug/create/create-after_custom_fields.html.tmpl
+++ b/extensions/UserStory/template/en/default/hook/bug/create/create-after_custom_fields.html.tmpl
@@ -12,12 +12,12 @@
 <tbody id="cf_user_story_container" class="expert_fields bz_default_hidden">
   <tr>
     <th class="field_label">
-      <label for="cf_user_story">User Story:</label>
+      <label for="user_story">User Story:</label>
     </th>
     <td colspan="3">
       <div id="user_story_header">
         <span id="user_story_edit">
-          <button type="button" class="minor"
+          <button type="button" class="minor" aria-label="Edit User Story"
                   id="user_story_edit_action">Edit</button>
         </span>
       </div>

--- a/js/attachment.js
+++ b/js/attachment.js
@@ -452,7 +452,6 @@ Bugzilla.AttachmentForm = class AttachmentForm {
       this.$description.value = file.name;
     }
 
-    this.$textarea.hidden = true;
     this.$description.select();
     this.$description.focus();
   }
@@ -473,8 +472,8 @@ Bugzilla.AttachmentForm = class AttachmentForm {
     const message_short = invalid ? 'File too large' : '';
 
     this.$error_message.innerHTML = message;
-    this.$data.setCustomValidity(message_short);
-    this.$data.setAttribute('aria-invalid', invalid);
+    this.$textarea.setCustomValidity(message_short);
+    this.$textarea.setAttribute('aria-invalid', invalid);
     this.$dropbox.classList.toggle('invalid', invalid);
 
     return !invalid;

--- a/skins/standard/attachment.css
+++ b/skins/standard/attachment.css
@@ -407,10 +407,6 @@ textarea#viewFrame {
   resize: none;
 }
 
-#att-data:invalid {
-  display: block; /* To display the validation message */
-}
-
 #att-textarea {
   margin: 0;
   border: 0;

--- a/template/en/default/attachment/createformcontents.html.tmpl
+++ b/template/en/default/attachment/createformcontents.html.tmpl
@@ -37,10 +37,10 @@
         </span>
       </header>
       <div>
-        <textarea hidden id="att-data" name="data_base64"
-                  aria-errormessage="data-error" aria-invalid="false"></textarea>
+        <textarea hidden id="att-data" name="data_base64" aria-hidden="true"></textarea>
         <textarea id="att-textarea" name="attach_text" cols="80" rows="10"
-                  aria-label="Paste the text, link or image to be added as an attachment"></textarea>
+                  aria-label="Attachment Content" aria-invalid="false" aria-errormessage="att-error-message"
+                  aria-description="Paste text, link or image to be added as an attachment"></textarea>
         <div hidden id="att-preview">
           <figure role="img" aria-labelledby="att-preview-name" itemscope itemtype="http://schema.org/MediaObject">
             <meta itemprop="encodingFormat">
@@ -79,12 +79,15 @@
       <div>
         <input id="att-type-list" type="radio" name="contenttypemethod" value="list" checked>
         <label for="att-type-list">select from list</label>:
-        <select id="att-type-select" name="contenttypeselection">[% PROCESS content_types %]</select>
+        <select id="att-type-select" name="contenttypeselection" aria-label="Select Content Type">
+          [% PROCESS content_types %]
+        </select>
       </div>
       <div>
       <input id="att-type-manual" type="radio" name="contenttypemethod" value="manual">
         <label for="att-type-manual">enter manually</label>:
-        <input id="att-type-input" type="text" name="contenttypeentry" size="30" maxlength="200">
+        <input id="att-type-input" type="text" name="contenttypeentry" size="30" maxlength="200"
+               aria-label="Enter Content Type">
       </div>
     </div>
   </td>

--- a/template/en/default/bug/comment.html.tmpl
+++ b/template/en/default/bug/comment.html.tmpl
@@ -13,7 +13,7 @@
   #%]
 
 <div id="bugzilla-etiquette">
-  <a href="[% basepath FILTER none %]page.cgi?id=etiquette.html" target="_blank" tabindex="-1">
+  <a href="[% basepath FILTER none %]page.cgi?id=etiquette.html" target="_blank">
     Comments Subject to Etiquette and Contributor Guidelines</a>
 </div>
 
@@ -48,7 +48,7 @@
 
 [% IF Param('use_markdown') %]
   <div id="comment-markdown-tip">
-    <img src="extensions/BMO/web/images/notice.png" width="16" height="16">
+    <img src="extensions/BMO/web/images/notice.png" width="16" height="16" alt="">
     <a href="https://guides.github.com/features/mastering-markdown/" target="_blank">Markdown styling now supported</a>
   </div>
 [% END %]

--- a/template/en/default/bug/create/create.html.tmpl
+++ b/template/en/default/bug/create/create.html.tmpl
@@ -236,7 +236,7 @@ TUI_hide_default('expert_fields');
 <input type="hidden" name="token" value="[% token FILTER html %]">
 <input type="hidden" name="bug_ignored" value="[% bug_ignored ? "1" : "0" %]">
 
-<table>
+<table role="none">
 <tbody>
   <tr>
     <td colspan="4">
@@ -281,6 +281,7 @@ TUI_hide_default('expert_fields');
     %]
     <td id="field_container_component">
       <select name="component" id="component" onchange="set_assign_to();"
+              aria-description="[% help_html.component FILTER txt FILTER collapse FILTER html %]"
               size="7" aria-required="true" class="required">
         [%# Build the lists of assignees and QA contacts if "usemenuforusers" is enabled. %]
         [% IF Param("usemenuforusers") %]
@@ -320,7 +321,7 @@ TUI_hide_default('expert_fields');
     <td colspan="2" id="comp_desc_container">
       [%# Enclose the fieldset in a nested table so that its width changes based
         # on the length on the component description. %]
-      <table>
+      <table role="none">
         <tr>
           <td>
             <fieldset>
@@ -338,7 +339,8 @@ TUI_hide_default('expert_fields');
       field = bug_fields.version editable = 1 rowspan = 3
     %]
     <td rowspan="3">
-      <select name="version" id="version" size="5">
+      <select name="version" id="version" size="5"
+          aria-description="[% help_html.version FILTER txt FILTER collapse FILTER html %]">
         [%- FOREACH v = version %]
           [% NEXT IF NOT v.is_active %]
           <option value="[% v.name FILTER html %]"
@@ -363,22 +365,22 @@ TUI_hide_default('expert_fields');
         <span title="Hardware">
           [% INCLUDE bug/field.html.tmpl
             no_tds = 1, bug = default, field = bug_fields.rep_platform, editable = 1,
-            value = default.rep_platform %]
+            value = default.rep_platform, aria_label = field_descs.rep_platform %]
         </span>
         <span title="Operating System">
           [% INCLUDE bug/field.html.tmpl
             no_tds = 1, bug = default, field = bug_fields.op_sys, editable = 1,
-            value = default.op_sys %]
+            value = default.op_sys, aria_label = field_descs.op_sys %]
         </span>
       </div>
       [% IF !cloned_bug_id %]
         <div class="comment">
           Update the <i>platform</i> field if this [% terms.bug %] is applicable to specific platforms.<br>
           <span id="rep_hw_os">
-            (<a href="javascript:void(0)"
+            (<a href="javascript:void(0)" role="button" aria-controls="rep_platform op_sys"
                 onclick="$('#rep_platform').val('[% rep_platform FILTER js FILTER html %]');
                          $('#op_sys').val('[% rep_op_sys FILTER js FILTER html %]')">use my platform</a>)
-            (<a href="javascript:void(0)"
+            (<a href="javascript:void(0)" role="button" aria-controls="rep_platform op_sys"
                 onclick="$('#rep_platform').val('All');
                          $('#op_sys').val('All')">applies to all platforms</a>)
           </span>
@@ -427,6 +429,7 @@ TUI_hide_default('expert_fields');
       field = bug_fields.assigned_to editable = 1
     %]
     <td>
+      [% assigned_to_desc = help_html.assigned_to FILTER txt FILTER collapse %]
       [% INCLUDE global/userselect.html.tmpl
          id       => "assigned_to"
          name     => "assigned_to"
@@ -435,11 +438,12 @@ TUI_hide_default('expert_fields');
          size     => 30
          emptyok  => 1
          custom_userlist => assignees_list
+         aria_description => assigned_to_desc
       %]
       [% UNLESS assigned_to_disabled %]
         <span id="take_bug">
           <button title="Assign to yourself"
-                  type="button" class="minor"
+                  type="button" class="minor" aria-controls="assigned_to"
                   onclick="return take_bug('[% user.login FILTER js %]')">Take</button>
         </span>
       [% END %]
@@ -451,6 +455,7 @@ TUI_hide_default('expert_fields');
       field = bug_fields.qa_contact editable = 1
     %]
     <td>
+    [% qa_contact_desc = help_html.qa_contact FILTER txt FILTER collapse %]
     [% INCLUDE global/userselect.html.tmpl
        id       => "qa_contact"
        name     => "qa_contact"
@@ -459,6 +464,7 @@ TUI_hide_default('expert_fields');
        size     => 30
        emptyok  => 1
        custom_userlist => qa_contacts_list
+       aria_description => qa_contact_desc
      %]
       <noscript>(Leave blank to assign to default qa contact)</noscript>
     </td>
@@ -470,6 +476,7 @@ TUI_hide_default('expert_fields');
       field = bug_fields.cc editable = 1
     %]
     <td>
+      [% cc_desc = help_html.cc FILTER txt FILTER collapse %]
       [% INCLUDE global/userselect.html.tmpl
          id       => "cc"
          name     => "cc"
@@ -477,6 +484,7 @@ TUI_hide_default('expert_fields');
          disabled => cc_disabled
          size     => 30
          multiple => 5
+         aria_description => cc_desc
        %]
      </td>
      <th>
@@ -499,7 +507,8 @@ TUI_hide_default('expert_fields');
       field = bug_fields.alias editable = 1
     %]
     <td colspan="2">
-      <input name="alias" size="30" maxlength="40" value="[% alias FILTER html %]">
+      <input id="alias" name="alias" size="30" maxlength="40" value="[% alias FILTER html %]"
+             aria-description="[% help_html.alias FILTER txt FILTER collapse FILTER html %]">
     </td>
   </tr>
 [% END %]
@@ -513,6 +522,7 @@ TUI_hide_default('expert_fields');
     <td colspan="3" class="field_value">
       <input name="short_desc" size="70" value="[% short_desc FILTER html %]"
              maxlength="255" spellcheck="true" aria-required="true"
+             aria-description="[% help_html.short_desc FILTER txt FILTER collapse FILTER html %]"
              class="required text_input" id="short_desc">
     </td>
   </tr>
@@ -554,7 +564,7 @@ TUI_hide_default('expert_fields');
   [% END %]
 
   <tr>
-    <th>Description:</th>
+    <th><label for="comment">Description</label>:</th>
     <td colspan="3">
 
       [% defaultcontent = BLOCK %]
@@ -584,6 +594,7 @@ TUI_hide_default('expert_fields');
     %]
     <td colspan="3" class="field_value">
       <input name="bug_file_loc" id="bug_file_loc" class="text_input"
+             aria-description="[% help_html.bug_file_loc FILTER txt FILTER collapse FILTER html %]"
              size="40" value="[% bug_file_loc FILTER html %]" placeholder="https://">
     </td>
   </tr>
@@ -601,7 +612,7 @@ TUI_hide_default('expert_fields');
                class="bz_default_hidden"  onClick="handleWantsAttachment(false)">
         <fieldset>
           <legend>Add an attachment</legend>
-          <table class="attachment_entry">
+          <table role="none" class="attachment_entry">
             [% PROCESS attachment/createformcontents.html.tmpl
                        flag_types = product.flag_types.attachment
                        any_flags_requesteeble = 1
@@ -630,13 +641,15 @@ TUI_hide_default('expert_fields');
         field = bug_fields.dependson editable = 1
       %]
       <td>
-        <input name="dependson" accesskey="d" value="[% dependson FILTER html %]" size="30">
+        <input id="dependson" name="dependson" accesskey="d" value="[% dependson FILTER html %]" size="30"
+               aria-description="[% help_html.dependson FILTER txt FILTER collapse FILTER html %]">
       </td>
       [% INCLUDE "bug/field-label.html.tmpl"
         field = bug_fields.blocked editable = 1
       %]
       <td>
-        <input name="blocked" accesskey="b" value="[% blocked FILTER html %]" size="30">
+        <input id="blocked" name="blocked" accesskey="b" value="[% blocked FILTER html %]" size="30"
+               aria-description="[% help_html.blocked FILTER txt FILTER collapse FILTER html %]">
       </td>
     </tr>
 
@@ -647,7 +660,8 @@ TUI_hide_default('expert_fields');
           editable = 1
         %]
         <td>
-          <input name="regressed_by" value="[% regressed_by FILTER html %]" size="30">
+          <input id="regressed_by" name="regressed_by" value="[% regressed_by FILTER html %]" size="30"
+                 aria-description="[% help_html.regressed_by FILTER txt FILTER collapse FILTER html %]">
         </td>
         <td colspan="2">
           [%~# Regressions field is hidden from new bugs ~%]
@@ -666,7 +680,7 @@ TUI_hide_default('expert_fields');
     [% END %]
 
     <tr>
-      <th>Whiteboard:</th>
+      <th><label for="status_whiteboard">Whiteboard</label>:</th>
       <td colspan="3" class="field_value">
         <input id="status_whiteboard" name="status_whiteboard" size="70"
                value="[% status_whiteboard FILTER html %]" class="text_input">
@@ -828,10 +842,10 @@ TUI_hide_default('expert_fields');
 [% Hook.process("end") %]
 
 <div id="guided">
-  <a id="guided_img" href="[% basepath FILTER none %]enter_bug.cgi?format=guided&amp;product=[% product.name FILTER uri %]"><img
-   src="[% basepath FILTER none %]extensions/BMO/web/images/guided.png" width="16" height="16" border="0" align="absmiddle"></a>
-  <a id="guided_link" href="[% basepath FILTER none %]enter_bug.cgi?format=guided&amp;product=[% product.name FILTER uri %]"
-   >Switch to the [% terms.Bugzilla %] Helper</a>
+  <a id="guided_img" href="[% basepath FILTER none %]enter_bug.cgi?format=guided&amp;product=[% product.name FILTER uri %]">
+    <img src="[% basepath FILTER none %]extensions/BMO/web/images/guided.png" width="16" height="16" alt="">
+    Switch to the [% terms.Bugzilla %] Helper
+  </a>
   | <a href="[% basepath FILTER none %]page.cgi?id=custom_forms.html">Custom [% terms.bug %] entry forms</a>
 </div>
 
@@ -847,8 +861,8 @@ TUI_hide_default('expert_fields');
     field = field editable = 1
   %]
   <td>
-    <select name="[% field.name FILTER html %]"
-            id="[% field.name FILTER html %]">
+    <select name="[% field.name FILTER html %]" id="[% field.name FILTER html %]"
+            aria-description="[% help_html.${field.name} FILTER txt FILTER collapse FILTER html %]">
     [%- FOREACH x = ${field.name} %]
       [% NEXT IF NOT x.is_active %]
       <option value="[% x.name FILTER html %]"

--- a/template/en/default/bug/field-label.html.tmpl
+++ b/template/en/default/bug/field-label.html.tmpl
@@ -51,7 +51,7 @@
     [% ELSE %]
       href="https://wiki.mozilla.org/BMO/UserGuide/BugFields#[% field.name FILTER uri %]"
     [% END %]
-  >[%- field_descs.${field.name} FILTER html %]:</a>
+  >[%- field_descs.${field.name} FILTER html %]</a>
 
-  [% '</label>' IF editable %]
+  [%~ '</label>' IF editable %]:
 </[% tag_name FILTER html %]>

--- a/template/en/default/bug/field.html.tmpl
+++ b/template/en/default/bug/field.html.tmpl
@@ -39,11 +39,17 @@
   #           wrapping <td> for the field.
   #   bug (optional): The current Bugzilla::Bug being displayed, or a hash
   #                   with default field values being displayed on a page.
+  #   aria_label (optional): Accessible label for the form widget.
   #%]
 
 [% SET hidden = 0 %]
 [% IF bug AND !field.is_visible_on_bug(bug) %]
   [% SET hidden = 1 %]
+[% END %]
+
+[% SET aria_description = '' %]
+[% IF help_html.${field.name}.defined %]
+  [% SET aria_description = help_html.${field.name} FILTER txt FILTER collapse %]
 [% END %]
 
 [% IF NOT no_tds %]
@@ -61,6 +67,8 @@
                name="[% field.name FILTER html %]"
                value="[% value FILTER html %]" size="40"
                maxlength="[% constants.MAX_FREETEXT_LENGTH FILTER none %]"
+               [% IF aria_label %] aria-label="[% aria_label FILTER html %]" [% END %]
+               [% IF aria_description %] aria-description="[% aria_description FILTER html %]" [% END %]
                [% IF field.type == constants.FIELD_TYPE_INTEGER %] pattern="\d+[% IF dontchange %]|[% dontchange FILTER html %][% END %]" [% END %]
                [% ' aria-required="true"' IF (field.is_mandatory || required) %]>
     [% CASE [constants.FIELD_TYPE_DATETIME, constants.FIELD_TYPE_DATE] %]
@@ -68,6 +76,8 @@
       <input name="[% field.name FILTER html %]" size="[% size FILTER none %]"
              id="[% field.name FILTER html %]"
              value="[% value FILTER html %]"
+             [% IF aria_label %] aria-label="[% aria_label FILTER html %]" [% END %]
+             [% IF aria_description %] aria-description="[% aria_description FILTER html %]" [% END %]
              [% ' aria-required="true"' IF (field.is_mandatory || required) %]
              onchange="updateCalendarFromField(this)">
       <button type="button" class="calendar_button"
@@ -85,6 +95,8 @@
         <span id="[% field.name FILTER html %]_input_area">
           <input name="[% field.name FILTER html %]" id="[% field.name FILTER html %]"
                  value="[% value FILTER html %]" size="7"
+                 [% IF aria_label %] aria-label="[% aria_label FILTER html %]" [% END %]
+                 [% IF aria_description %] aria-description="[% aria_description FILTER html %]" [% END %]
                  [% ' aria-required="true"' IF (field.is_mandatory || required) %]>
 
         </span>
@@ -108,10 +120,14 @@
         <input type="hidden" id="[% field.name FILTER html %]_dirty">
         [% IF use_buttons %]
         <div role="radiogroup" class="buttons toggle" id="[% field.name FILTER html %]"
+             [% IF aria_label %] aria-label="[% aria_label FILTER html %]" [% END %]
+             [% IF aria_description %] aria-description="[% aria_description FILTER html %]" [% END %]
              [% ' aria-required="true"' IF (field.is_mandatory || required) %]>
         [% ELSE %]
         <select id="[% field.name FILTER html %]"
                 name="[% field.name FILTER html %]"
+                [% IF aria_label %] aria-label="[% aria_label FILTER html %]" [% END %]
+                [% IF aria_description %] aria-description="[% aria_description FILTER html %]" [% END %]
                 [% IF field.type == constants.FIELD_TYPE_MULTI_SELECT %]
                     [% SET field_size = 5 %]
                     [% IF field.legal_values.size < 5 %]
@@ -219,6 +235,7 @@
        <div id="[% field.name FILTER html %]_input">
          [% INCLUDE global/textarea.html.tmpl
             id = field.name name = field.name minrows = 4 maxrows = 8
+            aria_label = aria_label aria_description = aria_description
             cols = 60 defaultcontent = value mandatory = (field.is_mandatory || required) %]
        </div>
        <script [% script_nonce FILTER none %]>
@@ -237,6 +254,8 @@
            <li>
              [% PROCESS bug_url_link bug_url = bug_url %]
              <label><input type="checkbox" value="[% bug_url.name FILTER html %]"
+                           [% IF aria_label %] aria-label="[% aria_label FILTER html %]" [% END %]
+                           [% IF aria_description %] aria-description="[% aria_description FILTER html %]" [% END %]
                            name="remove_[% field.name FILTER html %]">
                Remove</label>
            </li>
@@ -251,7 +270,7 @@
          <div id="container_[% field.name FILTER html %]">
            <input type="text" id="[% field.name FILTER html %]" size="40"
                   class="text_input" name="[% field.name FILTER html %]"
-                  [% IF !bug.id %]value="[% value FILTER html %]"[% END %]>
+                  [% IF !bug.id %] value="[% value FILTER html %]"[% END %]>
          </div>
          [% IF bug.id %]
            <script [% script_nonce FILTER none %]>
@@ -264,6 +283,8 @@
               class="text_input bz_autocomplete_values"
               name="[% field.name FILTER html %]"
               data-values="[% field.name FILTER html %]"
+              [% IF aria_label %] aria-label="[% aria_label FILTER html %]" [% END %]
+              [% IF aria_description %] aria-description="[% aria_description FILTER html %]" [% END %]
               value="[% value FILTER html %]">
        <script [% script_nonce FILTER none %]>
           if (typeof BUGZILLA.autocomplete_values === 'undefined')

--- a/template/en/default/flag/list.html.tmpl
+++ b/template/en/default/flag/list.html.tmpl
@@ -129,6 +129,7 @@
                   disabled="disabled"
                 [% END %]
                 title="[% type.description FILTER html %]"
+                aria-label="[% type.name FILTER html %] Flag Value"
                 onchange="toggleRequesteeField(this);"
                 class="flag_select flag_type-[% type.id %]"
                 data-id="[% type.id %]" data-name="[% type.name FILTER html %]"
@@ -140,18 +141,18 @@
         [% IF !flag
               || (can_edit_flag && user.can_unset_flag(type, flag.status) && user.can_request_flag(type))
               || flag.setter_id == user.id %]
-          <option value="X"></option>
+          <option value="X" aria-label="None"></option>
         [% END %]
         [% IF type.is_active && can_edit_flag %]
           [% IF (!flag && type.is_requestable && user.can_request_flag(type))
                  || (flag && (user.can_unset_flag(type, flag.status) || flag.status == "?")) %]
-            <option value="?" [% "selected" IF flag && flag.status == "?" %]>?</option>
+            <option value="?" [% "selected" IF flag && flag.status == "?" %] aria-label="Requested">?</option>
           [% END %]
           [% IF user.can_set_flag(type) || (flag && flag.status == "+") %]
-            <option value="+" [% "selected" IF flag && flag.status == "+" %]>+</option>
+            <option value="+" [% "selected" IF flag && flag.status == "+" %] aria-label="Accepted">+</option>
           [% END %]
           [% IF user.can_set_flag(type) || (flag && flag.status == "-") %]
-            <option value="-" [% "selected" IF flag && flag.status == "-" %]>-</option>
+            <option value="-" [% "selected" IF flag && flag.status == "-" %] aria-label="Rejected">-</option>
           [% END %]
         [% ELSE %]
           <option value="[% flag.status %]" selected="selected">[% flag.status %]</option>
@@ -187,6 +188,7 @@
                          custom_userlist => grant_list
                          disabled => !can_edit_flag
                          request_type => type.name
+                         aria_label => type.name _ " Flag Requestee"
               %]
               [% Hook.process("requestee", "flag/list.html.tmpl") %]
             </span>

--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -295,8 +295,8 @@
     <h1 id="header-title" class="title"><a href="[% c.url_for('/home').to_abs FILTER html %]" title="Go to home page">[% terms.Bugzilla %]</a></h1>
     <form role="search" id="header-search" class="quicksearch" action="[% basepath FILTER none %]buglist.cgi" data-no-csrf>
       <section class="searchbox-outer dropdown" role="combobox" aria-expanded="false" aria-haspopup="listbox"
-               aria-owns="header-search-dropdown">
-        <h2>Quick Search</h2>
+               aria-labelledby="header-search-label" aria-owns="header-search-dropdown">
+        <h2 id="header-search-label">Quick Search</h2>
         <span class="icon" aria-hidden="true"></span>
         <input role="searchbox" id="quicksearch_top" class="dropdown-button" name="quicksearch" autocomplete="off"
                value="[% quicksearch FILTER html %]" placeholder="Search [% terms.Bugs %]"

--- a/template/en/default/global/textarea.html.tmpl
+++ b/template/en/default/global/textarea.html.tmpl
@@ -35,11 +35,15 @@
   # defaultcontent: (optional) Default content for the textarea.
   # mandatory:      (optional) Boolean specifying whether or not the textarea
   #                 is mandatory.
+  # aria_label      (optional) Accessible label for the textarea.
+  # aria_description (optional) Accessible description for the textarea.
   #%]
 
 <textarea [% IF name %]name="[% name FILTER html %]"[% END %]
           [% IF id %] id="[% id FILTER html %]"[% END %]
           [% IF accesskey %] accesskey="[% accesskey FILTER html %]"[% END %]
+          [% IF aria_label %] aria-label="[% aria_label FILTER html %]" [% END %]
+          [% IF aria_description %] aria-description="[% aria_description FILTER html %]" [% END %]
           [% IF style %] style="[% style FILTER html %]"[% END %]
           [% IF classes %] class="[% classes FILTER html %]"[% END %]
           [% IF wrap %] wrap="[% wrap FILTER html %]"[% END %]

--- a/template/en/default/global/userselect.html.tmpl
+++ b/template/en/default/global/userselect.html.tmpl
@@ -21,7 +21,9 @@
   # field_title: optional, extra information to display as a tooltip
   # placeholder: optional, input only; placeholder attribute value
   # mandatory: optional; if true, the field cannot be empty.
-  # aria_labelledby: optional; extra information to use for WAI-ARIA labels
+  # aria_label: optional; accessible label for the form widget
+  # aria_labelledby: optional; element ID that has accessible label for the form widget
+  # aria_description: optional; accessible description for the form widget
   # request_type: optional; one of the request flag types: "review", "feedback" or "needinfo"
   #%]
 
@@ -36,7 +38,9 @@
   [% IF multiple %] multiple="multiple" size="[% multiple FILTER html %]" [% END %]
   [% IF field_title %] title="[% field_title FILTER html %]" [% END %]
   [% IF mandatory %] required [% END %]
-  [% IF aria_labelledby %]aria-labelledby="[% aria_labelledby FILTER html %]"[% END %]
+  [% IF aria_label %] aria-label="[% aria_label FILTER html %]" [% END %]
+  [% IF aria_labelledby %] aria-labelledby="[% aria_labelledby FILTER html %]" [% END %]
+  [% IF aria_description %] aria-description="[% aria_description FILTER html %]" [% END %]
 >
   [% IF emptyok %]
     <option value=""></option>
@@ -98,6 +102,8 @@
     [% IF mandatory %] required [% END %]
     [% IF multiple %] data-multiple="1" [% END %]
     [% IF request_type %] data-request-type="[% request_type FILTER html %]" [% END %]
+    [% IF aria_label %] aria-label="[% aria_label FILTER html %]" [% END %]
     [% IF aria_labelledby %] aria-labelledby="[% aria_labelledby FILTER html %]" [% END %]
+    [% IF aria_description %] aria-description="[% aria_description FILTER html %]" [% END %]
   >
 [% END %]


### PR DESCRIPTION
Improve accessibility of the Enter Bug page by making sure form input fields have an accessible label (plus a description where possible) and modifying the markup. Tested with VoiceOver.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1626543