### PR TITLE
Bug 1787294 - Allow optional tolerance in the /rest/user endpoint when querying users that are not exist

### DIFF
--- a/docs/en/rst/api/core/v1/user.rst
+++ b/docs/en/rst/api/core/v1/user.rst
@@ -340,6 +340,9 @@ include_disabled  boolean  By default, when using the ``match`` parameter,
                            ``true`` will include disabled users in the returned
                            results even if their username doesn't fully match
                            the input string.
+permissive        boolean  When querying for users using names, do not fail the
+                           entire request if one or more errors occur. A `faults`
+                           list is included that contains the individual errors.
 ================  =======  ======================================================
 
 **Response**


### PR DESCRIPTION
This PR adds  a new `permissive` parameter which is similar to what we already have for getting a list of bugs. This parameter allows for ignoring errors when passing in a list of names to query for user information. If one or more cause an error such as not found, etc. it will just add the error to a `faults` list and return the ones that were found. This does not change the API in a way that would break any current clients so it should not be an issue. 