### PR TITLE
Bug 1785454 - Update component editing API to not required full editcomponents to just update triage owner

### DIFF
--- a/qa/t/rest_components.t
+++ b/qa/t/rest_components.t
@@ -95,6 +95,18 @@ $t->get_ok($url
   ->json_is('/triage_owner' => 'admin@mozilla.test')
   ->json_is('/description'  => 'Updated description');
 
+# Update an existing user and give edittriageowners permissions
+my $user_update = {groups => {add => ['edittriageowners']}};
+$t->put_ok($url
+    . 'rest/user/no-privs@mozilla.test' => {'X-Bugzilla-API-Key' => $api_key} =>
+    json                                => $user_update)->status_is(200);
+my $triage_api_key = $config->{unprivileged_user_api_key};
+$update = {triage_owner => 'nobody@mozilla.org'};
+$t->put_ok($url
+    . 'rest/component/Firefox/TestComponent' =>
+    {'X-Bugzilla-API-Key' => $api_key}       => json => $update)->status_is(200)
+  ->json_is('/triage_owner' => 'nobody@mozilla.org');
+
 ### Section 1: Create a new component with a slash (/) in the name
 
 $new_component = {


### PR DESCRIPTION
This PR updates the permissions checking in the component update API code to also look for edittriageowners membership instead of the all encompassing editcomponents group. This supports the change we did a while back to the component admin UI that allowed those less privileged members to edit just the triage owner field. I also updated the rest_components.t test script to check this new behavior change.