### PR TITLE
Bug 1631051-Store current configuration of auto refresh button in My  Dashboard

### DIFF
--- a/extensions/MyDashboard/web/js/flags.js
+++ b/extensions/MyDashboard/web/js/flags.js
@@ -11,12 +11,23 @@ $(function () {
     YUI({
         base: 'js/yui3/',
         combine: false
-    }).use('node', 'datatable', 'datatable-sort', 'escape', function(Y) {
+    }).use('node', 'datatable', 'datatable-sort', 'escape','cookie', function(Y) {
         // Common
         var dataTable = {
             requestee: null,
             requester: null
         };
+
+        var button_state = false,
+            refresh_interval = null;
+
+        // Grab last used auto-refresh configuration from cookie or use default
+        var autorefresh_cookie = Y.Cookie.get("my_dashboard_autorefresh");
+        if (autorefresh_cookie) {
+            if ("true" == autorefresh_cookie) {
+                button_state = true;
+            }
+        }
 
         var updateFlagTable = async type => {
             if (!type) return;
@@ -97,6 +108,17 @@ $(function () {
             }
         };
 
+        var auto_updateFlagTable = function(o){
+            if(button_state == true){
+                refresh_interval = setInterval(function(e) {
+                    updateFlagTable('requestee');
+                    updateFlagTable('requester');
+                },1000*60*10);
+            }else if(button_state == false){
+                clearInterval(refresh_interval);
+            }
+        };
+
         // Requestee
         dataTable.requestee = new Y.DataTable({
             columns: [
@@ -148,21 +170,15 @@ $(function () {
             loadBugList('requester');
         });
 
-        var refresh_interval;
         Y.one('#auto_refresh').on('click', function(e) {
-            if(auto_refresh.checked == true){
-                refresh_interval = setInterval(function(e) {
-                    updateFlagTable("requester");
-                    updateFlagTable("requestee");
-                },1000*60*10);
-            }else if(auto_refresh.checked == false){
-                clearInterval(refresh_interval);
-            }
+            button_state = auto_refresh.checked;
+            auto_updateFlagTable();
         });
 
         // Initial load
         Y.on("contentready", function (e) {
             updateFlagTable("requestee");
+            auto_updateFlagTable();
         }, "#requestee_table");
         Y.on("contentready", function (e) {
             updateFlagTable("requester");

--- a/extensions/MyDashboard/web/js/flags.js
+++ b/extensions/MyDashboard/web/js/flags.js
@@ -11,7 +11,7 @@ $(function () {
     YUI({
         base: 'js/yui3/',
         combine: false
-    }).use('node', 'datatable', 'datatable-sort', 'escape','cookie', function(Y) {
+    }).use('node', 'datatable', 'datatable-sort', 'escape', 'cookie', function(Y) {
         // Common
         var dataTable = {
             requestee: null,
@@ -108,13 +108,13 @@ $(function () {
             }
         };
 
-        var auto_updateFlagTable = function(o){
-            if(button_state == true){
+        var auto_updateFlagTable = function(o) {
+            if (button_state == true) {
                 refresh_interval = setInterval(function(e) {
                     updateFlagTable('requestee');
                     updateFlagTable('requester');
-                },1000*60*10);
-            }else if(button_state == false){
+                }, 1000*60*10);
+            } else {
                 clearInterval(refresh_interval);
             }
         };

--- a/extensions/MyDashboard/web/js/query.js
+++ b/extensions/MyDashboard/web/js/query.js
@@ -28,7 +28,6 @@ $(function() {
             lastChangesCache = {},
             default_query    = "assignedbugs";
             refresh_interval = null;
-            button_state     = false;
 
         // Grab last used query name from cookie or use default
         var query_cookie = Y.Cookie.get("my_dashboard_query");
@@ -49,7 +48,7 @@ $(function() {
         // Grab last used auto-refresh configuration from cookie or use default
         var autorefresh_cookie = Y.Cookie.get("my_dashboard_autorefresh");
         if (autorefresh_cookie) {
-            if ("true" == autorefresh_cookie) {
+            if (autorefresh_cookie == 'true') {
                 Y.one("#auto_refresh").set('checked', true);
             } else {
                 Y.Cookie.set("my_dashboard_autorefresh", "false");
@@ -167,8 +166,7 @@ $(function() {
         bugQueryTable.plug(Y.Plugin.DataTableSort);
 
         var auto_updateQueryTable = function(o) {
-            button_state = auto_refresh.checked;
-            if (button_state == true) {
+            if (auto_refresh.checked == true) {
                 refresh_interval = setInterval(function(e) {
                     updateQueryTable(default_query);
                 }, 1000*60*10);
@@ -199,7 +197,7 @@ $(function() {
 
         Y.one('#auto_refresh').on('click', function(e) {
             auto_updateQueryTable();
-            Y.Cookie.set("my_dashboard_autorefresh", button_state, { expires: new Date("January 12, 2030") });
+            Y.Cookie.set("my_dashboard_autorefresh", auto_refresh.checked, { expires: new Date("January 12, 2030") });
         });
 
         Y.one('#query_markread').on('click', function(e) {

--- a/extensions/MyDashboard/web/js/query.js
+++ b/extensions/MyDashboard/web/js/query.js
@@ -49,12 +49,9 @@ $(function() {
         // Grab last used auto-refresh configuration from cookie or use default
         var autorefresh_cookie = Y.Cookie.get("my_dashboard_autorefresh");
         if (autorefresh_cookie) {
-            var cookie_value_found = 0;
             if ("true" == autorefresh_cookie) {
                 Y.one("#auto_refresh").set('checked', true);
-                cookie_value_found = 1;
-            }
-            if (!cookie_value_found) {
+            } else {
                 Y.Cookie.set("my_dashboard_autorefresh", "false");
             }
         }
@@ -169,13 +166,13 @@ $(function() {
 
         bugQueryTable.plug(Y.Plugin.DataTableSort);
 
-        var auto_updateQueryTable = function(o){
+        var auto_updateQueryTable = function(o) {
             button_state = auto_refresh.checked;
-            if(button_state == true){
+            if (button_state == true) {
                 refresh_interval = setInterval(function(e) {
                     updateQueryTable(default_query);
-                },1000*60*10);
-            }else if(button_state == false){
+                }, 1000*60*10);
+            } else {
                 clearInterval(refresh_interval);
             }
         };


### PR DESCRIPTION
Added a cookie to store the current setting of the auto-refresh button in My dashboard so that it is either on all of the time or off even if the page is reloaded. @dklawren 