### PR TITLE
no bug - Fix header interacting with scrolling using scroll-padding-top

### DIFF
--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -976,6 +976,11 @@ input[type="radio"]:checked {
   #wrapper {
     width: 100%;
   }
+  
+  html {
+    /* Ensure that shift-tab and other ways of scrolling up take the fixed header into account. */
+    scroll-padding-top: 48px;
+  }
 
   #header {
     height: 48px;


### PR DESCRIPTION
STR:

0. set bugzilla to have the comment field at the top
1. open [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1741104) or any other bug with sufficient comments to cause scrolling

STR-A:
2. put the cursor in the comment field
3. scroll down with the mouse scroll wheel, without leaving the focus in the comment field
4. type any letter to bring the comment field back into view

STR-B:
2. scroll down to a comment near the bottom, then click the +/- button on the right-hand side of any comment to focus it
3. repeatedly hit shift-tab on the keyboard.

Expected: focused elements are always fully visible

Pre-patch: the header obscures focused elements and/or the top of the comment field

I tested this patch by just using the inspector to add the scroll-padding-top, and that seems to be sufficient to fix it.