### PR TITLE
Bug 1783576 - Add field to REST API that returns timestamp of bug last change by an actual person

### DIFF
--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -267,28 +267,28 @@ use constant MAX_LINE_LENGTH => 254;
 # of Bugzilla. (These are the field names that the WebService and email_in.pl
 # use.)
 use constant FIELD_MAP => {
-  blocks                => 'blocked',
-  commentprivacy        => 'comment_is_private',
-  creation_time         => 'creation_ts',
-  creator               => 'reporter',
-  description           => 'comment',
-  depends_on            => 'dependson',
-  dupe_of               => 'dup_id',
-  id                    => 'bug_id',
-  is_confirmed          => 'everconfirmed',
-  is_cc_accessible      => 'cclist_accessible',
-  is_creator_accessible => 'reporter_accessible',
-  last_change_time      => 'delta_ts',
+  blocks                   => 'blocked',
+  commentprivacy           => 'comment_is_private',
+  creation_time            => 'creation_ts',
+  creator                  => 'reporter',
+  description              => 'comment',
+  depends_on               => 'dependson',
+  dupe_of                  => 'dup_id',
+  id                       => 'bug_id',
+  is_confirmed             => 'everconfirmed',
+  is_cc_accessible         => 'cclist_accessible',
+  is_creator_accessible    => 'reporter_accessible',
+  last_change_time         => 'delta_ts',
   last_change_time_non_bot => 'delta_ts_non_bot',
-  comment_count         => 'longdescs.count',
-  platform              => 'rep_platform',
-  regressions           => 'regresses',
-  severity              => 'bug_severity',
-  status                => 'bug_status',
-  summary               => 'short_desc',
-  type                  => 'bug_type',
-  url                   => 'bug_file_loc',
-  whiteboard            => 'status_whiteboard',
+  comment_count            => 'longdescs.count',
+  platform                 => 'rep_platform',
+  regressions              => 'regresses',
+  severity                 => 'bug_severity',
+  status                   => 'bug_status',
+  summary                  => 'short_desc',
+  type                     => 'bug_type',
+  url                      => 'bug_file_loc',
+  whiteboard               => 'status_whiteboard',
 };
 
 use constant REQUIRED_FIELD_MAP =>
