### PR TITLE
Bumped version to 20200504.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20200429.1';
+our $VERSION = '20200504.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1635148" target="_blank">1635148</a>] Recent changes to add support for attachments in S3 caused a memory leak in the phabbugz feed daemon</li>
</ul>