### PR TITLE
Bug 1751596 - Use of uninitialized value $component in string ne at /app/extensions/BMO/Extension.pm line 2266.

### DIFF
--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -2253,6 +2253,7 @@ sub forced_format {
   # note: this is also called from the guided bug entry extension
   my ($product, $component) = @_;
   return undef unless defined $product;
+  $component ||= '';
 
   # always work on the correct product name
   $product = Bugzilla::Product->new({name => $product, cache => 1})


### PR DESCRIPTION
This just sets the component value to '' if not provided to eliminate the Perl warning from going to the logs.