### PR TITLE
Bug 1654456 - needinfo? request email enhancements

### DIFF
--- a/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
+++ b/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
@@ -12,7 +12,8 @@
 ---
 --- Someone has asked for you for information about this [% terms.bug %].
 ---
---- Please go to the [% terms.bug %] URL listed above to respond.
+--- Please go to [% urlbase %]show_bug.cgi?id=[% bug.bug_id %] to respond
+--- to the question below.
 [% IF flag.requestee.login_name == bug.reporter.login_name %]
 ---
 --- Since you reported this [% terms.bug %], then the person asking the

--- a/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
+++ b/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
@@ -12,8 +12,7 @@
 ---
 --- Someone has asked for you for information about this [% terms.bug %].
 ---
---- Please go to the [% terms.bug %] URL listed above to see the question
---- and respond to it.
+--- Please go to the [% terms.bug %] URL listed above to respond.
 [% IF flag.requestee.login_name == bug.reporter.login_name %]
 ---
 --- Since you reported this [% terms.bug %], then the person asking the

--- a/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
+++ b/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
@@ -8,15 +8,27 @@
 
 [% RETURN UNLESS flag && flag.type.name == 'needinfo' && flag.status == '?' %]
 ---
---- Hello!
+--- Hello from [% terms.Bugzilla %], the bug tracker for Mozilla and Firefox:
 ---
 --- Someone has asked for you for information about this [% terms.bug %].
 ---
---- Please go to [% terms.bug %] to see the question, and respond
---- to it. If you reported this [% terms.bug %], then the person asking the
---- question most-likely needs more information to understand
---- the [% terms.bug %].
+--- Please go to [%+ urlbase %]show_bug.cgi?id=[% bug.bug_id %] to see the
+--- question and respond to it.
+[% IF flag.requestee.login_name == bug.reporter.login_name %]
 ---
---- This request has set a needinfo flag on the [% terms.bug %].
---- You can clear it by logging in and replying in a comment.
+--- Since you reported this [% terms.bug %], then the person asking the
+--- question needs more information from you to understand it.
+[% END %]
+---
+--- Responding to the question will enable developers to take further
+--- action on this [% terms.bug %].
+---
+--- Please log into [% terms.Bugzilla %] and respond as soon as possible
+--- so developers may take action on this [% terms.bug %].
+---
+--- If you have questions on this report, please contact the
+--- [% terms.Bugzilla %] team on https://chat.mozilla.org/#/room/#bmo:mozilla.org.
+---
+--- Thank you,
+--- The [% terms.Bugzilla %] team
 ---

--- a/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
+++ b/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
@@ -13,7 +13,7 @@
 --- Someone has asked for you for information about this bug.
 ---
 --- Please go to [% terms.bug %] to see the question, and respond
---- to it. If you reported this bug, then the person asking the
+--- to it. If you reported this [% terms.bug %], then the person asking the
 --- question most-likely needs more information to understand
 --- the bug.
 ---

--- a/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
+++ b/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
@@ -28,7 +28,7 @@
 [% END %]
 ---
 --- If you have questions about responding to needinfo requests, please
---- see https://mozilla.tld/some/path/to/documentation.
+--- see https://wiki.mozilla.org/BMO/UserGuide#Needinfo_Flag.
 ---
 --- Thank you
 ---

--- a/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
+++ b/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
@@ -12,7 +12,8 @@
 ---
 --- Someone has asked for you for information about this [% terms.bug %].
 ---
---- Please go to the bug URL listed above to see the question and respond to it.
+--- Please go to the [% terms.bug %] URL listed above to see the question
+--- and respond to it.
 [% IF flag.requestee.login_name == bug.reporter.login_name %]
 ---
 --- Since you reported this [% terms.bug %], then the person asking the

--- a/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
+++ b/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
@@ -12,8 +12,7 @@
 ---
 --- Someone has asked for you for information about this [% terms.bug %].
 ---
---- Please go to [%+ urlbase %]show_bug.cgi?id=[% bug.bug_id %] to see the
---- question and respond to it.
+--- Please go to the bug URL listed above to see the question and respond to it.
 [% IF flag.requestee.login_name == bug.reporter.login_name %]
 ---
 --- Since you reported this [% terms.bug %], then the person asking the

