### PR TITLE
Bug 1765917 - Open Redirectionwhen using OAuth2 authentication

### DIFF
--- a/Bugzilla/App.pm
+++ b/Bugzilla/App.pm
@@ -17,7 +17,7 @@ use FileHandle;    # this is for compat back to 5.10
 use Bugzilla          ();
 use Bugzilla::BugMail ();
 use Bugzilla::CGI     ();
-use Bugzilla::Constants qw(bz_locations MAX_STS_AGE);
+use Bugzilla::Constants;
 use Bugzilla::Extension             ();
 use Bugzilla::Install::Requirements ();
 use Bugzilla::Logging;
@@ -83,6 +83,10 @@ sub startup {
       catch {
         ERROR($_);
       };
+
+      # Set usage mode and store controller for Error.pm exception handling
+      Bugzilla->usage_mode(USAGE_MODE_MOJO);
+      Bugzilla->request_cache->{mojo_controller} = $c;
     }
   );
 

--- a/Bugzilla/App/Plugin/OAuth2/Provider.pm
+++ b/Bugzilla/App/Plugin/OAuth2/Provider.pm
@@ -101,7 +101,8 @@ sub _resource_owner_confirm_scopes {
 
     # Deny access if hostname of redirect_uri doesn't match
     # the hostname assigned to the client id
-    _validate_redirect_uri($client->{hostname}, $c->param('redirect_uri')) || return 0;
+    _validate_redirect_uri($client->{hostname}, $c->param('redirect_uri'))
+      || ThrowUserError('oauth2_invalid_redirect_uri');
 
     my $vars = {
       client => $client,
@@ -115,7 +116,8 @@ sub _resource_owner_confirm_scopes {
 
   # Deny access if hostname of redirect_uri doesn't match
   # the hostname assigned to the client id
-  _validate_redirect_uri($client->{hostname}, $c->param('redirect_uri')) || return 0;
+  _validate_redirect_uri($client->{hostname}, $c->param('redirect_uri'))
+    || ThrowUserError('oauth2_invalid_redirect_uri');
 
   my $token = $c->param('token');
   check_token_data($token, 'oauth_confirm_scopes');

--- a/Bugzilla/Error.pm
+++ b/Bugzilla/Error.pm
@@ -81,7 +81,7 @@ sub _throw_error {
   if (Bugzilla->error_mode == ERROR_MODE_MOJO) {
     my ($type) = $name =~ /^global\/(user|code)-error/;
     my $c = Bugzilla->request_cache->{mojo_controller};
-    $c->stash({type => $type, error => $error, message => $message, vars => $vars,}) and die;
+    $c->stash({type => $type, error => $error, vars => $vars,}) and die;
   }
 
   if (Bugzilla->error_mode == ERROR_MODE_WEBPAGE) {

--- a/template/en/default/global/user-error.html.tmpl
+++ b/template/en/default/global/user-error.html.tmpl
@@ -271,6 +271,10 @@
     An error occurred completing the login process using the single signon provider.
     Contact an administrator explaining the problem.
 
+  [% ELSIF error == "oauth2_invalid_redirect_uri" %]
+    [% title = 'Invalid Redirect URI' %]
+    The redirect uri provided is not allowed for the OAuth2 client.
+
   [% ELSIF error == "attachment_deletion_disabled" %]
     [% title = "Attachment Deletion Disabled" %]
     Attachment deletion is disabled on this installation.


### PR DESCRIPTION
1. Bugzilla/App.pm sets the usage mode and stores away the universal controller for use by native Mojo code and routes.
2. Provider.pm now throws a user exception when  the redirect_uri hostname does not match the one configured for the OAutht2 client instead of just returning a false value as before. Before, when a false is returned, BMO just redirected to whatever redirect_uri had set and gave a request denied error to the client which was the incorrect solution in this case.
3. Error.pm removes the message value from stash as it was interfering with a different message value that is used sometimes in the templates and various BMO pages. In this case, message was unused and not needed.