### PR TITLE
Show Bounty Attachments to the Bug Reporter

### DIFF
--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -344,6 +344,7 @@ sub bounty_attachment {
 }
 
 sub _attachment_is_bounty_attachment {
+  # Keep this in sync with Bugzilla/Attachment.pm
   my ($attachment) = @_;
 
   return 0 unless $attachment->filename eq 'bugbounty.data';

--- a/extensions/BMO/template/en/default/hook/bug_modal/attachments-row.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/bug_modal/attachments-row.html.tmpl
@@ -24,8 +24,10 @@
     [% END %]
   </td>
   <td class="attach-actions">
+    [% IF user.is_insider %]
     <a href="[% basepath FILTER none %]page.cgi?id=attachment_bounty_form.html&bug_id=[% bug.id FILTER none %]">
       Edit Bounty
     </a>
+    [% END %]
   </td>
 </tr>

--- a/extensions/BugModal/template/en/default/bug_modal/attachments.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/attachments.html.tmpl
@@ -16,7 +16,10 @@
 <table role="table" class="layout-table" id="attachments">
   [% FOREACH attachment IN bug.attachments %]
     [%
-      NEXT IF attachment.isprivate && !(user.is_insider || attachment.attacher.id == user.id);
+      NEXT IF attachment.isprivate
+        && !(user.is_insider
+              || attachment.attacher.id == user.id
+              || (attachment.is_bounty_attachment && user.id == bug.reporter.id));
       attachment_rendered = 0;
       Hook.process("row");
       NEXT IF attachment_rendered;

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -48,7 +48,7 @@
   active_attachments = 0;
   obsolete_attachments = 0;
   FOREACH attachment IN bug.attachments;
-    NEXT IF attachment.isprivate && !(user.is_insider || attachment.attacher.id == user.id);
+    NEXT IF attachment.isprivate && !(user.is_insider || attachment.attacher.id == user.id || (attachment.is_bounty_attachment && bug.reporter.id == user.id)) ;
     IF attachment.isobsolete;
       obsolete_attachments = obsolete_attachments + 1;
     ELSE;

--- a/template/en/default/attachment/list.html.tmpl
+++ b/template/en/default/attachment/list.html.tmpl
@@ -66,7 +66,7 @@ function toggle_display(link) {
 
   [% FOREACH attachment = attachments %]
     [% count = count + 1 %]
-    [% IF !attachment.isprivate || user.is_insider || attachment.attacher.id == user.id %]
+    [% IF !attachment.isprivate || user.is_insider || attachment.attacher.id == user.id || (attachment.is_bounty_attachment && user.id == bug.reporter.id) %]
       [% IF attachment.isobsolete %]
         [% obsolete_attachments = obsolete_attachments + 1 %]
       [% END %]


### PR DESCRIPTION
This will allow most bug bounty recipients to view the amount of their bounty. It will not show it to reporters if we filed the bug for them, however those are less likely to be repeat filers.