### PR TITLE
Bumped version to 20201116.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20201027.2';
+our $VERSION = '20201116.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1670319" target="_blank">1670319</a>] Allow use of OAuth2 bearer token as authentication for API calls same as API keys</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1674166" target="_blank">1674166</a>] Note that created bugs will be private for the blocklist form</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1673348" target="_blank">1673348</a>] request for possibility to prevent auto-assignment of bug to author of submitted patch if bug is leave-open or only disables tests</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1675466" target="_blank">1675466</a>] using browser's feature to got back one page in history from intermittent failures page for a bug goes to to blank page, second call of 'back' function needed</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1622867" target="_blank">1622867</a>] Add an equivalent to `/latest/configuration` to the REST api</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1673948" target="_blank">1673948</a>] Add "Team Name" as a search column</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1676877" target="_blank">1676877</a>] With recent changes to the Mojo REST endpoints, we need to disallow using cookies for auth when using API</li>
</ul>