### PR TITLE
Bug 1752191 - [WEBHOOKS] Allow Webhook Setup with "Any" Product

### DIFF
--- a/extensions/Push/lib/Connector/Webhook.pm
+++ b/extensions/Push/lib/Connector/Webhook.pm
@@ -62,8 +62,8 @@ sub should_send {
 
   my $webhook = Bugzilla::Extension::Webhooks::Webhook->new($self->{webhook_id});
   my $event   = $webhook->event;
-  my $product = $webhook->product_name;
-  my $component = $webhook->component_name ? $webhook->component_name : 'any';
+  my $product   = $webhook->product_name;
+  my $component = $webhook->component_name;
 
   my $payload  = $message->payload_decoded;
   my $target   = $payload->{event}->{target};
@@ -72,8 +72,8 @@ sub should_send {
 
   my $bug = Bugzilla::Bug->new({id => $bug_data->{id}, cache => 1});
 
-  if ($product eq $bug->product
-    && ($component eq $bug->component || $component eq 'any'))
+  if (($product eq $bug->product || $product eq 'Any')
+    && ($component eq $bug->component || $component eq 'Any'))
   {
     if ( ($event =~ /create/ && $message->routing_key eq 'bug.create')
       || ($event =~ /change/ && $message->routing_key =~ /^bug\.modify/)

--- a/extensions/Push/template/en/default/pages/webhooks_config.html.tmpl
+++ b/extensions/Push/template/en/default/pages/webhooks_config.html.tmpl
@@ -58,8 +58,8 @@
         </a>
       </td>
       <td>[% webhook.event FILTER html %]</td>
-      <td>[% webhook.product.name FILTER html %]</td>
-      <td>[% webhook.component ? webhook.component.name : 'Any' FILTER html %]</td>
+      <td>[% webhook.product_name FILTER html %]</td>
+      <td>[% webhook.component_name FILTER html %]</td>
     </tr>
   [% END %]
   </tbody>

--- a/extensions/Webhooks/Extension.pm
+++ b/extensions/Webhooks/Extension.pm
@@ -45,7 +45,7 @@ sub db_schema_abstract_schema {
       event      => {TYPE => 'VARCHAR(64)', NOTNULL => 1,},
       product_id => {
         TYPE       => 'INT2',
-        NOTNULL    => 1,
+        NOTNULL    => 0,
         REFERENCES => {TABLE => 'products', COLUMN => 'id', DELETE => 'CASCADE',}
       },
       component_id => {
@@ -66,6 +66,15 @@ sub install_update_db {
   my $dbh = Bugzilla->dbh;
   $dbh->bz_add_column('webhooks', 'api_key_header', {TYPE => 'VARCHAR(64)'});
   $dbh->bz_add_column('webhooks', 'api_key_value',  {TYPE => 'VARCHAR(64)'});
+  $dbh->bz_alter_column(
+    'webhooks',
+    'product_id',
+    {
+      TYPE       => 'INT2',
+      NOTNULL    => 0,
+      REFERENCES => {TABLE => 'products', COLUMN => 'id', DELETE => 'CASCADE',}
+    }
+  );
 }
 
 sub db_sanitize {
@@ -126,16 +135,28 @@ sub user_preferences {
         ThrowUserError('webhooks_select_event');
       }
 
-      my $product_name = $input->{add_product};
-      my $product = Bugzilla::Product->check({name => $product_name, cache => 1});
-      $params->{product_id} = $product->id;
+      my $product_name = $input->{product};
 
-      if (my $component_name = $input->{add_component}) {
-        my $component
-          = Bugzilla::Component->check({
-          name => $component_name, product => $product, cache => 1
-          });
-        $params->{component_id} = $component->id;
+      # Selecting product equal to 'any' requires special group membership
+      if (!$product_name || $product_name eq 'Any') {
+        if (!$user->in_group(Bugzilla->params->{webhooks_any_product_group})) {
+          ThrowUserError('webhooks_any_product_not_allowed');
+        }
+        $params->{product_id}   = undef;
+        $params->{component_id} = undef;
+      }
+      else {
+        my $product = Bugzilla::Product->check({name => $product_name, cache => 1});
+        $params->{product_id} = $product->id;
+
+        my $component_name = $input->{component};
+        if ($component_name && $component_name ne 'Any') {
+          my $component
+            = Bugzilla::Component->check({
+            name => $component_name, product => $product, cache => 1
+            });
+          $params->{component_id} = $component->id;
+        }
       }
 
       if ($input->{api_key_header}) {

--- a/extensions/Webhooks/lib/Config.pm
+++ b/extensions/Webhooks/lib/Config.pm
@@ -18,9 +18,15 @@ sub get_param_list {
 
   my @param_list = (
     {name => 'webhooks_enabled', type => 'b', default => '0',},
-
     {
       name    => 'webhooks_group',
+      type    => 's',
+      choices => \&get_all_group_names,
+      default => 'admin',
+      checker => \&check_group
+    },
+    {
+      name    => 'webhooks_any_product_group',
       type    => 's',
       choices => \&get_all_group_names,
       default => 'admin',

--- a/extensions/Webhooks/lib/Webhook.pm
+++ b/extensions/Webhooks/lib/Webhook.pm
@@ -79,24 +79,33 @@ sub component_id {
 
 sub product {
   my ($self) = @_;
-  return $self->{product} ||=
-    Bugzilla::Product->new({id => $self->{product_id}, cache => 1});
+  return $self->{product} if exists $self->{product};
+  $self->{product}
+    = $self->{product_id}
+    ? Bugzilla::Product->new({id => $self->{product_id}, cache => 1})
+    : undef;
+  return $self->{product};
 }
 
 sub product_name {
   my ($self) = @_;
-  return $self->{product_name} ||= $self->{product_id} ? $self->product->name : '';
+  return $self->{product_name} ||= $self->product ? $self->product->name : 'Any';
 }
 
 sub component {
   my ($self) = @_;
-  return $self->{component} ||= $self->{component_id}
-    ? Bugzilla::Component->new({id => $self->{component_id}, cache => 1}) : undef;
+  return $self->{component} if exists $self->{component};
+  $self->{component}
+    = $self->{component_id}
+    ? Bugzilla::Component->new({id => $self->{component_id}, cache => 1})
+    : undef;
+  return $self->{component};
 }
 
 sub component_name {
   my ($self) = @_;
-  return $self->{component_name} ||= $self->{component_id} ? $self->component->name : '';
+  return $self->{component_name}
+    ||= $self->component ? $self->component->name : 'Any';
 }
 
 sub api_key_header {

--- a/extensions/Webhooks/template/en/default/account/prefs/webhooks.html.tmpl
+++ b/extensions/Webhooks/template/en/default/account/prefs/webhooks.html.tmpl
@@ -16,7 +16,12 @@ var useclassification = false;
 var first_load = true;
 var last_sel = [];
 var cpts = new Array();
-[% n = 0 %]
+[% IF user.in_group(Param('webhooks_any_product_group')) %]
+  cpts['0'] = ['Any'];
+  [% n = 1 %]
+[% ELSE %]
+  [% n = 0 %]
+[% END %]
 [% FOREACH prod = selectable_products %]
   cpts['[% n %]'] = [
     [%- FOREACH comp = prod.components %]'[% comp.name FILTER js %]'[% ", " UNLESS loop.last %] [%- END -%] ];
@@ -33,10 +38,10 @@ function onSelectProduct() {
   // selectProduct only supports Any on both elements
   // we only want it on component, so add it back in
   try {
-    component.add(new Option('Any', ''), component.options[0]);
+    component.add(new Option('Any', 'Any'), component.options[0]);
   } catch(e) {
     // support IE
-    component.add(new Option('Any', ''), 0);
+    component.add(new Option('Any', 'Any'), 0);
   }
   document.getElementById('component').options[0].selected = true;
 }
@@ -84,9 +89,13 @@ window.onload = function() {
 <tr>
   <th align="right">Product:</th>
   <td>
-    <select name="add_product" id="product" onChange="onSelectProduct()">
+    <select name="product" id="product" onChange="onSelectProduct()">
+    [% IF user.in_group(Param('webhooks_any_product_group')) %]
+      <option value="Any">Any</option>
+    [% END %]
     [% FOREACH product IN selectable_products %]
-      <option>[% product.name FILTER html %]</option>
+      <option value="[% product.name FILTER html %]">
+        [% product.name FILTER html %]</option>
     [% END %]
     </select>
   </td>
@@ -94,11 +103,12 @@ window.onload = function() {
 <tr>
   <th align="right">Component:</th>
   <td>
-    <select name="api_key" id="api_key">
-      <option value="">Any</option>
+    <select name="component" id="component">
+      <option value="Any">Any</option>
     [% FOREACH product IN selectable_products %]
       [% FOREACH component IN product.components %]
-        <option>[% component.name FILTER html %]</option>
+        <option value="[% component.name FILTER html %]">
+          [% component.name FILTER html %]</option>
       [% END %]
     [% END %]
     </select>
@@ -171,8 +181,8 @@ window.onload = function() {
         </a>
       </td>
       <td>[% webhook.event FILTER html %]</td>
-      <td>[% webhook.product.name FILTER html %]</td>
-      <td>[% webhook.component ? webhook.component.name : 'Any' FILTER html %]</td>
+      <td>[% webhook.product_name FILTER html %]</td>
+      <td>[% webhook.component_name FILTER html %]</td>
       <td>[% webhook.api_key_value FILTER html %]</td>
       <td>
         [% config = connector.config %]

--- a/extensions/Webhooks/template/en/default/admin/params/webhooks.html.tmpl
+++ b/extensions/Webhooks/template/en/default/admin/params/webhooks.html.tmpl
@@ -15,5 +15,6 @@
    param_descs = {
      webhooks_enabled => "Enable or disable the webhooks feature.",
      webhooks_group => "The name of the group of users who can create webhooks."
+     webhooks_any_product_group => "The name of the group of users who can create webhooks for any product."
    }
 %]

--- a/extensions/Webhooks/template/en/default/hook/global/user-error-errors.html.tmpl
+++ b/extensions/Webhooks/template/en/default/hook/global/user-error-errors.html.tmpl
@@ -26,4 +26,9 @@
   [% title = "Wrong webhook" %]
   This webhook doesn't belong to you.
 
+[% ELSIF error == "webhooks_any_product_not_allowed" %]
+  [% title = "Any Product Not Allowed" %]
+  You do not have the proper permissions to create a hook
+  for any product.
+
 [% END %]


### PR DESCRIPTION
1. Update table schema to allow product_id column to be NULL which means any product.
2. Update product_name() and component_name() in Webhooks.pm to return 'Any' if product_id and/or component_id are NULL values in the DB.
3. Update the Push connector for Webhooks to allow all messages if product equals 'Any'.
4. Create a new permission group configuration option to limit amount of users who can select 'Any' as a product choice. Defaults to 'admin'.
5. Extended current test_webhooks.t test script to test for the 'Any' product support.
6. Fixed a current bug in the edit webhooks form where the component field name was incorrectly set to 'api_key'.