### PR TITLE
Bug 1780693 - Use selected-control-background-color for the hovered phabricator revision row.

### DIFF
--- a/extensions/PhabBugz/web/style/phabricator.css
+++ b/extensions/PhabBugz/web/style/phabricator.css
@@ -41,6 +41,10 @@
   border-collapse: collapse;
 }
 
+.phabricator-revisions tr:hover {
+  background-color: var(--grid-background-hover-color);
+}
+
 .phabricator-revisions th {
   padding: 2px;
 }

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -231,6 +231,7 @@
 
     /** Grid */
     --grid-background-color: var(--primary-region-background-color);
+    --grid-background-hover-color: var(--selected-control-background-color);
     --grid-border-color: var(--control-border-color);
     --grid-header-background-color: rgb(230, 231, 232);
     --grid-subheader-background-color: rgb(210, 211, 212);


### PR DESCRIPTION
Fore [bug 1780693](https://bugzilla.mozilla.org/show_bug.cgi?id=1780693)

<img width="1055" alt="hover" src="https://user-images.githubusercontent.com/6299746/180348072-33a3bdf3-07e8-4f67-bf88-89c226cd2e03.png">
