### PR TITLE
Message for disabled accounts should reflect Mozilla's environment

### DIFF
--- a/template/en/default/admin/users/bounce-disabled.txt.tmpl
+++ b/template/en/default/admin/users/bounce-disabled.txt.tmpl
@@ -13,7 +13,7 @@
 
 [% PROCESS global/variables.none.tmpl %]
 
-Your [% terms.Bugzilla %] account has been disabled due to issues delivering
-emails to your address.<br>
+Your [% terms.Bugzilla %] account has been disabled. Our official excuse is
+that there have been issues delivering emails to your address.<br>
 <br>
-Your mail server ([% mta FILTER html %]) said: [% reason FILTER html %]<br>
+Our mail server ([% mta FILTER html %]) said: [% reason FILTER html %]<br>

--- a/template/en/default/global/user-error.html.tmpl
+++ b/template/en/default/global/user-error.html.tmpl
@@ -67,6 +67,7 @@
     <hr>
     If you believe your account should be restored, please
     send email to [% Param("maintainer") %] explaining why.
+    We love seeing your effort at trying to convince us.
 
   [% ELSIF error == "account_exists" %]
     [% title = "Account Already Exists" %]


### PR DESCRIPTION
Message for disabled accounts should reflect Mozilla's environment better. Just in case, I clarify that I care about Mozilla and their users, which is proved by my past contributions.