### PR TITLE
Bug 1742725 - Add an option to disable the feature that converts long paste into attachment file.

### DIFF
--- a/extensions/BugModal/Extension.pm
+++ b/extensions/BugModal/Extension.pm
@@ -347,6 +347,12 @@ sub install_before_final_checks {
     default  => 'off',
     category => 'User Interface',
   });
+  add_setting({
+    name     => 'ui_attach_long_paste',
+    options  => ['on', 'off'],
+    default  => 'on',
+    category => 'User Interface',
+  });
 }
 
 __PACKAGE__->NAME;

--- a/extensions/BugModal/template/en/default/bug_modal/new_comment.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/new_comment.html.tmpl
@@ -42,7 +42,7 @@
   </ul>
 
   <div id="comment-edit-tabpanel" class="comment-tabpanel" role="tabpanel" aria-labelledby="comment-edit-tab">
-    <textarea rows="5" cols="80" name="comment" id="comment" aria-labelledby="comment-edit-tab"></textarea>
+    <textarea rows="5" cols="80" name="comment" id="comment" aria-labelledby="comment-edit-tab"[% IF user.setting("ui_attach_long_paste") == "on" %] class="attach-long-paste"[% END %]></textarea>
   </div>
   <div id="comment-preview-tabpanel" class="comment-tabpanel" role="tabpanel" aria-labelledby="comment-preview-tab" style="display:none">
     [% IF Param('use_markdown') %]

--- a/extensions/BugModal/template/en/default/hook/global/setting-descs-settings.none.tmpl
+++ b/extensions/BugModal/template/en/default/hook/global/setting-descs-settings.none.tmpl
@@ -9,4 +9,5 @@
 [%
   setting_descs.ui_remember_collapsed = "Remember visibility of header sections when viewing a bug"
   setting_descs.ui_use_absolute_time = "Use absolute format instead of relative time when viewing a bug"
+  setting_descs.ui_attach_long_paste = "When pasting long text in bug comments, convert it into an attachment text file"
 %]

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -1419,43 +1419,46 @@ $(function() {
             saveBugComment(event.target.value);
         });
 
-    // Allow to attach pasted text directly
-    document.querySelector('#comment').addEventListener('paste', async event => {
-      const text = event.clipboardData.getData('text');
-      const lines = text.split(/(?:\r\n|\r|\n)/).length;
+    const comment = document.querySelector('#comment');
+    if (comment.classList.contains('attach-long-paste')) {
+      // Convert long paste into an attachment
+      comment.addEventListener('paste', async event => {
+        const text = event.clipboardData.getData('text');
+        const lines = text.split(/(?:\r\n|\r|\n)/).length;
 
-      if (lines < 50) {
-        return;
-      }
+        if (lines < 50) {
+          return;
+       }
 
-      const extract = text.replace(/(?:\r\n|\r|\n)/, ' ').trim().substr(0, 20);
-      const summary = (window.prompt(
-        `You’re pasting ${lines} lines of text starting with “${extract}”. ` +
-        'Enter the summary below and click OK to upload it as an attachment. Click Cancel to paste it normally.'
-      ) || '').trim();
+        const extract = text.replace(/(?:\r\n|\r|\n)/, ' ').trim().substr(0, 20);
+        const summary = (window.prompt(
+          `You’re pasting ${lines} lines of text starting with “${extract}”. ` +
+          'Enter the summary below and click OK to upload it as an attachment. Click Cancel to paste it normally.'
+        ) || '').trim();
 
-      if (!summary) {
-        return;
-      }
+        if (!summary) {
+          return;
+        }
 
-      event.preventDefault();
+        event.preventDefault();
 
-      try {
-        await Bugzilla.API.post(`bug/${BUGZILLA.bug_id}/attachment`, {
-          // https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding
-          data: btoa(encodeURIComponent(text).replace(/%([0-9A-F]{2})/g, (m, p1) => String.fromCharCode(`0x${p1}`))),
-          file_name: 'pasted.txt',
-          summary,
-          content_type: 'text/plain',
-          comment: event.target.value.trim(),
-        });
+        try {
+          await Bugzilla.API.post(`bug/${BUGZILLA.bug_id}/attachment`, {
+            // https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding
+            data: btoa(encodeURIComponent(text).replace(/%([0-9A-F]{2})/g, (m, p1) => String.fromCharCode(`0x${p1}`))),
+            file_name: 'pasted.txt',
+            summary,
+            content_type: 'text/plain',
+            comment: event.target.value.trim(),
+          });
 
-        // Reload the page once upload is complete
-        location.replace(`${BUGZILLA.config.basepath}show_bug.cgi?id=${BUGZILLA.bug_id}`);
-      } catch ({ message }) {
-        window.alert(`Couldn’t upload the text as an attachment. Please try again later. Error: ${message}`);
-      }
-    });
+          // Reload the page once upload is complete
+          location.replace(`${BUGZILLA.config.basepath}show_bug.cgi?id=${BUGZILLA.bug_id}`);
+        } catch ({ message }) {
+          window.alert(`Couldn’t upload the text as an attachment. Please try again later. Error: ${message}`);
+        }
+      });
+    }
 
     restoreEditMode();
     restoreSavedBugComment();


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1742725

Add "User Interface" setting to enable/disable "attach pasted text" feature