### PR TITLE
Bug 1764246 - Use "triaged" keyword to track bug's triaged state instead of severity

### DIFF
--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -873,7 +873,7 @@ sub create {
     $comment->update();
   }
 
-  # BMO - add the stash param from bug_start_of_create
+  # BMO - add the stash param from bug_before_create
   Bugzilla::Hook::process('bug_end_of_create',
     {bug => $bug, timestamp => $timestamp, stash => $stash,});
 
@@ -3904,6 +3904,29 @@ sub has_keyword {
   my ($self, $keyword) = @_;
   $keyword = lc($keyword);
   return any { lc($_->name) eq $keyword } @{$self->keyword_objects};
+}
+
+sub add_keyword {
+  my ($self, $keyword) = @_;
+  return if $self->has_keyword($keyword);
+  push @{$self->{'keyword_objects'}}, Bugzilla::Keyword->check({name => $keyword});
+}
+
+sub del_keyword {
+  my ($self, $keyword) = @_;
+  $keyword = lc($keyword);
+  my $index = -1;
+  my $i = 0;
+  foreach my $keyword_obj (@{$self->{'keyword_objects'}}) {
+    if (lc($keyword_obj->name) eq $keyword) {
+      $index = $i;
+      last;
+    }
+    $i++;
+  }
+  if ($index != -1) {
+    splice @{$self->{'keyword_objects'}}, $index, 1;
+  }
 }
 
 sub comments {

--- a/buglist.cgi
+++ b/buglist.cgi
@@ -725,9 +725,13 @@ do {
   local $SIG{__DIE__}  = undef;
   local $SIG{__WARN__} = undef;
   ($data, $extra_data) = eval { $search->data };
-  # If the search query failed in any way, log the error and return an empty
-  # list of bugs
-  ERROR 'buglist.cgi?' . $cgi->query_string . " $@" if $@;
+  # If the search query failed, handle Throw*Error correctly, or for all other
+  # failures log it and return an empty list of bugs.
+  if (my $search_err = $@) {
+    return if ref $search_err eq 'ARRAY' && $search_err->[0] eq "EXIT\n";
+    use Data::Dumper;
+    ERROR 'buglist.cgi?' . $cgi->query_string . " " . Dumper($search_err);
+  }
 };
 
 $vars->{'search_description'} = $search->search_description;

--- a/enter_bug.cgi
+++ b/enter_bug.cgi
@@ -308,6 +308,8 @@ if ($cloned_bug_id) {
   # BMO Allow mentors to be cloned as well
   $vars->{'bug_mentors'} = join(', ', map { $_->login } @{$cloned_bug->mentors});
 
+  # Cloned bugs should never inherit the 'triaged' keyword
+  $vars->{'keywords'} = join(', ', grep { $_ ne 'triaged' } split(/,\s*/, $vars->{keywords}));
 }    # end of cloned bug entry form
 
 else {

--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -88,8 +88,11 @@ BEGIN {
   *Bugzilla::Bug::last_closed_date               = \&_last_closed_date;
   *Bugzilla::Bug::reporters_hw_os                = \&_bug_reporters_hw_os;
   *Bugzilla::Bug::is_unassigned                  = \&_bug_is_unassigned;
+  *Bugzilla::Bug::is_untriaged                   = \&_bug_is_untriaged;
+  *Bugzilla::Bug::uses_triaged_keyword           = \&_bug_uses_triaged_keyword;
   *Bugzilla::Bug::has_current_patch              = \&_bug_has_current_patch;
   *Bugzilla::Bug::missing_sec_approval           = \&_bug_missing_sec_approval;
+  *Bugzilla::User::can_triage                    = \&_user_can_triage;
   *Bugzilla::Product::default_security_group     = \&_default_security_group;
   *Bugzilla::Product::default_security_group_obj = \&_default_security_group_obj;
   *Bugzilla::Product::group_always_settable      = \&_group_always_settable;
@@ -890,6 +893,20 @@ sub _bug_is_unassigned {
   return $assignee eq 'nobody@mozilla.org' || $assignee =~ /@(?!invalid).+\.bugs$/;
 }
 
+sub _bug_uses_triaged_keyword {
+  my ($self) = @_;
+  my $product = $self->product;
+  return any { $_ eq $product } @triage_keyword_products;
+}
+
+sub _bug_is_untriaged {
+  # Bugs of type 'task' are never flagged as untriaged.
+  my ($self) = @_;
+  return $self->uses_triaged_keyword
+    && $self->bug_type ne 'task'
+    && !$self->has_keyword('triaged');
+}
+
 sub _bug_has_current_patch {
   my ($self) = @_;
   foreach my $attachment (@{$self->attachments}) {
@@ -950,6 +967,8 @@ sub _bug_missing_sec_approval {
   # sec-approval is required if no tracking flags are set
   return $set == 0;
 }
+
+sub _user_can_triage { $_[0]->in_group('can_triage_bugs') }
 
 sub _product_default_platform_id { $_[0]->{default_platform_id} }
 sub _product_default_op_sys_id   { $_[0]->{default_op_sys_id} }
@@ -1025,6 +1044,77 @@ sub bug_end_of_create {
       "INSERT INTO bug_user_agent (bug_id, user_agent) VALUES (?, ?)",
       undef, $bug->id, $ua);
   }
+
+  # require severity if the triage keyword is present
+  if (
+    $bug->uses_triaged_keyword
+    && $bug->has_keyword('triaged')
+    && $bug->bug_type ne 'task'
+    && $bug->bug_severity !~ /^S\d+$/
+  ) {
+    ThrowUserError('triage_severity_required');
+  }
+}
+
+sub bug_start_of_update {
+  my ($self, $args) = @_;
+  my $old_bug = $args->{old_bug};
+  my $new_bug = $args->{bug};
+
+  # silently drop changes to the triaged keyword from users without permissions
+  # to triage
+  if (!Bugzilla->user->can_triage) {
+
+    # note: $args->{changes}->{keywords} is generated after this hook is called
+    if (
+      !$old_bug->has_keyword('triaged')
+      && $new_bug->has_keyword('triaged')
+    ) {
+      $new_bug->del_keyword('triaged');
+
+    } elsif (
+      $old_bug->has_keyword('triaged')
+      && !$new_bug->has_keyword('triaged')
+    ) {
+      $new_bug->add_keyword('triaged');
+    }
+  }
+
+  # remove the triaged keyword when a bug is moved to a component owned by a
+  # different team
+  my $o = $old_bug->component_obj->team_name;
+  my $n = $new_bug->component_obj->team_name;
+  if (
+    $new_bug->component_obj->team_name ne $old_bug->component_obj->team_name
+  ) {
+    $new_bug->del_keyword('triaged');
+  }
+}
+
+sub bug_end_of_update {
+  my ($self, $args) = @_;
+  my $bug = $args->{bug};
+
+  # require severity if the triaged keyword is present
+  if (
+    $bug->uses_triaged_keyword
+    && $bug->has_keyword('triaged')
+    && $bug->bug_type ne 'task'
+    && $bug->bug_severity !~ /^S\d+$/
+  ) {
+    ThrowUserError('triage_severity_required');
+  }
+}
+
+sub bug_end_of_create_validators {
+  my ($self, $args) = @_;
+  my $params = $args->{params};
+
+  # silently drop changes to the triaged keyword from users without permissions
+  # to triage
+  return if Bugzilla->user->can_triage;
+  return unless exists $params->{keywords};
+  $params->{keywords} =  [grep { $_->name ne 'triaged' } @{$params->{keywords}}];
 }
 
 sub sanitycheck_check {
@@ -1452,6 +1542,15 @@ sub install_update_db {
         }
       }
     }
+  }
+
+  # Add triaged field to expose it as a field for search.
+  if (!Bugzilla::Field->new({name => 'is_triaged'})) {
+    Bugzilla::Field->create({
+      name        => 'is_triaged',
+      description => 'Is Triaged',
+      type        => FIELD_TYPE_BOOLEAN,
+    });
   }
 }
 
