### PR TITLE
Bug 1782257 - /rest/component endpoint - handle cases where a component name has `/`

### DIFF
--- a/Bugzilla/API/V1/Component.pm
+++ b/Bugzilla/API/V1/Component.pm
@@ -21,9 +21,20 @@ sub setup_routes {
   my ($class, $r) = @_;
   my $comp_routes = $r->under(
     '/component' => sub { Bugzilla->usage_mode(USAGE_MODE_MOJO_REST); });
-  $comp_routes->post('/:product')->to('V1::Component#create');
-  $comp_routes->put('/:product/:component')->to('V1::Component#update');
-  $comp_routes->get('/:product/:component')->to('V1::Component#get');
+  # /*product allows product names containing a /
+  $comp_routes->post('/*product')->to('V1::Component#create');
+  $comp_routes->post('/')->to('V1::Component#create');
+
+  # /*component allows component names containing a /
+  # Unfortunately when specifying a product and component together,
+  # the product name cannot contain a / so you have to instead use
+  # named parameters as described below.
+  $comp_routes->put('/:product/*component')->to('V1::Component#update');
+  $comp_routes->get('/:product/*component')->to('V1::Component#get');
+  # Allow fallback route for use if product name contains a /
+  # Must use named parameters such as ?product=Firefox&component=General
+  $comp_routes->put('/')->to('V1::Component#update');
+  $comp_routes->get('/')->to('V1::Component#get');
 }
 
 sub create {

--- a/docs/en/rst/api/core/v1/component.rst
+++ b/docs/en/rst/api/core/v1/component.rst
@@ -19,6 +19,7 @@ To get information about the General component under the Firefox product:
    GET /rest/component/Firefox/General
 
 To get information about a component where the product name contains a slash (/) character.
+Named parameters must be used instead of path based parameters.
 
 .. code-block:: text
 
@@ -128,6 +129,7 @@ This allows you to update an existing component in Bugzilla.
    PUT /rest/component/Firefox/General
 
 To update information about a component where the product name contains a slash (/) character.
+Named parameters must be used instead of path based parameters.
 
 .. code-block:: text
 

--- a/docs/en/rst/api/core/v1/component.rst
+++ b/docs/en/rst/api/core/v1/component.rst
@@ -18,6 +18,12 @@ To get information about the General component under the Firefox product:
 
    GET /rest/component/Firefox/General
 
+To get information about a component where the product name contains a slash (/) character.
+
+.. code-block:: text
+
+   GET /rest/component?product=Firefox%20%2F%20Bugs&component=General
+
 **Response**
 
 .. code-block:: js
@@ -120,6 +126,14 @@ This allows you to update an existing component in Bugzilla.
 .. code-block:: text
 
    PUT /rest/component/Firefox/General
+
+To update information about a component where the product name contains a slash (/) character.
+
+.. code-block:: text
+
+   PUT /rest/component?product=Firefox%20%2F%20Bugs&component=General
+
+The body of the request should look similar to below.
 
 .. code-block:: js
 

--- a/qa/t/rest_components.t
+++ b/qa/t/rest_components.t
@@ -41,7 +41,7 @@ $t->post_ok($url . 'rest/component/Firefox' => json => $new_component)
   ->json_is(
   '/message' => 'You must log in before using this part of Bugzilla.');
 
-# Now try as authenticated user using API key. But a required field is missing (initialowner).
+# Now try as authenticated user using API key. But a required field is missing (default_assignee).
 $t->post_ok($url
     . 'rest/component/Firefox' => {'X-Bugzilla-API-Key' => $api_key} => json =>
     $new_component)->status_is(400)
@@ -94,5 +94,31 @@ $t->get_ok($url
     {'X-Bugzilla-API-Key' => $api_key})->status_is(200)
   ->json_is('/triage_owner' => 'admin@mozilla.test')
   ->json_is('/description'  => 'Updated description');
+
+### Section 1: Create a new component with a slash (/) in the name
+
+$new_component = {
+  name        => 'Test / Component',
+  product     => 'Firefox',
+  description => 'This is a new test component with slash',
+  team_name   => 'Mozilla',
+  default_assignee => 'admin@mozilla.test'
+};
+
+$t->post_ok($url
+    . 'rest/component/Firefox' => {'X-Bugzilla-API-Key' => $api_key} => json =>
+    $new_component)->status_is(200)->json_is('/name' => 'Test / Component');
+
+# Retrieve the new component and verify
+$t->get_ok($url
+    . 'rest/component/Firefox/Test / Component' =>
+    {'X-Bugzilla-API-Key' => $api_key})->status_is(200)
+  ->json_is('/name' => 'Test / Component');
+
+# Retrieve the component using named query parameters
+$t->get_ok($url
+    . 'rest/component?product=Firefox&component=Test / Component' =>
+    {'X-Bugzilla-API-Key' => $api_key})->status_is(200)
+  ->json_is('/name' => 'Test / Component');
 
 done_testing();


### PR DESCRIPTION
Updated the routing for the /rest/component API endpoints to allow for component names with / in the name. If the product has a / in the name, then named query parameters must be used.