### PR TITLE
Bumped version to 20200603.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20200526.1';
+our $VERSION = '20200603.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1641249" target="_blank">1641249</a>] Enable the crash signature field for the Focus and Fenix Stability components</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1641897" target="_blank">1641897</a>] Cleanup old severity values in custom forms and other places</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1641117" target="_blank">1641117</a>] Add Sentry to the list of See Also URLs.</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1642654" target="_blank">1642654</a>] Add ability for users to reactivate their own account when disabled from inactivity</li>
</ul>