### PR TITLE
Bug 1324011 - "See also" elements should be links in emails

### DIFF
--- a/extensions/BMO/template/en/default/email/bugmail.html.tmpl
+++ b/extensions/BMO/template/en/default/email/bugmail.html.tmpl
@@ -141,6 +141,8 @@
         <td class="c2">
           [% IF change.field_name == "bug_id" %]
             [% new_value FILTER bug_link(bug, full_url => 1) FILTER none %]
+          [% ELSIF change.field_name == "see_also" %]
+            <a href="[% new_value FILTER html %]">[% new_value FILTER html %]</a>
           [% ELSE %]
             [% new_value FILTER html %]
           [% END %]

--- a/extensions/BMO/template/en/default/email/bugmail.html.tmpl
+++ b/extensions/BMO/template/en/default/email/bugmail.html.tmpl
@@ -196,17 +196,17 @@
     <tr>
       <td class="c1" style="border-right: 1px solid #969696" nowrap>[% field_label FILTER html %]</td>
       <td class="c2" style="border-right: 1px solid #969696">
-        [% IF old_value %]
-          [% old_value FILTER html %]
+        [% IF change.field_name == "see_also" %]
+          <a href="[% old_value FILTER html %]">[% old_value FILTER html %]</a>
         [% ELSE %]
-          &nbsp;
+          [% old_value FILTER html %]
         [% END %]
       </td>
       <td>
-        [% IF new_value %]
-          [% new_value FILTER html %]
+        [% IF change.field_name == "see_also" %]
+          <a href="[% new_value FILTER html %]">[% new_value FILTER html %]</a>
         [% ELSE %]
-          &nbsp;
+          [% new_value FILTER html %]
         [% END %]
       </td>
     </tr>


### PR DESCRIPTION
This patch creates links instead of plain text values if the field that is changes is the See Also field. bugmail.html.tmpl is the template generates the HTML version of a bug change email. Text versions do not change.