### PR TITLE
Bumper version to 20200908.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20200828.1';
+our $VERSION = '20200908.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1657542" target="_blank">1657542</a>] During recent bmo deployment, emails were delivered to a file instead of SES which caused interruption of email service</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1658622" target="_blank">1658622</a>] "product responsibilities" on editusers should include Triage Owner</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1588661" target="_blank">1588661</a>] Design for WebHooks</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1659177" target="_blank">1659177</a>] Replace mozillians.org with people.mozilla.org in Reps Mentorship From</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1649841" target="_blank">1649841</a>] Include data-review? requests in notification count</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1658317" target="_blank">1658317</a>] Make scopes more descriptive and user friendly when authenticating to BMO using OAuth2</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1656609" target="_blank">1656609</a>] Consider structuring show_bug.cgi in such a way that it's the &lt;html&gt; element that scrolls, not a descendant</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1657778" target="_blank">1657778</a>] Offer link to Bugzilla for filing security issues in Fenix and iOS</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1658846" target="_blank">1658846</a>] Allow users to enable and disable their webhooks</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1658845" target="_blank">1658845</a>] Allow users to see their own queue for their webhooks</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1662747" target="_blank">1662747</a>] Version number not visible in bug query results because of Long version numbers</li>
</ul>