### PR TITLE
Bumped version to 20201130.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20201119.1';
+our $VERSION = '20201130.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1678513" target="_blank">1678513</a>] The request_uri column in the user_request_log table is not being populated properly</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1679081" target="_blank">1679081</a>] Global symbol "$C" requires explicit package name (did you forget to declare "my $C"?)</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1675625" target="_blank">1675625</a>] Refactor error handing in Mojolicious to allow for native mojo code to something other than Bugzilla::Error</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1677419" target="_blank">1677419</a>] Token cancellation and verification should take an extra step to confirm</li>
</ul>