### PR TITLE
Bug 1782341 - Show graph in phabricator revisions

### DIFF
--- a/extensions/PhabBugz/template/en/default/phabricator/table.html.tmpl
+++ b/extensions/PhabBugz/template/en/default/phabricator/table.html.tmpl
@@ -10,6 +10,7 @@
        data-phabricator-base-uri="[% Param('phabricator_base_uri') FILTER html %]">
   <thead>
     <tr>
+      <th></th>
       <th>ID</th>
       <th>Status</th>
       <th>Reviewers</th>
@@ -18,16 +19,16 @@
   </thead>
   <tbody class="phabricator-revision">
     <tr class="phabricator-loading-row">
-      <td colspan="4">Loading...</td>
+      <td colspan="5">Loading...</td>
     </tr>
     <tr class="phabricator-loading-error-row bz_default_hidden">
-      <td colspan="4">Error loading Phabricator revisions:
+      <td colspan="5">Error loading Phabricator revisions:
         <span class="phabricator-load-error-string"></span></td>
     </tr>
   </tbody>
   <tbody class="phabricator-show-abandoned bz_default_hidden">
     <tr>
-      <td colspan="4">
+      <td colspan="5">
         <input id="phabricator-show-abandoned" type="checkbox">
         <label for="phabricator-show-abandoned">Show Abandoned Revisions</label>
       </td>

--- a/extensions/PhabBugz/web/js/phabricator.js
+++ b/extensions/PhabBugz/web/js/phabricator.js
@@ -110,7 +110,25 @@ function splitBranches(revisions, revMap, branchCount) {
   }
 }
 