@@ -2185,18 +2284,41 @@ sub buglist_columns {
     # `0` otherwise
     name  => 'COALESCE(MAX(attachments.ispatch OR ' .
       'attachments.mimetype LIKE "text/x-%-request"), 0)',
-  }
+  };
+
+  $columns->{'is_triaged'} = {
+    name => '(CASE WHEN map_triaged_keywords.keywordid IS NULL ' .
+      "THEN 'No' ELSE 'Yes' END)",
+  };
 }
 
 sub buglist_column_joins {
   my ($self, $args) = @_;
   my $column_joins = $args->{column_joins};
+
   $column_joins->{'attachments.ispatch'} = {
     as    => 'attachments',
     from  => 'bug_id',
     to    => 'bug_id',
     table => 'attachments',
     join  => 'LEFT',
+  };
+
+  state $triaged_keyword_id = -1;
+  if ($triaged_keyword_id == -1) {
+    my $keyword_obj = Bugzilla::Keyword->new({name => 'triaged'});
+    $triaged_keyword_id = $keyword_obj ? $keyword_obj->id : 0;
+  }
+
+  $column_joins->{'is_triaged'} = {
+    table   => 'keywords',
+    then_to => {
+      from  => 'bug_id',
+      to    => 'bug_id',
+      as    => 'map_triaged_keywords',
+      table => 'keywords',
+      extra => ["map_triaged_keywords.keywordid = $triaged_keyword_id"],
+    },
   };
 }
 
