### PR TITLE
Bug 1761594 - Bugzilla should reject redirect_uri tampering when being used for authentication with Phabricator

### DIFF
--- a/Bugzilla/DB/Schema.pm
+++ b/Bugzilla/DB/Schema.pm
@@ -1859,6 +1859,7 @@ use constant ABSTRACT_SCHEMA => {
       client_id     => {TYPE => 'varchar(255)', NOTNULL => 1},
       description   => {TYPE => 'varchar(255)', NOTNULL => 1},
       secret        => {TYPE => 'varchar(255)', NOTNULL => 1},
+      hostname      => {TYPE => 'varchar(255)', NOTNULL => 1},
       active        => {TYPE => 'BOOLEAN',      NOTNULL => 1, DEFAULT => 'TRUE'},
       last_modified => {TYPE => 'DATETIME'},
     ],

--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -825,6 +825,10 @@ sub update_table_definitions {
   # Bug 1697642 - dkl@mozilla.com
   $dbh->bz_add_column('logincookies', 'auth_method',{TYPE => 'varchar(40)'});
 
+  # Bug 1761594 - dkl@mozilla.com
+  $dbh->bz_add_column('oauth2_client', 'hostname',
+    {TYPE => 'varchar(255)', NOTNULL => 1, DEFAULT => "''"});
+
   ################################################################
   # New --TABLE-- changes should go *** A B O V E *** this point #
   ################################################################

--- a/Bugzilla/Test/Util.pm
+++ b/Bugzilla/Test/Util.pm
@@ -21,6 +21,7 @@ use Bugzilla::Bug;
 use Bugzilla::User::APIKey;
 use Bugzilla::Util qw(generate_random_password);
 use Mojo::Message::Response;
+use Sys::Hostname;
 use Test2::Tools::Mock qw(mock);
 
 use Type::Params -all;
@@ -63,8 +64,8 @@ sub create_oauth_client {
   my $id     = generate_random_password(20);
   my $secret = generate_random_password(40);
 
-  $dbh->do('INSERT INTO oauth2_client (client_id, description, secret) VALUES (?, ?, ?)',
-    undef, $id, $description, $secret);
+  $dbh->do('INSERT INTO oauth2_client (client_id, description, secret, hostname) VALUES (?, ?, ?, ?)',
+    undef, $id, $description, $secret, hostname());
 
   my $client_data
     = $dbh->selectrow_hashref('SELECT * FROM oauth2_client WHERE client_id = ?',

--- a/scripts/generate_conduit_data.pl
+++ b/scripts/generate_conduit_data.pl
@@ -247,7 +247,7 @@ if ($oauth_id && $oauth_secret) {
   print "creating phabricator oauth2 client...\n";
 
   $dbh->do(
-    'REPLACE INTO oauth2_client (client_id, description, secret) VALUES (?, \'Phabricator\', ?)',
+    'REPLACE INTO oauth2_client (client_id, description, secret, hostname) VALUES (?, \'Phabricator\', ?, \'phabricator.test\')',
     undef, $oauth_id, $oauth_secret
   );
 

--- a/template/en/default/admin/oauth/provider/confirm-delete.html.tmpl
+++ b/template/en/default/admin/oauth/provider/confirm-delete.html.tmpl
@@ -15,6 +15,10 @@
   <td valign="top">Client ID</td>
   <td valign="top">[% client.client_id FILTER html %]</td>
 </tr>
+<tr>
+  <td valign="top">Redirect Hostname</td>
+  <td valign="top">[% client.hostname FILTER html %]</td>
+</tr>
 </table>
 
 <h2>Confirmation</h2>

--- a/template/en/default/admin/oauth/provider/create.html.tmpl
+++ b/template/en/default/admin/oauth/provider/create.html.tmpl
@@ -18,6 +18,10 @@
       <td>[% secret FILTER html %]</td>
     </tr>
     <tr>
+      <th class="field_label"><label for="hostname">Redirect Hostname:</label></th>
+      <td><input id="hostname" size="20" maxlength="20" name="hostname"></td>
+    </tr>
+    <tr>
       <th class="field_label"><label for="scopes">Scopes:</label></th>
       <td>
         At least one required<br>

--- a/template/en/default/admin/oauth/provider/edit.html.tmpl
+++ b/template/en/default/admin/oauth/provider/edit.html.tmpl
@@ -19,6 +19,11 @@
       <td>[% client.secret FILTER html %]</td>
     </tr>
     <tr>
+      <th class="field_label"><label for="hostname">Redirect Hostname:</label></th>
+      <td><input id="hostname" size="20" maxlength="20" name="hostname" value="
+      [%- client.hostname FILTER html %]"></td>
+    </tr>
+    <tr>
       <th class="field_label"><label for="active">Active:</label></th>
       <td><input id="active" name="active" type="checkbox" value="1"
                  [%+ 'checked="checked"' IF client.active %]></td>


### PR DESCRIPTION
This pull request adds another value to the client data stored in Bugzilla. The new value is a hostname that the client will have Bugzilla redirect back to once the user has approved the login request. This will allow Bugzilla to verify that the redirect hostname provided in the URL has not been changed to a different location which could steal the users token. If the redirect URL and its hostname has been altered, then the user is redirect back to the client site as if access request was not granted at all.

We can also put this change on bugzilla-dev for extra testing in addition to code review here.