### PR TITLE
Bug 1769541 - Update group permission needed to view the groups a user is a member of using the REST API

### DIFF
--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -309,7 +309,7 @@ sub get {
       last_activity_time => $self->type('dateTime', $user->last_activity_time),
       };
 
-    if (Bugzilla->user->in_group('editusers')) {
+    if (Bugzilla->user->in_group('disableusers')) {
       $user_info->{email_enabled}     = $self->type('boolean', $user->email_enabled);
       $user_info->{login_denied_text} = $self->type('string',  $user->disabledtext);
     }
@@ -322,7 +322,9 @@ sub get {
     }
 
     if (filter_wants($params, 'groups')) {
-      if (Bugzilla->user->id == $user->id || Bugzilla->user->in_group('editusers')) {
+      if ( Bugzilla->user->id == $user->id
+        || Bugzilla->user->in_group('mozilla-employee-confidential'))
+      {
         $user_info->{groups} = [map { $self->_group_to_hash($_) } @{$user->groups}];
       }
       else {

--- a/docs/en/rst/api/core/v1/user.rst
+++ b/docs/en/rst/api/core/v1/user.rst
@@ -361,14 +361,16 @@ name                string    The login name of the user. Note that in some
 can_login           boolean   A boolean value to indicate if the user can login
                               into Bugzilla.
 email_enabled       boolean   A boolean value to indicate if bug-related mail will
-                              be sent to the user or not.
+                              be sent to the user or not. Only users in the
+                              *disableusers* group can see this field.
 login_denied_text   string    A text field that holds the reason for disabling a
                               user from logging into Bugzilla. If empty then the
                               user account is enabled; otherwise it is
-                              disabled/closed.
+                              disabled/closed. Only users in the *disableusers*
+                              group can see this field.
 groups              array     Groups the user is a member of. If the currently
                               logged in user is querying their own account or is a
-                              member of the 'editusers' group, the array will
+                              member of a privileged permission group, the array will
                               contain all the groups that the user is a member of.
                               Otherwise, the array will only contain groups that
                               the logged in user can bless. Each object describes


### PR DESCRIPTION
If a user is a member of `mozilla-employee-confidential` then they are by default able to see the groups a user is a member of. This should be ok for employees to see but not the general public. The old group was `editusers` which was too narrow and a group we cannot just add people to for no good reason. Another part that used the `editusers` group was viewing whether a user was disabled or not and if they had email turned off. I changed that to be `disabledusers` instead which is the permission group allowed to edit those fields for any user in BMO anyway. 