### PR TITLE
Bumped version to 20210517.1

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use Bugzilla::Logging;
 
-our $VERSION = '20210317.2';
+our $VERSION = '20210517.1';
 
 use Bugzilla::Auth;
 use Bugzilla::Auth::Persist::Cookie;


### PR DESCRIPTION
<ul>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1690202" target="_blank">1690202</a>] Automatically set severity to S2 for all new bugs with the crash keyword</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1705743" target="_blank">1705743</a>] Make frequently reported bugs more obvious for enter bug form and duplicates.cgi more intuitive</li>
<li>[<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1708052" target="_blank">1708052</a>] Create edittriageowners group allowing specific users to edit triage owners of components but nothing else</li>
</ul>