### PR TITLE
Bug 1767526 - Add auditing to the Voting extension to record changes to votes for bug and user

### DIFF
--- a/extensions/Voting/Extension.pm
+++ b/extensions/Voting/Extension.pm
@@ -21,6 +21,8 @@ use Bugzilla::User;
 use Bugzilla::Util qw(detaint_natural);
 use Bugzilla::Token;
 
+use Bugzilla::Extension::Voting::Vote;
+
 use List::Util qw(min sum);
 
 use constant VERSION               => BUGZILLA_VERSION;
@@ -59,6 +61,7 @@ sub db_schema_abstract_schema {
   my ($self, $args) = @_;
   $args->{'schema'}->{'votes'} = {
     FIELDS => [
+      id  => {TYPE => 'SMALLSERIAL', NOTNULL => 1, PRIMARYKEY => 1},
       who => {
         TYPE       => 'INT3',
         NOTNULL    => 1,
@@ -109,6 +112,9 @@ sub install_update_db {
     $dbh->bz_alter_column('products', 'maxvotesperbug',
       {TYPE => 'INT2', NOTNULL => 1, DEFAULT => DEFAULT_VOTES_PER_BUG});
   }
+
+  $dbh->bz_add_column('votes', 'id',
+    {TYPE => 'SMALLSERIAL', NOTNULL => 1, PRIMARYKEY => 1});
 }
 
 ###########
@@ -438,16 +444,11 @@ sub _page_user {
 
     # Make sure there is an entry for this bug
     # in the vote table, just so that things display right.
-    my $has_votes = $dbh->selectrow_array(
-      'SELECT vote_count FROM votes
-                                               WHERE bug_id = ? AND who = ?', undef,
-      ($bug->id, $who->id)
-    );
-    if (!$has_votes) {
-      $dbh->do(
-        'INSERT INTO votes (who, bug_id, vote_count)
-                      VALUES (?, ?, 0)', undef, ($who->id, $bug->id)
-      );
+    my $vote_obj = Bugzilla::Extension::Voting::Vote->new(
+      {condition => 'bug_id = ? AND who = ?', values => [$bug->id, $who->id]});
+    if (!$vote_obj) {
+      Bugzilla::Extension::Voting::Vote->create(
+        {who => $who->id, bug_id => $bug->id, vote_count => 0});
     }
   }
 
@@ -500,7 +501,11 @@ sub _page_user {
   }
 
   if ($canedit && $bug) {
-    $dbh->do('DELETE FROM votes WHERE vote_count = 0 AND who = ?', undef, $who->id);
+    my $vote_objs = Bugzilla::Extension::Voting::Vote->match(
+      {who => $who->id, vote_count => 0});
+    foreach my $vote_obj (@{$vote_objs}) {
+      $vote_obj->remove_from_db();
+    }
   }
   $dbh->bz_commit_transaction();
 
@@ -608,23 +613,10 @@ sub _update_votes {
   # Update the user's votes in the database.
   $dbh->bz_start_transaction();
 
-  my $old_list = $dbh->selectall_arrayref(
-    'SELECT bug_id, vote_count FROM votes
-                                             WHERE who = ?', undef, $who
-  );
-
-  my %old_votes = map { $_->[0] => $_->[1] } @$old_list;
-
-  my $sth_insertVotes = $dbh->prepare(
-    'INSERT INTO votes (who, bug_id, vote_count)
-                                         VALUES (?, ?, ?)'
-  );
-  my $sth_updateVotes = $dbh->prepare(
-    'UPDATE votes SET vote_count = ?
-                                         WHERE bug_id = ? AND who = ?'
-  );
-
-  my %affected = map { $_ => 1 } (@buglist, keys %old_votes);
+  my $vote_objs    = Bugzilla::Extension::Voting::Vote->match({who => $who});
+  my %vote_obj_map = map { $_->bug_id => $_ } @{$vote_objs};
+  my %old_votes    = map { $_->bug_id => $_->vote_count } @{$vote_objs};
+  my %affected     = map { $_ => 1 } (@buglist, keys %old_votes);
   my @deleted_votes;
 
   foreach my $id (keys %affected) {
@@ -639,19 +631,19 @@ sub _update_votes {
 
     # We use 'defined' in case 0 was accidentally stored in the DB.
     if (defined $old_votes{$id}) {
-      $sth_updateVotes->execute($votes{$id}, $id, $who);
+      $vote_obj_map{$id}->set_vote_count($votes{$id});
+      $vote_obj_map{$id}->update();
     }
     else {
-      $sth_insertVotes->execute($who, $id, $votes{$id});
+      Bugzilla::Extension::Voting::Vote->create(
+        {who => $who, bug_id => $id, vote_count => $votes{$id}});
     }
   }
 
   if (@deleted_votes) {
-    $dbh->do(
-      'DELETE FROM votes WHERE who = ? AND '
-        . $dbh->sql_in('bug_id', \@deleted_votes),
-      undef, $who
-    );
+    foreach my $id (@deleted_votes) {
+      $vote_obj_map{$id}->remove_from_db();
+    }
   }
 
   # Update the cached values in the bugs table
@@ -662,7 +654,7 @@ sub _update_votes {
                                       WHERE bug_id = ?"
   );
 
-  $sth_updateVotes = $dbh->prepare('UPDATE bugs SET votes = ? WHERE bug_id = ?');
+  my $sth_updateVotes = $dbh->prepare('UPDATE bugs SET votes = ? WHERE bug_id = ?');
 
   foreach my $id (keys %affected) {
     $sth_getVotes->execute($id);

--- a/extensions/Voting/lib/Vote.pm
+++ b/extensions/Voting/lib/Vote.pm
@@ -44,9 +44,10 @@ use constant VALIDATORS => {vote_count => \&_check_vote_count};
 ################################
 
 # We override the parent audit_log so we can store the bug id
-# value instead of the vote table id. Also is we are creating a
+# value instead of the vote table id. Also when we are creating a
 # new vote table entry, then we record it as a vote_count change
-# from 0 to the new count or vice versa.
+# from 0 to the new count and the opposite when removing a vote
+# table entry.
 sub audit_log {
   my ($self, $changes) = @_;
   my $new_changes = $changes;

--- a/extensions/Voting/lib/Vote.pm
+++ b/extensions/Voting/lib/Vote.pm
@@ -1,0 +1,92 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::Extension::Voting::Vote;
+
+use 5.10.1;
+use strict;
+use warnings;
+
+use base qw(Bugzilla::Object);
+
+use Bugzilla::Constants;
+use Bugzilla::Error;
+
+use Scalar::Util qw(looks_like_number);
+
+################################
+####     Initialization     ####
+################################
+
+use constant DB_TABLE   => 'votes';
+use constant LIST_ORDER => 'bug_id';
+use constant ID_FIELD   => 'id';
+
+use constant DB_COLUMNS => qw(
+  id
+  who
+  bug_id
+  vote_count
+);
+
+use constant UPDATE_COLUMNS => qw(
+  vote_count
+);
+
+use constant VALIDATORS => {vote_count => \&_check_vote_count};
+
+################################
+####     Overrides          ####
+################################
+
+# We override the parent audit_log so we can store the bug id
+# value instead of the vote table id. Also is we are creating a
+# new vote table entry, then we record it as a vote_count change
+# from 0 to the new count or vice versa.
+sub audit_log {
+  my ($self, $changes) = @_;
+  my $new_changes = $changes;
+
+  if ($changes eq AUDIT_CREATE || $changes eq AUDIT_REMOVE) {
+    return if $self->vote_count == 0; # Do not record if changing from 0 to 0
+    my @added_removed = $changes eq AUDIT_CREATE ? (0, $self->vote_count) : ($self->vote_count, 0);
+    $new_changes = {vote_count => \@added_removed};
+  }
+
+  local $self->{id} = $self->bug_id;
+
+  $self->SUPER::audit_log($new_changes);
+}
+
+################################
+####     Validators         ####
+################################
+
+sub _check_vote_count {
+  my ($invocant, $count) = @_;
+  if ($count !~ /^[0-9]+$/) {
+    ThrowCodeError('voting_count_invalid', {count => $count});
+  }
+  return $count;
+}
+
+###############################
+####     Methods           ####
+###############################
+
+sub set_vote_count { $_[0]->set('vote_count', $_[1]); }
+
+###############################
+####     Accessors         ####
+###############################
+
+sub id         { return $_[0]->{'id'}; }
+sub who        { return $_[0]->{'who'}; }
+sub bug_id     { return $_[0]->{'bug_id'}; }
+sub vote_count { return $_[0]->{'vote_count'}; }
+
+1;

--- a/extensions/Voting/template/en/default/hook/global/code-error-errors.html.tmpl
+++ b/extensions/Voting/template/en/default/hook/global/code-error-errors.html.tmpl
@@ -22,4 +22,9 @@
     [% title = "$terms.Bug Cannot Be Confirmed" %]
     There is no valid transition from
     [%+ display_value("bug_status", "UNCONFIRMED") FILTER html %] to an open state
+
+[% ELSIF error == "voting_count_invalid" %]
+    [% title = "Invalid Vote Count" %]
+    The vote count provided '[% count FILTER html %]' is not a valid integer.
+
 [% END %]


### PR DESCRIPTION
* Create a new Vote.pm class that stores the current vote data for a given user and bug id. By subclassing Object.pm we get the create() and remove_from_db() methods.
* Since there is not currently a table to track vote changes per user/bug over time, I decided to use the audit_log table to record the changes since they do not need to be visible in the UI. The audit_log table was not exactly compatible so I overrode the audit_log() method to use the bug_id as the identifier instead of the object id (normally the primary key of the table).
* Extension.pm changes are mostly to remove the direct SQL calls where appropriate and use the object methods for storing instead.