### PR TITLE
Bug 1767484 - Expose `last_seen_date` in the `/rest/user` endpoint

### DIFF
--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -298,13 +298,14 @@ sub get {
   foreach my $user (@$in_group) {
     my $user_info = filter $params,
       {
-      id           => $self->type('int',     $user->id),
-      real_name    => $self->type('string',  $user->name),
-      nick         => $self->type('string',  $user->nick),
-      name         => $self->type('email',   $user->login),
-      email        => $self->type('email',   $user->email),
-      can_login    => $self->type('boolean', $user->is_enabled ? 1 : 0),
-      iam_username => $self->type('string',  $user->iam_username),
+      id             => $self->type('int',     $user->id),
+      real_name      => $self->type('string',  $user->name),
+      nick           => $self->type('string',  $user->nick),
+      name           => $self->type('email',   $user->login),
+      email          => $self->type('email',   $user->email),
+      can_login      => $self->type('boolean', $user->is_enabled ? 1 : 0),
+      iam_username   => $self->type('string',  $user->iam_username),
+      last_seen_date => $self->type('dateTime',  $user->last_seen_date),
       };
 
     if (Bugzilla->user->in_group('editusers')) {

--- a/docs/en/rst/api/core/v1/user.rst
+++ b/docs/en/rst/api/core/v1/user.rst
@@ -378,6 +378,7 @@ saved_searches     array    User's saved searches, each having the following
                             Search object items described below.
 saved_reports      array    User's saved reports, each having the following
                             Search object items described below.
+last_seen_date     datetime The time when the user last loaded any page.
 =================  =======  =====================================================
 
 Group object:


### PR DESCRIPTION
The Docker development setup does not support my machine (Mac M1), so fully reling on the CI and the reviewer.

This PR is following @globau hints on [Slack](https://mozilla.slack.com/archives/C5F7KFJ4R/p1651586330688789?thread_ts=1651574356.938399&cid=C5F7KFJ4R).