### PR TITLE
Bug 1774673 - The new component API introduced by bug 1773137 has incorrect documentation about data returned from a component update

### DIFF
--- a/docs/en/rst/api/core/v1/component.rst
+++ b/docs/en/rst/api/core/v1/component.rst
@@ -160,30 +160,6 @@ bug_description_template  string   The string included in the comment field of a
      "name": "General",
      "team_name": "Mozilla",
      "triage_owner": "nobody@mozilla.org",
-     "changes" : {
-       "default_assignee" : {
-         "removed" : "otheruser@mozilla.bugs",
-         "added" : "admin@mozilla.bugs"
-       },
-       "triage_owner" : {
-         "removed" : "",
-         "added" : "nobody@mozilla.org"
-       }
-     }
    }
 
 A component object `rest_component_object`_ is returned.
-
-The following fields are added to the object:
-
-=======  ======  ================================================================
-name     type    description
-=======  ======  ================================================================
-changes  object  The changes that were actually done on this component. The
-                 keys are the names of the fields that were changed, and the
-                 values are an object with two items:
-
-                 * added: (string) The value that this field was changed to.
-                 * removed: (string) The value that was previously set in this
-                   field.
-=======  ======  ================================================================

--- a/qa/t/rest_components.t
+++ b/qa/t/rest_components.t
@@ -68,8 +68,11 @@ $t->post_ok($url
 
 ### Section 2: Make updates to the component
 
-my $update = {triage_owner => 'admin@mozilla.test',
-  description => 'Updated description'};
+my $update = {
+  triage_owner     => 'admin@mozilla.test',
+  description      => 'Updated description',
+  default_assignee => 'permanent_user@mozilla.test'
+};
 
 # Unauthenticated update should fail
 $t->put_ok($url . 'rest/component/Firefox/TestComponent' => json => $update)
@@ -81,7 +84,9 @@ $t->put_ok($url . 'rest/component/Firefox/TestComponent' => json => $update)
 $t->put_ok($url
     . 'rest/component/Firefox/TestComponent' =>
     {'X-Bugzilla-API-Key' => $api_key}       => json => $update)->status_is(200)
-  ->json_is('/triage_owner' => 'admin@mozilla.test');
+  ->json_is('/triage_owner'     => 'admin@mozilla.test')
+  ->json_is('/description'      => 'Updated description')
+  ->json_is('/default_assignee' => 'permanent_user@mozilla.test');
 
 # Retrieve the new component and verify
 $t->get_ok($url


### PR DESCRIPTION
Update test script and documentation to better reflect the data returned from updating a component using the REST API. Looking at other APIs outside of BMO, it is more common to just return a 200 and the current object with the updated values. No need to add a 'changes' list as the client already knows what was changed.