### PR TITLE
Bug 1782806 - move of bug to different component shouldn't drop its keywords

### DIFF
--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -3918,7 +3918,7 @@ sub del_keyword {
   $keyword = lc($keyword);
   my $index = -1;
   my $i = 0;
-  foreach my $keyword_obj (@{$self->{'keyword_objects'}}) {
+  foreach my $keyword_obj (@{$self->keyword_objects}) {
     if (lc($keyword_obj->name) eq $keyword) {
       $index = $i;
       last;

--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -1062,6 +1062,8 @@ sub bug_start_of_update {
   my $old_bug = $args->{old_bug};
   my $new_bug = $args->{bug};
 
+  return unless $new_bug->uses_triaged_keyword;
+
   # silently drop changes to the triaged keyword from users without permissions
   # to triage
   if (!Bugzilla->user->can_triage) {
@@ -1083,8 +1085,6 @@ sub bug_start_of_update {
 
   # remove the triaged keyword when a bug is moved to a component owned by a
   # different team
-  my $o = $old_bug->component_obj->team_name;
-  my $n = $new_bug->component_obj->team_name;
   if (
     $new_bug->component_obj->team_name ne $old_bug->component_obj->team_name
   ) {


### PR DESCRIPTION
This issue was only occurring when changing component via the REST API and not through the UI, This was due the team name changing and using del_keyword(). del_keyword() had not yet initialized $self->{keyword_objects} to the real list so it assumed it was empty which essentially removed any keywords that were there. I updated del_keyword() to initialize by calling $self->keyword_objects in the for each loop which fixes this issue for API calls.

I also remove two unused variables in the extension hook as well as return early if not using triaged keyword for the product.