### PR TITLE
Bug 1669330 - Should not be possible to override bug type requirement when submitting a bug using API

### DIFF
--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -1884,7 +1884,7 @@ sub _check_bug_type {
     }
     return $invocant->_check_select_field($type, 'bug_type');
   }
-d
+
   $type_required && ThrowUserError('bug_type_required');
 
   if (blessed $invocant) {

--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -1875,14 +1875,17 @@ sub _check_bug_status {
 
 sub _check_bug_type {
   my ($invocant, $type, undef, $params) = @_;
+  my $type_required = Bugzilla->params->{'require_bug_type'};
 
   if (defined $type && trim($type)) {
+    # Treat '--' type value same as empty
+    if ($type_required && $type eq '--') {
+      ThrowUserError('bug_type_required');
+    }
     return $invocant->_check_select_field($type, 'bug_type');
   }
-
-  if (Bugzilla->params->{'require_bug_type'}) {
-    ThrowUserError('bug_type_required');
-  }
+d
+  $type_required && ThrowUserError('bug_type_required');
 
   if (blessed $invocant) {
     return $invocant->component_obj->default_bug_type;

--- a/t/model.t
+++ b/t/model.t
@@ -38,7 +38,8 @@ create_bug(
   short_desc  => "test bug $_",
   comment     => "Hello, world: $_",
   provided $_ % 3 == 0, keywords => ['regression'],
-  assigned_to => 'reportuser@invalid.tld'
+  assigned_to => 'reportuser@invalid.tld',
+  bug_type    => 'defect'
 ) for (1..10);
 
 my $model = Bugzilla->dbh->model;

--- a/t/report-ping-simple.t
+++ b/t/report-ping-simple.t
@@ -1,4 +1,3 @@
-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/t/report-ping-simple.t
+++ b/t/report-ping-simple.t
@@ -1,3 +1,4 @@
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -51,7 +52,8 @@ for (1..250) {
     short_desc  => "test bug $_",
     comment     => "Hello, world: $_",
     provided $_ % 3 == 0, keywords => ['regression'],
-    assigned_to => 'reportuser@invalid.tld'
+    assigned_to => 'reportuser@invalid.tld',
+    bug_type    => 'defect'
   );
   $time{ $bug->id } = datetime_from($bug->delta_ts)->epoch;
 }

--- a/template/en/default/global/user-error.html.tmpl
+++ b/template/en/default/global/user-error.html.tmpl
@@ -330,7 +330,14 @@
   [% ELSIF error == "bug_type_required" %]
     [% title = "Bug Type Required" %]
     To file a new [% terms.bug %], you must first choose a type:
-    [% FOREACH type = bug_fields.bug_type.legal_values.pluck('name') %]
+    [%
+      bug_types = [];
+      FOREACH type = bug_fields.bug_type.legal_values.pluck('name');
+        NEXT IF type == "--";
+        bug_types.push(type);
+      END;
+    %]
+    [% FOREACH type = bug_types %]
       [% IF loop.last %] or [% ELSIF !loop.first %], [% END %]
       <strong>[% type FILTER html %]</strong>
     [% END %].


### PR DESCRIPTION
We are currently blocking from creating/updating a bug via API/UI but not if the bug_type is '--' which in the DB is a legal value. What we mean when we set the 'require_bug_type' data/params setting, we do not want '--' to be allowed. Now enforcing this properly.