### PR TITLE
Bug 1774351 - Allow adding GitHub projects to "See Also"

### DIFF
--- a/Bugzilla/BugUrl/GitHub.pm
+++ b/Bugzilla/BugUrl/GitHub.pm
@@ -26,9 +26,12 @@ sub should_handle {
 #  https://github.com/USER_OR_TEAM_OR_ORGANIZATION_NAME/REPOSITORY_NAME/pull/111
 # Github security advisories have the form of:
 #  https://github.com/USER_OR_TEAM_OR_ORGANIZATION_NAME/REPOSITORY_NAME/security/advisories/GHSA-XXXX-XXXX-XXXX
+# Github projects have the form of:
+#  https://gUSER_OR_TEAM_OR_ORGANIZATION_NAME/REPOSITORY_NAME/projects/111
   if (lc($uri->authority) eq 'github.com') {
-    if ( $uri->path =~ m!^/[^/]+/[^/]+/(?:issues|pull)/\d+$!
-      || $uri->path =~ m!^/[^/]+/[^/]+/security/advisories/GHSA-.*$!)
+    if ( $uri->path =~ m{^/[^/]+/[^/]+/(?:issues|pull)/\d+$}
+      || $uri->path =~ m{^/[^/]+/[^/]+/security/advisories/GHSA-.*$}
+      || $uri->path =~ m{^/[^/]+/[^/]+/projects/\d+$})
     {
       return 1;
     }

--- a/Bugzilla/BugUrl/GitHub.pm
+++ b/Bugzilla/BugUrl/GitHub.pm
@@ -27,7 +27,7 @@ sub should_handle {
 # Github security advisories have the form of:
 #  https://github.com/USER_OR_TEAM_OR_ORGANIZATION_NAME/REPOSITORY_NAME/security/advisories/GHSA-XXXX-XXXX-XXXX
 # Github projects have the form of:
-#  https://gUSER_OR_TEAM_OR_ORGANIZATION_NAME/REPOSITORY_NAME/projects/111
+#  https://github.com/USER_OR_TEAM_OR_ORGANIZATION_NAME/REPOSITORY_NAME/projects/111
   if (lc($uri->authority) eq 'github.com') {
     if ( $uri->path =~ m{^/[^/]+/[^/]+/(?:issues|pull)/\d+$}
       || $uri->path =~ m{^/[^/]+/[^/]+/security/advisories/GHSA-.*$}


### PR DESCRIPTION
Adds the ability to add github project links to the see also field. The links take the form of https://github.com/USER_OR_TEAM_OR_ORGANIZATION_NAME/REPOSITORY_NAME/projects/111 which the regex will check for.