### PR TITLE
Bug 1773137 - New API endpoints needed for creating new components and editing current ones

### DIFF
--- a/Bugzilla/API/V1/Component.pm
+++ b/Bugzilla/API/V1/Component.pm
@@ -1,0 +1,135 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::API::V1::Component;
+
+use 5.10.1;
+use Mojo::Base qw( Mojolicious::Controller );
+
+use Mojo::JSON qw(decode_json false true);
+use Try::Tiny;
+
+use Bugzilla::Component;
+use Bugzilla::Constants;
+use Bugzilla::Util qw(email_filter trim);
+
+sub setup_routes {
+  my ($class, $r) = @_;
+  my $comp_routes = $r->under(
+    '/component' => sub { Bugzilla->usage_mode(USAGE_MODE_MOJO_REST); });
+  $comp_routes->post('/:product')->to('V1::Component#create');
+  $comp_routes->put('/:product/:component')->to('V1::Component#update');
+  $comp_routes->get('/:product/:component')->to('V1::Component#get');
+}
+
+sub create {
+  my ($self) = @_;
+
+  my $user = $self->bugzilla->login;
+  $user->id || return $self->user_error('login_required');
+
+  $user->in_group('editcomponents')
+    || return $self->user_error('auth_failure',
+    {group => 'editcomponents', action => 'add', object => 'components'});
+
+  my ($params, $error) = $self->_get_params();
+  return $self->user_error($error) if $error;
+
+  my $product = Bugzilla::Product->check({name => $self->param('product')});
+
+  # Check user related fields
+  foreach my $field (qw(default_assignee default_qa_contact triage_owner)) {
+    my $value = trim($params->{$field});
+    next if !$value;
+    my $user = Bugzilla::User->check({name => $value});
+
+    # Triage owner value needs to be in the form of user id, not login
+    $params->{$field} = $user->id if $field eq 'triage_owner';
+  }
+
+  my $create = {
+    name                     => trim($params->{name}                     || ''),
+    description              => trim($params->{description}              || ''),
+    default_bug_type         => trim($params->{default_bug_type}         || ''),
+    initialowner             => trim($params->{default_assignee}         || ''),
+    initialqacontact         => trim($params->{default_qa_contact}       || ''),
+    triage_owner_id          => trim($params->{triage_owner}             || ''),
+    team_name                => trim($params->{team_name}                || ''),
+    bug_description_template => trim($params->{bug_description_template} || ''),
+    product                  => $product,
+  };
+
+  my $component = Bugzilla::Component->create($create);
+
+  return $self->render(json => $self->_component_to_hash($component));
+}
+
+sub update {
+  my ($self) = @_;
+
+  my $user = $self->bugzilla->login;
+  $user->id || return $self->user_error('login_required');
+
+  $user->in_group('editcomponents')
+    || return $self->user_error('auth_failure',
+    {group => 'editcomponents', action => 'modify', object => 'components'});
+
+  my $product   = Bugzilla::Product->check({name => $self->param('product')});
+  my $component = Bugzilla::Component->check(
+    {name => $self->param('component'), product => $product});
+
+  my ($params, $error) = $self->_get_params();
+  return $self->user_error($error) if $error;
+
+  $component->set_all($params);
+  $component->update();
+
+  return $self->render(json => $self->_component_to_hash($component));
+}
+
+sub get {
+  my ($self) = @_;
+  my $user = $self->bugzilla->login;
+
+  my $product   = Bugzilla::Product->check({name => $self->param('product')});
+  my $component = Bugzilla::Component->check(
+    {name => $self->param('component'), product => $product});
+
+  return $self->render(json => $self->_component_to_hash($component));
+}
+
+sub _component_to_hash {
+  my ($self, $component) = @_;
+
+  return {
+    id                       => $component->id,
+    name                     => $component->name,
+    description              => $component->description,
+    default_assignee         => $component->default_assignee->login,
+    default_qa_contact       => $component->default_qa_contact->login,
+    triage_owner             => $component->triage_owner->login,
+    is_active                => $component->is_active ? true : false,
+    default_bug_type         => $component->default_bug_type,
+    team_name                => $component->team_name,
+    bug_description_template => $component->bug_description_template,
+  };
+}
+
+sub _get_params {
+  my ($self) = @_;
+  my $params = {};
+  my $error  = '';
+  try {
+    $params = decode_json($self->req->body);
+  }
+  catch {
+    $error = 'rest_malformed_json';
+  };
+  return ($params, $error);
+}
+
+1;

--- a/docs/en/rst/api/core/v1/component.rst
+++ b/docs/en/rst/api/core/v1/component.rst
@@ -47,7 +47,7 @@ name                      string   The name of the component.
 description               string   A description of the component, which may contain HTML.
 is_active                 boolean  A boolean indicating if the component is active.
 default_bug_type          string   The default type for bugs filed under this component.
