### PR TITLE
Bug 1649841 - Include data-review? requests in notification count

### DIFF
--- a/extensions/Review/lib/Util.pm
+++ b/extensions/Review/lib/Util.pm
@@ -30,7 +30,7 @@ sub rebuild_review_counters {
                INNER JOIN profiles ON profiles.userid = flags.requestee_id
                INNER JOIN flagtypes ON flagtypes.id = flags.type_id
          WHERE flags.status = '?'
-               AND flagtypes.name IN ('review', 'feedback', 'needinfo')
+               AND flagtypes.name IN ('review', 'data-review', 'feedback', 'needinfo')
          GROUP BY flags.requestee_id, flagtypes.name
     ", {Slice => {}});
 
@@ -71,7 +71,7 @@ sub _update_profile {
            SET review_request_count = ?,
                feedback_request_count = ?,
                needinfo_request_count = ?
-         WHERE userid = ?", undef, $data->{review} || 0, $data->{feedback} || 0,
+         WHERE userid = ?", undef, ($data->{review} || 0) + ($data->{'data-review'} || 0), $data->{feedback} || 0,
     $data->{needinfo} || 0, $data->{id});
   Bugzilla->memcached->clear({table => 'profiles', id => $data->{id}});
 }


### PR DESCRIPTION
I lumped the data-review flag count in with the normal review count so I would not need to create a new database column in the profiles table. They are essentially similar and the count is the correct in the header of each BMO page.