@@ -2566,6 +2688,40 @@ sub search_params_to_data_structure {
       $params->{$key} = $canonical;
     }
   }
+
+  # Map `is_triaged` to a keyword search
+  # We support is[not]empty and [not]equals yes|no|true|false
+  my $i = 0;
+  while (1) {
+    $i++;
+    last unless exists $params->{"f$i"};
+    next unless $params->{"f$i"} eq 'is_triaged';
+    my $op = $params->{"o$i"} // next;
+    my $value = lc($params->{"v$i"} // '');
+
+    $params->{"f$i"} = 'keywords';
+    $params->{"v$i"} = 'triaged';
+    $value = 'true' if $value eq 'yes';
+    $value = 'false' if $value eq 'no';
+    if (
+      $op eq 'isempty'
+      || ($op eq 'equals' && $value eq 'false')
+      || ($op eq 'notequals' && $value eq 'true')
+    ) {
+      $params->{"o$i"} = 'notsubstring';
+    }
+    elsif (
+      $op eq 'isnotempty'
+      || ($op eq 'equals' && $value eq 'true')
+      || ($op eq 'notequals' && $value eq 'false')
+    ) {
+      $params->{"o$i"} = 'substring';
+    }
+    else {
+      ThrowUserError('search_field_operator_invalid',
+        {field => 'is_triaged', operator => $op});
+    }
+  }
 }
 
 # Allow to use Firefox release date pronouns, including `%LAST_MERGE_DATE%`,
