### PR TITLE
Bug 1651591 - remove preloading of fonts and ga; r=dkl

### DIFF
--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -410,26 +410,6 @@ sub header {
 
   $self->{_header_done} = 1;
 
-  if (Bugzilla->usage_mode == USAGE_MODE_BROWSER) {
-    my @fonts = (
-      "skins/standard/fonts/FiraMono-Regular.woff2?v=3.202",
-      "skins/standard/fonts/FiraSans-Bold.woff2?v=4.203",
-      "skins/standard/fonts/FiraSans-Italic.woff2?v=4.203",
-      "skins/standard/fonts/FiraSans-Regular.woff2?v=4.203",
-      "skins/standard/fonts/FiraSans-SemiBold.woff2?v=4.203",
-      "skins/standard/fonts/MaterialIcons-Regular.woff2",
-    );
-    $headers{'-link'} = join(
-      ", ",
-      map {
-        sprintf('</static/v%s/%s>; rel="preload"; as="font"', Bugzilla->VERSION, $_)
-      } @fonts
-    );
-    if (Bugzilla->params->{google_analytics_tracking_id}) {
-      $headers{'-link'}
-        .= ', <https://www.google-analytics.com>; rel="preconnect"; crossorigin';
-    }
-  }
   my $headers = $self->SUPER::header(%headers) || '';
   if ($self->server_software eq 'Bugzilla::App::CGI') {
     my $c = $Bugzilla::App::CGI::C;


### PR DESCRIPTION
Font preloading has been broken for more than a year, and doesn't appear
to work correctly even when provided URLs which exist; removed.

google-analytics likely does little to improve page load time
performance against all the other assets, is loaded async, and exists
outside of the GoogleAnalytics making it easy to miss when updating that
extension (eg. the preloading doesn't honour DNT); also removed.