### PR TITLE
no bug - remove warning "Odd number of elements"

### DIFF
--- a/Bugzilla/App/Plugin/OAuth2.pm
+++ b/Bugzilla/App/Plugin/OAuth2.pm
@@ -40,6 +40,7 @@ sub register {
     if (!$args->{user_id}) {
       return (user_id => Bugzilla->user->id);
     }
+    return;
   };
 
   $app->helper(


### PR DESCRIPTION
The callback jwt_claims is called in list context.
Without an explicit return, when the if (!...) does not match it will
return a single false item. This causes the "Odd number of elements..."
perl warning.

Adding a `return` will prevent the warning and is also probably the
intent of the code.