### PR TITLE
Bug 1641117 - Add Sentry to the list of See Also URLs.

### DIFF
--- a/Bugzilla/BugUrl.pm
+++ b/Bugzilla/BugUrl.pm
@@ -63,6 +63,7 @@ use constant SUB_CLASSES => qw(
   Bugzilla::BugUrl::JIRA
   Bugzilla::BugUrl::Trac
   Bugzilla::BugUrl::MantisBT
+  Bugzilla::BugUrl::MozSentry
   Bugzilla::BugUrl::SourceForge
   Bugzilla::BugUrl::GitHub
   Bugzilla::BugUrl::GitLab

--- a/Bugzilla/BugUrl/MozSentry.pm
+++ b/Bugzilla/BugUrl/MozSentry.pm
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::BugUrl::MozSentry;
+
+use 5.10.1;
+use strict;
+use warnings;
+
+use base qw(Bugzilla::BugUrl);
+
+sub should_handle {
+  my ($class, $uri) = @_;
+  return $uri =~ m{^https?://sentry[.]prod[.]mozaws[.]net/operations/[^/]+/issues/\d+/?$}sxm;
+}
+
+sub _check_value {
+  my ($class, $uri) = @_;
+  $uri = $class->SUPER::_check_value($uri);
+  $uri->scheme('https');    # force https
+  return $uri;
+}
+
+1;

--- a/template/en/default/global/user-error.html.tmpl
+++ b/template/en/default/global/user-error.html.tmpl
@@ -364,6 +364,7 @@
         <li>A request on ServiceNow.</li>
         <li>A ticket on hellosplat.com.</li>
         <li>A revision, support ticket, or task in Phabricator.</li>
+        <li>A Mozilla Sentry issue.</li>
       </ul>
     [% ELSIF reason == 'id' %]
       There is no valid [% terms.bug %] id in that URL.


### PR DESCRIPTION
Test with different format Sentry URLs. Examples:

https://sentry.prod.mozaws.net/operations/fenix/issues/8252183/ (PASS)
https://sentry.prod.mozaws.net/operations/issues/8252183/ (FAIL)
https://sentry.prod.mozaws.net/operations/fenix/issues/825abc/ (FAIL)
etc.

