### PR TITLE
Bug 1780733 - Sort phabricator revisions by stack order.

### DIFF
--- a/extensions/PhabBugz/web/js/phabricator.js
+++ b/extensions/PhabBugz/web/js/phabricator.js
@@ -8,6 +8,154 @@
 
 var Phabricator = {};
 
+// Add pseudo root revision that has all root revisions as child.
+function addPseudoRoot(revisions, revMap) {
+  for (const rev of revisions) {
+    rev.isChild = false;
+  }
+
+  for (const rev of revisions) {
+    for (const id of rev.children) {
+      const child = revMap[id];
+      if (!child) {
+        continue;
+      }
+
+      child.isChild = true;
+    }
+  }
+
+  // This code assumes the passed `revs` is already sorted by the submitted
+  // order. If there's no relation between revisions, the original order
+  // is kept.
+  const roots = [];
+  for (const rev of revisions) {
+    if (!rev.isChild) {
+      roots.push(rev.id);
+    }
+  }
+
+  const pseudoRoot = {
+    id: "ROOT",
+    children: roots,
+  };
+
+  revisions.push(pseudoRoot);
+
+  return pseudoRoot;
+}
+
+// Let child revision's rank be higher than parent revision's rank.
+// This code assumes there's no cycle, that's guaranteed by phabricator.
+function fixRank(root, revMap) {
+  const queue = [root];
+  while (queue.length) {
+    const rev = queue.shift();
+    for (const id of rev.children) {
+      const child = revMap[id];
+      if (!child) {
+        continue;
+      }
+
+      child.rank = Math.max(child.rank, rev.rank + 1);
+
+      if (!queue.some(rev => rev == child)) {
+        queue.push(child);
+      }
+    }
+  }
+}
+
+function sortByRank(revisions) {
+  revisions.sort((a, b) => {
+    if (a.rank != b.rank) {
+      return a.rank - b.rank;
+    }
+    return a.sortkey - b.sortkey;
+  });
+}
+
+function findFirstUnhandledBranch(revisions) {
+  for (const rev of revisions) {
+    if (rev.hasBranch && !rev.isBranchHandled) {
+      return rev;
+    }
+  }
+  return null;
+}
+
+// Split branches into contiguous space.
+function splitBranches(revisions, revMap, branchCount) {
+  let N = revisions.length;
+  let n = N ** branchCount;
+  while (true) {
+    const rev = findFirstUnhandledBranch(revisions);
+    if (!rev) {
+      break;
+    }
+
+    // Split the range of rank for each child.
+    for (const [i, id] of rev.children.entries()) {
+      const child = revMap[id];
+      if (!child) {
+        continue;
+      }
+
+      child.rank += n * i;
+    }
+    n /= N;
+
+    fixRank(rev, revMap);
+    sortByRank(revisions);
+
+    rev.isBranchHandled = true;
+  }
+}
+
+// Sort revisions based on the graph.
+function sortRevisions(revs) {
+  if (!revs.length) {
+    return revs;
+  }
+
+  const revisions = revs.slice();
+
+  const revMap = {};
+  for (const rev of revisions) {
+    // If the data is old, do nothing.
+    if (!rev.children) {
+      return revs;
+    }
+
+    revMap[rev.id] = rev;
+  }
+
+  const pseudoRoot = addPseudoRoot(revisions, revMap);
+
+  // Setup extra fields.
+  let branchCount = 0;
+  for (const rev of revisions) {
+    rev.rank = 1;
+    rev.hasBranch = rev.children.length > 1;
+    rev.isBranchHandled = false;
+
+    if (rev.hasBranch) {
+      branchCount++;
+    }
+  }
+
+  // Make the revisions partially ordered.
+  fixRank(pseudoRoot, revMap);
+  sortByRank(revisions);
+
+  if (branchCount < 8) {
+    // Perform only if the stack is simple enough.
+    splitBranches(revisions, revMap, branchCount);
+  }
+
+  return revisions.filter(rev => rev != pseudoRoot);
+}
+
 Phabricator.getBugRevisions = async () => {
     var phabUrl = $('.phabricator-revisions').data('phabricator-base-uri');
     var tr      = $('<tr/>');
@@ -88,7 +236,7 @@ Phabricator.getBugRevisions = async () => {
         const { revisions } = await Bugzilla.API.get(`phabbugz/bug_revisions/${BUGZILLA.bug_id}`);
 
         if (revisions.length) {
-            revisions.forEach(rev => tbody.append(revisionRow(rev)));
+            sortRevisions(revisions).forEach(rev => tbody.append(revisionRow(rev)));
         } else {
             displayLoadError('none returned from server');
         }


### PR DESCRIPTION
This patch sorts the revisions by the stack order.

This patch does not show any graph, so if there's branch, that information is not shown, but at least the revisions table shows revisions in the order that reviewer needs to look.

On the server side, use `edge.search` API to get child revisions (in `_get_children_map` function), and add the info into the response,
by adding `"children": ["D1111", "D1112"],` property to the revision data (in `bug_revisions` function).

I've used dummy data during testing the feature, instead of actually calling `request` function.
So there might be some bug in the `request` function call.


On the client side, use the `children` property to sort the revisions in the stack order (in `sortRevisions` function).

The sort algorithm first sorts the revisions as partially ordered.

If there's no branch, then the result is already sorted, and the remaining operations is no-op.

```
D1
|
D2
|
D3
```

If there's branch, then the result at this point looks like the following:
(note that the line is not shown in the revision table)

```
D1
|
D2
|
+--+
|  |
D3 |
|  |
|  D5
|  |
D4 |
   |
   D6
```

Then split branches into contiguous range (in `splitBranches` function):

```
D1
|
D2
|
+--+
|  |
D3 |
|  |
D4 |
   |
   D5
   |
   D6
```

The sort algorithm adds pseudo root node before performing sort (in `addPseudoRoot` function), so, if there are multiple roots (such as, 2 patches submitted separately, and "Child" relation is not yet set), they're treated as a branch on the pseudo root.
