### PR TITLE
Bug 1191821 - The Add button when trying to add something to the See Also field is pointless

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
@@ -395,10 +395,7 @@ END;
   [% END %]
 
   [% IF edit %]
-    <button type="button" id="[% name FILTER html %]-btn" class="bug-urls-btn minor"
-            aria-label="[% 'Add ' _ label FILTER html %]">Add</button>
-    <input id="[% name FILTER html %]" name="[% name FILTER html %]" style="display:none"
-           aria-label="[% label FILTER html %]">
+    <input id="[% name FILTER html %]" name="[% name FILTER html %]" aria-label="[% label FILTER html %]">
   [% END %]
 [% END %]
 

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -870,15 +870,6 @@ $(function() {
             other.val(that.val());
         });
 
-    // add see-also button
-    $('.bug-urls-btn')
-        .click(function(event) {
-            event.preventDefault();
-            var name = event.target.id.replace(/-btn$/, '');
-            $(event.target).hide();
-            $('#' + name).show().focus();
-        });
-
     // bug flag value <select>
     $('.bug-flag')
         .change(function(event) {


### PR DESCRIPTION
I agree that the Add button is a nuisance and we should just show single line text fields by default when clicking Edit. This is what happens in this patch for the see also field.