### PR TITLE
Bumped version to 20201215.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20201202.2';
+our $VERSION = '20201215.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1677416" target="_blank">1677416</a>] Don't use &lt;input type="number"&gt; for MFA form on mobile</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1680775" target="_blank">1680775</a>] Hover position wrong</li>
</ul>