### PR TITLE
Bug 1643526 - Attachment comments don't render markdown, but their preview does

### DIFF
--- a/js/attachment.js
+++ b/js/attachment.js
@@ -177,6 +177,7 @@ function switchToMode(mode, patchviewerinstalled)
     if (current_mode == 'edit') {
       hideElementById('editFrame');
       hideElementById('undoEditButton');
+      document.querySelector('input[name="markdown_off"]').value = 0;
     } else if (current_mode == 'raw') {
       hideElementById('viewFrame');
       if (patchviewerinstalled)
@@ -195,6 +196,7 @@ function switchToMode(mode, patchviewerinstalled)
     if (mode == 'edit') {
       showElementById('editFrame');
       showElementById('undoEditButton');
+      document.querySelector('input[name="markdown_off"]').value = 1;
     } else if (mode == 'raw') {
       showElementById('viewFrame');
       if (patchviewerinstalled)

--- a/template/en/default/attachment/edit.html.tmpl
+++ b/template/en/default/attachment/edit.html.tmpl
@@ -180,7 +180,7 @@
           [% Hook.process('view') %]
           [% UNLESS custom_attachment_viewer %]
             <div>
-              <input type="hidden" name="markdown_off" value="1">
+              <input type="hidden" name="markdown_off" value="0">
               [% INCLUDE global/textarea.html.tmpl
                 id      = 'editFrame'
                 name    = 'comment'


### PR DESCRIPTION
This adds simple code to attachment.js to set the markdown_off value to either 1 or 0 based on whether we are adding a normal comment or editing the patch itself as a comment. Editing a patch as a comment will disable markdown which is proper behavior IMO.