### PR TITLE
Bug 1729270 - When changing severity from -- to something, bugzilla complains that a comment is needed

### DIFF
--- a/extensions/MozChangeField/Extension.pm
+++ b/extensions/MozChangeField/Extension.pm
@@ -29,14 +29,14 @@ my @pre_instances = (
 use Bugzilla::Extension::MozChangeField::Post::CrashKeywordSetSeverity;
 use Bugzilla::Extension::MozChangeField::Post::SeverityS1PriorityP1;
 use Bugzilla::Extension::MozChangeField::Post::ClearTrackingPriorityS1;
-use Bugzilla::Extension::MozChangeField::Post::CommentOnSeverity;
+#use Bugzilla::Extension::MozChangeField::Post::CommentOnSeverity;
 use Bugzilla::Extension::MozChangeField::Post::SetTrackingSeverityS1;
 
 my @post_instances = (
   Bugzilla::Extension::MozChangeField::Post::CrashKeywordSetSeverity->new,
   Bugzilla::Extension::MozChangeField::Post::SeverityS1PriorityP1->new,
   Bugzilla::Extension::MozChangeField::Post::ClearTrackingPriorityS1->new,
-  Bugzilla::Extension::MozChangeField::Post::CommentOnSeverity->new,
+  #Bugzilla::Extension::MozChangeField::Post::CommentOnSeverity->new,
   Bugzilla::Extension::MozChangeField::Post::SetTrackingSeverityS1->new,
 );
 

--- a/extensions/MozChangeField/template/en/default/hook/bug_modal/header-end.html.tmpl
+++ b/extensions/MozChangeField/template/en/default/hook/bug_modal/header-end.html.tmpl
@@ -6,7 +6,7 @@
   # defined by the Mozilla Public License, v. 2.0.
   #%]
 
-[% javascript_urls.push("extensions/MozChangeField/web/js/comment-on-severity.js") %]
+[%# javascript_urls.push("extensions/MozChangeField/web/js/comment-on-severity.js") %]
 [% javascript_urls.push("extensions/MozChangeField/web/js/severity-s1-priority-p1.js") %]
 [% javascript_urls.push("extensions/MozChangeField/web/js/clear-tracking-priority-s1.js") %]
 [% javascript_urls.push("extensions/MozChangeField/web/js/set-tracking-severity-s1.js") %]


### PR DESCRIPTION
- Disabled the requirement of comment on severity changes for now