### PR TITLE
Bug 1535000 - Allow anyone with edit-comments to edit any bug's comment 0; r=dkl

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -292,11 +292,11 @@
   [% IF comment.body || comment.count == 0 %]
     <[% comment_tag FILTER none %]
         class="comment-text [%= "markdown-body" IF comment.is_markdown %] [%= "bz_private" IF comment.is_private %]
-               [% "empty" IF !comment.body %]"
+               [% "empty" IF comment.body == "" %]"
         id="ct-[% comment.count FILTER none %]" data-comment-id="[% comment.id FILTER none %]"
         [% IF comment.is_markdown +%] data-ismarkdown="true" [% END ~%]
         [% IF comment.collapsed +%] style="display:none"[% END ~%]>
-      [%~ IF comment.body ~%]
+      [%~ IF comment.body != "" ~%]
         [%~ comment.body_full({ exclude_attachment => 1 }) FILTER renderMarkdown(bug, comment) ~%]
       [%~ ELSE ~%]
         <em>No description provided.</em>

--- a/extensions/EditComments/Extension.pm
+++ b/extensions/EditComments/Extension.pm
@@ -115,6 +115,9 @@ sub _comment_is_editable_by {
   # Need to be able to edit comments via group membership
   return 0 unless $user->can_edit_comments;
 
+  # Comment admins can edit any comment
+  return 1 if $user->is_edit_comments_admin;
+
   # Can always edit your own comments
   return 1 if $self->author->id == $user->id;
 

--- a/extensions/EditComments/Extension.pm
+++ b/extensions/EditComments/Extension.pm
@@ -98,24 +98,22 @@ sub page_before_template {
 
 BEGIN {
   no warnings 'redefine';
-  *Bugzilla::Comment::edit_count = \&_edit_count;
-  *Bugzilla::Comment::is_editable_by = \&_is_editable_by;
-  *Bugzilla::Comment::activity   = \&_get_activity;
+  *Bugzilla::Comment::edit_count          = \&_comment_edit_count;
+  *Bugzilla::Comment::is_editable_by      = \&_comment_is_editable_by;
+  *Bugzilla::Comment::activity            = \&_comment_get_activity;
+  *Bugzilla::User::can_edit_comments      = \&_user_can_edit_comments;
+  *Bugzilla::User::is_edit_comments_admin = \&_user_is_edit_comments_admin;
 }
 
-sub _edit_count { return $_[0]->{'edit_count'}; }
+sub _comment_edit_count { return $_[0]->{'edit_count'}; }
 
-sub _is_editable_by {
+sub _comment_is_editable_by {
   my ($self, $user) = @_;
   # Note: Does not verify that the bug is visible or editable by the user; the calling
   # code needs to perform this validation at the bug level.
 
-  # Insiders can always edit all comments
-  return 1 if $user->is_insider;
-
-  # Need to be a member of edit_comments_group
-  my $edit_comments_group = Bugzilla->params->{edit_comments_group};
-  return 0 unless $edit_comments_group && $user->in_group($edit_comments_group);
+  # Need to be able to edit comments via group membership
+  return 0 unless $user->can_edit_comments;
 
   # Can always edit your own comments
   return 1 if $self->author->id == $user->id;
@@ -128,7 +126,7 @@ sub _is_editable_by {
   return 0;
 }
 
-sub _get_activity {
+sub _comment_get_activity {
   my ($self, $activity_sort_order) = @_;
 
   return $self->{'activity'} if $self->{'activity'};
@@ -162,7 +160,6 @@ sub _get_activity {
       {
         author       => Bugzilla::User->new({id => $revision->{userid}, cache => 1}),
         created_time => $revision->{time},
-        old          => $revision->{old},
         revised_time => $current ? undef : $prev_rev->{time},
         new          => $current ? $self->body : $prev_rev->{old},
         is_hidden    => $current ? 0 : $prev_rev->{is_hidden},
@@ -199,6 +196,29 @@ sub _get_activity {
   return $self->{'activity'};
 }
 
+sub _user_can_edit_comments {
+  my ($self) = @_;
+  # Checks that edit-comments is enabled, and if the user is a member of a group
+  # controlling it, or if the user is an edit-comments-admin.
+
+  my $edit_comments_group = Bugzilla->params->{edit_comments_group};
+
+  return $self->{can_edit_comments} //=
+    $self->is_edit_comments_admin()
+    || ($edit_comments_group && $self->in_group($edit_comments_group));
+}
+
+sub _user_is_edit_comments_admin {
+  my ($self) = @_;
+  # Checks that edit-all-comments is enabled, and if the user is a member of a group
+  # controlling it.
+
+  my $edit_comments_admins_group = Bugzilla->params->{edit_comments_admins_group};
+
+  return $self->{is_edit_comments_admin} //=
+    $edit_comments_admins_group && $self->in_group($edit_comments_admins_group);
+}
+
 #########
 # Hooks #
 #########
@@ -214,13 +234,9 @@ sub object_columns {
 sub bug_end_of_update {
   my ($self, $args) = @_;
 
-  # Silently return if not in the proper group
-  # or if editing comments is disabled
-  my $user                = Bugzilla->user;
-  my $edit_comments_group = Bugzilla->params->{edit_comments_group};
-  return
-    unless $user->is_insider
-    || $edit_comments_group && $user->in_group($edit_comments_group);
+  # Silently return if not in the proper group or if editing comments is disabled
+  my $user = Bugzilla->user;
+  return unless $user->can_edit_comments();
 
   my $bug       = $args->{bug};
   my $timestamp = $args->{timestamp};
@@ -244,9 +260,9 @@ sub bug_end_of_update {
     my $old_comment = $comment_obj->body;
     next if $old_comment eq $new_comment;
 
-    # Insiders can hide comment revisions where needed
+    # edit_comments_admins_group members can hide comment revisions where needed
     my $is_hidden
-      = (  $user->is_insider
+      = (  $user->is_edit_comments_admin
         && defined $params->{"edit_comment_checkbox_$comment_id"}
         && $params->{"edit_comment_checkbox_$comment_id"} == 'on') ? 1 : 0;
 
@@ -286,6 +302,14 @@ sub config_modify_panels {
     };
   push @{$args->{panels}->{groupsecurity}->{params}},
     {
+    name    => 'edit_comments_admins_group',
+    type    => 's',
+    choices => \&get_all_group_names,
+    default => 'admin',
+    checker => \&check_group
+    };
+  push @{$args->{panels}->{groupsecurity}->{params}},
+    {
     name    => 'allow_global_initial_comment_editing',
     type    => 'b',
     default => 1
@@ -297,9 +321,10 @@ sub get_bug_activity {
 
   return unless $args->{include_comment_activity};
 
-  my $list       = $args->{list};
-  my $starttime  = $args->{start_time};
-  my $is_insider = Bugzilla->user->is_insider;
+  my $list               = $args->{list};
+  my $starttime          = $args->{start_time};
+  my $is_insider         = Bugzilla->user->is_insider;
+  my $is_comments_admin  = Bugzilla->user->is_edit_comments_admin;
   my $hidden_placeholder = '(Hidden by Administrator)';
 
   my $query = "SELECT DISTINCT(c.comment_id) from longdescs_activity AS a

--- a/extensions/EditComments/lib/WebService.pm
+++ b/extensions/EditComments/lib/WebService.pm
@@ -110,9 +110,9 @@ sub update_comment {
   my $dbh         = Bugzilla->dbh;
   my $change_when = $dbh->selectrow_array('SELECT NOW()');
 
-  # Insiders can hide comment revisions where needed
+  # edit_comments_admins_group members can hide comment revisions where needed
   my $is_hidden
-    = (  $user->is_insider
+    = (  $user->is_edit_comments_admin
       && defined $params->{is_hidden}
       && $params->{is_hidden} == 1) ? 1 : 0;
 
@@ -157,10 +157,10 @@ sub modify_revision {
   my ($self, $params) = @_;
   my $user = Bugzilla->login(LOGIN_REQUIRED);
 
-  # Only allow insiders to modify revisions
+  # Only allow edit_comments_admins_group members to modify revisions
   ThrowUserError('auth_failure',
-    {group => 'insidergroup', action => 'view', object => 'editcomments'})
-    unless $user->is_insider;
+    {group => 'edit_comments_admins_group', action => 'view', object => 'editcomments'})
+    unless $user->is_edit_comments_admin;
 
   my $comment_id
     = (defined $params->{comment_id} && $params->{comment_id} =~ /^(\d+)$/)

--- a/extensions/EditComments/template/en/default/hook/admin/params/editparams-current_panel.html.tmpl
+++ b/extensions/EditComments/template/en/default/hook/admin/params/editparams-current_panel.html.tmpl
@@ -8,8 +8,12 @@
 
 [% IF panel.name == "groupsecurity" %]
   [% panel.param_descs.edit_comments_group =
-    'The name of the group of users who can edit their own comments. Leave it blank to disable comment editing. ' _
-    'Insiders can always edit any comment and hide revisions where needed.'
+    'The name of the group of users who can edit their own comments. ' _
+    'Leave it blank to disable comment editing.'
+  %]
+  [% panel.param_descs.edit_comments_admins_group =
+    'The name of the group of users who can edit any comments, and hide revisions where needed.' _
+    'Leave it blank to disable comment editing administrators.'
   %]
   [% panel.param_descs.allow_global_initial_comment_editing =
     'Allow anyone with the ability to edit comments to edit the description (comment 0) of any bug.'

--- a/extensions/EditComments/template/en/default/hook/admin/params/editparams-current_panel.html.tmpl
+++ b/extensions/EditComments/template/en/default/hook/admin/params/editparams-current_panel.html.tmpl
@@ -12,7 +12,7 @@
     'Leave it blank to disable comment editing.'
   %]
   [% panel.param_descs.edit_comments_admins_group =
-    'The name of the group of users who can edit any comments, and hide revisions where needed.' _
+    'The name of the group of users who can edit any comments, and hide revisions where needed. ' _
     'Leave it blank to disable comment editing administrators.'
   %]
   [% panel.param_descs.allow_global_initial_comment_editing =

--- a/extensions/EditComments/template/en/default/hook/admin/params/editparams-current_panel.html.tmpl
+++ b/extensions/EditComments/template/en/default/hook/admin/params/editparams-current_panel.html.tmpl
@@ -11,4 +11,7 @@
     'The name of the group of users who can edit their own comments. Leave it blank to disable comment editing. ' _
     'Insiders can always edit any comment and hide revisions where needed.'
   %]
+  [% panel.param_descs.allow_global_initial_comment_editing =
+    'Allow anyone with the ability to edit comments to edit the description (comment 0) of any bug.'
+  %]
 [% END -%]

--- a/extensions/EditComments/template/en/default/hook/bug_modal/activity_stream-comment_action.html.tmpl
+++ b/extensions/EditComments/template/en/default/hook/bug_modal/activity_stream-comment_action.html.tmpl
@@ -8,8 +8,7 @@
 
 [%
   RETURN UNLESS comment.body || comment.count == 0;
-  RETURN UNLESS user.is_insider
-    || Param('edit_comments_group') && user.in_group(Param('edit_comments_group')) && comment.author.id == user.id;
+  RETURN UNLESS comment.is_editable_by(user);
   RETURN UNLESS
     comment.type == constants.CMT_NORMAL
     || comment.type == constants.CMT_DUPE_OF

--- a/extensions/EditComments/template/en/default/hook/bug_modal/header-end.html.tmpl
+++ b/extensions/EditComments/template/en/default/hook/bug_modal/header-end.html.tmpl
@@ -10,8 +10,6 @@
   # Always load CSS to style the "Edited" revision link
   style_urls.push('extensions/EditComments/web/styles/inline-editor.css');
 
-  RETURN UNLESS user.is_insider
-    || Param('edit_comments_group') && user.in_group(Param('edit_comments_group'));
-
+  RETURN UNLESS user.can_edit_comments();
   javascript_urls.push('extensions/EditComments/web/js/inline-editor.js');
 %]

--- a/extensions/EditComments/template/en/default/hook/global/header-start.html.tmpl
+++ b/extensions/EditComments/template/en/default/hook/global/header-start.html.tmpl
@@ -24,7 +24,7 @@
     preview_error = 'Preview could not be loaded. Please try again later.',
     revision_count => [ '%d revision', '%d revisions' ],
     save => 'Update Comment',
-    save_error => 'Updated comment could not be saved. Please try again later.',
+    save_error => 'Updated comment could not be saved.',
     save_tooltip => 'Save the changes',
     saving => 'Saving…',
     toolbar => 'Comment Editor Toolbar',

--- a/extensions/EditComments/template/en/default/hook/global/header-start.html.tmpl
+++ b/extensions/EditComments/template/en/default/hook/global/header-start.html.tmpl
@@ -8,8 +8,7 @@
 
 [%
   RETURN UNLESS bug.defined;
-  RETURN UNLESS user.is_insider
-    || Param('edit_comments_group') && user.in_group(Param('edit_comments_group'));
+  RETURN UNLESS user.can_edit_comments();
 
   # Expose strings used in JavaScript
   js_BUGZILLA.string.InlineCommentEditor = {

--- a/extensions/EditComments/template/en/default/pages/comment-revisions.html.tmpl
+++ b/extensions/EditComments/template/en/default/pages/comment-revisions.html.tmpl
@@ -11,7 +11,7 @@
   PROCESS global/header.html.tmpl
     title           = "$terms.Bug $bug.id Comment $comment.count Edit History"
     style_urls      = ['extensions/EditComments/web/styles/revisions.css']
-    javascript_urls = (user.is_insider ? ['extensions/EditComments/web/js/revisions.js'] : [])
+    javascript_urls = (user.is_edit_comments_admin ? ['extensions/EditComments/web/js/revisions.js'] : [])
     generate_api_token = 1
 %]
 
@@ -27,11 +27,11 @@
   <article class="revision" data-comment-id="[% comment.id FILTER html %]" data-revised-time="[% a.revised_time FILTER html %]">
     <header>
       <div class="metadata">
-        [% a.old ? "Revision $rev_count" : "Original comment" FILTER html %]
+        [% rev_count == 0 ? "Original comment" : "Revision $rev_count" FILTER html %]
         by [% INCLUDE bug_modal/user.html.tmpl u=a.author %]
         on <time datetime="[% a.created_time FILTER html %]">[% a.created_time FILTER time %]</time>
       </div>
-      [% IF user.is_insider && a.revised_time %]
+      [% IF user.is_edit_comments_admin && a.revised_time %]
         <div class="actions">
           <label><input type="checkbox" name="is_hidden" [% "checked" IF a.is_hidden %]> Hide</label>
         </div>
@@ -40,7 +40,7 @@
     <div class="body">
       [% IF !user.is_insider && a.is_hidden %]
         <div class="hidden-comment">(Hidden by Administrator)</div>
-      [% ELSIF comment.count == 0 && !a.new %]
+      [% ELSIF comment.count == 0 && a.new == "" %]
         <div class="empty-comment">No description provided.</div>
       [% ELSE %]
         <pre class="bz_comment_text">[% a.new FILTER quoteUrls(bug) %]</pre>

--- a/js/util.js
+++ b/js/util.js
@@ -450,11 +450,9 @@ Bugzilla.API = class API {
         reject(new Bugzilla.Error({ name: 'TimeoutError', message: 'Request Timeout' }));
       }, 30000);
 
-      /** @throws {AbortError} */
-      fetch(request, init).then(response => {
-        /** @throws {SyntaxError} */
-        return response.ok ? response.json() : { error: true };
-      }).then(result => {
+      fetch(request, init)
+      .then(response => response.json())
+      .then(result => {
         const { error, code, message } = result;
 
         if (error) {


### PR DESCRIPTION
Allow any member of the `edit_comments_group` and insiders to edit the
description (comment 0) of any bug.

- adds new `allow_global_initial_comment_editing` parameter
- consolidates permissions check into a single location
- fixes Bugzilla.API error handling to return the error message instead
  of always "Unexpected Error" (all errors are unexpected; this message
  is meaningless).

- adds new `edit_comments_admins_group` parameter
- reference `edit_comments_admins_group` group membership instead of
  `insider` for global edit comments and revision hiding features
- fix issues caused by a comment body that returns a falsy value (eg. "0")