### PR TITLE
Bug 1555583 - Remove whine queries owned by disabled users no longer with the company

### DIFF
--- a/whine.pl
+++ b/whine.pl
@@ -303,6 +303,16 @@ sub get_next_event {
 while (my $event = get_next_event) {
 
   my $eventid = $event->{'eventid'};
+  my $author  = $event->{'author'};
+
+  # Do not send this whine if the authors account is disabled. The timer
+  # is already reset and if/when the account is reactivated, the next whine
+  # will execute.
+  if (!$author->is_enabled) {
+    Bugzilla->audit(sprintf 'whine: event id %d skipped since owner %s is disabled',
+      $eventid, $author->login);
+    next;
+  }
 
   # We loop for each target user because some of the queries will be using
   # subjective pronouns


### PR DESCRIPTION
Current behavior is we ignore whether an user is disabled or not and continue to send their whine events indefinitely. As you can imagine, this not ideal. This patch just skips the current event, resets the timer and does not send out the email. Then when the account is no longer disabled, the next schedule event will execute and send the email.

The other option was to delete the events when a user has been disabled, but that is not ideal as some accounts only get disabled temporarily and we do not want them to have to recreate the whines all over again.