### PR TITLE
Bug 1678376 - Make t/001compile.t Great Again

### DIFF
--- a/Bugzilla/Attachment/Archive.pm
+++ b/Bugzilla/Attachment/Archive.pm
@@ -80,7 +80,7 @@ sub _build_input_fh {
     croak "I will not read and write a file at the same time";
   }
   my $file = $self->file;
-  return IO::File->new($self->file, '<:bytes') or die "cannot read $file: $!";
+  return IO::File->new($self->file, '<:bytes') || die "cannot read $file: $!";
 }
 
 sub _build_output_fh {

--- a/t/001compile.t
+++ b/t/001compile.t
@@ -20,16 +20,20 @@ use Support::Files;
 use Test::More;
 
 BEGIN {
-  if ($ENV{CI}) {
-    plan skip_all => 'Not running compile tests in CI.';
-    exit;
-  }
   plan tests => @Support::Files::testitems + @Support::Files::test_files;
 
   use_ok('Bugzilla::Constants');
   use_ok('Bugzilla::Install::Requirements');
   use_ok('Bugzilla');
+
+  if (-f 'data/db/model_test') {
+    unlink 'data/db/model_test' || die $!;
+  }
+  $ENV{test_db_name} = 'model_test';
 }
+
+use Bugzilla::Test::MockDB;
+
 Bugzilla->usage_mode(USAGE_MODE_TEST);
 
 sub compile_file {
@@ -45,28 +49,28 @@ sub compile_file {
     return;
   }
 
-  if ($file =~ s/\.pm$//) {
+  if ($file =~ s/[.]pm$//) {
     $file =~ s{/}{::}g;
     use_ok($file);
     return;
   }
 
-  open(my $fh, $file);
+  open my $fh, '<', $file || die $!;
   my $bang = <$fh>;
-  close $fh;
+  close $fh || die $!;
 
-  my $T = "";
+  my $T = '';
   if ($bang =~ m/#!\S*perl\s+-.*T/) {
-    $T = "T";
+    $T = 'T';
   }
 
   my $libs = '-It ';
   if ($ENV{PERL5LIB}) {
-    $libs .= join " ", map {"-I\"$_\""} split /$Config{path_sep}/, $ENV{PERL5LIB};
+    $libs .= join ' ', map {"-I\"$_\""} split /$Config{path_sep}/, $ENV{PERL5LIB};
   }
   my $perl   = qq{"$^X"};
   my $output = `$perl $libs -c$T -MSupport::Systemexec $file 2>&1`;
-  chomp($output);
+  chomp $output;
   my $return_val = $?;
   $output =~ s/^\Q$file\E syntax OK$//ms;
   diag($output) if $output;
@@ -89,15 +93,15 @@ SKIP: {
       skip 'mod_perl.pl cannot be compiled from the command line', 1;
     }
     my $feature = $file_features->{$file};
-    if ($feature and !Bugzilla->feature($feature)) {
+    if ($feature && !Bugzilla->feature($feature)) {
       skip "$file: $feature not enabled", 1;
     }
 
     # Check that we have a DBI module to support the DB, if this
     # is a database module (but not Schema)
-    if ($file =~ m{Bugzilla/DB/([^/]+)\.pm$} and $file ne "Bugzilla/DB/Schema.pm") {
-      my $module = lc($1);
-      Bugzilla->feature($module) or skip "$file: Driver for $module not installed", 1;
+    if ($file =~ m{Bugzilla/DB/([^/]+)[.]pm$} and $file ne 'Bugzilla/DB/Schema.pm') {
+      my $module = lc $1;
+      Bugzilla->feature($module) || skip "$file: Driver for $module not installed", 1;
     }
 
     compile_file($file);

--- a/t/001compile.t
+++ b/t/001compile.t
@@ -27,7 +27,7 @@ BEGIN {
   use_ok('Bugzilla');
 
   if (-f 'data/db/model_test') {
-    unlink 'data/db/model_test' || die $!;
+    unlink 'data/db/model_test' or die $!;
   }
   $ENV{test_db_name} = 'model_test';
 }
@@ -55,9 +55,9 @@ sub compile_file {
     return;
   }
 
-  open my $fh, '<', $file || die $!;
+  open my $fh, '<', $file or die $!;
   my $bang = <$fh>;
-  close $fh || die $!;
+  close $fh or die $!;
 
   my $T = '';
   if ($bang =~ m/#!\S*perl\s+-.*T/) {


### PR DESCRIPTION
Mainly this added some code to create a temp test DB using SQLite to allow the compiling of the Bugzilla/Model/* modules which require a DB. Also some critic warnings fixed in Archive.pm and 001compile.t

This does not *yet* test extension modules as there is added complexity to get them to load without lots of redefined warnings. I will address extensions as a separate bug.