### PR TITLE
Bumped version to 20201119.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20201117.1';
+our $VERSION = '20201119.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1678128" target="_blank">1678128</a>] Additional CORS headers are missing in the new versioned MOJO based REST API</li>
</ul>