### PR TITLE
Bug 1783044 - Unable to link profile to People due to error page not being rendered properly

### DIFF
--- a/Bugzilla/Token.pm
+++ b/Bugzilla/Token.pm
@@ -279,6 +279,10 @@ sub check_hash_token {
       = (!$token) ? 'missing_token'
       : ($expected_token ne $token) ? 'invalid_token'
       :                               'expired_token';
+
+    # We will display confirmation later if native Mojo.
+    return $vars if Bugzilla->usage_mode == USAGE_MODE_MOJO;
+
     print Bugzilla->cgi->header();
     $template->process('global/confirm-action.html.tmpl', $vars)
       || ThrowTemplateError($template->error());

--- a/template/en/default/account/auth/confirm_scopes.html.tmpl
+++ b/template/en/default/account/auth/confirm_scopes.html.tmpl
@@ -10,6 +10,27 @@
    title = "Request for access to your account" %]
 
 <h1>[% title FILTER html %] </h1>
+
+[% IF error %]
+  <div class="throw_error">
+    [% IF error == "expired_token" %]
+      Your changes have been rejected because you exceeded the time limit
+      of [% constants.MAX_TOKEN_AGE FILTER html %] days before attempting to
+      allow access to your account. Your page may have been displayed
+      for too long, or the page was reloaded by accident.
+    [% ELSIF error == "missing_token" %]
+      It looks like you didn't come from the right page.
+      One reason could be that you entered the URL in the address bar of your
+      web browser directly, which should be safe. Another reason could be that
+      you clicked on a URL which redirected you here <b>without your consent</b>.
+    [% ELSIF error == "invalid_token" %]
+      You attempted to allow access to your account with an invalid token, which
+      may indicate that someone tried to abuse you, for instance by making you
+      click on a URL which redirected you here <b>without your consent</b>.
+    [% END %]
+  </div>
+[% END %]
+
 <p>
   A third-party website <em>[% client.description FILTER html %]</em> would like to have
   the following access to your [% terms.Bugzilla %] account.
@@ -31,7 +52,7 @@
 <div>
   <form action="/oauth/authorize" method="get">
     <input type="hidden" name="oauth_confirm_[% client.client_id FILTER html %]" value="1">
-    <input type="hidden" name="token" value="[% token FILTER html %]">
+    <input type="hidden" id="token" name="token" value="[% issue_hash_token(['oauth_confirm_scopes']) FILTER html %]">
     <input type="submit" name="submit" value="Allow">
     [% FOREACH field = c.req.params.names %]
       <input type="hidden" name="[% field FILTER html %]"


### PR DESCRIPTION
When running code under fully native Mojo code instead of the Mojo wrapper around legacy cgi scripts (all files with .cgi) we should not use the cgi method of printing the HTTP headers. The OAuth2 authentication process uses native Mojo code but yet calls a utility function in Token.pm that assumes it is running under a cgi environment. So when it tries to do `print $cgi->header` an error is thrown about the header() call masking the actual page that is supposed to be displayed explaining the real error. 

So I have update the utility function in Token.pm to check if it is running under Mojo native or cgi and return a data structure instead if running Mojo. Otherwise it prints the warning page as usual.

Provider.pm is updated to receive the result from the utility function and display a similar warning except it renders it itself. There may be other cases where something similar needs to be done but this one change should help this issue in particular.