### PR TITLE
Bug 1658841 - Webhooks should include comments added to a bug

### DIFF
--- a/extensions/Push/lib/Connector/Webhook.pm
+++ b/extensions/Push/lib/Connector/Webhook.pm
@@ -74,13 +74,11 @@ sub should_send {
   if ($product eq $bug->product
       && ($component eq $bug->component || $component eq 'any'))
   {
-    if ($event =~ /create/ && $message->routing_key eq 'bug.create') {
-      return 1;
-    }elsif ($event =~ /change/ && $message->routing_key =~ /^bug\.modify/) {
-      return 1;
-    }elsif ($event =~ /comment/ && $message->routing_key eq 'comment.create') {
-      return 1;
-    }elsif ($event =~ /attachment/ &&  $message->routing_key eq 'attachment.create') {
+    if (($event =~ /create/ && $message->routing_key eq 'bug.create')
+      || ($event =~ /change/ && $message->routing_key =~ /^bug\.modify/)
+      || ($event =~ /comment/ && $message->routing_key eq 'comment.create')
+      || ($event =~ /attachment/ &&  $message->routing_key eq 'attachment.create'))
+    {
       return 1;
     }
   }

--- a/extensions/Push/lib/Connector/Webhook.pm
+++ b/extensions/Push/lib/Connector/Webhook.pm
@@ -20,7 +20,6 @@ use Bugzilla::Attachment;
 use Bugzilla::Extension::Webhooks::Webhook;
 use Bugzilla::Extension::Push::Constants;
 use Bugzilla::Extension::Push::Util;
-use Bugzilla::Extension::Push::Serialize qw(_integer _boolean _bug);
 use Bugzilla::Util ();
 
 use JSON qw(decode_json encode_json);
@@ -107,7 +106,7 @@ sub send {
       delete @{$payload}{$target};
       $payload->{$target}->{id}         = _integer($target_id) ;
       $payload->{$target}->{is_private} = _boolean($target_is_private);
-      $payload->{$target}->{bug}        = _bug($bug_data);
+      $payload->{$target}->{bug}        = $bug_data;
     }
 
     if ($bug_is_private){
@@ -174,6 +173,16 @@ sub _user_agent {
   }
 
   return $ua;
+}
+
+sub _boolean {
+  my ($value) = @_;
+  return $value ? JSON::true : JSON::false;
+}
+
+sub _integer {
+  my ($value) = @_;
+  return defined($value) ? $value + 0 : undef;
 }
 
 1;

--- a/extensions/Push/lib/Serialize.pm
+++ b/extensions/Push/lib/Serialize.pm
@@ -266,7 +266,7 @@ sub _attachment {
 sub _comment {
   my ($self, $comment, $is_shallow) = @_;
   my $rh = {
-    id            => _integer($comment->bug_id),
+    id            => _integer($comment->id),
     body          => _string($comment->body),
     creation_time => _time($comment->creation_ts),
     is_private    => _boolean($comment->is_private),

--- a/extensions/Webhooks/Extension.pm
+++ b/extensions/Webhooks/Extension.pm
@@ -103,14 +103,9 @@ sub user_preferences {
         $params->{url} = $input->{url};
       }
 
-      if ($input->{create_event} && $input->{change_event}) {
-        $params->{event} = 'create,change';
-      }
-      elsif ($input->{create_event}) {
-        $params->{event} = 'create';
-      }
-      elsif ($input->{change_event}) {
-        $params->{event} = 'change';
+      if ($input->{event}) {
+        $params->{event} = ref($input->{event}) eq 'ARRAY' ? join(',', @{$input->{event}})
+                          : $input->{event};
       }
       else {
         ThrowUserError('webhooks_select_event');

--- a/extensions/Webhooks/template/en/default/account/prefs/webhooks.html.tmpl
+++ b/extensions/Webhooks/template/en/default/account/prefs/webhooks.html.tmpl
@@ -76,11 +76,17 @@ window.onload = function() {
 <h4>Events</h4>
 <p>Select the events you want to receive.</p>
 <p>
-  <input type="checkbox" id="create_event" name="create_event" value="1">
-  <label for="create_event">When a new [% terms.bug %] is created</label>
+  <input type="checkbox" id="create_event" name="event" value="create">
+  <label for="create_event">When a new <b>[% terms.bug %]</b> is <b>created</b></label>
 <br>
-  <input type="checkbox" id="change_event" name="change_event" value="1">
-  <label for="change_event">When an existing [% terms.bug %] is modified</label>
+  <input type="checkbox" id="change_event" name="event" value="change">
+  <label for="change_event">When an existing <b>[% terms.bug %]</b> is <b>modified</b></label>
+<br>
+  <input type="checkbox" id="attachment_event" name="event" value="attachment">
+  <label for="attachment_event">When a new <b>attachment</b> is created</label>
+<br>
+  <input type="checkbox" id="comment_event" name="event" value="comment">
+  <label for="comment_event">When a new <b>comment</b> is created</label>
 </p>
 <h4>Filters</h4>
 <p>
@@ -129,7 +135,6 @@ window.onload = function() {
   <thead>
     <tr>
       <th>Remove</th>
-      <th>ID</th>
       <th>Name</th>
       <th>URL</th>
       <th>Events</th>

--- a/extensions/Webhooks/template/en/default/account/prefs/webhooks.html.tmpl
+++ b/extensions/Webhooks/template/en/default/account/prefs/webhooks.html.tmpl
@@ -150,7 +150,6 @@ window.onload = function() {
         <input type="checkbox" onChange="onRemoveChange()"
                name="remove" value="[% webhook.id FILTER none %]">
       </td>
-      <td>[% webhook.id FILTER html %]</td>
       <td>[% webhook.name FILTER html %]</td>
       <td>
         <a href="[% webhook.url FILTER html %]">


### PR DESCRIPTION
@dklawren I'm trying to use the `HTML::Strip` module but it throws me an error to remove html, I think I need to install the module on the project but I'm not sure.
Here I took the message when a comment is created and modify it in order it seems as current change event message from webhooks, and also are sent as part of change event, as you suggest.
And the description is sent as a parameter that changes but not as part of the bug body, because it is sent as a comment too, and for that reason is sent in another message when a bug is created not in the same:
```
"event": {
      "action": "change",
      "time": "2020-07-24T20:11:22",
      "user": {
          "id": 1,
            "login": "admin@bmo.test",
            "real_name": "Vagrant User"
      },
      "changes": [
          {
            "field": "description",
            "removed": "",
            "added": "This is a my description"
            }
        ],
}
```
If we want to send it in all webhooks messages as part of the bug body maybe I can modify the push message payload and add it. 