### PR TITLE
Bug 1657778 - Offer link to Bugzilla for filing security issues in Fenix and iOS

### DIFF
--- a/extensions/GuidedBugEntry/template/en/default/guided/products.html.tmpl
+++ b/extensions/GuidedBugEntry/template/en/default/guided/products.html.tmpl
@@ -21,6 +21,10 @@ For [% terms.bugs %] in Firefox, the Mozilla Foundation's web browser.
 %]
 Firefox for Android is the Firefox mobile experience developed for Android. [% terms.Bugs %] for
 this product are tracked on GitHub.
+
+<i>If you are reporting a security issue that will affect users,
+<b><a href="/enter_bug.cgi?format=guided#h=dupes|Fenix|Security%3A%20Android">use
+this form</a>.</i></b>
 [% END %]
 [% WRAPPER product_block
    name="Firefox for iOS"
@@ -29,6 +33,10 @@ this product are tracked on GitHub.
 %]
 Firefox for iOS is the Firefox mobile experience developed for the iOS platform. [% terms.Bugs %] for
 this product are tracked on GitHub.
+
+<i>If you are reporting a security issue that will affect users,
+<b><a href="/enter_bug.cgi?format=guided#h=dupes|Focus|Security%3A iOS">use
+this form</a>.</i></b>
 [% END %]
 [% INCLUDE product_block
    name="Thunderbird"

--- a/extensions/GuidedBugEntry/template/en/default/guided/products.html.tmpl
+++ b/extensions/GuidedBugEntry/template/en/default/guided/products.html.tmpl
@@ -22,7 +22,7 @@ For [% terms.bugs %] in Firefox, the Mozilla Foundation's web browser.
 Firefox for Android is the Firefox mobile experience developed for Android. [% terms.Bugs %] for
 this product are tracked on GitHub.
 
-<i>If you are reporting a security issue that will affect users,
+<i>If you are reporting a security issue that puts users at risk,
 <b><a href="/enter_bug.cgi?format=guided#h=dupes|Fenix|Security%3A%20Android">use
 this form</a>.</i></b>
 [% END %]
@@ -34,7 +34,7 @@ this form</a>.</i></b>
 Firefox for iOS is the Firefox mobile experience developed for the iOS platform. [% terms.Bugs %] for
 this product are tracked on GitHub.
 
-<i>If you are reporting a security issue that will affect users,
+<i>If you are reporting a security issue that puts users at risk,
 <b><a href="/enter_bug.cgi?format=guided#h=dupes|Focus|Security%3A iOS">use
 this form</a>.</i></b>
 [% END %]

--- a/extensions/GuidedBugEntry/template/en/default/guided/products.html.tmpl
+++ b/extensions/GuidedBugEntry/template/en/default/guided/products.html.tmpl
@@ -24,7 +24,7 @@ this product are tracked on GitHub.
 
 <i>If you are reporting a security issue that puts users at risk,
 <b><a href="/enter_bug.cgi?format=guided#h=dupes|Fenix|Security%3A%20Android">use
-this form</a>.</i></b>
+this form</a>.</b></i>
 [% END %]
 [% WRAPPER product_block
    name="Firefox for iOS"
@@ -36,7 +36,7 @@ this product are tracked on GitHub.
 
 <i>If you are reporting a security issue that puts users at risk,
 <b><a href="/enter_bug.cgi?format=guided#h=dupes|Focus|Security%3A iOS">use
-this form</a>.</i></b>
+this form</a>.</b></i>
 [% END %]
 [% INCLUDE product_block
    name="Thunderbird"


### PR DESCRIPTION
This PR updates the template in guided bug entry for Fenix and iOS. So that security issues are filed in Bugzilla, this adds links to the guided bug entry workflow for the respective mobile components. 