### PR TITLE
Bumped version to 20201202.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20201130.1';
+our $VERSION = '20201202.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1680302" target="_blank">1680302</a>] Under certain conditions, user will not be abe to login using header login form if path is /home</li>
</ul>