### PR TITLE
Bug 1729091 - [GCP] Move as much as possible of data/params parameters to a table in the database (schema only)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,9 @@
+version: 2
+
+sphinx:
+  configuration: docs/en/rst/conf.py
+
+python:
+  version: 3.8
+  install:
+    - requirements: docs/en/rst/requirements.txt

--- a/Bugzilla/DB/Schema.pm
+++ b/Bugzilla/DB/Schema.pm
@@ -1943,6 +1943,17 @@ use constant ABSTRACT_SCHEMA => {
       class        => {TYPE => 'varchar(255)', NOTNULL => 1},
       last_ping_ts => {TYPE => 'DATETIME',     NOTNULL => 1},
     ]
+  },
+
+  # Parameters Table
+  # ----------------
+
+  params => {
+    FIELDS => [
+      id    => {TYPE => 'MEDIUMSERIAL',  NOTNULL => 1, PRIMARYKEY => 1},
+      name  => {TYPE => 'VARCHAR(64)',   NOTNULL => 1},
+      value => {TYPE => 'VARCHAR(4000)', NOTNULL => 1},
+    ],
   }
 
 };

--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -27,6 +27,7 @@ use Date::Parse;
 use Date::Format;
 use IO::File;
 use List::MoreUtils qw(uniq);
+use Scalar::Util qw(looks_like_number);
 use URI;
 use URI::QueryParam;
 
@@ -824,6 +825,9 @@ sub update_table_definitions {
 
   # Bug 1697642 - dkl@mozilla.com
   $dbh->bz_add_column('logincookies', 'auth_method',{TYPE => 'varchar(40)'});
+
+  # Bug 1729091 - dkl@mozilla.com
+  _migrate_db_parameters();
 
   ################################################################
   # New --TABLE-- changes should go *** A B O V E *** this point #
@@ -2825,15 +2829,8 @@ sub _fix_whine_queries_title_and_op_sys_value {
     $dbh->do('UPDATE bugs SET op_sys = ? WHERE op_sys = ?', undef, "Other",
       "other");
     if (Bugzilla->params->{'defaultopsys'} eq 'other') {
-
-      # We can't actually fix the param here, because WriteParams() will
-      # make $datadir/params unwriteable to the webservergroup.
-      # It's too much of an ugly hack to copy the permission-fixing code
-      # down to here. (It would create more potential future bugs than
-      # it would solve problems.)
       print "WARNING: Your 'defaultopsys' param is set to 'other', but"
-        . " Bugzilla now\n"
-        . "         uses 'Other' (capital O).\n";
+        . " Bugzilla now uses 'Other' (capital O).\n";
     }
 
     # Add a DEFAULT to whine_queries stuff so that editwhines.cgi
@@ -4387,6 +4384,33 @@ sub _populate_attachment_storage_class {
   }
 }
 
+sub _migrate_db_parameters {
+  my $dbh = Bugzilla->dbh;
+
+  # Return if the old data/params file has already been removed
+  my $datadir = bz_locations()->{'datadir'};
+  return if !-e "$datadir/params";
+
+  # Return if we have already populated the params table before
+  my $count = $dbh->selectrow_array('SELECT COUNT(*) FROM params');
+  return if $count;
+
+  print "Migrating old parameters from data/params to database...\n";
+
+  # Read in the old data/params values
+  my $s = Safe->new;
+  $s->rdo("$datadir/params");
+  die "Error reading $datadir/params: $!"    if $!;
+  die "Error evaluating $datadir/params: $@" if $@;
+  my $params = $s->varglob('param');
+
+  # Insert the key/values into the params table
+  foreach my $key (keys %{$params}) {
+    my $value = $params->{$key};
+    next if !defined $value;
+    $dbh->do('INSERT INTO params (name, value) VALUES (?, ?)', undef, $key, $value);
+  }
+}
 
 1;
 

--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -27,7 +27,6 @@ use Date::Parse;
 use Date::Format;
 use IO::File;
 use List::MoreUtils qw(uniq);
-use Scalar::Util qw(looks_like_number);
 use URI;
 use URI::QueryParam;
 
@@ -2826,8 +2825,15 @@ sub _fix_whine_queries_title_and_op_sys_value {
     $dbh->do('UPDATE bugs SET op_sys = ? WHERE op_sys = ?', undef, "Other",
       "other");
     if (Bugzilla->params->{'defaultopsys'} eq 'other') {
+
+      # We can't actually fix the param here, because WriteParams() will
+      # make $datadir/params unwriteable to the webservergroup.
+      # It's too much of an ugly hack to copy the permission-fixing code
+      # down to here. (It would create more potential future bugs than
+      # it would solve problems.)
       print "WARNING: Your 'defaultopsys' param is set to 'other', but"
-        . " Bugzilla now uses 'Other' (capital O).\n";
+        . " Bugzilla now\n"
+        . "         uses 'Other' (capital O).\n";
     }
 
     # Add a DEFAULT to whine_queries stuff so that editwhines.cgi
@@ -4380,6 +4386,7 @@ sub _populate_attachment_storage_class {
     );
   }
 }
