### PR TITLE
no bug - clear request cache in Glue plugin, before setting usage mode

### DIFF
--- a/Bugzilla/App/CGI.pm
+++ b/Bugzilla/App/CGI.pm
@@ -73,7 +73,7 @@ sub load_one {
     tie *STDOUT, 'Bugzilla::App::Stdout', controller => $c;   ## no critic (tie)
 
     # the finally block calls cleanup.
-    $c->stash->{cleanup_guard}->dismiss;
+    $Bugzilla::App::Plugin::Glue::cleanup_guard->dismiss if $Bugzilla::App::Plugin::Glue::cleanup_guard;
     Bugzilla->usage_mode(USAGE_MODE_BROWSER);
     try {
       Bugzilla->init_page();

--- a/Bugzilla/App/Plugin/Glue.pm
+++ b/Bugzilla/App/Plugin/Glue.pm
@@ -19,6 +19,8 @@ use Mojo::JSON qw(decode_json);
 use Scalar::Util qw(blessed);
 use Scope::Guard;
 
+our $cleanup_guard;
+
 sub register {
   my ($self, $app, $conf) = @_;
 
@@ -36,11 +38,23 @@ sub register {
   }
 
   $app->hook(
-    before_dispatch => sub {
-      my ($c) = @_;
+    around_dispatch => sub {
+      my ($next, $c) = @_;
       Log::Log4perl::MDC->put(request_id => $c->req->request_id);
-      $c->stash->{cleanup_guard} = Scope::Guard->new(\&Bugzilla::cleanup);
+      # Below we localize a package scoped variable, and put a scope guard in it
+      # this means the cleanup routine will be called when this around_dispatch
+      # hook returns. We do this to avoid having to handle any exceptions.
+      # Think of this as like a "defer cleanup()" in the Go language.
+      local $cleanup_guard = Scope::Guard->new(\&Bugzilla::cleanup);
+
+      # Ensure the request_cache is always cleared prior to every request,
+      # regardless of routing or Bugzilla::App wrapping.
+      # This is not an expensive operation.
+      Bugzilla->clear_request_cache();
+      # We also need to clear CGI's globals.
+      CGI::initialize_globals();
       Bugzilla->usage_mode(USAGE_MODE_MOJO);
+      $next->();
     }
   );
 


### PR DESCRIPTION
This patch fixes the behavior of `Bugzilla->usage_mode` so it is always consistent, and also cleans things up by keeping this in one place.

The trick is to replace `before_dispatch` with `around_dispatch`, and use a localized package variable. As `around_dispatch` wraps the entire request, the localized package variable (`$cleanup_guard`) will not be cleared until dispatch is totally done.

Prior to this change, even if you were to set the `usage_mode` after clearing the request cache, it would be cleared at an *unpredictable* time as Mojolicious does not clear the stash when it used to. Granted, we should have never relied on that but meh.

Anyway, this fixes a number of problems and potential problems.

