### PR TITLE
Bug 1770528 - Add new audit events

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -815,6 +815,10 @@ sub iprepd_report {
   my $ip      = remote_ip();
   my $ua      = mojo_user_agent({request_timeout => 5});
   my $payload = {object => $ip, type => "ip", violation => $name};
+
+  # We should also audit this so it is recorded in the logs
+  Bugzilla->audit(sprintf 'iprepd: violation %s from ip address %s', $name, $ip);
+
   try {
     my $tx = $ua->put(
       $params->{iprepd_base_url} . '/violations/type/ip/' . $ip,

--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -436,8 +436,9 @@ sub _translate_comment {
 
 sub get {
   my ($self, $params) = validate(@_, 'ids');
+  my $user = Bugzilla->user;
 
-  unless (Bugzilla->user->id) {
+  unless ($user->id) {
     Bugzilla->check_rate_limit("get_bug", remote_ip());
   }
   Bugzilla->switch_to_shadow_db() unless Bugzilla->user->id;
@@ -451,7 +452,7 @@ sub get {
   # Cache permissions for bugs. This highly reduces the number of calls to the DB.
   # visible_bugs() is only able to handle bug IDs, so we have to skip aliases.
   my @int = grep { defined $_ && $_ =~ /^\d+$/ } @$ids;
-  Bugzilla->user->visible_bugs(\@int);
+  $user->visible_bugs(\@int);
 
   foreach my $bug_id (@$ids) {
     my $bug;
@@ -478,11 +479,18 @@ sub get {
 
   $self->_add_update_tokens($params, \@bugs, \@hashes);
 
-  if (Bugzilla->user->id) {
+  if ($user->id) {
     foreach my $bug (@bugs) {
       Bugzilla->log_user_request($bug->id, undef, 'bug-get');
+
+      # Audit when a non-public bug is viewed including the groups the bug belongs to
+      my $groups_in = $bug->groups_in;
+      next if !@$groups_in;
+      Bugzilla->audit(sprintf 'api: %s viewed non-public bug %d belonging to groups %s',
+        $user->login, $bug->id, join ', ', map { $_->name } @$groups_in);
     }
   }
+
   return {bugs => \@hashes, faults => \@faults};
 }
 

--- a/show_bug.cgi
+++ b/show_bug.cgi
@@ -109,6 +109,14 @@ else {
 
 Bugzilla::Bug->preload(\@bugs);
 
+# Audit when a non-public bug is viewed including the groups the bug belongs to
+foreach my $bug (@bugs) {
+  my $groups_in = $bug->groups_in;
+  next if !@$groups_in;
+  Bugzilla->audit(sprintf 'web: %s viewed non-public bug %d belonging to groups %s',
+    $user->login, $bug->id, join ', ', map { $_->name } @$groups_in);
+}
+
 $vars->{'bugs'}  = \@bugs;
 $vars->{'marks'} = \%marks;
 


### PR DESCRIPTION
This PR adds some additional auditing events to the core Bugzilla code that can be used for outside tools to monitor for bug access, etc. All the audit() calls do, as far as Bugzilla is concerned, is log a specially formatted message to the standard error logs. These messages, along with all other logging, go to GCP for storage. The external tools will be looking at GCP to filter out what they need and will be given access by cloudops. So nothing special for Bugzilla admins to do on our end.

The following audit events were added:
* audit | login: invalid password was entered for account dklawren@gmail.com
* audit | login: account dklawren@gmail.com was locked after too many failed attempts
* audit | web: admin@mozilla.bugs viewed non-public bug 1 belonging to groups secret-group-1, secret-group-2
* audit | api: admin@mozilla.bugs viewed non-public bug 1 belonging to groups secret-group-1, secret-group-2

The web and api events are to show that a user accessed a private bug and list the private groups that the bug was under. The login even records when a client has entered the wrong password for a specific user and also when the user account was locked for a specific amount of time.

Also I added a line to audit to the logs anytime we send a violation to iprepd which allows for several additional important events to be recorded such as mfa failures, token failures, etc.

They will look like:
* audit | iprepd: violation bmo.api_key_mismatch from ip address 192.168.112.3
* audit | iprepd: violation bmo.username_password_mismatch from ip address 192.168.112.3
* audit | iprepd: violation bmo.mfa_mismatch from ip address 192.168.112.3