### PR TITLE
Bug 1692222 - Show bug ids in reference fields when user has editbugs even if the user cannot see the actual bugs

### DIFF
--- a/qa/t/test_security.t
+++ b/qa/t/test_security.t
@@ -138,9 +138,9 @@ logout($sel);
 log_in($sel, $config, 'editbugs');
 go_to_bug($sel, $bug1_id);
 ok(!$sel->is_text_present("secret_qa_bug_$bug2_id"),
-  "The alias 'secret_qa_bug_$bug2_id' is not visible for unauthorized users");
-ok(!$sel->is_text_present($bug2_id),
-  "Even the bug ID is not visible for unauthorized users");
+  "The alias 'secret_qa_bug_$bug2_id' is not visible for editbugs users");
+ok($sel->is_text_present($bug2_id),
+  "But the bug ID is visible for editbugs users");
 logout($sel);
 
 go_to_bug($sel, $bug1_id, 1);

--- a/qa/t/webservice_bug_get.t
+++ b/qa/t/webservice_bug_get.t
@@ -16,7 +16,7 @@ use Data::Dumper;
 use DateTime;
 use QA::Util;
 use QA::Tests qw(bug_tests PRIVATE_BUG_USER);
-use Test::More tests => 1009;
+use Test::More tests => 1096;
 my ($config, @clients) = get_rpc_clients();
 
 my $xmlrpc = $clients[0];
@@ -108,7 +108,11 @@ sub post_success {
   is(scalar @{$call->result->{bugs}}, 1, "Got exactly one bug");
   my $bug = $call->result->{bugs}->[0];
   my $is_private_bug  = $bug->{id} == $private_bug->{id};
-  my $is_private_user = $t->{user} && $t->{user} eq PRIVATE_BUG_USER;
+  my $is_privileged_user
+    = $t->{user}
+    && ($t->{user} eq 'editbugs'
+    || $t->{user} eq 'admin'
+    || $t->{user} eq PRIVATE_BUG_USER);
 
   if ($t->{user} && $t->{user} eq 'admin') {
     ok(exists $bug->{estimated_time} && exists $bug->{remaining_time},
@@ -127,21 +131,13 @@ sub post_success {
   if (exists $bug->{depends_on}) {
     is_deeply(
       $bug->{depends_on},
-      $is_private_bug ? [] : $is_private_user ? [$private_id] : [],
-      $is_private_bug
-        ? 'depends_on value is correct'
-        : $is_private_user
-        ? 'Private bug ID in depends_on is returned to private bug user'
-        : 'Private bug ID in depends_on is not returned to non-private bug user (' . $t->{user} . ')'
+      $is_private_bug ? [] : $is_privileged_user ? [$private_id] : [],
+      $is_private_bug ? 'depends_on value is correct'
+      : $is_privileged_user
+      ? 'Private bug ID in depends_on is returned to privileged bug user'
+      : 'Private bug ID in depends_on is not returned to non-privileged bug user'
+        . ($t->{user} ? ' (' . $t->{user} . ')' : '')
     );
-  }
-
-  if ($t->{user}) {
-    ok($bug->{update_token}, 'Update token returned for logged-in user');
-  }
-  else {
-    ok(!exists $bug->{update_token},
-      'Update token not returned for logged-out users');
   }
 
   my $expect = $is_private_bug ? $private_bug : $public_bug;
@@ -170,6 +166,11 @@ my @tests = (
       exclude_fields => ['summary']
     },
     test => 'exclude_fields overrides include_fields'
+  },
+  {
+    user => 'editbugs',
+    args => {ids => [$public_id], include_fields => ['id', 'depends_on']},
+    test => 'editbugs can see private ids in bug references',
   },
 );
 


### PR DESCRIPTION
* Also removed the update_token test from a couple of the webservice tests as the update_token is (has never been?) not used anyway.