@@ -2591,8 +2747,9 @@ sub tf_buglist_columns {
     foreach my $product (keys %{PRODUCT_CHANNELS()}) {
       foreach my $channel (keys %{PRODUCT_CHANNELS->{$product}}) {
         my ($canonical, $alias) = _get_search_param_name($type, $product, $channel);
+        next unless $canonical || $alias;
 
-        if ($columns->{$canonical} && $canonical) {
+        if ($canonical && $columns->{$canonical}) {
           $columns->{$alias}->{name} = $columns->{$canonical}->{name};
         } else {
           delete $columns->{$alias};
@@ -2611,6 +2768,7 @@ sub tf_buglist_column_joins {
     foreach my $product (keys %{PRODUCT_CHANNELS()}) {
       foreach my $channel (keys %{PRODUCT_CHANNELS->{$product}}) {
         my ($canonical, $alias) = _get_search_param_name($type, $product, $channel);
+        next unless $canonical || $alias;
 
         if ($column_joins->{$canonical} && $canonical) {
           $column_joins->{$alias} = $column_joins->{$canonical};
@@ -2631,6 +2789,7 @@ sub tf_search_operator_field_override {
     foreach my $product (keys %{PRODUCT_CHANNELS()}) {
       foreach my $channel (keys %{PRODUCT_CHANNELS->{$product}}) {
         my ($canonical, $alias) = _get_search_param_name($type, $product, $channel);
+        next unless $canonical || $alias;
 
         if ($operators->{$canonical} && $canonical) {
           $operators->{$alias} = $operators->{$canonical};

--- a/extensions/BMO/lib/Data.pm
+++ b/extensions/BMO/lib/Data.pm
@@ -20,7 +20,8 @@ our @EXPORT = qw( $cf_visible_in_products
   %group_auto_cc
   %create_bug_formats
   @default_named_queries
-  %autodetect_attach_urls );
+  %autodetect_attach_urls
+  @triage_keyword_products );
 
 # Creating an attachment whose contents is a URL matching one of these regexes
 # will result in the user being redirected to that URL when viewing the
@@ -165,6 +166,27 @@ tie(
     "Toolkit"                             => [],
     "WebExtensions"                       => [],
   },
+);
+
+# Products that use the triage keyword.
+our @triage_keyword_products = (
+    'Conduit',
+    'Core',
+    'DevTools',
+    'External Software Affecting Firefox',
+    'Fenix',
+    'Firefox Build System',
+    'Firefox for Android',
+    'Firefox for iOS',
+    'Firefox',
+    'GeckoView',
+    'JSS',
+    'NSPR',
+    'NSS',
+    'Remote Protocol',
+    'Testing',
+    'Toolkit',
+    'WebExtensions',
 );
 
 # Who to CC on particular bugmails when certain groups are added or removed.

--- a/extensions/BMO/template/en/default/hook/bug/edit-after_op_sys.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/bug/edit-after_op_sys.html.tmpl
@@ -9,12 +9,17 @@
 [%# because the "from reporter" button adds likely unnecessary noise to a bug,
   # we only show it on unconfirmed or untriaged bugs %]
 [%
-  RETURN UNLESS
-    (bug.status.value == "UNCONFIRMED" || bug.component == "Untriaged")
-    && bug.check_can_change_field('op_sys', 0, 1).allowed;
+  RETURN UNLESS bug.check_can_change_field('op_sys', 0, 1).allowed;
+
   hw_os = bug.reporters_hw_os;
   RETURN UNLESS hw_os.size;
   RETURN IF bug.rep_platform == hw_os.0 && bug.op_sys == hw_os.1;
+
+  IF bug.uses_triaged_keyword;
+    RETURN IF bug.has_keyword("triaged");
+  ELSE;
+    RETURN IF bug.status.value != "UNCONFIRMED" || bug.component != "Untriaged";
+  END;
 
   title = "Set platform to reporter's: " _ hw_os.0 _ " / " _ hw_os.1;
 %]
@@ -34,9 +39,17 @@
 [% END %]
 
 [% BLOCK modal %]
-  <button id="rep_hw_os" type="button" class="secondary" title="[% title FILTER html %]">
-    From&nbsp;Reporter
-  </button>
+  [% WRAPPER bug_modal/field.html.tmpl
+        label = ""
+        no_label = 1
+        hide_on_view =1
+        container = 1
+        no_indent = 1
+  %]
+    <button id="rep_hw_os" type="button" class="secondary" title="[% title FILTER html %]">
+      Set Platform from Reporter
+    </button>
+  [% END %]
 [% END %]
 
 <script [% script_nonce FILTER none %]>

--- a/extensions/BMO/template/en/default/hook/global/user-error-errors.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/global/user-error-errors.html.tmpl
@@ -56,4 +56,8 @@
   The pronoun for the merge date and release date cannot be used at this time.
   Please try again later or use actual dates instead.
 
+[% ELSIF error == "triage_severity_required" %]
+  [% title = "Missing Bug Severity" %]
+  Severity of S1-S4 is required to mark a [% terms.bug %] as triaged.
+
 [% END %]

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -285,6 +285,9 @@
       <span class="bug-status-label text" data-status="[% bug.isopened ? 'open' : 'closed' %]">
         [%~ bug.isopened ? 'Open' : 'Closed' ~%]
       </span>
+      [% IF bug.is_untriaged %]
+        <span class="bug-status-label text" data-status="untriaged">Untriaged</span>
+      [% END %]
       <span id="field-value-bug_id">
         <a href="[% basepath _ "show_bug.cgi?id=" _ bug.id FILTER html %]">
           [%~ terms.Bug _ " " _ bug.id FILTER none ~%]
@@ -343,6 +346,13 @@
   sub.push(bug.product _ " :: " _ bug.component);
   sub.push(bug.bug_type);
   sub.push(bug.priority) IF bug.priority != "--";
+  IF bug.uses_triaged_keyword;
+    IF bug.has_keyword("triaged");
+      sub.push("triaged");
+    ELSIF bug.is_untriaged;
+      sub.push("untriaged");
+    END;
+  END;
 %]
 [% WRAPPER bug_modal/module.html.tmpl
   title = "Categories"
@@ -481,8 +491,9 @@
           inline = 1
       %]
       [% WRAPPER bug_modal/field.html.tmpl
+          no_label = 1
+          no_indent = 1
           container = 1
-          inline = 1
       %]
         [% Hook.process("after_op_sys", 'bug/edit.html.tmpl') %]
       [% END %]
@@ -544,6 +555,18 @@
             hide_on_edit = !user.in_group('rank-setters')
             help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#rank"
         %]
+      [% END %]
+    [% END %]
+
+    [% IF bug.is_untriaged && user.can_triage %]
+      [% WRAPPER bug_modal/field.html.tmpl
+          label = ""
+          hide_on_view =1
+          container = 1
+      %]
+        <button type="button" class="secondary" id="mark-as-triaged-btn">
+          Mark as Triaged
+        </button>
       [% END %]
     [% END %]
 

--- a/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
@@ -93,6 +93,7 @@
     is_insider: [% user.is_insider ? "true" : "false" %],
     is_timetracker: [% user.is_timetracker ? "true" : "false" %],
     can_tag: [% user.can_tag_comments ? "true" : "false" %],
+    can_triage: [% user.can_triage ? "true" : "false" %],
     timezone: '[% user.timezone.name FILTER js %]',
     settings: {
       quote_replies: '[% user.settings.quote_replies.value FILTER js %]',

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -22,10 +22,10 @@
   padding: 1px 0;
 }
 
-.inline {
-  display: table-cell !important;
-  width: auto !important;
-  vertical-align: middle !important;
+.module .field .inline {
+  display: table-cell;
+  width: auto;
+  vertical-align: middle;
 }
 
 .offscreen {
@@ -285,6 +285,14 @@ input[type="number"] {
 }
 
 #field-status_summary .bug-status-label[data-status="closed"] {
+  background-color: var(--bug-status-color-closed);
+}
+
+#field-status_summary .bug-status-label[data-status="untriaged"] {
+  background-color: var(--bug-status-color-untriaged);
+}
+
+#field-status_summary .bug-status-label {
   background-color: var(--bug-status-color-closed);
 }
 
@@ -1067,9 +1075,10 @@ h3.change-name a {
 }
 
 #floating-message {
-  position: absolute;
+  position: fixed;
   left: 50%;
-  margin: 4px;
+  top: 50px;
+  z-index: 100;
 }
 
 #floating-message-text {

--- a/extensions/MozChangeField/web/js/severity-s1-priority-p1.js
+++ b/extensions/MozChangeField/web/js/severity-s1-priority-p1.js
@@ -31,6 +31,7 @@ Bugzilla.SeverityS1PriorityP1 = class SeverityS1PriorityP1 {
    * Called when severity select is changed. Updated priority field options appropriately
    */
   severity_onselect() {
+    if (!(this.priority && this.severity)) return;
     const s1_selected = this.severity.value === 'S1';
     const options = this.priority.querySelectorAll("option");
     options.forEach(opt => opt.disabled = s1_selected);

--- a/qa/t/test_bug_edit.t
+++ b/qa/t/test_bug_edit.t
@@ -40,7 +40,7 @@ check_page_load($sel, q{http://HOSTNAME/editgroups.cgi});
 $sel->title_is("Edit Groups");
 $sel->click_ok("link=Master");
 check_page_load($sel,
-  q{http://HOSTNAME/editgroups.cgi?action=changeform&group=27});
+  q{http://HOSTNAME/editgroups.cgi?action=changeform&group=28});
 $sel->title_is("Change Group: Master");
 my $group_url = $sel->get_location();
 $group_url =~ /group=(\d+)$/;

--- a/scripts/bug1764246.pl
+++ b/scripts/bug1764246.pl
@@ -1,0 +1,119 @@
+#!/usr/bin/env perl
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+use 5.10.1;
+use strict;
+use warnings;
+use lib qw(. lib local/lib/perl5);
+
+use Bugzilla;
+use Bugzilla::Bug;
+use Bugzilla::Constants;
+use Bugzilla::Group;
+use Bugzilla::Search;
+use Getopt::Long;
+use URI qw();
+
+BEGIN { Bugzilla->extensions(); }
+
+# Bug 1764246
+# Use "triaged" keyword to track bug's triaged state instead of severity
+#
+# Adds triaged keyword to open Firefox bugs with a valid severity set.
+
+use Bugzilla::Extension::BMO::Data qw(@triage_keyword_products);
+
+Bugzilla->usage_mode(USAGE_MODE_CMDLINE);
+
+my $dbh = Bugzilla->dbh;
+
+# Make all changes as the automation user
+my $auto_user = Bugzilla::User->check({name => 'automation@bmo.tld'});
+$auto_user->{groups}       = [Bugzilla::Group->get_all];
+$auto_user->{bless_groups} = [Bugzilla::Group->get_all];
+Bugzilla->set_user($auto_user);
+
+my $query = {
+  product       => \@triage_keyword_products,
+  resolution    => '---',
+  keywords      => 'triaged',
+  keywords_type => 'nowords',
+  f1            => 'bug_severity',
+  o1            => 'notequals',
+  v1            => '--',
+};
+
+# Show the buglist URL to to make it easier to sanity check
+my $url = URI->new('https://bugzilla.mozilla.org/buglist.cgi');
+$url->query_form(%$query);
+say "$url\n";
+
+my $search = Bugzilla::Search->new(fields => ['bug_id'], params => $query,);
+my ($data) = $search->data;
+
+my $bug_count = @$data;
+if ($bug_count == 0) {
+  warn "There are no bugs to update.\n";
+  exit 1;
+}
+
+print STDERR <<"EOF";
+About to update $bug_count bugs by adding the triaged keyword.
+
+Press <Ctrl-C> to stop or <Enter> to continue...
+EOF
+getc();
+
+my $severity_fieldid = Bugzilla::Field->check({name => 'bug_severity'})->id;
+
+my $i = 0;
+foreach my $row (@$data) {
+  $i++;
+  my $bug_id = shift @$row;
+  warn "$i/$bug_count Bug $bug_id\n";
+
+  $dbh->bz_start_transaction;
+
+  my $bug      = Bugzilla::Bug->new($bug_id);
+  my $delta_ts = $bug->delta_ts;
+
+  # Add the keyword
+  $bug->modify_keywords(['triaged'], 'add');
+
+  # Find the timestamp when severity was first set to a S* value
+  my $triaged_ts = $dbh->selectrow_array(
+    "SELECT bug_when FROM bugs_activity
+      WHERE bug_id = ?
+            AND fieldid = $severity_fieldid
+            AND added IS NOT NULL
+            AND added LIKE 'S%'
+      ORDER BY bug_when ASC LIMIT 1", undef, $bug->id
+  );
+
+  # If no timestamp was found in the activity table, it was added
+  # at the time the bug was created
+  $triaged_ts ||= $bug->creation_ts;
+
+  # Update database, using the triaged timestamp as the delta_ts; mostly for
+  # the bugs_activity entry, but this will also set the bug's delta_ts
+  $bug->update($triaged_ts);
+
+  # Restore bug's delta_ts to its original value
+  $dbh->do('UPDATE bugs SET delta_ts = ? WHERE bug_id = ?',
+    undef, $delta_ts, $bug->id);
+
+  # Tidy up
+  Bugzilla::Hook::process('request_cleanup');
+  Bugzilla::Bug->CLEANUP;
+  Bugzilla->clear_request_cache(
+    except => [qw(user dbh dbh_main dbh_shadow memcached)]);
+
+  $dbh->bz_commit_transaction;
+}
+
+Bugzilla->memcached->clear_all();

--- a/scripts/generate_bmo_data.pl
+++ b/scripts/generate_bmo_data.pl
@@ -450,6 +450,13 @@ my @groups = (
     all_products => 0,
     bug_group    => 1,
   },
+  {
+    name => 'can_triage_bugs',
+    description  => 'Can triage bugs (via the "triaged" keyword)',
+    no_admin     => 0,
+    all_products => 0,
+    bug_group    => 0,
+  },
 );
 
 print "creating groups...\n";
@@ -825,7 +832,11 @@ my @keywords = (
   },
   {
     name        => 'crash',
-    description => ' A Critical Severity bug which causes a crash.'
+    description => 'A Critical Severity bug which causes a crash.'
+  },
+  {
+    name        => 'triaged',
+    description => 'Bugs that have been triaged.'
   },
 );
 

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -2794,6 +2794,7 @@ pre.comment-text {
 :root {
   --bug-status-color-open: #188716;
   --bug-status-color-closed: #1B6AB8;
+  --bug-status-color-untriaged: #1B9BB8;
   --bug-type-color-defect: #EA3C3D;
   --bug-type-color-enhancement: #2ABA27;
   --bug-type-color-task: #2886C9;


### PR DESCRIPTION
Note: requires manual creation of a `can_triage_bugs` group, and a
`triaged` keyword.

- limits most features to products that follow Firefox triage processes
- adds "Mark as Triaged" button to show_bug, visible only to
  can_triage_bugs members
- adds an indicator on show_bug when a bug is not triaged
- requires a severity to be set when adding the triaged keyword
- prevents users that are not in can_triage_bugs from being able to add
  or remove the triaged keyword
- removes the triaged keyword when cloning bugs
- adds "is triaged" as a search field
  - to find untriaged bugs use either:
    - "is triaged" "is empty"
    - "is triaged" "equals" "false" (or "no")
- add "is triaged" as an optional column to search results
  - displays as "Yes" or "No"
- add migration script
  - adds triaged keyword to all open bugs that have a severity set
  - sets the timestamp of the keyword addition to the same as when
    severity was first set
  - does not change a bug's last-modified
  - does not generate email