### PR TITLE
Bug 1751090 - Exiting subroutine via next at /app/extensions/PhabBugz/Extension.pm line 71.

### DIFF
--- a/extensions/PhabBugz/Extension.pm
+++ b/extensions/PhabBugz/Extension.pm
@@ -64,8 +64,8 @@ sub object_end_of_update {
   my ($object, $changes) = @$args{qw(object changes)};
   my $params = Bugzilla->params;
 
-  next
-    if !$params->{phabricator_enabled}
+  return
+       if !$params->{phabricator_enabled}
     || !$object->isa('Bugzilla::User')
     || !$changes
     || !$changes->{disabledtext};


### PR DESCRIPTION
While technically next works it is not the preferred way to return from a sub and is causing a warning in the logs over and over when a user object is changed. I can roll this fix out in the next normal deployment.