### PR TITLE
Bug 1781121 - moving both the status and reviewer columns before the summary for phabricator list make it more readable

### DIFF
--- a/extensions/PhabBugz/template/en/default/phabricator/table.html.tmpl
+++ b/extensions/PhabBugz/template/en/default/phabricator/table.html.tmpl
@@ -11,9 +11,9 @@
   <thead>
     <tr>
       <th>ID</th>
-      <th>Title</th>
       <th>Status</th>
       <th>Reviewers</th>
+      <th>Title</th>
     </tr>
   </thead>
   <tbody class="phabricator-revision">

--- a/extensions/PhabBugz/web/js/phabricator.js
+++ b/extensions/PhabBugz/web/js/phabricator.js
@@ -220,9 +220,9 @@ Phabricator.getBugRevisions = async () => {
 
         trRevision.append(
             tdId,
-            tdTitle,
             tdRevisionStatus,
-            tdReviewers
+            tdReviewers,
+            tdTitle
         );
 
         return trRevision;


### PR DESCRIPTION
This is a simple patch that reorders the columns in the Phabricator Revisions table so that the (possibly long) summary is the last column.