### PR TITLE
Bug 1780308 - Allow a group of users to delete attachments when needed due to sensitive information

### DIFF
--- a/Bugzilla/Install.pm
+++ b/Bugzilla/Install.pm
@@ -260,6 +260,10 @@ use constant SYSTEM_GROUPS => (
   {
     name        => 'edittriageowners',
     description => 'Can edit triage owners of components'
+  },
+  {
+    name        => 'can_delete_attachments',
+    description => 'Can delete attachments'
   }
 );
 

--- a/attachment.cgi
+++ b/attachment.cgi
@@ -864,9 +864,9 @@ sub delete_attachment {
   my $dbh  = Bugzilla->dbh;
   my $C    = Bugzilla->request_cache->{mojo_controller};
 
-  $user->in_group('admin')
+  $user->in_group('can_delete_attachments')
     || ThrowUserError('auth_failure',
-    {group => 'admin', action => 'delete', object => 'attachment'});
+    {group => 'can_delete_attachments', action => 'delete', object => 'attachment'});
 
   Bugzilla->params->{'allow_attachment_deletion'}
     || ThrowUserError('attachment_deletion_disabled');

--- a/qa/t/test_bug_edit.t
+++ b/qa/t/test_bug_edit.t
@@ -40,7 +40,7 @@ check_page_load($sel, q{http://HOSTNAME/editgroups.cgi});
 $sel->title_is("Edit Groups");
 $sel->click_ok("link=Master");
 check_page_load($sel,
-  q{http://HOSTNAME/editgroups.cgi?action=changeform&group=29});
+  q{http://HOSTNAME/editgroups.cgi?action=changeform&group=30});
 $sel->title_is("Change Group: Master");
 my $group_url = $sel->get_location();
 $group_url =~ /group=(\d+)$/;

--- a/template/en/default/attachment/edit.html.tmpl
+++ b/template/en/default/attachment/edit.html.tmpl
@@ -302,7 +302,7 @@
     | <a href="[% basepath FILTER none %]attachment.cgi?id=[% attachment.id %]&amp;action=diff">Diff</a>
   [% END %]
   [% IF Param("allow_attachment_deletion")
-        && user.in_group('admin')
+        && user.in_group('can_delete_attachments')
         && attachment.datasize > 0 %]
     | <a href="[% basepath FILTER none %]attachment.cgi?id=[% attachment.id %]&amp;action=delete">Delete</a>
   [% END %]


### PR DESCRIPTION
Change the required group permissions from admin to new can_delete_attachments when showing the option to delete an attachment contents. 