### PR TITLE
Bumped version to 20200511.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20200504.1';
+our $VERSION = '20200511.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1633846" target="_blank">1633846</a>] Enable retries for uploading attachments to S3 when an error occurs</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1636549" target="_blank">1636549</a>] Guided Bug Helper extension filing bugs with 'normal' instead of '--' severity.</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1634342" target="_blank">1634342</a>] change links for security approval documents to source docs</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1594066" target="_blank">1594066</a>] reproducible "Can't use ARRAY(0x17340610) as a field name." when Custom Search used</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1635332" target="_blank">1635332</a>] [SECURITY] Upgrade Mojolicous to 8.42</li>
</ul>