### PR TITLE
Bug 1627601 - Copy Summary function doesn’t work properly if the bug summary contains HTML tags

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -404,7 +404,7 @@ $(function() {
         if (hasExecCopy) {
             const url = BUGZILLA.bug_url;
             const text = `Bug ${BUGZILLA.bug_id} - ${BUGZILLA.bug_summary}`;
-            const html = `<a href="${url}">${text}</a>`;
+            const html = `<a href="${url}">${text.htmlEncode()}</a>`;
 
             document.addEventListener('copy', event => {
                 if (event.target.nodeType === 1 && event.target.matches('#clip')) {


### PR DESCRIPTION
Escape HTML tags properly so copy will work with any summary.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1627601