### PR TITLE
Bug 1727027 - bug is not a valid parameter for the Bugzilla::Comment::create function

### DIFF
--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -1118,6 +1118,13 @@ sub update {
   my $dbh  = Bugzilla->dbh;
   my $user = Bugzilla->user;
 
+  # Do not allow calling up $bug->update from extensions,
+  # etc. inside the current update()
+  if ($self->{_inside_bug_update}) {
+    ThrowCodeError('inside_bug_update');
+  }
+  $self->{_inside_bug_update} = 1;
+
   # XXX This is just a temporary hack until all updating happens
   # inside this function.
   my $delta_ts = shift || $dbh->selectrow_array('SELECT LOCALTIMESTAMP(0)');
@@ -1453,6 +1460,9 @@ sub update {
       old_bug   => $old_bug
     }
   );
+
+  # Clear the inside of update flag
+  delete $self->{_inside_bug_update};
 
   return $changes;
 }

--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -1283,7 +1283,8 @@ sub update {
   # Comments and comment tags
   foreach my $comment (@{$self->{added_comments} || []}) {
 
-    # Override the Comment's timestamp to be identical to the update timestamp.
+    # Override the Comment's timestamp to be identical to the update
+    # timestamp.
     $comment->{bug_when} = $delta_ts;
     $comment = Bugzilla::Comment->insert_create_data($comment);
     if ($comment->work_time) {
@@ -1351,10 +1352,6 @@ sub update {
     $changes->{'flagtypes.name'} = [$removed, $added];
   }
 
-  use Bugzilla::Logging;
-  use Mojo::Util qw(dumper);
-  DEBUG(dumper $changes);
-
   # BMO - allow extensions to alter what is logged into bugs_activity
   Bugzilla::Hook::process(
     'bug_update_before_logging',
@@ -1365,8 +1362,6 @@ sub update {
       old_bug   => $old_bug
     }
   );
-
-  DEBUG(dumper $changes);
 
   # Log bugs_activity items
   # XXX Eventually, when bugs_activity is able to track the dupe_id,

--- a/extensions/MozChangeField/lib/Post/CrashKeywordSetSeverity.pm
+++ b/extensions/MozChangeField/lib/Post/CrashKeywordSetSeverity.pm
@@ -23,8 +23,10 @@ sub evaluate_create {
     && $bug->bug_severity eq Bugzilla->params->{defaultseverity}
     && grep { $_ eq 'S2' } @{get_legal_field_values('bug_severity')})
   {
-    $bug->set_severity('S2');
-    $bug->update($timestamp);
+    # Cannot call $bug->update here so set directly
+    Bugzilla->dbh->do('UPDATE bugs SET bug_severity = ? WHERE bug_id = ?',
+      undef, 'S2', $bug->id);
+    $bug->{bug_severity} = 'S2';
   }
 }
 

--- a/extensions/MozChangeField/lib/Post/SeverityS1PriorityP1.pm
+++ b/extensions/MozChangeField/lib/Post/SeverityS1PriorityP1.pm
@@ -40,9 +40,11 @@ sub evaluate_change {
     @{get_legal_field_values('priority')}
     )
   {
-    $bug->set_priority('P1');
-    $bug->update($timestamp);
+    # Cannot call $bug->update here so set directly
+    Bugzilla->dbh->do("UPDATE bugs SET priority = 'P1' WHERE bug_id = ?",
+      undef, $bug->id);
     $changes->{priority} = [$bug->priority, 'P1'];
+    $bug->{priority}     = 'P1';
   }
 }
 

--- a/extensions/MozChangeField/lib/Post/SeverityS1PriorityP1.pm
+++ b/extensions/MozChangeField/lib/Post/SeverityS1PriorityP1.pm
@@ -24,7 +24,7 @@ sub evaluate_create {
     @{get_legal_field_values('priority')}
     )
   {
-# Should call $bug->update here so set directly
+    # Should call $bug->update here so set directly
     Bugzilla->dbh->do('UPDATE bugs SET priority = ? WHERE bug_id = ?',
       undef, 'P1', $bug->id);
     $bug->{priority} = 'P1';

--- a/extensions/MozChangeField/lib/Post/SeverityS1PriorityP1.pm
+++ b/extensions/MozChangeField/lib/Post/SeverityS1PriorityP1.pm
@@ -24,8 +24,10 @@ sub evaluate_create {
     @{get_legal_field_values('priority')}
     )
   {
-    $bug->set_priority('P1');
-    $bug->update($timestamp);
+# Should call $bug->update here so set directly
+    Bugzilla->dbh->do('UPDATE bugs SET priority = ? WHERE bug_id = ?',
+      undef, 'P1', $bug->id);
+    $bug->{priority} = 'P1';
   }
 }
 

--- a/template/en/default/global/code-error.html.tmpl
+++ b/template/en/default/global/code-error.html.tmpl
@@ -501,6 +501,10 @@
     [% terms.Bugzilla %] does not support the search type
     "[% operator FILTER html %]".
 
+  [% ELSIF error == "inside_bug_update" %]
+    Extensions cannot call <code>$[% terms.bug %]->update()</code>
+    inside [% terms.Bug %] update hooks otherwise errors may occur.
+
   [% ELSE %]
     [%# Try to find hooked error messages %]
     [% error_message = Hook.process("errors") %]


### PR DESCRIPTION
When a comment is added it is not good idea to run $bug->update multiple times are it will try to add the same comment over again giving the duplicate key error. This change update Bugzilla::Bug::update to be able to be ran again and not try to re-add the comments.