### PR TITLE
Bug 1766393 - https://bugzilla.mozilla.org/rest/config/component_teams returns `A REST API resource was not found`

### DIFF
--- a/Bugzilla/API/V1/Teams.pm
+++ b/Bugzilla/API/V1/Teams.pm
@@ -9,6 +9,7 @@ package Bugzilla::API::V1::Teams;
 use 5.10.1;
 use Mojo::Base qw( Mojolicious::Controller );
 
+use Bugzilla::Constants;
 use Bugzilla::Teams qw(team_names get_team_info);
 
 sub setup_routes {

--- a/Bugzilla/App/API.pm
+++ b/Bugzilla/App/API.pm
@@ -99,7 +99,7 @@ sub _load_api_module {
     }
   }
   catch {
-    WARN("$module could not be loaded");
+    WARN("$module could not be loaded: $_");
   };
 }
 


### PR DESCRIPTION
Fallout from a recent change with error handling.

1. Bugzilla/App/API.pm change to include the actual module loading error in the warning log message.
2. Include Bugzilla/Constants.pm module in Teams.pm to import the USAGE_MODE_MOJO_REST constant properly.