### PR TITLE
Bug 1755884 - https://bugzilla.mozilla.org/ does not show logged in user as logged in

### DIFF
--- a/Bugzilla/App/Main.pm
+++ b/Bugzilla/App/Main.pm
@@ -26,7 +26,7 @@ sub setup_routes {
 sub root {
   my ($c) = @_;
   $c->res->headers->cache_control('public, max-age=3600, immutable');
-  $c->render('index', handler => 'bugzilla');
+  $c->render(handler => 'bugzilla');
 }
 
 sub testagent {


### PR DESCRIPTION
As part of the BMO IAM commit, this change snuck in and should not have. It was part of some debugging work that I was doing to figure out how the quick redirect from / to /home that we have in places was causing problems for other functionality. This patch adds it back so that when people go to / it will show them as logged in properly.