### PR TITLE
Bug 1769284 - Show phabricator links in user_profile

### DIFF
--- a/extensions/PhabBugz/Extension.pm
+++ b/extensions/PhabBugz/Extension.pm
@@ -33,6 +33,9 @@ sub template_before_process {
   return unless Bugzilla->user->id;
   return unless Bugzilla->params->{phabricator_enabled};
   return unless Bugzilla->params->{phabricator_base_uri};
+
+  $vars->{phabricator_available} = 1;
+
   return unless $file =~ /bug_modal\/(header|edit).html.tmpl$/;
 
   if (my $bug = exists $vars->{'bugs'} ? $vars->{'bugs'}[0] : $vars->{'bug'}) {

--- a/extensions/PhabBugz/lib/WebService.pm
+++ b/extensions/PhabBugz/lib/WebService.pm
@@ -211,6 +211,8 @@ sub user {
 
   $self->_check_phabricator();
 
+  Bugzilla->login(LOGIN_REQUIRED);
+
   my $bmo_user_id = $params->{user_id};
 
   my $response = request(

--- a/extensions/PhabBugz/web/js/phab_user.js
+++ b/extensions/PhabBugz/web/js/phab_user.js
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This Source Code Form is "Incompatible With Secondary Licenses", as
+ * defined by the Mozilla Public License, v. 2.0.
+ */
+
+var PhabUser = {};
+
+PhabUser.getUser = async () => {
+    var userCell = $('#phab_user');
+    var revisionsCell = $('#phab_revisions');
+    if (!userCell || !revisionsCell) {
+      return;
+    }
+
+    var user_id = userCell.data('target-user-id');
+
+    userCell.text('Loading...');
+    revisionsCell.text('Loading...');
+
+    try {
+        var { user } = await Bugzilla.API.get(`phabbugz/user/${user_id}`);
+        if (!user) {
+            userCell.text('Not Found');
+            revisionsCell.text('Not Found');
+            return;
+        }
+
+        var userLink = $('<a/>');
+        userLink.attr('href', user.userURL);
+        userLink.text(`${user.userName} (${user.realName})`);
+        userCell.text('');
+        userCell.append(userLink);
+
+        var revisionsLink = $('<a/>');
+        revisionsLink.attr('href', user.revisionsURL);
+        revisionsLink.text('Open revisions');
+        revisionsCell.text('');
+        revisionsCell.append(revisionsLink);
+    } catch ({ message }) {
+        userCell.text(message);
+        revisionsCell.text('');
+    }
+};
+
+
+$().ready(function() {
+    PhabUser.getUser();
+});

--- a/extensions/PhabBugz/web/js/phab_user.js
+++ b/extensions/PhabBugz/web/js/phab_user.js
@@ -9,43 +9,46 @@
 var PhabUser = {};
 
 PhabUser.getUser = async () => {
-    var userCell = $('#phab_user');
-    var revisionsCell = $('#phab_revisions');
+    var userCell = document.getElementById("phab_user");
+    var revisionsCell = document.getElementById("phab_revisions");
     if (!userCell || !revisionsCell) {
       return;
     }
 
-    var user_id = userCell.data('target-user-id');
+    var user_id = userCell.getAttribute("data-target-user-id");
 
-    userCell.text('Loading...');
-    revisionsCell.text('Loading...');
+    userCell.textContent = "Loading...";
+    revisionsCell.textContent = "Loading...";
+
+    function displayLoadError(errStr) {
+        userCell.textContent = errStr;
+        revisionsCell.textContent = "";
+    }
 
     try {
         var { user } = await Bugzilla.API.get(`phabbugz/user/${user_id}`);
         if (!user) {
-            userCell.text('Not Found');
-            revisionsCell.text('Not Found');
+            userCell.textContent = "Not Found";
+            revisionsCell.textContent = "Not Found";
             return;
         }
 
-        var userLink = $('<a/>');
-        userLink.attr('href', user.userURL);
-        userLink.text(`${user.userName} (${user.realName})`);
-        userCell.text('');
-        userCell.append(userLink);
+        var userLink = document.createElement("a");
+        userLink.setAttribute("href", user.userURL);
+        userLink.textContent = `${user.userName} (${user.realName})`;
+        userCell.textContent = "";
+        userCell.appendChild(userLink);
 
-        var revisionsLink = $('<a/>');
-        revisionsLink.attr('href', user.revisionsURL);
-        revisionsLink.text('Open revisions');
-        revisionsCell.text('');
-        revisionsCell.append(revisionsLink);
+        var revisionsLink = document.createElement("a");
+        revisionsLink.setAttribute("href", user.revisionsURL);
+        revisionsLink.textContent = "Open revisions";
+        revisionsCell.textContent = "";
+        revisionsCell.appendChild(revisionsLink);
     } catch ({ message }) {
-        userCell.text(message);
-        revisionsCell.text('');
+        displayLoadError('Error: ' + message);
     }
 };
 
-
-$().ready(function() {
+document.addEventListener("DOMContentLoaded", function(event) {
     PhabUser.getUser();
 });

--- a/extensions/UserProfile/template/en/default/pages/user_profile.html.tmpl
+++ b/extensions/UserProfile/template/en/default/pages/user_profile.html.tmpl
@@ -191,7 +191,7 @@
   <tr>
     <td>&nbsp;</td>
     <th>User</th>
-    <td colspan="2" id="phab_user" data-target-user-id="[% target.id %]"></td>
+    <td colspan="2" id="phab_user" data-target-user-id="[% target.id FILTER html %]"></td>
   </tr>
   <tr>
     <td>&nbsp;</td>

--- a/extensions/UserProfile/template/en/default/pages/user_profile.html.tmpl
+++ b/extensions/UserProfile/template/en/default/pages/user_profile.html.tmpl
@@ -13,11 +13,18 @@
 [% ELSE %]
   [% filtered_identity = target.name || target.address.user FILTER html %]
 [% END %]
+
+[% javascript_urls = [ "js/field.js" ] %]
+
+[% IF phabricator_available %]
+[% javascript_urls.push('extensions/PhabBugz/web/js/phab_user.js') %]
+[% END %]
+
 [% PROCESS global/header.html.tmpl
    title = "User Profile: $filtered_identity"
    generate_api_token = 1
    style_urls = [ "extensions/UserProfile/web/styles/user_profile.css" ]
-   javascript_urls = [ "js/field.js" ]
+   javascript_urls = javascript_urls
 %]
 
 <table id="user_profile_table">
@@ -171,6 +178,25 @@
       [% target.needinfo_request_count FILTER html %]
       [% "</a>" IF user.id %]
     </td>
+  </tr>
+[% END %]
+
+[% IF phabricator_available %]
+  <tr>
+    <td colspan="4" class="separator"><hr></td>
+  </tr>
+  <tr>
+    <td>Phabricator</td>
+  </tr>
+  <tr>
+    <td>&nbsp;</td>
+    <th>User</th>
+    <td colspan="2" id="phab_user" data-target-user-id="[% target.id %]"></td>
+  </tr>
+  <tr>
+    <td>&nbsp;</td>
+    <th>Revisions</th>
+    <td colspan="2" id="phab_revisions"></td>
   </tr>
 [% END %]
 


### PR DESCRIPTION
This adds 2 links in the `user_profile` page in new "Phabricator" section, under "Review Queue" section.
One link for user's profile page that shows recent activity: [example](https://phabricator.services.mozilla.com/p/arai/)
Other link for user's open revisions: [example](https://phabricator.services.mozilla.com/differential/?responsiblePHIDs[0]=PHID-USER-ovlr37yfp3loy53g6wgo&statuses[0]=open()&order=newest&bucket=action)

~~The data is retrieved during showing the user_profile page, with 2 requests, 5 seconds timeout for each.~~
~~If any error happens (including the user not found on phabricator), or if phabricator is not configured, nothing is shown.~~
