### PR TITLE
Bug 1678128 - Additional CORS headers are missing in the new versioned MOJO based REST API

### DIFF
--- a/Bugzilla/API/V1/Configuration.pm
+++ b/Bugzilla/API/V1/Configuration.pm
@@ -22,9 +22,7 @@ use Mojo::JSON qw( true false );
 
 sub setup_routes {
   my ($class, $r) = @_;
-  $r->get('/latest/configuration')->to('V1::Configuration#configuration');
-  $r->get('/rest/configuration')->to('V1::Configuration#configuration');
-  $r->get('/bzapi/configuration')->to('V1::Configuration#configuration');
+  $r->get('/configuration')->to('V1::Configuration#configuration');
 }
 
 sub configuration {

--- a/Bugzilla/API/V1/Configuration.pm
+++ b/Bugzilla/API/V1/Configuration.pm
@@ -27,8 +27,6 @@ sub setup_routes {
 
 sub configuration {
   my ($self) = @_;
-  Bugzilla->usage_mode(USAGE_MODE_REST);
-
   my $user = $self->bugzilla->login;
 
   my $can_cache = !$user->id && !$self->param('product') && !$self->param('flags');

--- a/Bugzilla/API/V1/Teams.pm
+++ b/Bugzilla/API/V1/Teams.pm
@@ -13,13 +13,12 @@ use JSON::MaybeXS qw(decode_json);
 
 sub setup_routes {
   my ($class, $r) = @_;
-  $r->get('/rest/config/component_teams')->to('V1::Teams#component_teams');
-  $r->get('/rest/config/component_security_teams')->to('V1::Teams#component_security_teams');
+  $r->get('/config/component_teams')->to('V1::Teams#component_teams');
+  $r->get('/config/component_security_teams')->to('V1::Teams#component_security_teams');
 }
 
 sub component_teams {
   my ($self) = @_;
-  Bugzilla->usage_mode(USAGE_MODE_REST);
   $self->bugzilla->login(LOGIN_REQUIRED)
     || return $self->render(status => 401, text => 'Unauthorized');
   $self->render(
@@ -29,7 +28,6 @@ sub component_teams {
 
 sub component_security_teams {
   my ($self) = @_;
-  Bugzilla->usage_mode(USAGE_MODE_REST);
   $self->bugzilla->login(LOGIN_REQUIRED)
     || return $self->render(status => 401, text => 'Unauthorized');
   $self->render(

--- a/Bugzilla/API/V1/User.pm
+++ b/Bugzilla/API/V1/User.pm
@@ -15,14 +15,11 @@ use Bugzilla::Constants;
 
 sub setup_routes {
   my ($class, $r) = @_;
-  $r->get('/api/user/profile')->to('V1::User#user_profile');
-  $r->get('/rest/user/profile')->to('V1::User#user_profile');
+  $r->get('/user_profile')->to('V1::User#user_profile');
 }
 
 sub user_profile {
   my ($self) = @_;
-  Bugzilla->usage_mode(USAGE_MODE_REST);
-
   my $user = $self->bugzilla->oauth('user:read');
   if ($user && $user->id) {
     $self->render(

--- a/Bugzilla/App/API.pm
+++ b/Bugzilla/App/API.pm
@@ -8,6 +8,7 @@
 package Bugzilla::App::API;
 
 use 5.10.1;
+use Bugzilla::Constants;
 use Bugzilla::Logging;
 use Module::Runtime qw(require_module);
 use Mojo::Base qw( Mojolicious::Controller );
@@ -24,13 +25,38 @@ sub setup_routes {
   push @$namespaces, 'Bugzilla::API';
   $r->namespaces($namespaces);
 
+  # Backwards compat routes
+  $r->under(
+    '/latest' => sub {
+      my ($c) = @_;
+      _insert_rest_headers($c);
+      Bugzilla->usage_mode(USAGE_MODE_REST);
+    }
+  )->get('/configuration')->to('V1::Configuration#configuration');
+  $r->under(
+    '/bzapi' => sub {
+      my ($c) = @_;
+      _insert_rest_headers($c);
+      Bugzilla->usage_mode(USAGE_MODE_REST);
+    }
+  )->get('/configuration')->to('V1::Configuration#configuration');
+
+  # Set the usage mode for all routes under /rest
+  my $rest_routes = $r->under(
+    '/rest' => sub {
+      my ($c) = @_;
+      _insert_rest_headers($c);
+      Bugzilla->usage_mode(USAGE_MODE_REST);
+    }
+  );
+
   foreach my $version (SUPPORTED_VERSIONS) {
     foreach my $module (find_modules("Bugzilla::API::$version")) {
       try {
         require_module($module);
         my $controller = $module->new;
         if ($controller->can('setup_routes')) {
-          $controller->setup_routes($r);
+          $controller->setup_routes($rest_routes);
         }
       }
       catch {
@@ -38,6 +64,17 @@ sub setup_routes {
       };
     }
   }
+}
+
+sub _insert_rest_headers {
+  my ($c) = @_;
+
+  # Access Control
+  my @allowed_headers
+    = qw(accept authorization content-type origin user-agent x-bugzilla-api-key x-requested-with);
+  $c->res->headers->header('Access-Control-Allow-Origin' => '*');
+  $c->res->headers->header('Access-Control-Allow-Headers' =>
+    join ', ', @allowed_headers);
 }
 
 1;

--- a/Bugzilla/App/API.pm
+++ b/Bugzilla/App/API.pm
@@ -25,7 +25,15 @@ sub setup_routes {
   push @$namespaces, 'Bugzilla::API';
   $r->namespaces($namespaces);
 
-  # Backwards compat routes
+  # Backwards compat with /api/user/profile which Phabricator requires
+  $r->under('/api' => sub {
+    my ($c) = @_;
+    _insert_rest_headers($c);
+    Bugzilla->usage_mode(USAGE_MODE_REST);
+  })
+  ->get('/user/profile')->to('V1::User#user_profile');
+
+  # Other backwards compat routes
   $r->under(
     '/latest' => sub {
       my ($c) = @_;

--- a/qa/t/rest_bugzilla.t
+++ b/qa/t/rest_bugzilla.t
@@ -29,6 +29,11 @@ $t->ua->max_redirects(1);
 # Check for version returned
 $t->get_ok($url . 'rest/version')->status_is(200)->json_has('/version');
 
+# Change for proper CORS headers
+my $headers = $t->tx->res->headers;
+ok($headers->header('Access-Control-Allow-Origin') eq '*');
+ok($headers->header('Access-control-allow-headers') =~ /x-bugzilla-api-key/);
+
 # Make sure list of enabled extensions is returned
 $t->get_ok($url . 'rest/extensions')->status_is(200)->json_has('/extensions');
 my $extensions = $t->tx->res->json->{extensions};

--- a/qa/t/rest_bugzilla.t
+++ b/qa/t/rest_bugzilla.t
@@ -29,10 +29,10 @@ $t->ua->max_redirects(1);
 # Check for version returned
 $t->get_ok($url . 'rest/version')->status_is(200)->json_has('/version');
 
-# Change for proper CORS headers
+# Check for proper CORS headers
 my $headers = $t->tx->res->headers;
 ok($headers->header('Access-Control-Allow-Origin') eq '*');
-ok($headers->header('Access-control-allow-headers') =~ /x-bugzilla-api-key/);
+ok($headers->header('Access-Control-Allow-Headers') =~ /x-bugzilla-api-key/);
 
 # Make sure list of enabled extensions is returned
 $t->get_ok($url . 'rest/extensions')->status_is(200)->json_has('/extensions');


### PR DESCRIPTION
Missed adding CORS headers for new API endpoints. Added _insert_rest_headers() function. This will not be needed in as many places once everything resides under a single /rest path.