-default_assignee       string   The login of the default assignee for the component.
+default_assignee          string   The login of the default assignee for the component.
 default_qa_contact        string   The login of the default assignee for the component.
 triage_owner              string   The login of the default assignee for the component.
 team_name                 string   The team name the component belongs to.
@@ -82,7 +82,7 @@ name                      string  The name of the component.
 description               string  A description of the component, which may contain HTML.
 default_bug_type          string  The default type for bugs filed under this component.
                                   If empty, then product's default bug type is used. (optional).
-default_assignee       string  The login of the default assignee for the component.
+default_assignee          string  The login of the default assignee for the component.
 default_qa_contact        string  The login of the default qa contact for the component (optional).
 triage_owner              string  The login of the triage owner for the component (optional).
 team_name                 string  The team name the component belongs to.
@@ -106,7 +106,7 @@ bug_description_template  string  The string included in the comment field of a 
      "triage_owner": ""
    }
 
-A component object :ref:`_rest_component_object` is returned.
+A component object `rest_component_object`_ is returned.
 
 .. _rest_component_update:
 
@@ -134,7 +134,7 @@ name                      type     description
 name                      string   The name of this component.
 description               string   A description for this component. Allows some simple
                                    HTML.
-default_assignee       string   The login of the default assignee for the component.
+default_assignee          string   The login of the default assignee for the component.
 default_qa_contact        string   The login of the default qa contact for the component.
 default_bug_type          string   The default type for bugs filed under this component.
                                    If empty, then product's default bug type is used.
@@ -172,7 +172,7 @@ bug_description_template  string   The string included in the comment field of a
      }
    }
 
-A component object :ref:`_rest_component_object` is returned.
+A component object `rest_component_object`_ is returned.
 
 The following fields are added to the object:
 

--- a/docs/en/rst/api/core/v1/component.rst
+++ b/docs/en/rst/api/core/v1/component.rst
@@ -1,7 +1,7 @@
 Components
 ==========
 
-This part of the Bugzilla API look at individual components and update their information.
+This part of the Bugzilla API looks at individual components and also allows updating their information.
 
 .. _rest_get_component:
 
@@ -38,9 +38,9 @@ To get information about the General component under the Firefox product:
 
 Component Object
 
-========================  =======  =======================================================
+========================  =======  ========================================================
 name                      type     description
-========================  =======  =======================================================
+========================  =======  ========================================================
 id                        int      An integer ID uniquely identifying the component in
                                    this installation only.
 name                      string   The name of the component.
@@ -48,12 +48,12 @@ description               string   A description of the component, which may con
 is_active                 boolean  A boolean indicating if the component is active.
 default_bug_type          string   The default type for bugs filed under this component.
 default_assignee          string   The login of the default assignee for the component.
-default_qa_contact        string   The login of the default assignee for the component.
-triage_owner              string   The login of the default assignee for the component.
+default_qa_contact        string   The login of the default qa contact for the component.
+triage_owner              string   The login of the default triage owner for the component.
 team_name                 string   The team name the component belongs to.
 bug_description_template  string   The string included in the comment field of a new bug
                                    when the component is selected.
-========================  =======  =======================================================
+========================  =======  ========================================================
 
 .. _rest_component_create:
 

