### PR TITLE
Bug 1757970 - For private bugs, add placeholder to release announcement text instead of failing

### DIFF
--- a/scripts/build-bmo-push-data.pl
+++ b/scripts/build-bmo-push-data.pl
@@ -177,6 +177,9 @@ sub fetch_bug {
   if (exists $response->{bugs}) {
     return $response->{bugs}->[0];
   }
+  # If we get here, bug is private. We will assume that it is fixed
+  # and add placeholder text for the summary. Admin will need to fill
+  # in the correct text once bug is public and before posting announcements.
   else {
     return {
       bug_id     => $bug_id,
@@ -213,7 +216,8 @@ sub _get {
   if ($response->code =~ /^2/) {
     return decode_json($response->decoded_content);
   }
-  elsif ($response->code =~ /^4/) {
+  # Bug is private, so do not fail, just return empty data
+  elsif ($response->code == 401) {
     return {};
   }
   else {


### PR DESCRIPTION
This allows us to commit a secure bug to github, deploy live and then verify that the fix works. All before the bug is made publicly available. This was a request of the security team.