### PR TITLE
Bumped version to 20200526.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20200511.1';
+our $VERSION = '20200526.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1638022" target="_blank">1638022</a>] Phabbugz should not try to set needs-review when the revision is closed or abandoned</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1639311" target="_blank">1639311</a>] Attaching a file with emojis breaks them</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1639903" target="_blank">1639903</a>] Fix `Use of uninitialized value in pattern match (m//) at /app/Bugzilla/App.pm line 71`</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1639902" target="_blank">1639902</a>] Fix `Use of uninitialized value in string eq at /app/Bugzilla/Bug.pm line 4674`</li>
</ul>