### PR TITLE
Bug 1775350 - Add dropdown menu to Copy Summary button that allows different text and format.

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -149,8 +149,26 @@
     [% PROCESS bug_modal/navigate.html.tmpl %]
   [% END %]
   <div role="group" class="buttons">
-    <button type="button" id="copy-summary" class="secondary"
-      title="Copy [% terms.bug %] number and summary to your clipboard">Copy Summary</button>
+    <button type="button" id="copy-summary" class="secondary separate-dropdown-button-main"
+      title="Copy [% terms.bug %] number and summary to your clipboard">Copy Summary</button
+    ><div id="copy-menu-dropdown" class="dropdown"><button type="button" id="copy-menu-btn" aria-haspopup="true" aria-label="View"
+      aria-expanded="false" aria-controls="copy-menu" class="dropdown-button secondary separate-dropdown-button-arrow"
+      title="More options for copy">&#9662;</button>
+      <ul class="dropdown-content left" id="copy-menu" role="menu" style="display:none;">
+        <li role="presentation">
+          <a id="copy-markdown-summary" role="menuitem" tabindex="-1">Markdown</a>
+        </li>
+        <li role="presentation">
+          <a id="copy-markdown-bug-number" role="menuitem" tabindex="-1">Markdown (bug number)</a>
+        </li>
+        <li role="presentation">
+          <a id="copy-text-summary" role="menuitem" tabindex="-1">Plain Text</a>
+        </li>
+        <li role="presentation">
+          <a id="copy-html-summary" role="menuitem" tabindex="-1">HTML</a>
+        </li>
+      </ul>
+    </div>
     <div id="clip-container" style="display:none"><input type="text" id="clip"></div>
     [% IF user.id %]
       <button type="button" class="secondary" id="cc-btn" data-is-cced="[% is_cced ? 1 : 0 %]">

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -385,32 +385,68 @@ $(function() {
         }
 
         if (hasExecCopy) {
-            const url = BUGZILLA.bug_url;
-            const text = `Bug ${BUGZILLA.bug_id} - ${BUGZILLA.bug_summary}`;
-            const html = `<a href="${url}">${text.htmlEncode()}</a>`;
+            function copy(text, name) {
+                const captalizedName = name[0].toUpperCase() + name.slice(1);
+                // execCommand("copy") only works on selected text
+                $('#clip-container').show();
+                $('#clip').val(text).select();
+                $('#floating-message-text')
+                  .text(document.execCommand("copy") ? `${captalizedName} copied!` : `Couldn’t copy ${name}`);
+                $('#floating-message').fadeIn(250).delay(2500).fadeOut();
+                $('#clip-container').hide();
+            }
 
-            document.addEventListener('copy', event => {
-                if (event.target.nodeType === 1 && event.target.matches('#clip')) {
-                    event.clipboardData.setData('text/uri-list', url);
-                    event.clipboardData.setData('text/plain', text);
-                    event.clipboardData.setData('text/html', html);
-                    event.preventDefault();
+            const url = BUGZILLA.bug_url;
+
+            const bugNumberText = `bug ${BUGZILLA.bug_id}`;
+            const summaryText = `Bug ${BUGZILLA.bug_id} - ${BUGZILLA.bug_summary}`;
+
+            const bugNumberHTML = `<a href="${url}">${bugNumberText.htmlEncode()}</a>`;
+            const summaryHTML = `<a href="${url}">${summaryText.htmlEncode()}</a>`;
+
+            $('#copy-summary').click(() => {
+                function onCopy(event) {
+                    if (event.target.nodeType === 1 && event.target.matches('#clip')) {
+                        event.clipboardData.setData('text/uri-list', url);
+                        event.clipboardData.setData('text/plain', summaryText);
+                        event.clipboardData.setData('text/html', summaryHTML);
+                        event.preventDefault();
+                        document.removeEventListener('copy', onCopy);
+                    }
                 }
+
+                document.addEventListener('copy', onCopy);
+                copy(summaryText, "bug summary");
             });
 
-            $('#copy-summary')
-                .click(function() {
-                    // execCommand("copy") only works on selected text
-                    $('#clip-container').show();
-                    $('#clip').val(text).select();
-                    $('#floating-message-text')
-                        .text(document.execCommand("copy") ? 'Bug summary copied!' : 'Couldn’t copy bug summary');
-                    $('#floating-message').fadeIn(250).delay(2500).fadeOut();
-                    $('#clip-container').hide();
-                });
+            $('#copy-markdown-summary').click(() => {
+                copy(`[${summaryText}](${url})`, "markdown link with bug summary");
+            });
+            $('#copy-markdown-bug-number').click(() => {
+                copy(`[${bugNumberText}](${url})`, "markdown link with bug number");
+            });
+
+            $('#copy-text-summary').click(() => {
+                copy(summaryText, "bug summary");
+            });
+
+            $('#copy-html-summary').click(() => {
+                function onCopy(event) {
+                    if (event.target.nodeType === 1 && event.target.matches('#clip')) {
+                        event.clipboardData.setData('text/plain', summaryHTML);
+                        event.clipboardData.setData('text/html', summaryHTML);
+                        event.preventDefault();
+                        document.removeEventListener('copy', onCopy);
+                    }
+                }
+
+                document.addEventListener('copy', onCopy);
+                copy(summaryHTML, "HTML link with bug summary");
+            });
         }
         else {
             $('#copy-summary').hide();
+            $('#copy-menu-dropdown').hide();
         }
     }
 

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -102,6 +102,7 @@
     /** Button */
     --button-border-radius: 4px;
     --button-padding: 6px 12px;
+    --button-center-padding: 6px;
   }
 }
 
@@ -2213,6 +2214,19 @@ table.tabs .clickable_area {
   padding: 8px 16px !important;
   color: inherit;
   line-height: 100% !important;
+}
+
+.separate-dropdown-button-main {
+  border-start-end-radius: 0px;
+  border-end-end-radius: 0px;
+  padding-inline-end: var(--button-center-padding);
+  border-inline-end: none;
+}
+
+.separate-dropdown-button-arrow {
+  border-start-start-radius: 0px;
+  border-end-start-radius: 0px;
+  padding-inline-start: var(--button-center-padding);
 }
 
 /**


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1775350

This adds drop down menu next to the current "Copy Summary" button (see the attachment).
The menu provides multiple kinds of text + format combination.

<img width="692" alt="copy-menu" src="https://user-images.githubusercontent.com/6299746/175224450-cba8de43-858a-4867-939c-105b93b9ccea.png">
