### PR TITLE
Bug 1778930 - Fix alignment of resolution buttons

### DIFF
--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -22,6 +22,7 @@
   padding: 1px 0;
 }
 
+.inline,
 .module .field .inline {
   display: table-cell;
   width: auto;

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -885,11 +885,13 @@ $(function() {
             other.val(val);
             if (val == "RESOLVED" || val == "VERIFIED") {
                 $('#resolution, #bottom-resolution').change().show();
+                $('#duplicate-actions').hide();
             }
             else {
                 $('#resolution, #bottom-resolution').hide();
                 $('#duplicate-container, #bottom-duplicate-container').hide();
                 $('#mark-as-dup-btn, #bottom-mark-as-dup-btn').show();
+                $('#duplicate-actions').show();
             }
         })
         .change();


### PR DESCRIPTION
- returns resolution buttons to aligning horizontally rather than
  vertically
- hides 'mark as duplicate' button in main edit form when value is
  RESOLVED or VERIFIED to avoid it dropping down to the next line and
  pushing the bottom resolution buttons off the screen