### PR TITLE
Bug 1787954 - Certain fields missing from get user API when added by extensions and specifically requested with include_fields

### DIFF
--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -310,8 +310,12 @@ sub get {
       };
 
     if (Bugzilla->user->in_group('disableusers')) {
-      $user_info->{email_enabled}     = $self->type('boolean', $user->email_enabled);
-      $user_info->{login_denied_text} = $self->type('string',  $user->disabledtext);
+      if (filter_wants($params, 'email_enabled')) {
+        $user_info->{email_enabled} = $self->type('boolean', $user->email_enabled);
+      }
+      if (filter_wants($params, 'login_denied_text')) {
+        $user_info->{login_denied_text} = $self->type('string', $user->disabledtext);
+      }
     }
 
     if (Bugzilla->user->id == $user->id) {
@@ -335,8 +339,15 @@ sub get {
     push(@users, $user_info);
   }
 
-  Bugzilla::Hook::process('webservice_user_get',
-    {webservice => $self, params => $params, users => \@users});
+  Bugzilla::Hook::process(
+    'webservice_user_get',
+    {
+      webservice   => $self,
+      params       => $params,
+      user_data    => \@users,
+      user_objects => $in_group,
+    }
+  );
 
   return {users => \@users};
 }

--- a/extensions/Gravatar/Extension.pm
+++ b/extensions/Gravatar/Extension.pm
@@ -65,23 +65,13 @@ sub install_before_final_checks {
 
 sub webservice_user_get {
   my ($self, $args) = @_;
-  my ($webservice, $params, $users) = @$args{qw(webservice params users)};
+  my ($webservice, $params, $user_data, $user_objects)
+    = @$args{qw(webservice params user_data user_objects)};
 
   return unless filter_wants($params, 'gravatar');
 
-  my $ids = [
-    map { blessed($_->{id}) ? $_->{id}->value : $_->{id} }
-    grep { exists $_->{id} }
-    @$users
-  ];
-
-  return unless @$ids;
-
-  my %user_map = map { $_->id => $_ } @{ Bugzilla::User->new_from_list($ids) };
-  foreach my $user (@$users) {
-    my $id = blessed($user->{id}) ? $user->{id}->value : $user->{id};
-    my $user_obj = $user_map{$id};
-    $user->{gravatar} = $user_obj->gravatar;
+  for (my $i = 0; $i < @{$user_data}; $i++) {
+    $user_data->[$i]->{gravatar} = $user_objects->[$i]->gravatar;
   }
 }
 

--- a/extensions/Review/Extension.pm
+++ b/extensions/Review/Extension.pm
@@ -992,35 +992,28 @@ sub config_modify_panels {
 
 sub webservice_user_get {
   my ($self, $args) = @_;
-  my ($webservice, $params, $users) = @$args{qw(webservice params users)};
+  my ($webservice, $params, $user_data, $user_objects)
+    = @$args{qw(webservice params user_data user_objects)};
 
   return unless filter_wants($params, 'requests');
 
-  my $ids = [map { blessed($_->{id}) ? $_->{id}->value : $_->{id} }
-      grep { exists $_->{id} } @$users];
-
-  return unless @$ids;
-
-  my %user_map = map { $_->id => $_ } @{Bugzilla::User->new_from_list($ids)};
-
-  foreach my $user (@$users) {
-    my $id = blessed($user->{id}) ? $user->{id}->value : $user->{id};
-    my $user_obj = $user_map{$id};
-
-    $user->{requests} = {
+  for (my $i = 0; $i < @{$user_data}; $i++) {
+    $user_data->[$i]->{requests} = {
       review => {
-        blocked => $webservice->type('boolean', $user_obj->reviews_blocked),
-        pending => $webservice->type('int',     $user_obj->{review_request_count}),
+        blocked => $webservice->type('boolean', $user_objects->[$i]->reviews_blocked),
+        pending =>
+          $webservice->type('int', $user_objects->[$i]->{review_request_count}),
       },
       feedback => {
-
         # reviews_blocked includes feedback as well
-        blocked => $webservice->type('boolean', $user_obj->reviews_blocked),
-        pending => $webservice->type('int',     $user_obj->{feedback_request_count}),
+        blocked => $webservice->type('boolean', $user_objects->[$i]->reviews_blocked),
+        pending =>
+          $webservice->type('int', $user_objects->[$i]->{feedback_request_count}),
       },
       needinfo => {
-        blocked => $webservice->type('boolean', $user_obj->needinfo_blocked),
-        pending => $webservice->type('int',     $user_obj->{needinfo_request_count}),
+        blocked => $webservice->type('boolean', $user_objects->[$i]->needinfo_blocked),
+        pending =>
+          $webservice->type('int', $user_objects->[$i]->{needinfo_request_count}),
       },
     };
   }

--- a/extensions/TagNewUsers/Extension.pm
+++ b/extensions/TagNewUsers/Extension.pm
@@ -253,19 +253,14 @@ sub mailer_before_send {
 
 sub webservice_user_get {
   my ($self, $args) = @_;
-  my ($webservice, $params, $users) = @$args{qw(webservice params users)};
+  my ($webservice, $params, $user_data, $user_objects)
+    = @$args{qw(webservice params user_data user_objects)};
 
   return unless filter_wants($params, 'is_new');
 
-  foreach my $user (@$users) {
-
-    # Most of the time the hash values are XMLRPC::Data objects
-    my $email
-      = blessed $user->{'email'} ? $user->{'email'}->value : $user->{'email'};
-    if ($email) {
-      my $user_obj = Bugzilla::User->new({name => $email});
-      $user->{'is_new'} = $webservice->type('boolean', $user_obj->is_new ? 1 : 0);
-    }
+  for (my $i = 0; $i < @{$user_data}; $i++) {
+    $user_data->[$i]->{'is_new'}
+      = $webservice->type('boolean', $user_objects->[$i]->is_new ? 1 : 0);
   }
 }
 


### PR DESCRIPTION
When a client was using `include_fields=requests` to get request information on one or more users, the data was not present as expected. This was due to the old way that extension code was looking for the `id` value for each user to look up request data, which was not there since it was not included. For example `include_fields=id,requests` would work but is a workaround. 

These changes pass the user objects as well as the result data along to the webservice_user_get extension hooks so that the objects can be used if needed to look up additional information. Using a for loop, we the result data and the user objects should line up one to one. 

Since the user_objects are now being passed along, I was also able to simplify the code in the other webservice_user_get sections in a few other extensions.

Lastly I fixed a section that was not using filter_wants where it should have been which meant email_enabled and login_denied_text was always being returned even when not requested.