### PR TITLE
Bug 1769246 - Make the header always above main content, in order to show request menu above other notifications.

### DIFF
--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -986,7 +986,7 @@ input[type="radio"]:checked {
     height: 48px;
     position: fixed;
     width: 100%;
-    z-index: 5;
+    z-index: 11;
   }
 
   #bugzilla-body {


### PR DESCRIPTION
`.new-changes-link` has `z-index: 10`, so header should have higher z-index, so that `.dropdown-content` inside it is shown above `.new-changes-link`