### PR TITLE
Bug 1669755 - Email address changes are not being stored on profiles activity for some reason

### DIFF
--- a/Bugzilla/User.pm
+++ b/Bugzilla/User.pm
@@ -446,7 +446,7 @@ sub check_login_name_for_creation {
 
   # Check the name if it's a new user, or if we're changing the name.
   if (!ref($invocant) || $invocant->login ne $name) {
-    is_available_username($name)
+    is_available_username($name, (ref $invocant ? $invocant->login : undef))
       || ThrowUserError('account_exists', {email => $name});
   }
 


### PR DESCRIPTION
Use Bugzilla::User->update instead of direct DB which will store login_name change in audit_log and also clear memcache for the userid. 