### PR TITLE
Bug 1632038 -  Remove number of people from bug update toast notification

### DIFF
--- a/extensions/BugModal/template/en/default/bug/show-modal.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug/show-modal.html.tmpl
@@ -31,7 +31,6 @@
       [% ELSE %]
         Changes submitted.
       [% END %]
-      [%+ PROCESS "bug/process/bugmail.html.tmpl" recipient_count = item.recipient_count %]
     [% END %]
   [% END %]
 [% END %]
@@ -51,7 +50,6 @@
       [% ELSE %]
         Attachment updated.
       [% END %]
-      [%+ PROCESS "bug/process/bugmail.html.tmpl" recipient_count = item.recipient_count %]
     [% END %]
   [% END %]
 [% END %]


### PR DESCRIPTION
Not to scare new contributors.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1632038