### PR TITLE
Bug 1772402 - Remove chart attachments from the Security Bug Reports

### DIFF
--- a/scripts/secbugsreport.pl
+++ b/scripts/secbugsreport.pl
@@ -141,21 +141,7 @@ my @parts_crit_high = (
       encoding     => 'quoted-printable',
     },
     body_str => $html_crit_high,
-  ),
-  map {
-    Email::MIME->create(
-      header_str => ['Content-ID' => "<$_.png>",],
-      attributes => {
-        filename     => "$_.png",
-        charset      => 'UTF-8',
-        content_type => 'image/png',
-        disposition  => 'inline',
-        name         => "$_.png",
-        encoding     => 'base64',
-      },
-      body => $report_crit_high->graphs->{$_}->slurp,
-    )
-  } sort { $a cmp $b } keys %{$report_crit_high->graphs}
+  )
 );
 
 my @recipients = split /[\s,]+/, Bugzilla->params->{report_secbugs_emails};

--- a/template/en/default/reports/email/security-risk.html.tmpl
+++ b/template/en/default/reports/email/security-risk.html.tmpl
@@ -169,9 +169,7 @@ counted in the report (as long as you do not modify the '[% terms.Bugs %] number
 Keep in mind that you will only be able to see [% terms.bugs %] that you are allowed to see. Also keep in mind that
 this report treats marking a [% terms.bug %] as 'stalled' the same as closing it.
 </p>
-
-<p>Attached to this email are some graphs with stats for the past 12 months.</p>
-
+  
 <p>This report was generated from the live Bugzilla instance. In rare cases, historical statistics may vary from prior reports if [% terms.bugs %] were reclassified after those reports were generated.</p>
 
 </body>


### PR DESCRIPTION
This PR basically just removes code that in the past attached 3 png charts to the security emails that are sent weekly. I have tested the code locally to make sure that the removals did not break the normal HTML tables that are generated in the email bodies.