### PR TITLE
Bug 1790623 - Extend the Triage Owners report to include an indication if the Triage Owner is a member of the default security group

### DIFF
--- a/extensions/BMO/lib/Reports/Triage.pm
+++ b/extensions/BMO/lib/Reports/Triage.pm
@@ -350,6 +350,22 @@ sub owners {
     }
     $bug_count_sth->execute($component_id);
 
+    # Show if current triage owner is in security group for current product.
+    # Check that the BMO extension is present and enabled by first checking
+    # if the product object has the default_security_group method.
+    # Also make sure the current user has permission to see this information
+    my $product_obj = Bugzilla::Product->new({name => $product_name, cache => 1});
+    if ( $product_obj->can('default_security_group')
+      && $product_obj->default_security_group
+      && $user->in_group('mozilla-employee-confidential'))
+    {
+      $data->{in_prod_security_group}
+        = $triage_owner
+        && $triage_owner->in_group($product_obj->default_security_group)
+        ? 'Yes'
+        : 'No';
+    }
+
     my $total = 0;
     while (my ($type, $count) = $bug_count_sth->fetchrow_array()) {
       $data->{bug_counts}->{$type} = $count;

--- a/extensions/BMO/template/en/default/pages/triage_owners.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/triage_owners.html.tmpl
@@ -102,6 +102,13 @@
           <tr>
             <th>[% r.product FILTER html %]</th>
             <th>Owner</th>
+            [% IF r.in_prod_security_group.defined %]
+              <th>
+                <span title="Triage owner is a member of the default security group for this product">
+                  Prod Sec Group Member
+                </span>
+              </th>
+            [% END %]
             [% FOREACH count IN r.bug_counts %]
               <th class="count">
                 [% IF count.key == "total"%]
@@ -129,6 +136,9 @@
             <em>None</em>
           [% END %]
         </td>
+        [% IF r.in_prod_security_group.defined %]
+          <td>[% r.in_prod_security_group FILTER html %]</td>
+        [% END %]
         [% FOREACH count IN r.bug_counts %]
           <td class="count">
             [% IF count.value %]


### PR DESCRIPTION
This PR adds a new column to the existing triage owners reporter. The column shows Yes or No if the triage owner for the component is in the default security group for the product the component belongs to. Triage.pm is the module that generates the data for the template and does the heavy lifting of checking for membership, etc. Only viewers who are in the mozilla-employee-confidential group should be able to see the column in the table. 

Thanks!