### PR TITLE
Bug 1790624 - Remove the ability for Triage Owners to via all bugs in the component

### DIFF
--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -1395,15 +1395,7 @@ sub _standard_joins {
       as    => 'security_cc',
       extra => ['security_cc.who = ' . $user->id],
     };
-    my $security_triage_join = {
-      table => 'components',
-      as    => 'security_triage',
-      from  => 'bugs.component_id',
-      to    => 'id',
-      join  => 'LEFT',
-      extra => ['security_triage.triage_owner_id = ' . $user->id],
-    };
-    push(@joins, $security_cc_join, $security_triage_join);
+    push(@joins, $security_cc_join);
   }
 
   return @joins;
@@ -1485,7 +1477,6 @@ sub _standard_where {
         OR (bugs.reporter_accessible = 1 AND bugs.reporter = $userid)
         OR (bugs.cclist_accessible = 1 AND security_cc.who IS NOT NULL)
         OR bugs.assigned_to = $userid
-        OR security_triage.triage_owner_id IS NOT NULL
 END
     if (Bugzilla->params->{'useqacontact'}) {
       $security_term .= "        OR bugs.qa_contact = $userid";

--- a/Bugzilla/User.pm
+++ b/Bugzilla/User.pm
@@ -1489,14 +1489,12 @@ sub visible_bugs {
       # same result for bug_group_map.bug_id (so DISTINCT filters
       # out duplicate rows).
       "SELECT DISTINCT bugs.bug_id, reporter, assigned_to, qa_contact,
-                    components.triage_owner_id, reporter_accessible,
-                    cclist_accessible, cc.who, bug_group_map.bug_id
+                    reporter_accessible, cclist_accessible, cc.who,
+                    bug_group_map.bug_id
                FROM bugs
                     LEFT JOIN cc
                               ON cc.bug_id = bugs.bug_id
                                  AND cc.who = $user_id
-                    LEFT JOIN components
-                              ON bugs.component_id = components.id
                     LEFT JOIN bug_group_map
                               ON bugs.bug_id = bug_group_map.bug_id
                                  AND bug_group_map.group_id NOT IN ("
@@ -1511,13 +1509,12 @@ sub visible_bugs {
     $sth->execute(@check_ids);
     my $use_qa_contact = Bugzilla->params->{'useqacontact'};
     while (my $row = $sth->fetchrow_arrayref) {
-      my ($bug_id, $reporter, $owner, $qacontact, $triage_owner, $reporter_access,
-          $cclist_access, $isoncclist, $missinggroup)
+      my ($bug_id, $reporter, $owner, $qacontact, $reporter_access, $cclist_access,
+        $isoncclist, $missinggroup)
         = @$row;
       $visible_cache->{$bug_id}
         ||= ((($reporter == $user_id) && $reporter_access)
           || ($use_qa_contact && $qacontact && ($qacontact == $user_id))
-          || ($triage_owner && $triage_owner == $user_id)
           || ($owner == $user_id)
           || ($isoncclist && $cclist_access)
           || !$missinggroup) ? 1 : 0;

--- a/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
@@ -138,7 +138,16 @@ END;
 
           [% CASE constants.FIELD_TYPE_USER %]
             [%# users %]
-            [% INCLUDE bug_modal/user.html.tmpl u=value nick_only=1 gravatar_size=20 %]
+            [% IF field.name == "triage_owner" && bug.defined && !bug.component_obj.triage_owner.can_see_bug(bug.id) %]
+              [% user_warning_html = BLOCK %]
+                <img src="[% basepath FILTER none %]extensions/BugModal/web/error.png" width="16"
+                     height="16" title="Triage owner not permitted to see this bug">
+              [% END %]
+            [% ELSE %]
+              [% user_warning_html = '' %]
+            [% END %]
+            [% INCLUDE bug_modal/user.html.tmpl
+               u=value nick_only=1 gravatar_size=20 user_addl_html=user_warning_html %]
 
           [% CASE constants.FIELD_TYPE_BUG_URLS %]
             [%# see also %]

--- a/extensions/BugModal/template/en/default/bug_modal/groups.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/groups.html.tmpl
@@ -108,8 +108,8 @@
              [% " disabled=\"disabled\"" UNLESS user_can_edit_accessible %]>
       <label for="cclist_accessible">CC List</label>
     </div>
-    The assignee[% IF (Param('useqacontact')) %], QA contact, [% END %]
-    and triage owner can always see [% terms.abug %], and this section does not
-    take effect unless the [% terms.bug %] is restricted to at least one group.
+    The assignee [% IF (Param('useqacontact')) %]and QA contact[% END %]
+    can always see [% terms.abug %], and this section does not take effect
+    unless the [% terms.bug %] is restricted to at least one group.
   [% END %]
 </div>

--- a/extensions/BugModal/template/en/default/bug_modal/user.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/user.html.tmpl
@@ -13,6 +13,7 @@
   # gravatar_only : boolean, if true output just the Gravatar (not-simple only)
   # nick_only : boolean, if true, the nickname will be used instead of the full name
   # id : string, if provided the id of the vCard div
+  # user_addl_html : string, if provided will be rendered after user information inside the same <div>
   #%]
 
 [%
@@ -58,5 +59,6 @@ END;
         </a>
       [% END %]
     [% END %]
+    [% user_addl_html FILTER none %]
   [% END %]
 </div>


### PR DESCRIPTION
This PR does the following

* Reverts the code added by bug 1417229 which allowed triage owners to see private bugs they were triaging similar to how qa contact and assignee can always see it. This means now the triage owner has no special access and must be added to the security group or cc'ed on the bug.
* The UI now shows a warning next to the triage owner on the show bug page if they triage owner does not have access to see the current bug. Someone who can edit the bug can add the triage owner to the cc list or the user can be added to the products security group if needed.