### PR TITLE
Bumped version 20200722.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20200624.1';
+our $VERSION = '20200722.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1645768" target="_blank">1645768</a>] Please add 'See Also' support for GitLab</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1651591" target="_blank">1651591</a>] BMO attempts to preload FiraSans, which was replaced with FiraGO in May 2019</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1535000" target="_blank">1535000</a>] Make Description (Comment 0) editable by everyone with edit_comments rights</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1652863" target="_blank">1652863</a>] setting the needinfo flag when filing a new bug in Core or Toolkit does not cause the textbox for user information to pop up</li>
</ul>