--- a/docs/en/rst/api/core/v1/component.rst
+++ b/docs/en/rst/api/core/v1/component.rst
@@ -1,0 +1,189 @@
+Components
+==========
+
+This part of the Bugzilla API look at individual components and update their information.
+
+.. _rest_get_component:
+
+Get Component
+-------------
+
+This allows you to retrieve information about a specific component.
+
+**Request**
+
+To get information about the General component under the Firefox product:
+
+.. code-block:: text
+
+   GET /rest/component/Firefox/General
+
+**Response**
+
+.. code-block:: js
+
+   {
+     "default_assignee": "nobody@mozilla.org",
+     "default_bug_type": "--",
+     "default_qa_contact": "",
+     "description": "For bugs in Firefox which do not fit into other more specific Firefox components",
+     "id": 2,
+     "is_active": true,
+     "name": "General",
+     "team_name": "Mozilla",
+     "triage_owner": "admin@mozilla.bugs"
+   }
+
+.. _rest_component_object:
+
+Component Object
+
+========================  =======  =======================================================
+name                      type     description
+========================  =======  =======================================================
+id                        int      An integer ID uniquely identifying the component in
+                                   this installation only.
+name                      string   The name of the component.
+description               string   A description of the component, which may contain HTML.
+is_active                 boolean  A boolean indicating if the component is active.
+default_bug_type          string   The default type for bugs filed under this component.
+default_assignee       string   The login of the default assignee for the component.
+default_qa_contact        string   The login of the default assignee for the component.
+triage_owner              string   The login of the default assignee for the component.
+team_name                 string   The team name the component belongs to.
+bug_description_template  string   The string included in the comment field of a new bug
+                                   when the component is selected.
+========================  =======  =======================================================
+
+.. _rest_component_create:
+
+Create Component
+----------------
+
+This allows you to create a new component under a specific product in Bugzilla.
+
+**Request**
+
+To create a new component called ``TestComponent`` under the ``Firefox`` product:
+
+.. code-block:: text
+
+  {
+    "name" : "TestComponent",
+    "description" : "This is a new test component",
+    "default_assignee" : "admin@mozilla.bugs",
+    "team_name" : "Mozilla"
+  }
+
+========================  ======  =================================================================
+name                      type    description
+========================  ======  =================================================================
+name                      string  The name of the component.
+description               string  A description of the component, which may contain HTML.
+default_bug_type          string  The default type for bugs filed under this component.
+                                  If empty, then product's default bug type is used. (optional).
+default_assignee       string  The login of the default assignee for the component.
+default_qa_contact        string  The login of the default qa contact for the component (optional).
+triage_owner              string  The login of the triage owner for the component (optional).
+team_name                 string  The team name the component belongs to.
+bug_description_template  string  The string included in the comment field of a new bug
+                                  when the component is selected (optional).
+========================  ======  =================================================================
+
+**Response**
+
+.. code-block:: js
+
+   {
+     "default_assignee": "admin@mozilla.bugs",
+     "default_bug_type": "--",
+     "default_qa_contact": "",
+     "description": "This is a new test component",
+     "id": 2,
+     "is_active": true,
+     "name": "TestComponent",
+     "team_name": "Mozilla",
+     "triage_owner": ""
+   }
+
+A component object :ref:`_rest_component_object` is returned.
+
+.. _rest_component_update:
+
+Update Component
+----------------
+
+This allows you to update an existing component in Bugzilla.
+
+**Request**
+
+.. code-block:: text
+
+   PUT /rest/component/Firefox/General
+
+.. code-block:: js
+
+   {
+     "default_assignee" : "admin@mozilla.bugs",
+     "triage_owner" : "nobody@mozilla.org"
+   }
+
+========================  =======  ======================================================
+name                      type     description
+========================  =======  ======================================================
+name                      string   The name of this component.
+description               string   A description for this component. Allows some simple
+                                   HTML.
+default_assignee       string   The login of the default assignee for the component.
+default_qa_contact        string   The login of the default qa contact for the component.
+default_bug_type          string   The default type for bugs filed under this component.
+                                   If empty, then product's default bug type is used.
+is_active                 boolean  ``true`` if you want the component to be active.
+                                   ``false`` if not.
+triage_owner              string   The login of the triage owner for the component.
+team_name                 string   The team name the component belongs to.
+bug_description_template  string   The string included in the comment field of a new bug
+                                   when the component is selected.
+========================  =======  ======================================================
+
+**Response**
+
+.. code-block:: js
+
+   {
+     "default_assignee": "admin@mozilla.bugs",
+     "default_bug_type": "--",
+     "default_qa_contact": "",
+     "description": "For bugs in Firefox which do not fit into other more specific Firefox components",
+     "id": 2,
+     "is_active": true,
+     "name": "General",
+     "team_name": "Mozilla",
+     "triage_owner": "nobody@mozilla.org",
+     "changes" : {
+       "default_assignee" : {
+         "removed" : "otheruser@mozilla.bugs",
+         "added" : "admin@mozilla.bugs"
+       },
+       "triage_owner" : {
+         "removed" : "",
+         "added" : "nobody@mozilla.org"
+       }
+     }
+   }
+
+A component object :ref:`_rest_component_object` is returned.
+
+The following fields are added to the object:
+
+=======  ======  ================================================================
+name     type    description
+=======  ======  ================================================================
+changes  object  The changes that were actually done on this component. The
+                 keys are the names of the fields that were changed, and the
+                 values are an object with two items:
+
+                 * added: (string) The value that this field was changed to.
+                 * removed: (string) The value that was previously set in this
+                   field.
+=======  ======  ================================================================

--- a/docs/en/rst/api/core/v1/index.rst
+++ b/docs/en/rst/api/core/v1/index.rst
@@ -3,15 +3,16 @@ Core API v1
 
 .. toctree::
 
-   general
    attachment
    bug
    bug-user-last-visit
-   flag-activity
    bugzilla
    classification
    comment
+   component
    field
+   flag-activity
+   general
    group
    product
    user

