### PR TITLE
Bug 1655808: send users in guided bug flow to GitHub for Android and iOS bug reports

### DIFF
--- a/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
+++ b/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
@@ -132,12 +132,6 @@ tabbed browsing or the location bar)
 
 <ul class="product-list">
 [% INCLUDE 'guided/products.html.tmpl' %]
-[% WRAPPER product_block
-   name="Other Products"
-   icon="other.png"
-   onclick="guided.setStep('otherProducts')" %]
-Other Mozilla products which aren't listed here
-[% END %]
 </ul>
 
 <div id="prod_comp_search_main">

--- a/extensions/GuidedBugEntry/template/en/default/guided/products.html.tmpl
+++ b/extensions/GuidedBugEntry/template/en/default/guided/products.html.tmpl
@@ -19,14 +19,16 @@ For [% terms.bugs %] in Firefox, the Mozilla Foundation's web browser.
    icon="firefox_android.png"
    onclick="document.location='https://github.com/mozilla-mobile/fenix/issues/'"
 %]
-Something about Fenix here
+Firefox for Android is the Firefox mobile experience developed for Android. Bugs for
+this product are tracked on GitHub.
 [% END %]
 [% WRAPPER product_block
    name="Firefox for iOS"
    icon="firefox_ios.png"
    onclick="document.location='https://github.com/mozilla-mobile/firefox-ios/issues'"
 %]
-Something about Firefox for iOS here
+Firefox for iOS is the Firefox mobile experience developed for the iOS platform. Bugs for
+this product are tracked on GitHub.
 [% END %]
 [% INCLUDE product_block
    name="Thunderbird"

--- a/extensions/GuidedBugEntry/template/en/default/guided/products.html.tmpl
+++ b/extensions/GuidedBugEntry/template/en/default/guided/products.html.tmpl
@@ -19,7 +19,7 @@ For [% terms.bugs %] in Firefox, the Mozilla Foundation's web browser.
    icon="firefox_android.png"
    onclick="document.location='https://github.com/mozilla-mobile/fenix/issues/'"
 %]
-Firefox for Android is the Firefox mobile experience developed for Android. Bugs for
+Firefox for Android is the Firefox mobile experience developed for Android. [% terms.Bugs %] for
 this product are tracked on GitHub.
 [% END %]
 [% WRAPPER product_block
@@ -27,7 +27,7 @@ this product are tracked on GitHub.
    icon="firefox_ios.png"
    onclick="document.location='https://github.com/mozilla-mobile/firefox-ios/issues'"
 %]
-Firefox for iOS is the Firefox mobile experience developed for the iOS platform. Bugs for
+Firefox for iOS is the Firefox mobile experience developed for the iOS platform. [% terms.Bugs %] for
 this product are tracked on GitHub.
 [% END %]
 [% INCLUDE product_block

--- a/extensions/GuidedBugEntry/template/en/default/guided/products.html.tmpl
+++ b/extensions/GuidedBugEntry/template/en/default/guided/products.html.tmpl
@@ -14,15 +14,27 @@ For [% terms.bugs %] in Firefox, the Mozilla Foundation's web browser.
 
 (<a href="https://www.mozilla.org/en-US/firefox/desktop/">more info</a>)
 [% END %]
-[% INCLUDE product_block
+[% WRAPPER product_block
    name="Firefox for Android"
    icon="firefox_android.png"
+   onclick="document.location='https://github.com/mozilla-mobile/fenix/issues/'"
 %]
-[% INCLUDE product_block
+Something about Fenix here
+[% END %]
+[% WRAPPER product_block
    name="Firefox for iOS"
    icon="firefox_ios.png"
+   onclick="document.location='https://github.com/mozilla-mobile/firefox-ios/issues'"
 %]
+Something about Firefox for iOS here
+[% END %]
 [% INCLUDE product_block
    name="Thunderbird"
    icon="thunderbird.png"
 %]
+[% WRAPPER product_block
+   name="Other Products"
+   icon="other.png"
+   onclick="guided.setStep('otherProducts')" %]
+Other Mozilla products which aren't listed here
+[% END %]


### PR DESCRIPTION
This pull request modifies the Guided Bug Entry extension:

The product selector has been changed such that when a user clicks Firefox for Android or iOS they are redirected to the corresponding GitHub projects' issue pages.