--- a/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
+++ b/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
@@ -10,14 +10,13 @@
 ---
 --- Hello!
 ---
---- Someone has asked for you for information about this bug.
+--- Someone has asked for you for information about this [% terms.bug %].
 ---
 --- Please go to [% terms.bug %] to see the question, and respond
 --- to it. If you reported this [% terms.bug %], then the person asking the
 --- question most-likely needs more information to understand
---- the bug.
+--- the [% terms.bug %].
 ---
 --- This request has set a needinfo flag on the [% terms.bug %].
 --- You can clear it by logging in and replying in a comment.
 ---
-

--- a/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
+++ b/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
@@ -26,9 +26,9 @@
 --- Please log into [% terms.Bugzilla %] and respond as soon as possible
 --- so developers may take action on this [% terms.bug %].
 ---
---- If you have questions on this report, please contact the
---- [% terms.Bugzilla %] team on https://chat.mozilla.org/#/room/#bmo:mozilla.org.
+--- If you have questions about responding to needinfo requests, please
+--- see https://mozilla.tld/some/path/to/documentation.
 ---
---- Thank you,
---- The [% terms.Bugzilla %] team
+--- Thank you
+---
 ---

--- a/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
+++ b/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
@@ -8,7 +8,7 @@
 
 [% RETURN UNLESS flag && flag.type.name == 'needinfo' && flag.status == '?' %]
 ---
---- Hello from [% terms.Bugzilla %], the bug tracker for Mozilla and Firefox:
+--- Hello from [% terms.Bugzilla %], the [% terms.bug %] tracker for Mozilla and Firefox:
 ---
 --- Someone has asked for you for information about this [% terms.bug %].
 ---

--- a/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
+++ b/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
@@ -6,6 +6,10 @@
   # defined by the Mozilla Public License, v. 2.0.
   #%]
 
+[%# Case for needinfo set for bug reporter here
+  #
+  #%]
+
 [% RETURN UNLESS flag && flag.type.name == 'needinfo' && flag.status == '?' %]
 ---
 --- This request has set a needinfo flag on the [% terms.bug %].

--- a/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
+++ b/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
@@ -6,12 +6,18 @@
   # defined by the Mozilla Public License, v. 2.0.
   #%]
 
-[%# Case for needinfo set for bug reporter here
-  #
-  #%]
-
 [% RETURN UNLESS flag && flag.type.name == 'needinfo' && flag.status == '?' %]
+---
+--- Hello!
+---
+--- Someone has asked for you for information about this bug.
+---
+--- Please go to [% terms.bug %] to see the question, and respond
+--- to it. If you reported this bug, then the person asking the
+--- question most-likely needs more information to understand
+--- the bug.
 ---
 --- This request has set a needinfo flag on the [% terms.bug %].
 --- You can clear it by logging in and replying in a comment.
 ---
+

--- a/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
+++ b/extensions/Needinfo/template/en/default/hook/request/email-after_summary.txt.tmpl
@@ -10,7 +10,7 @@
 ---
 --- Hello from [% terms.Bugzilla %], the [% terms.bug %] tracker for Mozilla and Firefox:
 ---
---- Someone has asked for you for information about this [% terms.bug %].
+--- Someone has asked you for information about this [% terms.bug %].
 ---
 --- Please go to [% urlbase %]show_bug.cgi?id=[% bug.bug_id %] to respond
 --- to the question below.
@@ -18,13 +18,14 @@
 ---
 --- Since you reported this [% terms.bug %], then the person asking the
 --- question needs more information from you to understand it.
-[% END %]
 ---
 --- Responding to the question will enable developers to take further
 --- action on this [% terms.bug %].
+[% ELSE %]
 ---
 --- Please log into [% terms.Bugzilla %] and respond as soon as possible
 --- so developers may take action on this [% terms.bug %].
+[% END %]
 ---
 --- If you have questions about responding to needinfo requests, please
 --- see https://mozilla.tld/some/path/to/documentation.


### PR DESCRIPTION
This commit adds a conditional section to the template that catches the case where the requestee of a needinfo is the bug's reporter, and describes why their assistance has been requested. 

For other cases, the text is modified to indicate that assistance is needed to help move the bug forward. 

The changes do not attempt to discern if the requestee is staff, other contributors, or 'drive-by' bug reporters.