--- a/qa/t/rest_components.t
+++ b/qa/t/rest_components.t
@@ -1,0 +1,93 @@
+#!/usr/bin/env perl
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+use strict;
+use warnings;
+use 5.10.1;
+use lib qw(lib ../../lib ../../local/lib/perl5);
+
+use Bugzilla;
+use QA::Util qw(get_config);
+
+use MIME::Base64 qw(encode_base64 decode_base64);
+use Test::Mojo;
+use Test::More;
+
+my $config  = get_config();
+my $api_key = $config->{admin_user_api_key};
+my $url     = Bugzilla->localconfig->urlbase;
+
+my $t = Test::Mojo->new();
+
+# Allow 1 redirect max
+$t->ua->max_redirects(1);
+
+### Section 1: Create a new component
+
+my $new_component = {
+  name        => 'TestComponent',
+  product     => 'Firefox',
+  description => 'This is a new test component',
+  team_name   => 'Mozilla',
+};
+
+# First try unauthenticated. Should fail with error.
+$t->post_ok($url . 'rest/component/Firefox' => json => $new_component)
+  ->status_is(401)
+  ->json_is(
+  '/message' => 'You must log in before using this part of Bugzilla.');
+
+# Now try as authenticated user using API key. But a required field is missing (initialowner).
+$t->post_ok($url
+    . 'rest/component/Firefox' => {'X-Bugzilla-API-Key' => $api_key} => json =>
+    $new_component)->status_is(400)
+  ->json_is('/message' => 'A default assignee is required for this component.');
+
+# Now try again with the missing field populated.
+$new_component->{default_assignee} = 'admin@mozilla.test';
+$t->post_ok($url
+    . 'rest/component/Firefox' => {'X-Bugzilla-API-Key' => $api_key} => json =>
+    $new_component)->status_is(200)->json_is('/name' => 'TestComponent');
+
+# Retrieve the new component and verify
+$t->get_ok($url
+    . 'rest/component/Firefox/TestComponent' =>
+    {'X-Bugzilla-API-Key' => $api_key})->status_is(200)
+  ->json_is('/name' => 'TestComponent');
+
+# Adding the same component should generate an error
+$t->post_ok($url
+    . 'rest/component/Firefox' => {'X-Bugzilla-API-Key' => $api_key} => json =>
+    $new_component)->status_is(400)
+  ->json_is('/message' =>
+    'The Firefox product already has a component named TestComponent.');
+
+### Section 2: Make updates to the component
+
+my $update = {triage_owner => 'admin@mozilla.test',
+  description => 'Updated description'};
+
+# Unauthenticated update should fail
+$t->put_ok($url . 'rest/component/Firefox/TestComponent' => json => $update)
+  ->status_is(401)
+  ->json_is(
+  '/message' => 'You must log in before using this part of Bugzilla.');
+
+# Authenticated request should work fine.
+$t->put_ok($url
+    . 'rest/component/Firefox/TestComponent' =>
+    {'X-Bugzilla-API-Key' => $api_key}       => json => $update)->status_is(200)
+  ->json_is('/triage_owner' => 'admin@mozilla.test');
+
+# Retrieve the new component and verify
+$t->get_ok($url
+    . 'rest/component/Firefox/TestComponent' =>
+    {'X-Bugzilla-API-Key' => $api_key})->status_is(200)
+  ->json_is('/triage_owner' => 'admin@mozilla.test')
+  ->json_is('/description'  => 'Updated description');
+
+done_testing();

--- a/qa/t/rest_triage_owners.t
+++ b/qa/t/rest_triage_owners.t
@@ -30,9 +30,6 @@ $t->get_ok(
   ->json_is('/Firefox/Installer/triage_owner', 'nobody@mozilla.org');
 
 my $data = $t->tx->res->json;
-use Bugzilla::Logging;
-use Mojo::Util qw(dumper);
-DEBUG(dumper $data);
 
 # Get the triage owner for Firefox for only General component
 $t->get_ok($url

--- a/template/en/default/global/user-error.html.tmpl
+++ b/template/en/default/global/user-error.html.tmpl
@@ -1212,6 +1212,9 @@
   [% ELSIF error == "rest_invalid_resource" %]
     A REST API resource was not found for '[% method FILTER html +%] [%+ path FILTER html %]'.
 
+  [% ELSIF error == "rest_malformed_json" %]
+    The JSON data used for the request was malformed. Please update your request and try again.
+
   [% ELSIF error == "get_products_invalid_type" %]
     The product type '[% type FILTER html %]' is invalid. Valid choices
     are 'accessible', 'selectable', and 'enterable'.


### PR DESCRIPTION
This PR introduces new API endpoints to the current REST API for managing components for products. It covers getting a component, editing a component and creating a new component. This API is in the new versioned area for adding REST API functionality that everything else will eventually be migrated to. I had to change some other non-related code such as API login to fix some error handling issues found during testing. This PR came about due to others wanting to update the triage owner field of components. Rather than make a special endpoint just for doing that one edit, I thought better to go ahead and make a more robust way of editing components that needed to be done eventually anyway. Please let me know if you have any specific questions related to these changes.