@@ -4415,7 +4415,7 @@ sub bug_alias_to_id {
 # Last changed timestamp of a non-bot user
 sub delta_ts_non_bot {
   my ($self) = @_;
-  return $self->{delta_ts_non_bot} if exists $self->{delat_ts_non_bot};
+  return $self->{delta_ts_non_bot} if exists $self->{delta_ts_non_bot};
 
   # If the skip list is empty, just always return the normal delta_ts
   my $params = Bugzilla->params;

--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -279,6 +279,7 @@ use constant FIELD_MAP => {
   is_cc_accessible      => 'cclist_accessible',
   is_creator_accessible => 'reporter_accessible',
   last_change_time      => 'delta_ts',
+  last_change_time_non_bot => 'delta_ts_non_bot',
   comment_count         => 'longdescs.count',
   platform              => 'rep_platform',
   regressions           => 'regresses',
@@ -4409,6 +4410,60 @@ sub bug_alias_to_id {
   my $dbh = Bugzilla->dbh;
   return $dbh->selectrow_array("SELECT bug_id FROM bugs WHERE alias = ?",
     undef, $alias);
+}
+
+# Last changed timestamp of a non-bot user
+sub delta_ts_non_bot {
+  my ($self) = @_;
+  return $self->{delta_ts_non_bot} if exists $self->{delat_ts_non_bot};
+
+  # If the skip list is empty, just always return the normal delta_ts
+  my $params = Bugzilla->params;
+  return $self->delta_ts if !$params->{last_change_time_non_bot_skip_list};
+
+  my $dbh = Bugzilla->dbh;
+
+  # Cache the bot account user ids for performance if we are
+  # fetching multiple bugs and their timestamps
+  my $cache = Bugzilla->request_cache;
+  if (!$cache->{bot_ids_string}) {
+    my $quoted_bot_names = join ',', map { $dbh->quote($_) } split /[\s,]+/,
+      $params->{last_change_time_non_bot_skip_list};
+    if ($quoted_bot_names) {
+      my $bot_ids = $dbh->selectcol_arrayref(
+        "SELECT userid FROM profiles
+                                     WHERE login_name IN ($quoted_bot_names)"
+      );
+      $cache->{bot_ids_string} = join ',', @{$bot_ids};
+    }
+  }
+
+  # Grab the latest timestamp for comments and bug changes that was not made by
+  # one of the accounts in the bot skip list. Return the greatest of the two values.
+  if (my $bot_ids_string = $cache->{bot_ids_string}) {
+    my %time_map;
+    my @result = $dbh->selectrow_array(
+      "SELECT bug_when, UNIX_TIMESTAMP(bug_when)
+         FROM bugs_activity
+        WHERE bug_id = ? AND who NOT IN ($bot_ids_string)
+        ORDER BY bug_when DESC LIMIT 1",
+      undef, $self->id
+    );
+    $time_map{$result[1]} = $result[0] if @result;
+    @result = $dbh->selectrow_array(
+      "SELECT bug_when, UNIX_TIMESTAMP(bug_when)
+         FROM longdescs
+        WHERE bug_id = ? AND who NOT IN ($bot_ids_string)
+        ORDER BY bug_when DESC LIMIT 1",
+      undef, $self->id
+    );
+    $time_map{$result[1]} = $result[0] if @result;
+
+    my $max_epoch = max keys %time_map;
+    $self->{delta_ts_non_bot} = $time_map{$max_epoch};
+  }
+
+  return $self->{delta_ts_non_bot};
 }
 
 #####################################################################

--- a/Bugzilla/Config/BugFields.pm
+++ b/Bugzilla/Config/BugFields.pm
@@ -82,7 +82,9 @@ sub get_param_list {
       checker => \&check_opsys
     },
 
-    {name => 'collapsed_comment_tags', type => 't', default => 'obsolete, spam',}
+    {name => 'collapsed_comment_tags', type => 't', default => 'obsolete, spam',},
+
+    {name => 'last_change_time_non_bot_skip_list', type => 't', default => ''}
   );
   return @param_list;
 }

--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -1571,6 +1571,10 @@ sub _bug_to_hash {
   if (filter_wants $params, 'last_change_time') {
     $item{'last_change_time'} = $self->type('dateTime', $bug->delta_ts);
   }
+  if (filter_wants $params, 'last_change_time_non_bot', ['extra']) {
+    $item{'last_change_time_non_bot'}
+      = $self->type('dateTime', $bug->delta_ts_non_bot);
+  }
   if (filter_wants $params, 'product') {
     $item{product} = $self->type('string', $bug->product);
   }

--- a/docs/en/rst/administering/parameters.rst
+++ b/docs/en/rst/administering/parameters.rst
@@ -280,6 +280,9 @@ collapsed_comment_tags
     A comma-separated list of tags which, when applied to comments, will
     cause them to be collapsed by default.
 
+last_change_time_non_bot_skip_list
+    List of user accounts to skip when calculating last changed by a person timestamp.
+
 .. _param-dependency-graphs:
 
 Graphs

--- a/docs/en/rst/api/core/v1/bug.rst
+++ b/docs/en/rst/api/core/v1/bug.rst
@@ -249,31 +249,32 @@ Extra fields:
 These fields are returned only by specifying ``_extra`` or the field name in
 ``include_fields``.
 
-===================  ======  ====================================================
-name                 type    description
-===================  ======  ====================================================
-attachments          array   Each array item is an Attachment object. See
-                             :ref:`rest_attachments` for details of the object.
-comments             array   Each array item is a Comment object. See
-                             :ref:`rest_comments` for details of the object.
-counts               object  An object containing the numbers of the items in the
-                             following fields: ``attachments``, ``cc``,
-                             ``comments``, ``keywords``, ``blocks``,
-                             ``depends_on``, ``regressed_by``, ``regressions``
-                             and ``duplicates``.
-description          string  The description (initial comment) of the bug.
-filed_via            string  How the bug was filed, e.g. ``standard_form``.
-history              array   Each array item is a History object. See
-                             :ref:`rest_history` for details of the object.
-tags                 array   Each array item is a tag name. Note that tags are
-                             personal to the currently logged in user and are not
-                             the same as comment tags.
-triage_owner         string  The login name of the Triage Owner of the bug's
-                             component.
-triage_owner_detail  object  An object containing detailed user information for
-                             the ``triage_owner``. To see the keys included in
-                             the user detail object, see below.
-===================  ======  ====================================================
+========================  ========  ====================================================
+name                      type      description
+========================  ========  ====================================================
+attachments               array     Each array item is an Attachment object. See
+                                    :ref:`rest_attachments` for details of the object.
+comments                  array     Each array item is a Comment object. See
+                                    :ref:`rest_comments` for details of the object.
+counts                    object    An object containing the numbers of the items in the
+                                    following fields: ``attachments``, ``cc``,
+                                    ``comments``, ``keywords``, ``blocks``,
+                                    ``depends_on``, ``regressed_by``, ``regressions``
+                                    and ``duplicates``.
+description               string    The description (initial comment) of the bug.
+filed_via                 string    How the bug was filed, e.g. ``standard_form``.
+history                   array     Each array item is a History object. See
+                                    :ref:`rest_history` for details of the object.
+tags                      array     Each array item is a tag name. Note that tags are
+                                    personal to the currently logged in user and are not
+                                    the same as comment tags.
+triage_owner              string    The login name of the Triage Owner of the bug's
+                                    component.
+triage_owner_detail       object    An object containing detailed user information for
+                                    the ``triage_owner``. To see the keys included in
+                                    the user detail object, see below.
+last_change_time_non_bot  datetime  When the bug was last changed human and not a bot.
+========================  ========  ====================================================
 
 User object:
 

--- a/qa/config/selenium_test.conf
+++ b/qa/config/selenium_test.conf
@@ -25,6 +25,8 @@
     'admin_user_passwd'                 => 'bo6aazeKohch',
     'admin_user_username'               => 'QA Admin',
     'admin_user_nick'                   => 'admin',
+    'automation_user_login'             => 'automation@bmo.tld',
+    'automation_user_api_key'           => '4fut0aBEfW260ULXEP1pvOqj7lwnhHoSB16wfpLP',
     'permanent_user_login'              => 'permanent_user@mozilla.test',
     'permanent_user_passwd'             => 'bo6aazeKohch',
     'unprivileged_user_login'           => 'no-privs@mozilla.test',

--- a/qa/t/rest_last_change_time_non_bot.t
+++ b/qa/t/rest_last_change_time_non_bot.t
@@ -1,0 +1,84 @@
+#!/usr/bin/env perl
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+use strict;
+use warnings;
+use 5.10.1;
+use lib qw(lib ../../lib ../../local/lib/perl5);
+
+use Bugzilla;
+use QA::Util qw(get_config);
+
+use Test::Mojo;
+use Test::More;
+
+my $config             = get_config();
+my $admin_user_api_key = $config->{'admin_user_api_key'};
+my $bot_user_api_key   = $config->{'automation_user_api_key'};
+my $url                = Bugzilla->localconfig->urlbase;
+
+my $t = Test::Mojo->new();
+
+# No products specified should only include Firefox for this test
+$t->get_ok($url
+    . 'rest/bug/1?include_fields=last_change_time' =>
+    {'X-Bugzilla-API-Key' => $admin_user_api_key})->status_is(200);
+my $data = $t->tx->res->json;
+my $old_timestamp = $data->{bugs}->[0]->{last_change_time};
+
+# Add a comment as the normal user (admin)
+my $update_bug = {comment => {body => 'Updating bug report'}};
+$t->put_ok($url
+    . 'rest/bug/1' => {'X-Bugzilla-API-Key' => $admin_user_api_key} => json =>
+    $update_bug)->status_is(200);
+
+# Retrieve the updated timestamps for comparison
+$t->get_ok($url
+    . "rest/bug/1?include_fields=last_change_time,last_change_time_non_bot" =>
+    {'X-Bugzilla-API-Key' => $admin_user_api_key})->status_is(200);
+$data = $t->tx->res->json;
+my $current_timestamp         = $data->{bugs}->[0]->{last_change_time};
+my $current_non_bot_timestamp = $data->{bugs}->[0]->{last_change_time_non_bot};
+ok(
+  $current_timestamp ne $old_timestamp,
+  "Normal timestamp is different than before"
+);
+ok(
+  $current_timestamp eq $current_non_bot_timestamp,
+  "Normal timestamp is equal to non-bot timestamp"
+);
+$old_timestamp = $current_timestamp;
+
+sleep(5);
+
+# Add a comment as a bot user
+$t->put_ok($url
+    . 'rest/bug/1' => {'X-Bugzilla-API-Key' => $bot_user_api_key} => json =>
+    $update_bug)->status_is(200);
+$data = $t->tx->res->json;
+
+# Retrieve the updated timestamps for comparison
+$t->get_ok($url
+    . "rest/bug/1?include_fields=last_change_time,last_change_time_non_bot" =>
+    {'X-Bugzilla-API-Key' => $admin_user_api_key})->status_is(200);
+$data = $t->tx->res->json;
+$current_timestamp         = $data->{bugs}->[0]->{last_change_time};
+$current_non_bot_timestamp = $data->{bugs}->[0]->{last_change_time_non_bot};
+
+# The normal timestamp is always updated
+ok(
+  $current_timestamp ne $old_timestamp,
+  "Normal timestamp is different than before"
+);
+
+# Non-bot timestamp should be equal to the previous normal timestamp.
+ok(
+  $old_timestamp eq $current_non_bot_timestamp,
+  "Normal timestamp is equal to non-bot timestamp"
+);
+
+done_testing();

--- a/scripts/generate_bmo_data.pl
+++ b/scripts/generate_bmo_data.pl
@@ -10,6 +10,7 @@ use lib qw(. lib local/lib/perl5);
 
 use Bugzilla;
 use Bugzilla::User;
+use Bugzilla::User::APIKey;
 use Bugzilla::Install;
 use Bugzilla::Milestone;
 use Bugzilla::Product;
@@ -180,7 +181,12 @@ my @users = (
     realname => 'Nobody; OK to take it and work on it',
     password => '*'
   },
-  {login => 'automation@bmo.tld', realname => 'BMO Automation', password => '*'},
+  {
+    login    => 'automation@bmo.tld',
+    realname => 'BMO Automation',
+    password => '*',
+    api_key  => '4fut0aBEfW260ULXEP1pvOqj7lwnhHoSB16wfpLP'
+  },
   map { {login => $_, realname => (split(/@/, $_, 2))[0], password => '*',} }
     map {
     map {@$_}
@@ -191,13 +197,20 @@ my @users = (
 print "creating user accounts...\n";
 foreach my $user (@users) {
   if (is_available_username($user->{login})) {
-    Bugzilla::User->create({
+    my $new_user = Bugzilla::User->create({
       login_name    => $user->{login},
       realname      => $user->{realname},
       cryptpassword => $user->{password},
     });
     if ($user->{admin}) {
       Bugzilla::Install::make_admin($user->{login});
+    }
+    if (exists $user->{api_key}) {
+      Bugzilla::User::APIKey->create_special({
+        user_id     => $new_user->id,
+        description => 'API key for Test User',
+        api_key     => $user->{api_key}
+      });
     }
   }
 }
@@ -577,6 +590,7 @@ my %set_params = (
   defaultseverity      => 'normal',
   edit_comments_group  => 'editbugs',
   insidergroup         => 'core-security-release',
+  last_change_time_non_bot_skip_list => 'automation@bmo.tld',
   last_visit_keep_days => '28',
   lxr_url              => 'http://mxr.mozilla.org/mozilla',
   lxr_root             => 'mozilla/',

--- a/template/en/default/admin/params/bugfields.html.tmpl
+++ b/template/en/default/admin/params/bugfields.html.tmpl
@@ -71,5 +71,8 @@
 
   collapsed_comment_tags => "A comma separated list of tags which, when applied " _
                             "to comments, will cause them to be collapsed by default",
+
+  last_change_time_non_bot_skip_list => "List of user accounts to skip when calculating last changed by " _
+                                        "a human timestamp."
   }
 %]


### PR DESCRIPTION
This PR adds a new field that can be returned if explicitly requested with the get bug API endpoint. It is NOT returned by default. It is called `last_change_time_non_bot` and is the last time the bug was changed by a non-bot Bugzilla account. There is a new config parameter that allows storing a comma or space separated list of email addresses that are considered *bot* accounts. Any account in the list, their change will be ignored when returning the last_change_time_non_bot value. A test cases has also been added that tests to make sure the right timestamps are returned depending on which account updated the bug last.