### PR TITLE
Bug 1789654 - User matching for user related fields in the web UI is broken due to regression caused by bug 1787954

### DIFF
--- a/extensions/Gravatar/Extension.pm
+++ b/extensions/Gravatar/Extension.pm
@@ -75,9 +75,4 @@ sub webservice_user_get {
   }
 }
 
-sub webservice_user_suggest {
-  my ($self, $args) = @_;
-  $self->webservice_user_get($args);
-}
-
 __PACKAGE__->NAME;

--- a/extensions/Review/Extension.pm
+++ b/extensions/Review/Extension.pm
@@ -1019,9 +1019,4 @@ sub webservice_user_get {
   }
 }
 
-sub webservice_user_suggest {
-  my ($self, $args) = @_;
-  $self->webservice_user_get($args);
-}
-
 __PACKAGE__->NAME;


### PR DESCRIPTION
I failed to notice that the /rest/user/suggest API endpoint internally calls the same function that the /rest/user endpoint uses which I changed the data passed in bug 1787954.

So this changes /rest/user/suggest to match the data structure needed by the webservice_user_get hook function and also removed some redundant code.