### PR TITLE
Bug 1532985 - Changing the product fails because of mismatch in version, should just use default

### DIFF
--- a/scripts/generate_bmo_data.pl
+++ b/scripts/generate_bmo_data.pl
@@ -331,12 +331,13 @@ for my $product (@products) {
     }
     $dbh->do(
       'INSERT INTO products (name, description, classification_id,
-                                        default_op_sys_id, default_platform_id)
-                  VALUES (?, ?, ?, ?, ?)',
+                             default_op_sys_id, default_platform_id, default_version)
+                  VALUES (?, ?, ?, ?, ?, ?)',
       undef,
       (
-        $product->{product_name}, $product->{description}, $class_id,
-        $default_op_sys_id,       $default_platform_id
+        $product->{product_name}, $product->{description},
+        $class_id,                $default_op_sys_id,
+        $default_platform_id,     $product->{default_version}
       )
     );
 


### PR DESCRIPTION
This PR changes the way we handle product changes when using the API (non-browser) when checking for the version field. It basically will fill choose the default version for the new product if the version value was omitted or was invalid. We already did this for milestones. Component values will still throw an exception if not valid as we do not have a default value for components like we do version and do not plan to.

Comments in the _set_product() function of Bug.pm will also explain more of what is happening here.

Note: Also had to fix a bug in generate_bmo_data.pl that was not populating the default version for a new product being INSERTed into the products table. This was missed in the earlier PR that added default version support.

Thanks!