+function findFreeIndex(edges) {
+  let index = 0;
+
+  while (true) {
+    if (!edges.has(index)) {
+      return index;
+    }
+    index++;
+  }
+}
+
+const svgns = "http://www.w3.org/2000/svg";
+
+const EdgeMargin = 8;
+
 const Phabricator = {
+  // A map from revision ID to graph's svg element.
+  svgs: new Map(),
+
   // A map from revision ID to table row.
   trs: new Map(),
 
@@ -166,6 +184,255 @@ const Phabricator = {
     this.revisions = revisions.filter(rev => rev != pseudoRoot);
   },
 
+  // Calculate a graph edges.
+  //
+  // The graph uses X-axis as index.
+  //
+  //    0 1 2
+  //
+  //    o
+  //    |
+  //    |\
+  //    | |
+  //    | o
+  //    | |
+  //    | | o
+  //    | | |
+  //    | |/
+  //    | o
+  //    | |\
+  //    | | |
+  //    | | o
+  //    | | |
+  //    | o |
+  //    | |/
+  //    o |
+  //    | |
+  //    |/
+  //    |
+  //    o
+  //
+  // Each revision has the following information:
+  //
+  //   * The node's index
+  //   * List of parent node's index
+  //   * Whether the node has children
+  //   * List of other edge, represented by from/to indices
+  //
+  // That correspnds to the following part in the above graph:
+  //
+  //    | | |
+  //    | o |
+  //    | |/
+  //
+  calculateGraph() {
+    if (!this.revisions.length) {
+      return;
+    }
+
+    let revisions = this.revisions;
+    if (!this.showAbandoned) {
+      revisions = revisions.filter(rev => rev.status !== "abandoned");
+    }
+
+    const revMap = {};
+    for (const rev of revisions) {
+      revMap[rev.id] = rev;
+    }
+
+    // A map from edge's index to a set of remaining children.
+    const edges = new Map();
+
+    let maxEdgeCount = 1;
+    for (const rev of revisions) {
+      const visibleChildren = rev.children.filter(child => child in revMap);
+
+      const graph = {
+        // This node's index.
+        index: null,
+
+        // List of parent node's index.
+        parentIndices: [],
+
+        // True if there are visible children.
+        hasChildren: visibleChildren.length > 0,
+
+        // Othe edges in the same row.
+        otherEdges: [],
+      };
+      rev.graph = graph;
+
+      // Find all parents, and clear the parent's edge if this node is the last
+      // remaining child.
+      for (const [index, edge] of edges) {
+        if (edge.remainingChildren.has(rev.id)) {
+          edge.remainingChildren.delete(rev.id);
+          if (edge.remainingChildren.size == 0) {
+            edges.delete(index);
+          }
+
+          graph.parentIndices.push(index);
+        }
+      }
+
+      // After cleaning up parent edges, the remaining edges are drawn
+      // concurrently.
+      for (const [index, edge] of edges) {
+        graph.otherEdges.push({
+          from: index,
+          to: index,
+        });
+      }
+
+      // Find this node's index.
+      if (graph.parentIndices.length > 0) {
+        for (const parentIndex of graph.parentIndices) {
+          if (!edges.has(parentIndex)) {
+            // If there's any parent where this node is the last remaining
+            // child, use that parent's index.
+            //
+            //   o <- this node
+            //   |
+            //   o <- parent
+            //   |
+            //
+            graph.index = parentIndex;
+            break;
+          }
+        }
+
+        if (graph.index === null) {
+          // If all parents still have remaining children, put this node
+          // at the first parent's index, and move the remaining children of
+          // the first child into a new index.
+          //
+          // | <--- edge for remaining chidlren
+          // |
+          // | o <- this node
+          //  \|
+          //   |
+          //   o <- parent
+          //   |
+          //
+          const parentIndex = graph.parentIndices[0];
+          graph.index = parentIndex;
+          const newParentIndex = findFreeIndex(edges);
+          const parentEdge = edges.get(parentIndex);
+          edges.delete(parentIndex);
+          edges.set(newParentIndex, parentEdge);
+
+          // The edge for the remaining children.
+          graph.otherEdges.push({
+            from: parentIndex,
+            to: newParentIndex,
+          });
+        }
+      } else {
+        // This node has no parent. Put it into a new index.
+        graph.index = findFreeIndex(edges);
+      }
+
+      // Put a new edge to this node's children.
+      if (graph.hasChildren) {
+        edges.set(graph.index, {
+          remainingChildren: new Set(visibleChildren),
+        });
+      }
+
+      maxEdgeCount = Math.max(maxEdgeCount, edges.size);
+    }
+
+    this.maxEdgeCount = maxEdgeCount;
+  },
+
+  svgWidth() {
+    return (this.maxEdgeCount + 1) * EdgeMargin;
+  },
+
+  toNodeX(index) {
+    return EdgeMargin * (1 + index);
+  },
+
+  // Draw graph in the pre-populated svg elements for each revision's row.
+  drawGraph() {
+    const color = "#cc0099";
+
+    for (const rev of this.revisions) {
+      if (!this.showAbandoned) {
+        if (rev.status === "abandoned") {
+          continue;
+        }
+      }
+
+      const svg = this.svgs.get(rev.id);
+
+      // Cleanup the previous result before switching showAbandoned checkbox.
+      svg.setAttribute("width", this.svgWidth());
+      svg.replaceChildren();
+
+      // Fit to the table row.
+      // The height of the row can differ for each, due to:
+      //   * The number of reviewers can be different for each
+      //   * Long title can be wrapped into multiple lines
+      const h = svg.parentNode.offsetHeight;
+      svg.setAttribute("height", h);
+
+      const graph = rev.graph;
+
+      const x = this.toNodeX(graph.index);
+      const y = h / 2;
+
+      // An edge to children.
+      if (graph.hasChildren) {
+        const path = document.createElementNS(svgns, "path");
+        svg.append(path);
+        path.setAttribute("d", `M ${x} ${y} L ${x} 0`);
+        path.setAttribute("fill", "none");
+        path.setAttribute("stroke", color);
+        path.setAttribute("stroke-width", "1");
+      }
+
+      // An edge from parents.
+      for (const index of graph.parentIndices) {
+        const px = this.toNodeX(index);
+
+        const path = document.createElementNS(svgns, "path");
+        svg.append(path);
+        path.setAttribute("d",
+                          `M ${x} ${y} ` +
+                          `C ${x} ${h},  ${px} ${y},  ${px} ${h}`);
+        path.setAttribute("fill", "none");
+        path.setAttribute("stroke", color);
+        path.setAttribute("stroke-width", "1");
+      }
+
+      // Other edges in the same row.
+      for (const {from, to} of graph.otherEdges) {
+        const fromX = this.toNodeX(from);
+        const toX = this.toNodeX(to);
+
+        const path = document.createElementNS(svgns, "path");
+        svg.append(path);
+        path.setAttribute("d",
+                          `M ${toX} 0 ` +
+                          `L ${toX} ${y} ` +
+                          `C ${toX} ${h}, ${fromX} ${y}, ${fromX} ${h}`);
+        path.setAttribute("fill", "none");
+        path.setAttribute("stroke", color);
+        path.setAttribute("stroke-width", "1");
+      }
+
+      // This node.
+      const circle = document.createElementNS(svgns, "circle");
+      svg.append(circle);
+      circle.setAttribute("fill", color);
+      circle.setAttribute("stroke", color);
+      circle.setAttribute("cx", x);
+      circle.setAttribute("cy", y);
+      circle.setAttribute("r", "3");
+    }
+  },
+
   createTable() {
     const phabUrl = document.querySelector(".phabricator-revisions").getAttribute("data-phabricator-base-uri");
 
@@ -176,6 +443,21 @@ const Phabricator = {
     for (const rev of this.revisions.slice().reverse()) {
       const trRevision = document.createElement("tr");
       this.trs.set(rev.id, trRevision);
+
+      // Graph
+
+      const tdGraph = document.createElement("td");
+      tdGraph.style.paddingTop = "0";
+      tdGraph.style.paddingBottom = "0";
+
+      const svg = document.createElementNS(svgns, "svg");
+      svg.setAttribute("xmlns", svgns);
+      svg.setAttribute("version", "1.1");
+      svg.setAttribute("width", this.svgWidth());
+      svg.setAttribute("height", 10);
+      svg.style.display = "block";
+      this.svgs.set(rev.id,  svg);
+      tdGraph.append(svg);
 
       // Revision ID
 
@@ -246,6 +528,7 @@ const Phabricator = {
       }
 
       trRevision.append(
+        tdGraph,
         tdId,
         tdRevisionStatus,
         tdReviewers,
@@ -290,7 +573,9 @@ const Phabricator = {
 
       if (revisions.length) {
         this.setRevisions(revisions);
+        this.calculateGraph();
         this.createTable();
+        this.drawGraph();
       } else {
         displayLoadError("none returned from server");
       }
@@ -303,6 +588,8 @@ const Phabricator = {
     showAbandonedCheckbox.addEventListener("click", event => {
       this.showAbandoned = showAbandonedCheckbox.checked;
       this.updateVisibility();
+      this.calculateGraph();
+      this.drawGraph();
     });
   },
 };

--- a/extensions/PhabBugz/web/js/phabricator.js
+++ b/extensions/PhabBugz/web/js/phabricator.js
@@ -161,14 +161,14 @@ const Phabricator = {
     var tbody = document.querySelector("tbody.phabricator-revision");
 
     for (const rev of this.revisions) {
-      var trRevision     = document.createElement("tr");
-      var tdId           = document.createElement("td");
-      var tdTitle        = document.createElement("td");
-      var tdRevisionStatus       = document.createElement("td");
-      var tdReviewers    = document.createElement("td");
-      var tableReviews   = document.createElement("table");
+      var trRevision = document.createElement("tr");
+      var tdId = document.createElement("td");
+      var tdTitle = document.createElement("td");
+      var tdRevisionStatus = document.createElement("td");
+      var tdReviewers = document.createElement("td");
+      var tableReviews = document.createElement("table");
 
-      var spanRevisionStatus     = document.createElement("span");
+      var spanRevisionStatus = document.createElement("span");
       var spanRevisionStatusIcon = document.createElement("span");
       var spanRevisionStatusText = document.createElement("span");
 
@@ -193,9 +193,9 @@ const Phabricator = {
 
       var i = 0, l = reviews.length;
       for (; i < l; i++) {
-        var trReview             = document.createElement("tr");
-        var tdReviewStatus       = document.createElement("td");
-        var tdReviewer           = document.createElement("td");
+        var trReview = document.createElement("tr");
+        var tdReviewStatus = document.createElement("td");
+        var tdReviewer = document.createElement("td");
         var spanReviewStatusIcon = document.createElement("span");
         trReview.title = reviews[i].long_status;
         spanReviewStatusIcon.classList.add("review-status-icon-" + reviews[i].status);

--- a/extensions/PhabBugz/web/js/phabricator.js
+++ b/extensions/PhabBugz/web/js/phabricator.js
@@ -323,11 +323,13 @@ const Phabricator = {
           edges.delete(parentIndex);
           edges.set(newParentIndex, parentEdge);
 
-          // The edge for the remaining children.
-          graph.otherEdges.push({
-            from: parentIndex,
-            to: newParentIndex,
-          });
+          // Redirect the edge for the remaining children.
+          for (const edge of graph.otherEdges) {
+            if (edge.from === parentIndex) {
+              edge.to = newParentIndex;
+              break;
+            }
+          }
         }
       } else {
         // This node has no parent. Put it into a new index.

--- a/extensions/PhabBugz/web/js/phabricator.js
+++ b/extensions/PhabBugz/web/js/phabricator.js
@@ -260,6 +260,19 @@ const Phabricator = {
     }
   },
 
+  // Show/hide abandoned revisions.
+  updateVisibility() {
+    for (const rev of this.revisions) {
+      const tr = this.trs.get(rev.id);
+
+      if (rev.status !== "abandoned") {
+        continue;
+      }
+
+      tr.classList.toggle("bz_default_hidden", !this.showAbandoned);
+    }
+  },
+
   async onLoad() {
     const showAbandonedCheckbox = document.querySelector("#phabricator-show-abandoned");
     this.showAbandoned = showAbandonedCheckbox.checked;
@@ -289,15 +302,7 @@ const Phabricator = {
 
     showAbandonedCheckbox.addEventListener("click", event => {
       this.showAbandoned = showAbandonedCheckbox.checked;
-      for (const rev of this.revisions) {
-        const tr = this.trs.get(rev.id);
-
-        if (rev.status !== "abandoned") {
-          continue;
-        }
-
-        tr.classList.toggle("bz_default_hidden", !this.showAbandoned);
-      }
+      this.updateVisibility();
     });
   },
 };

--- a/extensions/PhabBugz/web/js/phabricator.js
+++ b/extensions/PhabBugz/web/js/phabricator.js
@@ -6,6 +6,8 @@
  * defined by the Mozilla Public License, v. 2.0.
  */
 
+/* global Bugzilla, BUGZILLA */
+
 // Add pseudo root revision that has all root revisions as child.
 function addPseudoRoot(revisions, revMap) {
   for (const rev of revisions) {

--- a/extensions/PhabBugz/web/js/phabricator.js
+++ b/extensions/PhabBugz/web/js/phabricator.js
@@ -245,7 +245,7 @@ const Phabricator = {
     // A map from edge's index to a set of remaining children.
     const edges = new Map();
 
-    let maxEdgeCount = 1;
+    let maxEdgeIndex = 0;
     for (const rev of revisions) {
       const visibleChildren = rev.children.filter(child => child in revMap);
 
@@ -341,14 +341,14 @@ const Phabricator = {
         });
       }
 
-      maxEdgeCount = Math.max(maxEdgeCount, edges.size);
+      maxEdgeIndex = Math.max(maxEdgeIndex, graph.index);
     }
 
-    this.maxEdgeCount = maxEdgeCount;
+    this.maxEdgeIndex = maxEdgeIndex;
   },
 
   svgWidth() {
-    return (this.maxEdgeCount + 1) * EdgeMargin;
+    return (this.maxEdgeIndex + 2) * EdgeMargin;
   },
 
   toNodeX(index) {

--- a/extensions/PhabBugz/web/js/phabricator.js
+++ b/extensions/PhabBugz/web/js/phabricator.js
@@ -162,65 +162,82 @@ const Phabricator = {
   showAbandoned: false,
 
   createTable() {
-    var phabUrl = document.querySelector(".phabricator-revisions").getAttribute("data-phabricator-base-uri");
+    const phabUrl = document.querySelector(".phabricator-revisions").getAttribute("data-phabricator-base-uri");
 
-    var tbody = document.querySelector("tbody.phabricator-revision");
+    const tbody = document.querySelector("tbody.phabricator-revision");
+
+    let hasAbandonedRevisions = false;
 
     for (const rev of this.revisions) {
-      var trRevision = document.createElement("tr");
+      const trRevision = document.createElement("tr");
       this.trs.set(rev.id, trRevision);
 
-      var tdId = document.createElement("td");
-      var tdTitle = document.createElement("td");
-      var tdRevisionStatus = document.createElement("td");
-      var tdReviewers = document.createElement("td");
-      var tableReviews = document.createElement("table");
+      // Revision ID
 
-      var spanRevisionStatus = document.createElement("span");
-      var spanRevisionStatusIcon = document.createElement("span");
-      var spanRevisionStatusText = document.createElement("span");
-
-      var revLink = document.createElement("a");
+      const tdId = document.createElement("td");
+      const revLink = document.createElement("a");
       revLink.setAttribute("href", phabUrl + rev.id);
       revLink.append(rev.id);
       tdId.append(revLink);
 
-      tdTitle.append(rev.title);
-      tdTitle.classList.add("phabricator-title");
+      // Revision status
 
+      const tdRevisionStatus = document.createElement("td");
+
+      const spanRevisionStatus = document.createElement("span");
+      spanRevisionStatus.classList.add("revision-status-box-" + rev.status);
+
+      const spanRevisionStatusIcon = document.createElement("span");
       spanRevisionStatusIcon.classList.add("revision-status-icon-" + rev.status);
       spanRevisionStatus.append(spanRevisionStatusIcon);
+
+      const spanRevisionStatusText = document.createElement("span");
       spanRevisionStatusText.append(rev.long_status);
       spanRevisionStatus.append(spanRevisionStatusText);
-      spanRevisionStatus.classList.add("revision-status-box-" + rev.status);
+
       tdRevisionStatus.append(spanRevisionStatus);
 
-      var reviews = rev.reviews.slice().sort((a, b) => {
-        return a.user < b.user ? -1 : 1;
-      });
+      // Reviewers
 
-      var i = 0, l = reviews.length;
-      for (; i < l; i++) {
-        var trReview = document.createElement("tr");
-        var tdReviewStatus = document.createElement("td");
-        var tdReviewer = document.createElement("td");
-        var spanReviewStatusIcon = document.createElement("span");
-        trReview.title = reviews[i].long_status;
-        spanReviewStatusIcon.classList.add("review-status-icon-" + reviews[i].status);
+      const tdReviewers = document.createElement("td");
+
+      const tableReviews = document.createElement("table");
+      tableReviews.classList.add("phabricator-reviewers");
+
+      for (const review of rev.reviews.slice().sort((a, b) => {
+        return a.user < b.user ? -1 : 1;
+      })) {
+        const trReview = document.createElement("tr");
+        trReview.title = review.long_status;
+
+        const tdReviewStatus = document.createElement("td");
+        const spanReviewStatusIcon = document.createElement("span");
+        spanReviewStatusIcon.classList.add("review-status-icon-" + review.status);
         tdReviewStatus.append(spanReviewStatusIcon);
-        tdReviewer.append(reviews[i].user);
+
+        const tdReviewer = document.createElement("td");
         tdReviewer.classList.add("review-reviewer");
+        tdReviewer.append(review.user);
+
         trReview.append(tdReviewStatus, tdReviewer);
+
         tableReviews.append(trReview);
       }
-      tableReviews.classList.add("phabricator-reviewers");
       tdReviewers.append(tableReviews);
+
+      // Revision Title
+
+      const tdTitle = document.createElement("td");
+      tdTitle.classList.add("phabricator-title");
+      tdTitle.append(rev.title);
+
+      // Hide abandoned revisions
 
       if (rev.status === "abandoned") {
         if (!this.showAbandoned) {
           trRevision.classList.add("bz_default_hidden");
         }
-        document.querySelector("tbody.phabricator-show-abandoned").classList.remove("bz_default_hidden");
+        hasAbandonedRevisions = true;
       }
 
       trRevision.append(
@@ -232,16 +249,20 @@ const Phabricator = {
 
       tbody.append(trRevision);
     }
+
+    if (hasAbandonedRevisions) {
+      document.querySelector("tbody.phabricator-show-abandoned").classList.remove("bz_default_hidden");
+    }
   },
 
   async onLoad() {
     const showAbandonedCheckbox = document.querySelector("#phabricator-show-abandoned");
     this.showAbandoned = showAbandonedCheckbox.checked;
 
-    var tbody = document.querySelector("tbody.phabricator-revision");
+    const tbody = document.querySelector("tbody.phabricator-revision");
 
     function displayLoadError(errStr) {
-      var errRow = tbody.querySelector(".phabricator-loading-error-row");
+      const errRow = tbody.querySelector(".phabricator-loading-error-row");
       errRow.querySelector(".phabricator-load-error-string").replaceChildren(errStr);
       errRow.classList.remove("bz_default_hidden");
     }

--- a/extensions/PhabBugz/web/js/phabricator.js
+++ b/extensions/PhabBugz/web/js/phabricator.js
@@ -157,108 +157,108 @@ function sortRevisions(revs) {
 }
 
 Phabricator.getBugRevisions = async () => {
-    var phabUrl = document.querySelector('.phabricator-revisions').getAttribute('data-phabricator-base-uri');
+  var phabUrl = document.querySelector('.phabricator-revisions').getAttribute('data-phabricator-base-uri');
 
-    function revisionRow(revision) {
-        var trRevision     = document.createElement('tr');
-        var tdId           = document.createElement('td');
-        var tdTitle        = document.createElement('td');
-        var tdRevisionStatus       = document.createElement('td');
-        var tdReviewers    = document.createElement('td');
-        var tableReviews   = document.createElement('table');
+  function revisionRow(revision) {
+    var trRevision     = document.createElement('tr');
+    var tdId           = document.createElement('td');
+    var tdTitle        = document.createElement('td');
+    var tdRevisionStatus       = document.createElement('td');
+    var tdReviewers    = document.createElement('td');
+    var tableReviews   = document.createElement('table');
 
-        var spanRevisionStatus     = document.createElement('span');
-        var spanRevisionStatusIcon = document.createElement('span');
-        var spanRevisionStatusText = document.createElement('span');
+    var spanRevisionStatus     = document.createElement('span');
+    var spanRevisionStatusIcon = document.createElement('span');
+    var spanRevisionStatusText = document.createElement('span');
 
-        var revLink = document.createElement('a');
-        revLink.setAttribute('href', phabUrl + revision.id);
-        revLink.append(revision.id);
-        tdId.append(revLink);
+    var revLink = document.createElement('a');
+    revLink.setAttribute('href', phabUrl + revision.id);
+    revLink.append(revision.id);
+    tdId.append(revLink);
 
-        tdTitle.append(revision.title);
-        tdTitle.classList.add('phabricator-title');
+    tdTitle.append(revision.title);
+    tdTitle.classList.add('phabricator-title');
 
-        spanRevisionStatusIcon.classList.add('revision-status-icon-' + revision.status);
-        spanRevisionStatus.append(spanRevisionStatusIcon);
-        spanRevisionStatusText.append(revision.long_status);
-        spanRevisionStatus.append(spanRevisionStatusText);
-        spanRevisionStatus.classList.add('revision-status-box-' + revision.status);
-        tdRevisionStatus.append(spanRevisionStatus);
+    spanRevisionStatusIcon.classList.add('revision-status-icon-' + revision.status);
+    spanRevisionStatus.append(spanRevisionStatusIcon);
+    spanRevisionStatusText.append(revision.long_status);
+    spanRevisionStatus.append(spanRevisionStatusText);
+    spanRevisionStatus.classList.add('revision-status-box-' + revision.status);
+    tdRevisionStatus.append(spanRevisionStatus);
 
-        var reviews = revision.reviews.slice().sort((a, b) => {
-          return a.user < b.user ? -1 : 1;
-        });
+    var reviews = revision.reviews.slice().sort((a, b) => {
+      return a.user < b.user ? -1 : 1;
+    });
 
-        var i = 0, l = reviews.length;
-        for (; i < l; i++) {
-            var trReview             = document.createElement('tr');
-            var tdReviewStatus       = document.createElement('td');
-            var tdReviewer           = document.createElement('td');
-            var spanReviewStatusIcon = document.createElement('span');
-            trReview.title = reviews[i].long_status;
-            spanReviewStatusIcon.classList.add('review-status-icon-' + reviews[i].status);
-            tdReviewStatus.append(spanReviewStatusIcon);
-            tdReviewer.append(reviews[i].user);
-            tdReviewer.classList.add('review-reviewer');
-            trReview.append(tdReviewStatus, tdReviewer);
-            tableReviews.append(trReview);
-        }
-        tableReviews.classList.add('phabricator-reviewers');
-        tdReviewers.append(tableReviews);
+    var i = 0, l = reviews.length;
+    for (; i < l; i++) {
+      var trReview             = document.createElement('tr');
+      var tdReviewStatus       = document.createElement('td');
+      var tdReviewer           = document.createElement('td');
+      var spanReviewStatusIcon = document.createElement('span');
+      trReview.title = reviews[i].long_status;
+      spanReviewStatusIcon.classList.add('review-status-icon-' + reviews[i].status);
+      tdReviewStatus.append(spanReviewStatusIcon);
+      tdReviewer.append(reviews[i].user);
+      tdReviewer.classList.add('review-reviewer');
+      trReview.append(tdReviewStatus, tdReviewer);
+      tableReviews.append(trReview);
+    }
+    tableReviews.classList.add('phabricator-reviewers');
+    tdReviewers.append(tableReviews);
 
-        trRevision.setAttribute('data-status', revision.status);
-        if (revision.status === 'abandoned') {
-            trRevision.classList.add('bz_default_hidden');
-            document.querySelector('tbody.phabricator-show-abandoned').classList.remove('bz_default_hidden');
-        }
-
-        trRevision.append(
-            tdId,
-            tdRevisionStatus,
-            tdReviewers,
-            tdTitle
-        );
-
-        return trRevision;
+    trRevision.setAttribute('data-status', revision.status);
+    if (revision.status === 'abandoned') {
+      trRevision.classList.add('bz_default_hidden');
+      document.querySelector('tbody.phabricator-show-abandoned').classList.remove('bz_default_hidden');
     }
 
-    var tbody = document.querySelector('tbody.phabricator-revision');
+    trRevision.append(
+      tdId,
+      tdRevisionStatus,
+      tdReviewers,
+      tdTitle
+    );
 
-    function displayLoadError(errStr) {
-        var errRow = tbody.querySelector('.phabricator-loading-error-row');
-        errRow.querySelector('.phabricator-load-error-string').replaceChildren(errStr);
-        errRow.classList.remove('bz_default_hidden');
+    return trRevision;
+  }
+
+  var tbody = document.querySelector('tbody.phabricator-revision');
+
+  function displayLoadError(errStr) {
+    var errRow = tbody.querySelector('.phabricator-loading-error-row');
+    errRow.querySelector('.phabricator-load-error-string').replaceChildren(errStr);
+    errRow.classList.remove('bz_default_hidden');
+  }
+
+  try {
+    const { revisions } = await Bugzilla.API.get(`phabbugz/bug_revisions/${BUGZILLA.bug_id}`);
+
+    if (revisions.length) {
+      sortRevisions(revisions).forEach(rev => tbody.append(revisionRow(rev)));
+    } else {
+      displayLoadError('none returned from server');
     }
+  } catch ({ message }) {
+    displayLoadError(message);
+  }
 
-    try {
-        const { revisions } = await Bugzilla.API.get(`phabbugz/bug_revisions/${BUGZILLA.bug_id}`);
-
-        if (revisions.length) {
-            sortRevisions(revisions).forEach(rev => tbody.append(revisionRow(rev)));
-        } else {
-            displayLoadError('none returned from server');
-        }
-    } catch ({ message }) {
-        displayLoadError(message);
-    }
-
-    tbody.querySelector('.phabricator-loading-row').classList.add('bz_default_hidden');
+  tbody.querySelector('.phabricator-loading-row').classList.add('bz_default_hidden');
 };
 
 window.addEventListener("DOMContentLoaded", function() {
-    Phabricator.getBugRevisions();
+  Phabricator.getBugRevisions();
 
-    document.querySelector('#phabricator-show-abandoned').addEventListener('click', event => {
-        for (const row of document.querySelectorAll('tbody.phabricator-revision > tr')) {
-            if (row.getAttribute('data-status') === 'abandoned') {
-                if (document.querySelector('#phabricator-show-abandoned').checked) {
-                    row.classList.remove('bz_default_hidden');
-                }
-                else {
-                    row.classList.add('bz_default_hidden');
-                }
-            }
+  document.querySelector('#phabricator-show-abandoned').addEventListener('click', event => {
+    for (const row of document.querySelectorAll('tbody.phabricator-revision > tr')) {
+      if (row.getAttribute('data-status') === 'abandoned') {
+        if (document.querySelector('#phabricator-show-abandoned').checked) {
+          row.classList.remove('bz_default_hidden');
         }
-    });
+        else {
+          row.classList.add('bz_default_hidden');
+        }
+      }
+    }
+  });
 });

--- a/extensions/PhabBugz/web/js/phabricator.js
+++ b/extensions/PhabBugz/web/js/phabricator.js
@@ -157,38 +157,33 @@ function sortRevisions(revs) {
 }
 
 Phabricator.getBugRevisions = async () => {
-    var phabUrl = $('.phabricator-revisions').data('phabricator-base-uri');
-    var tr      = $('<tr/>');
-    var td      = $('<td/>');
-    var link    = $('<a/>');
-    var span    = $('<span/>');
-    var table   = $('<table/>');
+    var phabUrl = document.querySelector('.phabricator-revisions').getAttribute('data-phabricator-base-uri');
 
     function revisionRow(revision) {
-        var trRevision     = tr.clone();
-        var tdId           = td.clone();
-        var tdTitle        = td.clone();
-        var tdRevisionStatus       = td.clone();
-        var tdReviewers    = td.clone();
-        var tableReviews   = table.clone();
+        var trRevision     = document.createElement('tr');
+        var tdId           = document.createElement('td');
+        var tdTitle        = document.createElement('td');
+        var tdRevisionStatus       = document.createElement('td');
+        var tdReviewers    = document.createElement('td');
+        var tableReviews   = document.createElement('table');
 
-        var spanRevisionStatus     = span.clone();
-        var spanRevisionStatusIcon = span.clone();
-        var spanRevisionStatusText = span.clone();
+        var spanRevisionStatus     = document.createElement('span');
+        var spanRevisionStatusIcon = document.createElement('span');
+        var spanRevisionStatusText = document.createElement('span');
 
-        var revLink = link.clone();
-        revLink.attr('href', phabUrl + revision.id);
-        revLink.text(revision.id);
+        var revLink = document.createElement('a');
+        revLink.setAttribute('href', phabUrl + revision.id);
+        revLink.append(revision.id);
         tdId.append(revLink);
 
-        tdTitle.text(revision.title);
-        tdTitle.addClass('phabricator-title');
+        tdTitle.append(revision.title);
+        tdTitle.classList.add('phabricator-title');
 
-        spanRevisionStatusIcon.addClass('revision-status-icon-' + revision.status);
+        spanRevisionStatusIcon.classList.add('revision-status-icon-' + revision.status);
         spanRevisionStatus.append(spanRevisionStatusIcon);
-        spanRevisionStatusText.text(revision.long_status);
+        spanRevisionStatusText.append(revision.long_status);
         spanRevisionStatus.append(spanRevisionStatusText);
-        spanRevisionStatus.addClass('revision-status-box-' + revision.status);
+        spanRevisionStatus.classList.add('revision-status-box-' + revision.status);
         tdRevisionStatus.append(spanRevisionStatus);
 
         var reviews = revision.reviews.slice().sort((a, b) => {
@@ -197,25 +192,25 @@ Phabricator.getBugRevisions = async () => {
 
         var i = 0, l = reviews.length;
         for (; i < l; i++) {
-            var trReview             = tr.clone();
-            var tdReviewStatus       = td.clone();
-            var tdReviewer           = td.clone();
-            var spanReviewStatusIcon = span.clone();
-            trReview.prop('title', reviews[i].long_status);
-            spanReviewStatusIcon.addClass('review-status-icon-' + reviews[i].status);
+            var trReview             = document.createElement('tr');
+            var tdReviewStatus       = document.createElement('td');
+            var tdReviewer           = document.createElement('td');
+            var spanReviewStatusIcon = document.createElement('span');
+            trReview.title = reviews[i].long_status;
+            spanReviewStatusIcon.classList.add('review-status-icon-' + reviews[i].status);
             tdReviewStatus.append(spanReviewStatusIcon);
-            tdReviewer.text(reviews[i].user);
-            tdReviewer.addClass('review-reviewer');
+            tdReviewer.append(reviews[i].user);
+            tdReviewer.classList.add('review-reviewer');
             trReview.append(tdReviewStatus, tdReviewer);
             tableReviews.append(trReview);
         }
-        tableReviews.addClass('phabricator-reviewers');
+        tableReviews.classList.add('phabricator-reviewers');
         tdReviewers.append(tableReviews);
 
-        trRevision.attr('data-status', revision.status);
+        trRevision.setAttribute('data-status', revision.status);
         if (revision.status === 'abandoned') {
-            trRevision.addClass('bz_default_hidden');
-            $('tbody.phabricator-show-abandoned').removeClass('bz_default_hidden');
+            trRevision.classList.add('bz_default_hidden');
+            document.querySelector('tbody.phabricator-show-abandoned').classList.remove('bz_default_hidden');
         }
 
         trRevision.append(
@@ -228,12 +223,12 @@ Phabricator.getBugRevisions = async () => {
         return trRevision;
     }
 
-    var tbody = $('tbody.phabricator-revision');
+    var tbody = document.querySelector('tbody.phabricator-revision');
 
     function displayLoadError(errStr) {
-        var errRow = tbody.find('.phabricator-loading-error-row');
-        errRow.find('.phabricator-load-error-string').text(errStr);
-        errRow.removeClass('bz_default_hidden');
+        var errRow = tbody.querySelector('.phabricator-loading-error-row');
+        errRow.querySelector('.phabricator-load-error-string').replaceChildren(errStr);
+        errRow.classList.remove('bz_default_hidden');
     }
 
     try {
@@ -248,23 +243,22 @@ Phabricator.getBugRevisions = async () => {
         displayLoadError(message);
     }
 
-    tbody.find('.phabricator-loading-row').addClass('bz_default_hidden');
+    tbody.querySelector('.phabricator-loading-row').classList.add('bz_default_hidden');
 };
 
-$().ready(function() {
+window.addEventListener("DOMContentLoaded", function() {
     Phabricator.getBugRevisions();
 
-    $('#phabricator-show-abandoned').on('click', function (event) {
-        $('tbody.phabricator-revision > tr').each(function() {
-            var row = $(this);
-            if (row.attr('data-status') === 'abandoned') {
-                if ($('#phabricator-show-abandoned').prop('checked') == true) {
-                    row.removeClass('bz_default_hidden');
+    document.querySelector('#phabricator-show-abandoned').addEventListener('click', event => {
+        for (const row of document.querySelectorAll('tbody.phabricator-revision > tr')) {
+            if (row.getAttribute('data-status') === 'abandoned') {
+                if (document.querySelector('#phabricator-show-abandoned').checked) {
+                    row.classList.remove('bz_default_hidden');
                 }
                 else {
-                    row.addClass('bz_default_hidden');
+                    row.classList.add('bz_default_hidden');
                 }
             }
-        });
+        }
     });
 });

--- a/extensions/PhabBugz/web/js/phabricator.js
+++ b/extensions/PhabBugz/web/js/phabricator.js
@@ -581,8 +581,9 @@ const Phabricator = {
       } else {
         displayLoadError("none returned from server");
       }
-    } catch ({ message }) {
-      displayLoadError(message);
+    } catch (e) {
+      console.error(e);
+      displayLoadError(e.message);
     }
 
     tbody.querySelector(".phabricator-loading-row").classList.add("bz_default_hidden");

--- a/extensions/PhabBugz/web/js/phabricator.js
+++ b/extensions/PhabBugz/web/js/phabricator.js
@@ -157,33 +157,33 @@ function sortRevisions(revs) {
 }
 
 Phabricator.getBugRevisions = async () => {
-  var phabUrl = document.querySelector('.phabricator-revisions').getAttribute('data-phabricator-base-uri');
+  var phabUrl = document.querySelector(".phabricator-revisions").getAttribute("data-phabricator-base-uri");
 
   function revisionRow(revision) {
-    var trRevision     = document.createElement('tr');
-    var tdId           = document.createElement('td');
-    var tdTitle        = document.createElement('td');
-    var tdRevisionStatus       = document.createElement('td');
-    var tdReviewers    = document.createElement('td');
-    var tableReviews   = document.createElement('table');
+    var trRevision     = document.createElement("tr");
+    var tdId           = document.createElement("td");
+    var tdTitle        = document.createElement("td");
+    var tdRevisionStatus       = document.createElement("td");
+    var tdReviewers    = document.createElement("td");
+    var tableReviews   = document.createElement("table");
 
-    var spanRevisionStatus     = document.createElement('span');
-    var spanRevisionStatusIcon = document.createElement('span');
-    var spanRevisionStatusText = document.createElement('span');
+    var spanRevisionStatus     = document.createElement("span");
+    var spanRevisionStatusIcon = document.createElement("span");
+    var spanRevisionStatusText = document.createElement("span");
 
-    var revLink = document.createElement('a');
-    revLink.setAttribute('href', phabUrl + revision.id);
+    var revLink = document.createElement("a");
+    revLink.setAttribute("href", phabUrl + revision.id);
     revLink.append(revision.id);
     tdId.append(revLink);
 
     tdTitle.append(revision.title);
-    tdTitle.classList.add('phabricator-title');
+    tdTitle.classList.add("phabricator-title");
 
-    spanRevisionStatusIcon.classList.add('revision-status-icon-' + revision.status);
+    spanRevisionStatusIcon.classList.add("revision-status-icon-" + revision.status);
     spanRevisionStatus.append(spanRevisionStatusIcon);
     spanRevisionStatusText.append(revision.long_status);
     spanRevisionStatus.append(spanRevisionStatusText);
-    spanRevisionStatus.classList.add('revision-status-box-' + revision.status);
+    spanRevisionStatus.classList.add("revision-status-box-" + revision.status);
     tdRevisionStatus.append(spanRevisionStatus);
 
     var reviews = revision.reviews.slice().sort((a, b) => {
@@ -192,25 +192,25 @@ Phabricator.getBugRevisions = async () => {
 
     var i = 0, l = reviews.length;
     for (; i < l; i++) {
-      var trReview             = document.createElement('tr');
-      var tdReviewStatus       = document.createElement('td');
-      var tdReviewer           = document.createElement('td');
-      var spanReviewStatusIcon = document.createElement('span');
+      var trReview             = document.createElement("tr");
+      var tdReviewStatus       = document.createElement("td");
+      var tdReviewer           = document.createElement("td");
+      var spanReviewStatusIcon = document.createElement("span");
       trReview.title = reviews[i].long_status;
-      spanReviewStatusIcon.classList.add('review-status-icon-' + reviews[i].status);
+      spanReviewStatusIcon.classList.add("review-status-icon-" + reviews[i].status);
       tdReviewStatus.append(spanReviewStatusIcon);
       tdReviewer.append(reviews[i].user);
-      tdReviewer.classList.add('review-reviewer');
+      tdReviewer.classList.add("review-reviewer");
       trReview.append(tdReviewStatus, tdReviewer);
       tableReviews.append(trReview);
     }
-    tableReviews.classList.add('phabricator-reviewers');
+    tableReviews.classList.add("phabricator-reviewers");
     tdReviewers.append(tableReviews);
 
-    trRevision.setAttribute('data-status', revision.status);
-    if (revision.status === 'abandoned') {
-      trRevision.classList.add('bz_default_hidden');
-      document.querySelector('tbody.phabricator-show-abandoned').classList.remove('bz_default_hidden');
+    trRevision.setAttribute("data-status", revision.status);
+    if (revision.status === "abandoned") {
+      trRevision.classList.add("bz_default_hidden");
+      document.querySelector("tbody.phabricator-show-abandoned").classList.remove("bz_default_hidden");
     }
 
     trRevision.append(
@@ -223,12 +223,12 @@ Phabricator.getBugRevisions = async () => {
     return trRevision;
   }
 
-  var tbody = document.querySelector('tbody.phabricator-revision');
+  var tbody = document.querySelector("tbody.phabricator-revision");
 
   function displayLoadError(errStr) {
-    var errRow = tbody.querySelector('.phabricator-loading-error-row');
-    errRow.querySelector('.phabricator-load-error-string').replaceChildren(errStr);
-    errRow.classList.remove('bz_default_hidden');
+    var errRow = tbody.querySelector(".phabricator-loading-error-row");
+    errRow.querySelector(".phabricator-load-error-string").replaceChildren(errStr);
+    errRow.classList.remove("bz_default_hidden");
   }
 
   try {
@@ -237,26 +237,26 @@ Phabricator.getBugRevisions = async () => {
     if (revisions.length) {
       sortRevisions(revisions).forEach(rev => tbody.append(revisionRow(rev)));
     } else {
-      displayLoadError('none returned from server');
+      displayLoadError("none returned from server");
     }
   } catch ({ message }) {
     displayLoadError(message);
   }
 
-  tbody.querySelector('.phabricator-loading-row').classList.add('bz_default_hidden');
+  tbody.querySelector(".phabricator-loading-row").classList.add("bz_default_hidden");
 };
 
 window.addEventListener("DOMContentLoaded", function() {
   Phabricator.getBugRevisions();
 
-  document.querySelector('#phabricator-show-abandoned').addEventListener('click', event => {
-    for (const row of document.querySelectorAll('tbody.phabricator-revision > tr')) {
-      if (row.getAttribute('data-status') === 'abandoned') {
-        if (document.querySelector('#phabricator-show-abandoned').checked) {
-          row.classList.remove('bz_default_hidden');
+  document.querySelector("#phabricator-show-abandoned").addEventListener("click", event => {
+    for (const row of document.querySelectorAll("tbody.phabricator-revision > tr")) {
+      if (row.getAttribute("data-status") === "abandoned") {
+        if (document.querySelector("#phabricator-show-abandoned").checked) {
+          row.classList.remove("bz_default_hidden");
         }
         else {
-          row.classList.add('bz_default_hidden');
+          row.classList.add("bz_default_hidden");
         }
       }
     }

--- a/extensions/PhabBugz/web/js/phabricator.js
+++ b/extensions/PhabBugz/web/js/phabricator.js
@@ -153,7 +153,7 @@ function sortRevisions(revs) {
     splitBranches(revisions, revMap, branchCount);
   }
 
-  return revisions.filter(rev => rev != pseudoRoot);
+  return revisions.filter(rev => rev != pseudoRoot).reverse();
 }
 
 Phabricator.getBugRevisions = async () => {

--- a/extensions/PhabBugz/web/js/phabricator.js
+++ b/extensions/PhabBugz/web/js/phabricator.js
@@ -155,7 +155,7 @@ function sortRevisions(revs) {
 }
 
 const Phabricator = {
-  async getBugRevisions() {
+  async onLoad() {
     var phabUrl = document.querySelector(".phabricator-revisions").getAttribute("data-phabricator-base-uri");
 
     function revisionRow(revision) {
@@ -243,22 +243,22 @@ const Phabricator = {
     }
 
     tbody.querySelector(".phabricator-loading-row").classList.add("bz_default_hidden");
+
+    document.querySelector("#phabricator-show-abandoned").addEventListener("click", event => {
+      for (const row of document.querySelectorAll("tbody.phabricator-revision > tr")) {
+        if (row.getAttribute("data-status") === "abandoned") {
+          if (document.querySelector("#phabricator-show-abandoned").checked) {
+            row.classList.remove("bz_default_hidden");
+          }
+          else {
+            row.classList.add("bz_default_hidden");
+          }
+        }
+      }
+    });
   },
 };
 
 window.addEventListener("DOMContentLoaded", function() {
-  Phabricator.getBugRevisions();
-
-  document.querySelector("#phabricator-show-abandoned").addEventListener("click", event => {
-    for (const row of document.querySelectorAll("tbody.phabricator-revision > tr")) {
-      if (row.getAttribute("data-status") === "abandoned") {
-        if (document.querySelector("#phabricator-show-abandoned").checked) {
-          row.classList.remove("bz_default_hidden");
-        }
-        else {
-          row.classList.add("bz_default_hidden");
-        }
-      }
-    }
-  });
+  Phabricator.onLoad();
 });


### PR DESCRIPTION
A stack of:
  * Reverse the revision order ([bug 1523847](https://bugzilla.mozilla.org/show_bug.cgi?id=1523847))
  * de-jQuery
  * some code cleanup
  * Fix "Show Abandoned Revisions" checkbox handling
  * Show graph in phabricator revisions ([bug 1782341](https://bugzilla.mozilla.org/show_bug.cgi?id=1782341))