+
 
 1;
 

--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -826,9 +826,6 @@ sub update_table_definitions {
   # Bug 1697642 - dkl@mozilla.com
   $dbh->bz_add_column('logincookies', 'auth_method',{TYPE => 'varchar(40)'});
 
-  # Bug 1729091 - dkl@mozilla.com
-  _migrate_db_parameters();
-
   ################################################################
   # New --TABLE-- changes should go *** A B O V E *** this point #
   ################################################################
@@ -4381,34 +4378,6 @@ sub _populate_attachment_storage_class {
     $dbh->do(
       "INSERT INTO attachment_storage_class (id, storage_class) SELECT attachments.attach_id, 'database' FROM attachments ORDER BY attachments.attach_id"
     );
-  }
-}
-
-sub _migrate_db_parameters {
-  my $dbh = Bugzilla->dbh;
-
-  # Return if the old data/params file has already been removed
-  my $datadir = bz_locations()->{'datadir'};
-  return if !-e "$datadir/params";
-
-  # Return if we have already populated the params table before
-  my $count = $dbh->selectrow_array('SELECT COUNT(*) FROM params');
-  return if $count;
-
-  print "Migrating old parameters from data/params to database...\n";
-
-  # Read in the old data/params values
-  my $s = Safe->new;
-  $s->rdo("$datadir/params");
-  die "Error reading $datadir/params: $!"    if $!;
-  die "Error evaluating $datadir/params: $@" if $@;
-  my $params = $s->varglob('param');
-
-  # Insert the key/values into the params table
-  foreach my $key (keys %{$params}) {
-    my $value = $params->{$key};
-    next if !defined $value;
-    $dbh->do('INSERT INTO params (name, value) VALUES (?, ?)', undef, $key, $value);
   }
 }
 

--- a/docs/en/rst/requirements.txt
+++ b/docs/en/rst/requirements.txt
@@ -1,0 +1,3 @@
+sphinx==4.2.0
+sphinx_rtd_theme==1.0.0
+readthedocs-sphinx-search==0.1.1

--- a/docs/en/rst/using/finding.rst
+++ b/docs/en/rst/using/finding.rst
@@ -308,9 +308,9 @@ Change Several Bugs At Once:
     their assignee.
 
 Send Mail to Bug Assignees:
-    If more than one bug appear in the bug list and there are at least
-    two distinct bug assignees, this links is displayed which lets you
-    easily send a mail to the assignees of all bugs on the list.
+    If more than one bug appears in the bug list and there are at least
+    two distinct bug assignees, this link is displayed which lets you
+    easily send an e-mail to the assignees of all bugs on the list.
 
 Edit Search:
     If you didn't get exactly the results you were looking for, you can

--- a/docs/en/rst/using/finding.rst
+++ b/docs/en/rst/using/finding.rst
@@ -197,19 +197,19 @@ So if you are looking for bugs reported by any user being in the
 Searching for Bugs Restricted to Groups
 ---------------------------------------
 
-When administrators set up products, they can establish one or more 
-groups bugs in the product can be associated with. If a bug is associated
-with a group then only users who are members of the group can see them. 
+When administrators set up products, they can establish one or more
+groups that bugs in the product can be associated with. If a bug is associated
+with a group then only users who are members of the group can see it.
 
 This restriction is mostly used for security-related bugs, or internal tickets.
 
-In order to search for bugs restricted to a group, you must be a member of the group. 
+In order to search for bugs restricted to a group, you must be a member of the group.
 
-Visit `the Permissions page <https://bugzilla.mozilla.org/userprefs.cgi?tab=permissions>`_ 
+Visit `the Permissions page <https://bugzilla.mozilla.org/userprefs.cgi?tab=permissions>`_
 to find the groups you belong to, then search using the clause
 
     Group   is equal to "%group.groupname%"
-    
+
 to list the bugs restricted to `groupname`.
 
 .. _relative-dates:


### PR DESCRIPTION
This is just the schema change related code copied over from the main PR so should be a quick check over.
What we do is merge this one first, do a deploy to production, run checksetup.pl and then do a second deploy with the rest of the application code. Minimizes risk of downtime.