### PR TITLE
Bug 1708052 - Create edittriageowners group allowing specific users to edit triage owners of components but nothing else

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,9 @@ defaults:
       command: |
         apk update && apk add py-pip gcc python3-dev musl-dev \
           libffi-dev openssl-dev make
-        pip install "docker-compose==1.27.4"
+        pip install docker-compose
+      environment:
+        CRYPTOGRAPHY_DONT_BUILD_RUST: 1
 
   docker_image: &docker_image
     image: docker:19.03.13-git

--- a/Bugzilla/Component.pm
+++ b/Bugzilla/Component.pm
@@ -43,6 +43,7 @@ use constant DB_COLUMNS => qw(
   isactive
   triage_owner_id
   team_name
+  bug_description_template
 );
 
 use constant UPDATE_COLUMNS => qw(
@@ -387,22 +388,6 @@ sub bug_count {
   return $self->{'bug_count'};
 }
 
-# Lazy-load the bug_description_template column. If the component-specific
-# template is not found, look for the product's template instead. Can be empty.
-sub bug_description_template {
-  my $self = shift;
-
-  if (!exists $self->{'bug_description_template'}) {
-    my ($comp_template, $prod_template) = Bugzilla->dbh->selectrow_array('
-      SELECT c.bug_description_template, p.bug_description_template
-      FROM components AS c INNER JOIN products AS p ON c.product_id = p.id
-      WHERE c.id = ?', undef, $self->id);
-    $self->{'bug_description_template'} = $comp_template || $prod_template;
-  }
-
-  return $self->{'bug_description_template'};
-}
-
 sub bug_ids {
   my $self = shift;
   my $dbh  = Bugzilla->dbh;
@@ -509,11 +494,12 @@ sub product {
 ####      Accessors        ####
 ###############################
 
-sub description     { return $_[0]->{'description'}; }
-sub product_id      { return $_[0]->{'product_id'}; }
-sub is_active       { return $_[0]->{'isactive'}; }
-sub triage_owner_id { return $_[0]->{'triage_owner_id'} }
-sub team_name       { return $_[0]->{'team_name'} }
+sub description              { return $_[0]->{'description'}; }
+sub product_id               { return $_[0]->{'product_id'}; }
+sub is_active                { return $_[0]->{'isactive'}; }
+sub triage_owner_id          { return $_[0]->{'triage_owner_id'} }
+sub team_name                { return $_[0]->{'team_name'} }
+sub bug_description_template { return $_[0]->{'bug_description_template'} }
 
 ##############################################
 # Implement Bugzilla::Field::ChoiceInterface #

--- a/Bugzilla/Install.pm
+++ b/Bugzilla/Install.pm
@@ -263,6 +263,10 @@ use constant SYSTEM_GROUPS => (
     name        => 'bz_can_disable_mfa',
     description => 'Can disable MFA when editing users',
   },
+  {
+    name        => 'edittriageowners',
+    description => 'Can edit triage owners of components'
+  }
 );
 
 use constant DEFAULT_CLASSIFICATION =>

--- a/Bugzilla/User.pm
+++ b/Bugzilla/User.pm
@@ -1796,13 +1796,18 @@ sub check_can_admin_product {
   # First make sure the product name is valid.
   my $product = Bugzilla::Product->check($product_name);
 
-  (      $self->in_group('editcomponents', $product->id)
-      && $self->can_see_product($product->name))
-    || ThrowUserError('product_admin_denied', {product => $product->name});
+  (
+    (
+           $self->in_group('editcomponents', $product->id)
+        || $self->in_group('edittriageowners')
+    )
+      && $self->can_see_product($product->name)
+  ) || ThrowUserError('product_admin_denied', {product => $product->name});
 
   # Return the validated product object.
   return $product;
 }
+
 
 sub check_can_admin_flagtype {
   my ($self, $flagtype_id) = @_;

--- a/admin.cgi
+++ b/admin.cgi
@@ -31,11 +31,17 @@ print $cgi->header();
   && $user->in_group('editclassifications'))
   || $user->in_group('editcomponents')
   || scalar(@{$user->get_products_by_permission('editcomponents')})
+  || $user->in_group('edittriageowners')
   || $user->in_group('creategroups')
   || $user->in_group('editkeywords')
   || $user->in_group('bz_canusewhines')
   || ThrowUserError('auth_failure',
   {action => 'access', object => 'administrative_pages'});
 
-$template->process('admin/admin.html.tmpl')
+my $vars = {
+  editcomponents   => $user->in_group('editcomponents'),
+  edittriageowners => $user->in_group('edittriageowners'),
+};
+
+$template->process('admin/admin.html.tmpl', $vars)
   || ThrowTemplateError($template->error());

--- a/docs/en/rst/administering/users.rst
+++ b/docs/en/rst/administering/users.rst
@@ -132,6 +132,10 @@ fields:
   must be removed from any bugs upon which it is currently set
   before it can be destroyed.
 
+- *edittriageowners*:
+  This flag will allow a user to edit the triage owner values
+  of components.
+  
 - *editusers*:
   This flag allows a user to do what you're doing right now: edit
   other users. This will allow those with the right to do so to

--- a/docs/en/rst/using/preferences.rst
+++ b/docs/en/rst/using/preferences.rst
@@ -193,6 +193,9 @@ editcomponents
 editkeywords
     Indicates user can create, destroy and edit keywords.
 
+edittriageowners
+    Indicates user can edit the triage owner values for components.
+
 editusers
     Indicates user can create, disable and edit users.
 

--- a/enter_bug.cgi
+++ b/enter_bug.cgi
@@ -343,7 +343,7 @@ else {
 
   $vars->{'cc'} = join(', ', $cgi->param('cc'));
 
-  $vars->{'comment'}            = formvalue('comment', $product->bug_description_template);
+  $vars->{'comment'}            = formvalue('comment');
   $vars->{'comment_is_private'} = formvalue('comment_is_private');
 
   # BMO Add support for mentors

--- a/extensions/ComponentWatching/Extension.pm
+++ b/extensions/ComponentWatching/Extension.pm
@@ -110,7 +110,8 @@ sub template_before_process {
 #
 
 BEGIN {
-  *Bugzilla::Component::watch_user = \&_component_watch_user;
+  *Bugzilla::Component::watch_user     = \&_component_watch_user;
+  *Bugzilla::Component::set_watch_user = \&_set_watch_user;
 }
 
 sub _component_watch_user {
@@ -118,6 +119,37 @@ sub _component_watch_user {
   return unless $self->{watch_user};
   $self->{watch_user_object} ||= Bugzilla::User->new($self->{watch_user});
   return $self->{watch_user_object};
+}
+
+sub _set_watch_user {
+  my ($self, $watch_user) = @_;
+  # add the user if not yet exists
+  _create_watch_user($watch_user) if $watch_user;
+  $self->set('watch_user', $watch_user);
+}
+
+sub editcomponents_before_create {
+  my ($self, $args) = @_;
+  my $params = $args->{params};
+  my $cgi    = Bugzilla->cgi;
+
+  return if !Bugzilla->user->in_group('editcomponents');
+
+  if (defined $cgi->param('watch_user')) {
+    $params->{watch_user} = $cgi->param('watch_user');
+  }
+}
+
+sub editcomponents_before_update {
+  my ($self, $args) = @_;
+  my $component = $args->{component};
+  my $cgi       = Bugzilla->cgi;
+
+  return if !Bugzilla->user->in_group('editcomponents');
+
+  if (defined $cgi->param('watch_user')) {
+    $component->set_watch_user($cgi->param('watch_user'));
+  }
 }
 
 sub object_columns {
@@ -136,13 +168,6 @@ sub object_update_columns {
   return unless $object->isa('Bugzilla::Component');
 
   push(@$columns, 'watch_user');
-
-  # add the user if not yet exists and user chooses 'automatic'
-  $self->_create_watch_user();
-
-  # editcomponents.cgi doesn't call set_all, so we have to do this here
-  my $input = Bugzilla->input_params;
-  $object->set('watch_user', $input->{watch_user});
 }
 
 sub object_validators {
@@ -158,6 +183,7 @@ sub object_before_create {
   my ($self, $args) = @_;
   my $class  = $args->{class};
   my $params = $args->{params};
+
   return unless $class->isa('Bugzilla::Component');
 
   # We need to create a watch user for the default product/component
@@ -166,17 +192,14 @@ sub object_before_create {
   if (Bugzilla->usage_mode == USAGE_MODE_CMDLINE
     && !$dbh->selectrow_array('SELECT 1 FROM components'))
   {
-    my $watch_user = Bugzilla::User->create({
-      login_name    => 'testcomponent@testproduct.bugs',
-      cryptpassword => '*',
-      disable_mail  => 1
-    });
+    my $watch_user = _create_watch_user('testcomponent@testproduct.bugs');
     $params->{watch_user} = $watch_user->login;
   }
-  else {
-    my $input = Bugzilla->input_params;
-    $params->{watch_user} = $input->{watch_user};
-    $self->_create_watch_user();
+  elsif (my $watch_user = $params->{watch_user}) {
+    my $user = Bugzilla::User->new({name => $watch_user});
+    if (!$user) {
+      _create_watch_user($watch_user);
+    }
   }
 }
 
@@ -185,13 +208,8 @@ sub object_end_of_update {
   my $object     = $args->{object};
   my $old_object = $args->{old_object};
   my $changes    = $args->{changes};
-  my $user       = Bugzilla->user;
 
   return unless $object->isa('Bugzilla::Component');
-  return
-    unless $user->in_group('editcomponents')
-    || any { $_->id == $object->product->id }
-  @{$user->get_products_by_permission('editcomponents')};
 
   my $old_id = $old_object->watch_user ? $old_object->watch_user->id : 0;
   my $new_id = $object->watch_user     ? $object->watch_user->id     : 0;
@@ -234,18 +252,16 @@ sub _sanitize_name {
 }
 
 sub _create_watch_user {
-  my $input = Bugzilla->input_params;
-  if ($input->{watch_user_auto}
-    && !Bugzilla::User->new({name => $input->{watch_user}}))
-  {
-    Bugzilla::User->create({
-      login_name => $input->{watch_user}, cryptpassword => '*',
-    });
+  my ($watch_user) = @_;
+  my $user = Bugzilla::User->new({name => $watch_user});
+  if (!$user) {
+    $user = Bugzilla::User->create({login_name => $watch_user, cryptpassword => '*'});
   }
+  return $user;
 }
 
 sub _check_watch_user {
-  my ($self, $value, $field) = @_;
+  my ($self, $value) = @_;
   $value = trim($value || '');
   return undef if !REQUIRE_WATCH_USER && $value eq '';
   if ($value eq '') {

--- a/extensions/ComponentWatching/template/en/default/hook/admin/components/edit-common-rows.html.tmpl
+++ b/extensions/ComponentWatching/template/en/default/hook/admin/components/edit-common-rows.html.tmpl
@@ -6,6 +6,7 @@
   # defined by the Mozilla Public License, v. 2.0.
   #%]
 
+[% RETURN IF NOT editcomponents %]
 <tr>
   <th class="field_label"><label for="watch_user">Watch User:</label></th>
   <td>

--- a/extensions/Review/template/en/default/hook/admin/components/edit-common-rows.html.tmpl
+++ b/extensions/Review/template/en/default/hook/admin/components/edit-common-rows.html.tmpl
@@ -6,6 +6,7 @@
   # defined by the Mozilla Public License, v. 2.0.
   #%]
 
+[% RETURN IF NOT editcomponents %]
 <tr>
   <th align="right">Suggested Reviewers:</th>
   <td>

--- a/qa/t/test_bug_edit.t
+++ b/qa/t/test_bug_edit.t
@@ -40,7 +40,7 @@ check_page_load($sel, q{http://HOSTNAME/editgroups.cgi});
 $sel->title_is("Edit Groups");
 $sel->click_ok("link=Master");
 check_page_load($sel,
-  q{http://HOSTNAME/editgroups.cgi?action=changeform&group=25});
+  q{http://HOSTNAME/editgroups.cgi?action=changeform&group=26});
 $sel->title_is("Change Group: Master");
 my $group_url = $sel->get_location();
 $group_url =~ /group=(\d+)$/;

--- a/template/en/default/admin/admin.html.tmpl
+++ b/template/en/default/admin/admin.html.tmpl
@@ -49,7 +49,7 @@
         which will be used by default for all users. Users will be able to edit their
         own preferences from the <a href="[% basepath FILTER none %]userprefs.cgi?tab=settings">Preferences</a>.</dd>
 
-        [% class = user.in_group('editcomponents') ? "" : "forbidden" %]
+        [% class = editcomponents ? "" : "forbidden" %]
         <dt id="sanitycheck" class="[% class %]"><a href="[% basepath FILTER none %]sanitycheck.cgi">Sanity Check</a></dt>
         <dd class="[% class %]">Run sanity checks to locate problems in your database.
         This may take several tens of minutes depending on the size of your installation.
@@ -67,14 +67,25 @@
         it's a good idea to group these products into distinct categories. This lets users
         find information more easily when doing searches or when filing new [% terms.bugs %].</dd>
 
-        [% class = (user.in_group('editcomponents')
+        [% class = (editcomponents
+                    || edittriageowners
                     || user.get_products_by_permission("editcomponents").size) ? "" : "forbidden" %]
-        <dt id="products" class="[% class %]"><a href="[% basepath FILTER none %]editproducts.cgi">Products</a></dt>
+        <dt id="products" class="[% class %]">
+        [% IF editcomponents %]
+          <a href="[% basepath FILTER none %]editproducts.cgi">Products</a>
+        [% ELSE %]
+          Products
+        [% END %]</dt>
         <dd class="[% class %]">Edit all aspects of products, including group restrictions
         which let you define who can access [% terms.bugs %] being in these products. You
         can also edit some specific attributes of products such as
-        <a href="[% basepath FILTER none %]editcomponents.cgi">components</a>, <a href="[% basepath FILTER none %]editversions.cgi">versions</a>
-        and <a href="[% basepath FILTER none %]editmilestones.cgi">milestones</a> directly.</dd>
+        <a href="[% basepath FILTER none %]editcomponents.cgi">components</a>,
+        [% IF editcomponents %]
+          <a href="[% basepath FILTER none %]editversions.cgi">versions</a>, and
+          <a href="[% basepath FILTER none %]editmilestones.cgi">milestones</a>
+        [% ELSE %]
+          versions, and milestones
+        [% END %] directly.</dd>
 
         [% class = (user.in_group('editcomponents')
                    || user.get_products_by_permission('editcomponents').size) ? "" : "forbidden" %]

--- a/template/en/default/admin/components/edit-common.html.tmpl
+++ b/template/en/default/admin/components/edit-common.html.tmpl
@@ -22,80 +22,113 @@
   # comp: object; Bugzilla::Component object.
   #%]
 
-<script [% script_nonce FILTER none %]>
-  if (typeof BUGZILLA.autocomplete_values === 'undefined') {
-      BUGZILLA.autocomplete_values = [];
-  }
-  BUGZILLA.autocomplete_values['team_name'] = [
-  [%- FOREACH name = team_names %]
-    [%-# %]"[% name FILTER js %]"
-    [%- "," IF NOT loop.last %]
-  [% END %]];
-</script>
-
 <tr>
   <th class="field_label"><label for="component">Component:</label></th>
-  <td><input size="64" maxlength="64" name="component" id="component"
-             value="[%- comp.name FILTER html %]"></td>
-</tr>
-<tr>
-  <th class="field_label"><label for="[% desc_name FILTER html %]">Component Description:</label></th>
   <td>
-    [% INCLUDE global/textarea.html.tmpl
-      name           = 'description'
-      id             = 'description'
-      minrows        = 4
-      cols           = 64
-      wrap           = 'virtual'
-      defaultcontent = comp.description
-    %]
+    [% IF editcomponents %]
+      <input size="64" maxlength="64" name="component" id="component"
+             value="[%- comp.name FILTER html %]">
+    [% ELSE %]
+      [%- comp.name FILTER html %]
+    [% END %]
   </td>
 </tr>
-<tr>
-  <th class="field_label"><label for="bug_description_template">New [% terms.bug %] comment template:</label></th>
-  <td><textarea rows="8" cols="64" wrap="virtual" name="bug_description_template"
-                placeholder="[% product.bug_description_template FILTER html %]">
-        [% comp.bug_description_template FILTER html %]</textarea>
-  </td>
-</tr>
-<tr>
-  <th class="field_label"><label for="default_bug_type">Default [% terms.Bug %] Type:</label></th>
-  <td>
-    [% INCLUDE admin/default_select.html.tmpl
-        field_name   = 'default_bug_type'
-        field_value  = comp.default_bug_type || product.default_bug_type
-        field_values = bug_fields.bug_type.legal_values
-    %]
-  </td>
-</tr>
-<tr>
-  <th class="field_label"><label for="initialowner">Default Assignee:</label></th>
-  <td>
-    [% INCLUDE global/userselect.html.tmpl
-       name => "initialowner"
-       id => "initialowner"
-       value => comp.default_assignee.login
-       size => 64
-     %]
-  </td>
-</tr>
-[% IF Param('useqacontact') %]
+
+[% IF editcomponents %]
+  <script [% script_nonce FILTER none %]>
+    if (typeof BUGZILLA.autocomplete_values === 'undefined') {
+        BUGZILLA.autocomplete_values = [];
+    }
+    BUGZILLA.autocomplete_values['team_name'] = [
+    [%- FOREACH name = team_names %]
+      [%-# %]"[% name FILTER js %]"
+      [%- "," IF NOT loop.last %]
+    [% END %]];
+  </script>
   <tr>
-    <th class="field_label"><label for="initialqacontact">Default QA contact:</label></th>
+    <th class="field_label"><label for="[% desc_name FILTER html %]">Component Description:</label></th>
+    <td>
+      [% INCLUDE global/textarea.html.tmpl
+        name           = 'description'
+        id             = 'description'
+        minrows        = 4
+        cols           = 64
+        wrap           = 'virtual'
+        defaultcontent = comp.description
+      %]
+    </td>
+  </tr>
+  <tr>
+    <th class="field_label"><label for="bug_description_template">New [% terms.bug %] comment template:</label></th>
+    <td><textarea rows="8" cols="64" wrap="virtual" name="bug_description_template"
+                  placeholder="[% product.bug_description_template FILTER html %]">
+          [% comp.bug_description_template FILTER html %]</textarea>
+    </td>
+  </tr>
+  <tr>
+    <th class="field_label"><label for="default_bug_type">Default [% terms.Bug %] Type:</label></th>
+    <td>
+      [% INCLUDE admin/default_select.html.tmpl
+          field_name   = 'default_bug_type'
+          field_value  = comp.default_bug_type || product.default_bug_type
+          field_values = bug_fields.bug_type.legal_values
+      %]
+    </td>
+  </tr>
+  <tr>
+    <th class="field_label"><label for="initialowner">Default Assignee:</label></th>
     <td>
       [% INCLUDE global/userselect.html.tmpl
-         name => "initialqacontact"
-         id => "initialqacontact"
-         value => comp.default_qa_contact.login
-         size => 64
-         emptyok => 1
-       %]
+        name => "initialowner"
+        id => "initialowner"
+        value => comp.default_assignee.login
+        size => 64
+      %]
+    </td>
+  </tr>
+  [% IF Param('useqacontact') %]
+    <tr>
+      <th class="field_label"><label for="initialqacontact">Default QA contact:</label></th>
+      <td>
+        [% INCLUDE global/userselect.html.tmpl
+          name => "initialqacontact"
+          id => "initialqacontact"
+          value => comp.default_qa_contact.login
+          size => 64
+          emptyok => 1
+        %]
+      </td>
+    </tr>
+  [% END %]
+  <tr>
+    <th class="field_label"><label for="team_name">Team Name:</label></th>
+    <td><input size="64" maxlength="64" name="team_name"
+              id="team_name" class="bz_autocomplete_team"
+              data-values="team_name" data-identifier="team_name"
+              value="[% comp.team_name FILTER html %]"></td>
+  </tr>
+  <tr>
+    <th class="field_label"><label for="initialcc">Default CC List:</label></th>
+    <td>
+      [% INCLUDE global/userselect.html.tmpl
+        name     => "initialcc"
+        id       => "initialcc"
+        value    => initial_cc_names
+        size     => 64
+        multiple => 5
+      %]
+      <br>
+      [% IF !Param("usemenuforusers") %]
+        <em>Enter user names for the CC list as a comma-separated list.</em>
+      [% END %]
     </td>
   </tr>
 [% END %]
-<tr>
-  <td class="field_label"><label for="triage_owner">Triage Owner:</label></th>
-   <td>
+
+[% IF editcomponents || edittriageowners %]
+  <tr>
+    <td class="field_label"><label for="triage_owner">Triage Owner:</label></th>
+    <td>
       [% INCLUDE global/userselect.html.tmpl
          name    => "triage_owner"
          id      => "triage_owner"
@@ -104,29 +137,7 @@
          emptyok => 1
        %]
     </td>
-</tr>
-<tr>
-  <th class="field_label"><label for="team_name">Team Name:</label></th>
-  <td><input size="64" maxlength="64" name="team_name"
-             id="team_name" class="bz_autocomplete_team"
-             data-values="team_name" data-identifier="team_name"
-             value="[% comp.team_name FILTER html %]"></td>
-</tr>
-<tr>
-  <th class="field_label"><label for="initialcc">Default CC List:</label></th>
-  <td>
-    [% INCLUDE global/userselect.html.tmpl
-       name     => "initialcc"
-       id       => "initialcc"
-       value    => initial_cc_names
-       size     => 64
-       multiple => 5
-    %]
-    <br>
-    [% IF !Param("usemenuforusers") %]
-      <em>Enter user names for the CC list as a comma-separated list.</em>
-    [% END %]
-  </td>
-</tr>
+  </tr>
+[% END %]
 
 [% Hook.process('rows') %]

--- a/template/en/default/admin/components/edit.html.tmpl
+++ b/template/en/default/admin/components/edit.html.tmpl
@@ -70,7 +70,7 @@
    <input type="hidden" name="product" value="[% product.name FILTER html %]">
    <input type="hidden" name="token" value="[% token FILTER html %]">
    <input type="submit" value="Save Changes" id="update">
-   [% IF editcomponentsup %]
+   [% IF editcomponents %]
      or <a href="[% basepath FILTER none %]editcomponents.cgi?action=del&amp;product=
         [%- product.name FILTER uri %]&amp;component=
         [%- comp.name FILTER uri %]">Delete</a> this component.

--- a/template/en/default/admin/components/edit.html.tmpl
+++ b/template/en/default/admin/components/edit.html.tmpl
@@ -42,24 +42,26 @@
 
     [% PROCESS "admin/components/edit-common.html.tmpl" %]
 
-    <tr>
-      <th class="field_label"><label for="isactive">Enabled For [% terms.Bugs %]:</label></th>
-      <td><input id="isactive" name="isactive" type="checkbox" value="1"
-                 [% 'checked="checked"' IF comp.isactive %]></td>
-    </tr>
-    <tr>
-      <th class="field_label">[% terms.Bugs %]:</th>
-      <td>
-[% IF comp.bug_count > 0 %]
-        <a title="[% terms.Bugs %] in component '[% comp.name FILTER html %]'"
-           href="[% basepath FILTER none %]buglist.cgi?component=
-                [%- comp.name FILTER uri %]&amp;product=
-                [%- product.name FILTER uri %]">[% comp.bug_count %]</a>
-[% ELSE %]
-        None
-[% END %]
-      </td>
-    </tr>
+    [% IF editcomponents %]
+      <tr>
+        <th class="field_label"><label for="isactive">Enabled For [% terms.Bugs %]:</label></th>
+        <td><input id="isactive" name="isactive" type="checkbox" value="1"
+                  [% 'checked="checked"' IF comp.isactive %]></td>
+      </tr>
+      <tr>
+        <th class="field_label">[% terms.Bugs %]:</th>
+        <td>
+        [% IF comp.bug_count > 0 %]
+          <a title="[% terms.Bugs %] in component '[% comp.name FILTER html %]'"
+            href="[% basepath FILTER none %]buglist.cgi?component=
+                  [%- comp.name FILTER uri %]&amp;product=
+                  [%- product.name FILTER uri %]">[% comp.bug_count %]</a>
+        [% ELSE %]
+          None
+        [% END %]
+        </td>
+      </tr>
+    [% END %]
 
   </table>
 
@@ -67,11 +69,12 @@
    <input type="hidden" name="componentold" value="[% comp.name FILTER html %]">
    <input type="hidden" name="product" value="[% product.name FILTER html %]">
    <input type="hidden" name="token" value="[% token FILTER html %]">
-   <input type="submit" value="Save Changes" id="update"> or <a
-        href="[% basepath FILTER none %]editcomponents.cgi?action=del&amp;product=
+   <input type="submit" value="Save Changes" id="update">
+   [% IF editcomponentsup %]
+     or <a href="[% basepath FILTER none %]editcomponents.cgi?action=del&amp;product=
         [%- product.name FILTER uri %]&amp;component=
         [%- comp.name FILTER uri %]">Delete</a> this component.
-
+   [% END %]
 </form>
 
 [% PROCESS admin/components/footer.html.tmpl

--- a/template/en/default/admin/components/footer.html.tmpl
+++ b/template/en/default/admin/components/footer.html.tmpl
@@ -24,7 +24,15 @@
   #               which the component belongs.
   #%]
 
-<hr>
+[% IF NOT editcomponents %]
+  [% IF NOT no_edit_other_components_link %]
+    <p>Edit other components of product
+      <a title="Choose a component from product '[% product.name FILTER html %]' to edit"
+         href="[% basepath FILTER none %]editcomponents.cgi?product=
+        [%- product.name FILTER uri %]">'[% product.name FILTER html %]'</a>.</p>
+  [% END %]
+  [% RETURN %]
+[% END %]
 
 <p>
 Edit

--- a/template/en/default/admin/components/list.html.tmpl
+++ b/template/en/default/admin/components/list.html.tmpl
@@ -96,11 +96,13 @@
 
 [% END %]
 
-[% columns.push({
-     heading => "Action"
-     content => "Delete"
-     contentlink => delete_contentlink
-   }) %]
+[% IF editcomponents %]
+  [% columns.push({
+      heading => "Action"
+      content => "Delete"
+      contentlink => delete_contentlink
+    }) %]
+[% END %]
 
 [%# Overrides the initialowner and the initialqacontact with right values %]
 [% overrides.initialowner = {} %]
@@ -136,14 +138,14 @@
      overrides = overrides
 %]
 
-<p><a href="[% basepath FILTER none %]editcomponents.cgi?action=add&amp;product=[% product.name FILTER uri %]">Add</a>
+[% IF editcomponents %]
+  <p><a href="[% basepath FILTER none %]editcomponents.cgi?action=add&amp;product=[% product.name FILTER uri %]">Add</a>
     a new component to product '[% product.name FILTER html %]'</p>
+[% END %]
 
-[% IF ! showbugcounts %]
-
+[% IF NOT showbugcounts %]
   <p><a href="[% basepath FILTER none %]editcomponents.cgi?product=[% product.name FILTER uri %]&amp;showbugcounts=1">
       Redisplay table with [% terms.bug %] counts (slower)</a></p>
-
 [% END %]
 
 [% PROCESS admin/components/footer.html.tmpl

--- a/template/en/default/bug/create/create.html.tmpl
+++ b/template/en/default/bug/create/create.html.tmpl
@@ -103,7 +103,8 @@ var flags = new Array([% product.components.size %]);
     comp_desc[[% count %]] = "[% comp.description FILTER html_light FILTER js %]";
     initialowners[[% count %]] = "[% comp.default_assignee.login FILTER js %]";
     default_bug_types[[% count %]] = "[% comp.default_bug_type FILTER js %]";
-    desc_templates[[% count %]] = "[% comp.bug_description_template.replace('\\r', '') FILTER js %]";
+    [% bug_description_template = comp.bug_description_template || product.bug_description_template %]
+    desc_templates[[% count %]] = "[% bug_description_template.replace('\\r', '') FILTER js %]";
     [% flag_list = [] %]
     [% FOREACH f = comp.flag_types.bug %]
       [% flag_list.push(f.id) %]

--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -310,7 +310,8 @@
           </li>
           [% IF user.in_group('tweakparams') || user.in_group('editusers') || user.can_bless || user.in_group('disableusers')
                 || (Param('useclassification') && user.in_group('editclassifications'))
-                || user.in_group('editcomponents') || user.in_group('admin') || user.in_group('creategroups')
+                || user.in_group('editcomponents') || user.in_group('edittriageowners')
+                || user.in_group('admin') || user.in_group('creategroups')
                 || user.in_group('editkeywords') || user.in_group('bz_canusewhines')
                 || user.get_products_by_permission("editcomponents").size %]
             <li role="presentation">

--- a/template/en/default/global/messages.html.tmpl
+++ b/template/en/default/global/messages.html.tmpl
@@ -266,6 +266,13 @@
       [% IF changes.isactive.defined %]
         <li>[% comp.is_active ? "Enabled" : "Disabled" %] for [% terms.bugs %]</li>
       [% END %]
+      [% IF changes.bug_description_template.defined %]
+        [% IF comp.bug_description_template %]
+          <li>Bug description template updated.</li>
+        [% ELSE %]
+          <li>Bug description template deleted</li>
+        [% END %]
+      [% END %]
       [% Hook.process('component_updated_fields') %]
       </ul>
     [% ELSE %]

--- a/template/en/default/global/messages.html.tmpl
+++ b/template/en/default/global/messages.html.tmpl
@@ -268,9 +268,9 @@
       [% END %]
       [% IF changes.bug_description_template.defined %]
         [% IF comp.bug_description_template %]
-          <li>Bug description template updated.</li>
+          <li>[% terms.Bug %] description template updated.</li>
         [% ELSE %]
-          <li>Bug description template deleted</li>
+          <li>[% terms.Bug %] description template deleted</li>
         [% END %]
       [% END %]
       [% Hook.process('component_updated_fields') %]


### PR DESCRIPTION
Details:

- Create new edittriageowners system group and wrap the triage owner related fields with the new permission.
- Fixed work around for input_params and the ComponentWatching extension.
  - Originally ComponentWatching relied on input_params for setting watch_user from editcomponents.cgi. Since a person who only has edittriageowners cannot edit watch_user, an error would be generated on update. 
- Also fixed some issues related to new bug description templates
  - The way bug description templates were implemented, if a product has template defined and a component also had a template defined, the product template would always win out which was not as designed.