### PR TITLE
Bumped version to 20200805.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20200723.1';
+our $VERSION = '20200805.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1643526" target="_blank">1643526</a>] Attachment comments don't render markdown, but their preview does</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1654456" target="_blank">1654456</a>] [needinfo] Provide instructions and guidance when needinfo is requested of the bug's reporter</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1654370" target="_blank">1654370</a>] Remove remaining code that references Firefox OS from BMO code base</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1655808" target="_blank">1655808</a>] Send guided bug flow users to GitHub for Fenix issues</li>
</ul>