### PR TITLE
Bug 1776503 - [SELF-SERVICE] New form to add new version and milestone to select products when a new Firefox release comes out

### DIFF
--- a/Bugzilla/App.pm
+++ b/Bugzilla/App.pm
@@ -28,6 +28,7 @@ use Bugzilla::App::Main;
 use Bugzilla::App::OAuth2::Provider::Clients;
 use Bugzilla::App::SES;
 use Bugzilla::App::Static;
+use Bugzilla::App::BMO::NewRelease;
 use Mojo::Loader qw( find_modules );
 use Module::Runtime qw( require_module );
 use Bugzilla::Util ();
@@ -210,6 +211,7 @@ sub setup_routes {
   Bugzilla::App::Main->setup_routes($r);
   Bugzilla::App::OAuth2::Provider::Clients->setup_routes($r);
   Bugzilla::App::SES->setup_routes($r);
+  Bugzilla::App::BMO::NewRelease->setup_routes($r);
 
   $r->static_file('/__lbheartbeat__');
   $r->static_file(

--- a/Bugzilla/App/BMO/NewRelease.pm
+++ b/Bugzilla/App/BMO/NewRelease.pm
@@ -1,0 +1,153 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::App::BMO::NewRelease;
+
+use 5.10.1;
+use Mojo::Base 'Mojolicious::Controller';
+
+use Bugzilla::Constants;
+use Bugzilla::Product;
+use Bugzilla::Milestone;
+use Bugzilla::Version;
+use Bugzilla::Token;
+use Bugzilla::Util qw(fetch_product_versions trim);
+
+use Scalar::Util qw(blessed);
+
+sub setup_routes {
+  my ($class, $r) = @_;
+  $r->any('/admin/new_release')->to('BMO::NewRelease#new_release')
+    ->name('new_release');
+}
+
+sub new_release {
+  my ($self) = @_;
+  Bugzilla->usage_mode(USAGE_MODE_MOJO);
+  my $user = $self->bugzilla->login(LOGIN_REQUIRED) || return undef;
+
+  $user->in_group('editcomponents')
+    || return $self->user_error('auth_failure',
+    {group => 'editcomponents', action => 'edit', object => 'milestones'});
+
+  # Display the initial form
+  if ($self->req->method ne 'POST') {
+    my $versions          = fetch_product_versions('firefox');
+    my $latest_nightly    = $versions->{FIREFOX_NIGHTLY};
+    my ($current_nightly) = $latest_nightly =~ /^(\d+)/;
+
+    my $selectable_products = $user->get_selectable_products || [];
+    my $default_milestone_products
+      = Bugzilla->params->{default_milestone_products} || [];
+    my $default_version_products
+      = Bugzilla->params->{default_version_products} || [];
+    my $token = issue_session_token('new_release');
+
+    my $vars = {
+      next_release               => $current_nightly + 1,
+      selectable_products        => $selectable_products,
+      default_milestone_products => $default_milestone_products,
+      default_version_products   => $default_version_products,
+      token                      => $token
+    };
+
+    $self->stash(%{$vars});
+    return $self->render(template => 'pages/new_release', handler => 'bugzilla');
+  }
+
+  # Check token data
+  my $token = $self->param('token');
+  check_token_data($token, 'new_release');
+  delete_token($token);
+
+  # Sanity check new values for milestone and version
+  my $new_milestone = trim($self->param('new_milestone'));
+  my $new_version   = trim($self->param('new_version'));
+  $new_milestone =~ /^\d+$/
+    || return $self->user_error("number_not_numeric",
+    {field => 'milestone', num => $new_milestone});
+  $new_version =~ /^\d+$/
+    || return $self->user_error("number_not_numeric",
+    {field => 'version', num => $new_version});
+
+  # Process milestones
+  my @results;
+  foreach my $product (@{$self->every_param('milestone_products')}) {
+    my $success
+      = _add_value('milestone', $product, $new_milestone);
+    my $result = {
+      type    => 'milestone',
+      product => $product,
+      value   => "Firefox $new_milestone",
+      success => $success
+    };
+    push @results, $result;
+  }
+
+  # Process versions
+  foreach my $product (@{$self->every_param('version_products')}) {
+    my $success      = _add_value('version', $product, $new_version);
+    my $result       = {
+      type    => 'version',
+      product => $product,
+      value   => "$new_version Branch",
+      success => $success
+    };
+    push @results, $result;
+  }
+
+  $self->stash({results => \@results});
+  return $self->render('pages/new_release', handler => 'bugzilla');
+}
+
+sub _add_value {
+  my ($type, $product, $value) = @_;
+  $product
+    = blessed $product
+    ? $product
+    : Bugzilla::Product->new({name => $product, cache => 1});
+
+  if ($type eq 'milestone') {
+    my $full_milestone = "Firefox $value";
+
+    if (!Bugzilla::Milestone->new({product => $product, name => $full_milestone})) {
+      # Figure the proper sort key from the last version and add 10
+      my $old_value = $value - 1;
+      my $last_milestone = Bugzilla::Milestone->new({product => $product, name => "Firefox $old_value"});
+      my $sortkey = $last_milestone ? $last_milestone->sortkey + 10 : 0;
+
+      # Need to add 10 to the current default milestone '---' so it is placed right above the new milestone
+      my $default_milestone = Bugzilla::Milestone->new({product => $product, name => '---'});
+      if ($default_milestone) {
+        $default_milestone->set_sortkey($default_milestone->sortkey + 10);
+        $default_milestone->update();
+      }
+
+      # Finally create the new milestone
+      Bugzilla::Milestone->create({product => $product, value => $full_milestone, sortkey => $sortkey});
+      return 1;
+    }
+    else {
+      return 0;
+    }
+  }
+
+  # Versions are simple in that they do not use sortkeys yet
+  if ($type eq 'version') {
+    my $full_version = "$value Branch";
+
+    if (!Bugzilla::Version->new({product => $product, name => $full_version})) {
+      Bugzilla::Version->create({product => $product, value => $full_version});
+      return 1;
+    }
+    else {
+      return 0;
+    }
+  }
+}
+
+1;

--- a/Bugzilla/App/BMO/NewRelease.pm
+++ b/Bugzilla/App/BMO/NewRelease.pm
@@ -169,8 +169,6 @@ sub _add_value {
 # Helper function to return a fully formatted version or milestone
 sub _get_formatted_value {
   my ($product, $value, $type) = @_;
-  use Bugzilla::Logging;
-  DEBUG("product: $product");
   my $template
     = exists TEMPLATES->{$type}->{$product}
     ? TEMPLATES->{$type}->{$product}

--- a/Bugzilla/App/BMO/NewRelease.pm
+++ b/Bugzilla/App/BMO/NewRelease.pm
@@ -117,7 +117,7 @@ sub _add_value {
     if (!Bugzilla::Milestone->new({product => $product, name => $full_milestone})) {
       # Figure the proper sort key from the last version and add 10
       my $old_value = $value - 1;
-      my $last_milestone = Bugzilla::Milestone->new({product => $product, name => "Firefox $old_value"});
+      my $last_milestone = Bugzilla::Milestone->new({product => $product, name => "$old_value Branch"});
       my $sortkey = $last_milestone ? $last_milestone->sortkey + 10 : 0;
 
       # Need to add 10 to the current default milestone '---' so it is placed right above the new milestone
@@ -138,7 +138,7 @@ sub _add_value {
 
   # Versions are simple in that they do not use sortkeys yet
   if ($type eq 'version') {
-    my $full_version = "$value Branch";
+    my $full_version = "Firefox $value";
 
     if (!Bugzilla::Version->new({product => $product, name => $full_version})) {
       Bugzilla::Version->create({product => $product, value => $full_version});

--- a/Bugzilla/Config/NewRelease.pm
+++ b/Bugzilla/Config/NewRelease.pm
@@ -1,0 +1,23 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::Config::NewRelease;
+
+use 5.10.1;
+use strict;
+use warnings;
+
+sub get_param_list {
+  my $class      = shift;
+  my @param_list = (
+    {name => 'default_milestone_products', type => 'l', default => ''},
+    {name => 'default_version_products',   type => 'l', default => ''},
+  );
+  return @param_list;
+}
+
+1;

--- a/qa/t/test_new_release.t
+++ b/qa/t/test_new_release.t
@@ -1,0 +1,77 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+use strict;
+use warnings;
+use lib qw(lib ../../lib ../../local/lib/perl5);
+
+use Test::More "no_plan";
+
+use QA::Util;
+
+my ($sel, $config) = get_selenium();
+
+log_in($sel, $config, 'admin');
+
+# Add the milestone "Firefox 100" with sortkey 100 to Firefox product
+
+edit_product($sel, 'Firefox', 'Client Software');
+$sel->click_ok('link=Edit milestones:', undef,
+  'Go to the Edit milestones page');
+$sel->wait_for_page_to_load(WAIT_TIME);
+$sel->title_is("Select milestone of product 'Firefox'", 'Display milestones');
+$sel->click_ok('link=Add', undef, 'Go add a new milestone');
+$sel->wait_for_page_to_load(WAIT_TIME);
+$sel->title_is("Add Milestone to Product 'Firefox'", 'Enter new milestone');
+$sel->type_ok('milestone', 'Firefox 100', 'Set its name to Firefox 100');
+$sel->type_ok('sortkey',   '100',         'Set its sortkey to 100');
+$sel->click_ok('create', undef, 'Submit data');
+$sel->wait_for_page_to_load(WAIT_TIME);
+
+# Add the version "100 Branch" to Firefox product
+
+edit_product($sel, 'Firefox', 'Client Software');
+$sel->click_ok('link=Edit versions:', undef, 'Go to the Edit versions page');
+$sel->wait_for_page_to_load(WAIT_TIME);
+$sel->title_is("Select version of product 'Firefox'", 'Display versions');
+$sel->click_ok('link=Add', undef, 'Go add a new version');
+$sel->wait_for_page_to_load(WAIT_TIME);
+$sel->title_is("Add Version to Product 'Firefox'", 'Enter new version');
+$sel->type_ok('version', '100 Branch', 'Set its name to 100 Branch');
+$sel->click_ok('create', undef, 'Submit data');
+$sel->wait_for_page_to_load(WAIT_TIME);
+
+# Go to add new release admin page
+
+go_to_admin($sel);
+$sel->click_ok('link=New Firefox Release');
+$sel->wait_for_page_to_load_ok(WAIT_TIME);
+$sel->select_ok('milestone_products', 'label=Firefox');
+$sel->type_ok('new_milestone', '101');
+$sel->select_ok('version_products', 'label=Firefox');
+$sel->type_ok('new_version', '101');
+$sel->click_ok('submit', undef, 'Submit data');
+
+# Verify that the new milestone and version has been create and the proper sortkey is present
+
+edit_product($sel, 'Firefox', 'Client Software');
+$sel->click_ok('link=Edit milestones:', undef,
+  'Go to the Edit milestones page');
+$sel->wait_for_page_to_load(WAIT_TIME);
+$sel->title_is("Select milestone of product 'Firefox'", 'Display milestones');
+$sel->is_text_present_ok('Firefox 101', 'New milestone exists');
+$sel->click_ok('link=Firefox 101', undef, 'Go edit version');
+$sel->title_is("Edit Milestone 'Firefox 101' of product 'Firefox'", 'Edit milestone');
+$sel->value_is('sortkey', '110');
+
+edit_product($sel, 'Firefox', 'Client Software');
+$sel->click_ok('link=Edit versions:', undef, 'Go to the Edit versions page');
+$sel->wait_for_page_to_load(WAIT_TIME);
+$sel->title_is("Select version of product 'Firefox'", 'Display versions');
+$sel->is_text_present_ok('101 Branch', 'New version exists');
+
+logout($sel);

--- a/qa/t/test_new_release.t
+++ b/qa/t/test_new_release.t
@@ -17,7 +17,7 @@ my ($sel, $config) = get_selenium();
 
 log_in($sel, $config, 'admin');
 
-# Add the milestone "Firefox 100" with sortkey 100 to Firefox product
+# Add the milestone "100 Branch" with sortkey 100 to Firefox product
 
 edit_product($sel, 'Firefox', 'Client Software');
 $sel->click_ok('link=Edit milestones:', undef,
@@ -27,12 +27,12 @@ $sel->title_is("Select milestone of product 'Firefox'", 'Display milestones');
 $sel->click_ok('link=Add', undef, 'Go add a new milestone');
 $sel->wait_for_page_to_load(WAIT_TIME);
 $sel->title_is("Add Milestone to Product 'Firefox'", 'Enter new milestone');
-$sel->type_ok('milestone', 'Firefox 100', 'Set its name to Firefox 100');
+$sel->type_ok('milestone', '100 Branch', 'Set its name to 100 Branch');
 $sel->type_ok('sortkey',   '100',         'Set its sortkey to 100');
 $sel->click_ok('create', undef, 'Submit data');
 $sel->wait_for_page_to_load(WAIT_TIME);
 
-# Add the version "100 Branch" to Firefox product
+# Add the version "Firefox 100" to Firefox product
 
 edit_product($sel, 'Firefox', 'Client Software');
 $sel->click_ok('link=Edit versions:', undef, 'Go to the Edit versions page');
@@ -41,7 +41,7 @@ $sel->title_is("Select version of product 'Firefox'", 'Display versions');
 $sel->click_ok('link=Add', undef, 'Go add a new version');
 $sel->wait_for_page_to_load(WAIT_TIME);
 $sel->title_is("Add Version to Product 'Firefox'", 'Enter new version');
-$sel->type_ok('version', '100 Branch', 'Set its name to 100 Branch');
+$sel->type_ok('version', 'Firefox 100', 'Set its name to Firefox 100');
 $sel->click_ok('create', undef, 'Submit data');
 $sel->wait_for_page_to_load(WAIT_TIME);
 
@@ -63,15 +63,15 @@ $sel->click_ok('link=Edit milestones:', undef,
   'Go to the Edit milestones page');
 $sel->wait_for_page_to_load(WAIT_TIME);
 $sel->title_is("Select milestone of product 'Firefox'", 'Display milestones');
-$sel->is_text_present_ok('Firefox 101', 'New milestone exists');
-$sel->click_ok('link=Firefox 101', undef, 'Go edit version');
-$sel->title_is("Edit Milestone 'Firefox 101' of product 'Firefox'", 'Edit milestone');
+$sel->is_text_present_ok('101 Branch', 'New milestone exists');
+$sel->click_ok('link=101 Branch', undef, 'Go edit version');
+$sel->title_is("Edit Milestone '101 Branch' of product 'Firefox'", 'Edit milestone');
 $sel->value_is('sortkey', '110');
 
 edit_product($sel, 'Firefox', 'Client Software');
 $sel->click_ok('link=Edit versions:', undef, 'Go to the Edit versions page');
 $sel->wait_for_page_to_load(WAIT_TIME);
 $sel->title_is("Select version of product 'Firefox'", 'Display versions');
-$sel->is_text_present_ok('101 Branch', 'New version exists');
+$sel->is_text_present_ok('Firefox 101', 'New version exists');
 
 logout($sel);

--- a/template/en/default/admin/admin.html.tmpl
+++ b/template/en/default/admin/admin.html.tmpl
@@ -95,6 +95,10 @@
         You can set as many flags as desired per [% terms.bug %], and define which users
         are allowed to edit them.</dd>
 
+        [% class = user.in_group('editcomponents') ? "" : "forbidden" %]
+        <dt id="new_release" class="[% class %]"><a href="[% basepath FILTER none %]admin/new_release">New Firefox Release</a></dt>
+        <dd class="[% class %]">Add new version and milestone for a new release of Firefox</dd>
+
         [% Hook.process('end_links_left') %]
       </dl>
     </td>

--- a/template/en/default/admin/params/newrelease.html.tmpl
+++ b/template/en/default/admin/params/newrelease.html.tmpl
@@ -1,0 +1,19 @@
+[%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  #
+  # This Source Code Form is "Incompatible With Secondary Licenses", as
+  # defined by the Mozilla Public License, v. 2.0.
+  #%]
+[%
+   title = "New Release"
+   desc = "Adding Versions and Milestones for new Firefox releases"
+%]
+
+[% param_descs = {
+    default_milestone_products =>
+      "A one product per line list of the default products that require a new milestone for each Firefox release.",
+    default_version_products =>
+      "A one product per line list of the default products that require a new version for each Firefox release.",
+  }
+%]

--- a/template/en/default/pages/new_release.html.tmpl
+++ b/template/en/default/pages/new_release.html.tmpl
@@ -74,7 +74,7 @@
     <td>
       <input type="text" name="new_milestone" id="new_milestone" required="true"
              size="12" value="[% next_release FILTER html %]">
-      Milestone will be added in the format of "Firefox XXX"
+      Milestone will be added in the format of "XXX Branch"
     </td>
   </tr>
   </table>
@@ -100,7 +100,7 @@
     <td>
       <input type="text" name="new_version" id="new_version" required="true"
              size="10" value="[% next_release FILTER html %]">
-      Version will be added in the format of "XXX Branch"
+      Version will be added in the format of "Firefox XXX"
     </td>
   </tr>
   </table>

--- a/template/en/default/pages/new_release.html.tmpl
+++ b/template/en/default/pages/new_release.html.tmpl
@@ -1,0 +1,111 @@
+[%# The contents of this file are subject to the Mozilla Public
+  # License Version 1.1 (the "License"); you may not use this file
+  # except in compliance with the License. You may obtain a copy of
+  # the License at http://www.mozilla.org/MPL/
+  #
+  # Software distributed under the License is distributed on an "AS
+  # IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+  # implied. See the License for the specific language governing
+  # rights and limitations under the License.
+  #
+  # The Original Code is the BMO Extension
+  #
+  # The Initial Developer of the Original Code is the Mozilla Foundation
+  # Portions created by the Initial Developers are Copyright (C) 2011 the
+  # Initial Developer. All Rights Reserved.
+  #
+  # Contributor(s):
+  #   Byron Jones <bjones@mozilla.com>
+  #%]
+
+[% PROCESS global/variables.none.tmpl %]
+
+[% INCLUDE global/header.html.tmpl
+  title = "New Firefox Release"
+%]
+
+<h1>New Firefox Release</h1>
+
+[% IF results %]
+  [% FOREACH type = ['milestone', 'version'] %]
+    <p><h4>[% type FILTER ucfirst FILTER html %]s Added</h4>
+    [% FOREACH result = results %]
+      [% NEXT IF result.type != type %]
+      [% IF result.success %]
+        [% type FILTER ucfirst FILTER html %] <strong>[% result.value FILTER html %]</strong>
+        added to product <strong>[% result.product FILTER html %]</strong>.<br>
+      [% ELSE %]
+        <span style="color:red;">[% type FILTER ucfirst FILTER html %] <strong>[% result.value FILTER html %]</strong>
+        was not added to product <strong>[% result.product FILTER html %]</strong>.</span><br>
+      [% END %]
+    [% END %]
+    </p>
+  [% END %]
+
+  [% INCLUDE global/footer.html.tmpl %]
+  [% RETURN %]
+[% END %]
+
+<p>This page is useful for adding a new milestone and version to a select
+  list of products whenever a new release of Firefox comes out.</p>
+
+<form id="new_release" name="new_release" action="[% basepath FILTER none %]admin/new_release" method="POST">
+  <input type="hidden" name="id" value="new_release.html">
+  <input type="hidden" name="token" value="[% token FILTER html %]">
+
+  <h4>Select Products for New Milestone</h4>
+
+  <table class="standard">
+  <tr>
+    <td valign="top">Products</td>
+    <td>
+      <select name="milestone_products" id="milestone_products" multiple="multiple" size="8">
+        [% FOREACH p = selectable_products %]
+          <option value="[% p.name FILTER html %]"
+            [% " selected" IF default_milestone_products.contains(p.name) %]>
+            [% p.name FILTER html %]
+          </option>
+        [% END %]
+      </select>
+    </td>
+  </tr>
+  <tr>
+    <td>New Milestone</td>
+    <td>
+      <input type="text" name="new_milestone" id="new_milestone" required="true"
+             size="12" value="[% next_release FILTER html %]">
+      Milestone will be added in the format of "Firefox XXX"
+    </td>
+  </tr>
+  </table>
+
+  <h4>Select Products for New Version</h4>
+
+  <table class="standard">
+  <tr>
+    <td valign="top">Products</td>
+    <td>
+      <select name="version_products" id="version_products" multiple="multiple" size="8">
+        [% FOREACH p = selectable_products %]
+          <option value="[% p.name FILTER html %]"
+            [% " selected" IF default_version_products.contains(p.name) %]>
+            [% p.name FILTER html %]
+          </option>
+        [% END %]
+      </select>
+    </td>
+  </tr>
+  <tr>
+    <td>New Version</td>
+    <td>
+      <input type="text" name="new_version" id="new_version" required="true"
+             size="10" value="[% next_release FILTER html %]">
+      Version will be added in the format of "XXX Branch"
+    </td>
+  </tr>
+  </table>
+  <br>
+  <input type="submit" id="submit" value="Submit">
+</form>
+
+[% INCLUDE global/footer.html.tmpl %]

--- a/template/en/default/pages/new_release.html.tmpl
+++ b/template/en/default/pages/new_release.html.tmpl
@@ -1,21 +1,9 @@
-[%# The contents of this file are subject to the Mozilla Public
-  # License Version 1.1 (the "License"); you may not use this file
-  # except in compliance with the License. You may obtain a copy of
-  # the License at http://www.mozilla.org/MPL/
+[%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/.
   #
-  # Software distributed under the License is distributed on an "AS
-  # IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
-  # implied. See the License for the specific language governing
-  # rights and limitations under the License.
-  #
-  # The Original Code is the BMO Extension
-  #
-  # The Initial Developer of the Original Code is the Mozilla Foundation
-  # Portions created by the Initial Developers are Copyright (C) 2011 the
-  # Initial Developer. All Rights Reserved.
-  #
-  # Contributor(s):
-  #   Byron Jones <bjones@mozilla.com>
+  # This Source Code Form is "Incompatible With Secondary Licenses", as
+  # defined by the Mozilla Public License, v. 2.0.
   #%]
 
 [% PROCESS global/variables.none.tmpl %]


### PR DESCRIPTION
This new form will allow for quickly adding a new Firefox related milestone/version to the products selected. More details are in the bug.

To test:

```bash
$ docker compose down && docker compose build && docker compose up
```

Set your browsers proxy to localhost:1080. Go to http://bmo.test and login as the admin@mozilla.bugs user. Password is in the README.  You can then add a previous milestone and version to the Firefox product of 'Firefox 100' and '100 Branch' respectively. Then access the new release form from the Administrative menu. You should be able to select Firefox from both selects and add 101 to the test fields. When looking at the versions and milestones list, you should see the new 'Firefox 101' and '101 Branch' values create.

Ping me for any questions.