### PR TITLE
Bumped version to 20200624.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20200603.1';
+our $VERSION = '20200624.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1643821" target="_blank">1643821</a>] Add code to generate_conduit_data.pl to create an oauth2 client for Phabricator when used for development</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1645455" target="_blank">1645455</a>] Can't attach some text, 500 internal server error</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1646559" target="_blank">1646559</a>] Phabricator to BMO OAuth2 authentication fails to work properly due to CSP protections</li>
</ul>