### PR TITLE
Bug 1734463 - Add Data Platform and Tools to cf_crash_signature

### DIFF
--- a/extensions/BMO/lib/Data.pm
+++ b/extensions/BMO/lib/Data.pm
@@ -105,6 +105,7 @@ tie(
     "Calendar"                            => [],
     "Composer"                            => [],
     "Core"                                => [],
+    "Data Platform and Tools"             => [],
     "DevTools"                            => [],
     "Directory"                           => [],
     "External Software Affecting Firefox" => [],


### PR DESCRIPTION
This adds "Data Platform and Tools" product to the the `cf_crash_signature`
structure so that field is returned in the bug REST API.