### PR TITLE
Bug 1765286 - Creating a short URL of a bug list sorted by number of votes doesn't keep the sorting order in the short URL

### DIFF
--- a/extensions/Bitly/template/en/default/hook/list/list-links.html.tmpl
+++ b/extensions/Bitly/template/en/default/hook/list/list-links.html.tmpl
@@ -20,6 +20,6 @@
 </div>
 <a id="bitly-shorten" href="#"
    data-url="[% urlbase _ "buglist.cgi?" _
-                cgi.new(urlquerypart).canonicalize_query('list_id','query_format') FILTER html %]"
+                cgi.new(urlquerypart).canonicalize_query('list_id','query_format') FILTER html %]&order=[% order FILTER html %]"
 >Short URL</a>
 |&nbsp; [%# using nbsp because tt always trims trailing whitespace from templates %]


### PR DESCRIPTION
In  general the order= parameter is stripped away (along with a few others) when creating URLs on the bug results page due to the way they are used for navigation. This patch adds the order= parameter and its value back just for the URL used to create the Bitly link so that when someone shares the short link, it retains the proper order as well.