### PR TITLE
Bug 1430732 - Comments from a logged in user should be stylable differently

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -54,6 +54,11 @@
   FOREACH change_set IN bug.activity_stream;
     NEXT IF change_set.cc_only;
     extra_class = change_set.comment.collapsed ? " ca-" _ change_set.comment.author.id : "";
+
+    IF user.id == change_set.comment.author.id;
+      extra_class = extra_class _ ' yourself';
+    END;
+
     '<div class="change-set' _ extra_class _ '" id="' _ change_set.id _ '">';
 
     extra_class = "";


### PR DESCRIPTION
CSS class "yourself" is added to "change-set" div comment if logged in user is commenter.

This is my first PR :tada:
If I made any mistakes or if I missed anything, please let me know and I'll fix it.