### PR TITLE
Bug 1772408 - Not properly forbidding reporters to set the priority, severity and type fields unless they have editbugs privs for new bugs

### DIFF
--- a/extensions/BMO/lib/FakeBug.pm
+++ b/extensions/BMO/lib/FakeBug.pm
@@ -13,7 +13,7 @@ our $AUTOLOAD;
 
 sub new {
   my $class = shift;
-  my $self  = shift;
+  my $self  = shift || {};
   bless $self, $class;
   return $self;
 }

--- a/extensions/MozChangeField/Extension.pm
+++ b/extensions/MozChangeField/Extension.pm
@@ -33,6 +33,7 @@ use Bugzilla::Extension::MozChangeField::Post::SeverityS1PriorityP1;
 use Bugzilla::Extension::MozChangeField::Post::ClearTrackingPriorityS1;
 #use Bugzilla::Extension::MozChangeField::Post::CommentOnSeverity;
 use Bugzilla::Extension::MozChangeField::Post::SetTrackingSeverityS1;
+use Bugzilla::Extension::MozChangeField::Post::TypePriSevEditbugs;
 
 my @post_instances = (
   Bugzilla::Extension::MozChangeField::Post::CrashKeywordSetSeverity->new,
@@ -40,6 +41,7 @@ my @post_instances = (
   Bugzilla::Extension::MozChangeField::Post::ClearTrackingPriorityS1->new,
   #Bugzilla::Extension::MozChangeField::Post::CommentOnSeverity->new,
   Bugzilla::Extension::MozChangeField::Post::SetTrackingSeverityS1->new,
+  Bugzilla::Extension::MozChangeField::Post::TypePriSevEditbugs->new,
 );
 
 our $VERSION = '0.1';

--- a/extensions/MozChangeField/lib/Post/TypePriSevEditbugs.pm
+++ b/extensions/MozChangeField/lib/Post/TypePriSevEditbugs.pm
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::Extension::MozChangeField::Post::TypePriSevEditbugs;
+
+use 5.10.1;
+use Moo;
+
+use Bugzilla::Constants;
+
+sub evaluate_change {
+  my ($self, $args) = @_;
+  my $changes  = $args->{changes};
+  my $editbugs = $args->{editbugs};
+
+  # If changing the bug_type, severity, or priority, editbugs is required.
+  foreach my $field (qw(bug_type bug_severity priority)) {
+    if (exists $changes->{$field} && !$editbugs) {
+      ThrowUserError('mozchangefield_field_needs_editbugs', {field => $field});
+    }
+  }
+}
+
+1;

--- a/extensions/MozChangeField/template/en/default/hook/global/user-error-errors.html.tmpl
+++ b/extensions/MozChangeField/template/en/default/hook/global/user-error-errors.html.tmpl
@@ -9,4 +9,9 @@
 [% IF error == "mozchangefield_severity_comment_required" %]
   [% title = "Comment Required" %]
   A <b>comment</b> is required when changing the severity field.
+
+[% ELSIF error == "mozchangefield_field_needs_editbugs" %]
+  [% title = "Invalid Change" %]
+  You need "editbugs" permissions to alter the '[% field FILTER html %]' field.
+
 [% END %]

--- a/qa/t/test_bug_edit.t
+++ b/qa/t/test_bug_edit.t
@@ -53,7 +53,6 @@ logout($sel);
 
 log_in($sel, $config, 'QA_Selenium_TEST');
 file_bug_in_product($sel, 'TestProduct');
-$sel->select_ok("bug_severity", "label=critical");
 $sel->type_ok("short_desc", "Test bug editing");
 $sel->type_ok("comment",    "ploc");
 $sel->click_ok("commit");
@@ -343,7 +342,6 @@ logout($sel);
 
 log_in($sel, $config, 'QA_Selenium_TEST');
 file_bug_in_product($sel, 'TestProduct');
-$sel->select_ok("bug_severity", "label=blocker");
 $sel->type_ok("short_desc", "New bug from me");
 
 # We turned on the CANEDIT bit for TestProduct.
@@ -429,9 +427,8 @@ $sel->click_ok('action-history',  'Show bug history');
 my $windows = $sel->driver->get_window_handles;
 $sel->driver->switch_to_window($windows->[1]);
 check_page_load($sel, qq{http://HOSTNAME/show_activity.cgi?id=$bug1_id});
-$sel->title_is("Changes made to bug $bug1_id");
 $sel->is_text_present_ok("URL foo.cgi?action=bar");
-$sel->is_text_present_ok("Severity critical blocker");
+$sel->is_text_present_ok("Severity -- blocker");
 $sel->is_text_present_ok(
   "Whiteboard [Selenium was here] [Selenium was here][admin too]");
 $sel->is_text_present_ok("Product QA-Selenium-TEST TestProduct");

--- a/template/en/default/bug/field.html.tmpl
+++ b/template/en/default/bug/field.html.tmpl
@@ -161,7 +161,9 @@
             [% IF field.name.match("^cf_blocking_") OR
                   field.name.match("^cf_status_") OR
                   field.name.match("^cf_tracking_") OR
-                  field.name == "resolution" %]
+                  field.name == "resolution" OR
+                  field.name == "bug_severity" OR
+                  field.name == "priority" %]
               [% NEXT UNLESS bug.check_can_change_field(field.name, '---', legal_value.name).allowed OR
                              selected %]
             [% END %]


### PR DESCRIPTION
These changes allow BMO to filter the priority and severity values on the new bug form. Also priority and severity are not cloned from another bug as we will need to triage the new bug just as if it was entered fresh. Also A new post rule is added to catch updating of the fields by non-permitted users using REST API calls.