### PR TITLE
Bug 1677416 - Use inputmode attribute for MFA.

### DIFF
--- a/template/en/default/account/prefs/mfa.html.tmpl
+++ b/template/en/default/account/prefs/mfa.html.tmpl
@@ -130,7 +130,7 @@
         <label for="code">Code:</label>
         <input type="text" name="code" id="code"
                placeholder="123456" maxlength="9" pattern="\d{6,9}" size="10"
-               autocomplete="off" required>
+               autocomplete="off" inputmode="numeric" required>
 
       [%# disable/recovery - duo %]
       [% ELSIF user.mfa == "Duo" %]
@@ -213,7 +213,7 @@
           <label id="mfa-totp-enable-code">Code:</label>
           <input type="text" name="code" id="mfa-totp-enable-code"
                   placeholder="123456" maxlength="6" pattern="\d{6}" size="10"
-                  autocomplete="off">
+                  autocomplete="off" inputmode="numeric">
         </div>
       </div>
 

--- a/template/en/default/mfa/duo/verify.html.tmpl
+++ b/template/en/default/mfa/duo/verify.html.tmpl
@@ -77,7 +77,7 @@ $(function() {
       </p>
       <input type="text" name="code" id="code"
             placeholder="123456789" maxlength="9" pattern="\d{9}" size="10"
-            autocomplete="off"><br>
+            autocomplete="off" inputmode="numeric"><br>
       <br>
       <input type="submit" value="Submit" id="recovery-submit" disabled>
     </div>

--- a/template/en/default/mfa/totp/verify.html.tmpl
+++ b/template/en/default/mfa/totp/verify.html.tmpl
@@ -23,9 +23,9 @@
     [% FOREACH field IN postback.fields.keys %]
       <input type="hidden" name="[% field FILTER html %]" value="[% postback.fields.item(field) FILTER html %]">
     [% END %]
-    <input type="[% is_mobile_browser ? "number" : "text" %]" name="code" id="code"
+    <input type="text" name="code" id="code"
            placeholder="123456" maxlength="9" pattern="\d{6,9}" size="10"
-           autocomplete="off" required autofocus><br>
+           autocomplete="off" inputmode="numeric" required autofocus><br>
     <br>
     <input type="submit" value="Submit">
   </form>


### PR DESCRIPTION
Actually, BMO on mobile uses `<input type="number">` to input verify code by MFA. This is incorrect to input it. `type=number` won't input "0" as head character.

Best practice for 2FA is `type="tel"` (https://web.dev/sign-in-form-best-practices/) or use `inputmode` attribute. All modern mobile browsers (inc. Fenix) support `inputmode` attribute, so we should use `inputmode` instead of `type=tel` or `type=number`.