### PR TITLE
Bug 1790883 - Bugzilla Phab attachments should include the repo callsign

### DIFF
--- a/extensions/PhabBugz/lib/Repository.pm
+++ b/extensions/PhabBugz/lib/Repository.pm
@@ -1,0 +1,121 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::Extension::PhabBugz::Repository;
+
+use 5.10.1;
+use Moo;
+use Types::Standard -all;
+
+use Bugzilla::Util qw(trim);
+use Bugzilla::Extension::PhabBugz::Util qw(request);
+
+#########################
+#    Initialization     #
+#########################
+
+has id              => (is => 'ro',   isa => Int);
+has phid            => (is => 'ro',   isa => Str);
+has type            => (is => 'ro',   isa => Str);
+has name            => (is => 'ro',   isa => Str);
+has description     => (is => 'ro',   isa => Maybe [Str]);
+has vcs             => (is => 'ro',   isa => Str);
+has status          => (is => 'ro',   isa => Str);
+has call_sign       => (is => 'ro',   isa => Str);
+has short_name      => (is => 'ro',   isa => Str);
+has default_branch  => (is => 'ro',   isa => Str);
+has creation_ts     => (is => 'ro',   isa => Str);
+has modification_ts => (is => 'ro',   isa => Str);
+has view_policy     => (is => 'ro',   isa => Str);
+has edit_policy     => (is => 'ro',   isa => Str);
+has push_policy     => (is => 'ro',   isa => Str);
+
+sub new_from_query {
+  my ($class, $params) = @_;
+
+  my $data
+    = {queryKey => 'all', constraints => $params};
+
+  my $result = request('diffusion.repository.search', $data);
+
+  if (exists $result->{result}{data} && @{$result->{result}{data}}) {
+    return $class->new($result->{result}{data}[0]);
+  }
+
+  return undef;
+}
+
+sub BUILDARGS {
+  my ($class, $params) = @_;
+
+  $params->{name}            = $params->{fields}->{name};
+  $params->{description}     = $params->{fields}->{description}->{raw};
+  $params->{vcs}             = $params->{fields}->{vcs};
+  $params->{status}          = $params->{fields}->{status};
+  $params->{call_sign}       = $params->{fields}->{callsign};
+  $params->{short_name}      = $params->{fields}->{shortName};
+  $params->{default_branch}  = $params->{fields}->{defaultBranch};
+  $params->{creation_ts}     = $params->{fields}->{dateCreated};
+  $params->{modification_ts} = $params->{fields}->{dateModified};
+  $params->{view_policy}     = $params->{fields}->{policy}->{view};
+  $params->{edit_policy}     = $params->{fields}->{policy}->{edit};
+  $params->{push_policy}     = $params->{fields}->{policy}->{'diffusion.push'};
+
+  delete $params->{attachments};
+  delete $params->{fields};
+
+  return $params;
+}
+
+# {
+#   "data": [
+#     {
+#       "id": 16,
+#       "type": "REPO",
+#       "phid": "PHID-REPO-kiqorvpaq7yy6mybuvz4",
+#       "fields": {
+#         "name": "ci-configuration",
+#         "vcs": "hg",
+#         "callsign": "CICONFIG",
+#         "shortName": "ci-configuration",
+#         "status": "active",
+#         "isImporting": false,
+#         "almanacServicePHID": null,
+#         "refRules": {
+#           "fetchRules": [],
+#           "trackRules": [],
+#           "permanentRefRules": []
+#         },
+#         "defaultBranch": "default",
+#         "description": {
+#           "raw": "Configuration for CI automation relating to the Gecko source code."
+#         },
+#         "spacePHID": null,
+#         "dateCreated": 1523456273,
+#         "dateModified": 1549657483,
+#         "policy": {
+#           "view": "public",
+#           "edit": "admin",
+#           "diffusion.push": "no-one"
+#         }
+#       },
+#       "attachments": {}
+#     }
+#   ],
+#   "maps": {},
+#   "query": {
+#     "queryKey": null
+#   },
+#   "cursor": {
+#     "limit": 100,
+#     "after": null,
+#     "before": null,
+#     "order": null
+#   }
+# }
+
+1;

--- a/extensions/PhabBugz/lib/Revision.pm
+++ b/extensions/PhabBugz/lib/Revision.pm
@@ -20,8 +20,9 @@ use Bugzilla::Types qw(JSONBool);
 use Bugzilla::Error;
 use Bugzilla::Util qw(trim);
 use Bugzilla::Extension::PhabBugz::Project;
-use Bugzilla::Extension::PhabBugz::User;
+use Bugzilla::Extension::PhabBugz::Repository;
 use Bugzilla::Extension::PhabBugz::Types qw(:types);
+use Bugzilla::Extension::PhabBugz::User;
 use Bugzilla::Extension::PhabBugz::Util qw(request);
 
 #########################
@@ -39,12 +40,14 @@ has creation_ts      => (is => 'ro',   isa => Str);
 has modification_ts  => (is => 'ro',   isa => Str);
 has author_phid      => (is => 'ro',   isa => Str);
 has diff_phid        => (is => 'ro',   isa => Str);
+has repository_phid  => (is => 'ro',   isa => Str);
 has bug_id           => (is => 'ro',   isa => Str);
 has view_policy      => (is => 'ro',   isa => Str);
 has edit_policy      => (is => 'ro',   isa => Str);
 has subscriber_count => (is => 'ro',   isa => Int);
 has bug              => (is => 'lazy', isa => Object);
 has author           => (is => 'lazy', isa => Object);
+has repository       => (is => 'lazy', isa => PhabRepo);
 has reviews =>
   (is => 'lazy', isa => ArrayRef [Dict [user => PhabUser | PhabProject, status => Str]]);
 has subscribers => (is => 'lazy', isa => ArrayRef [PhabUser]);
@@ -113,6 +116,7 @@ sub BUILDARGS {
   $params->{modification_ts} = $params->{fields}->{dateModified};
   $params->{author_phid}     = $params->{fields}->{authorPHID};
   $params->{diff_phid}       = $params->{fields}->{diffPHID};
+  $params->{repository_phid} = $params->{fields}->{repositoryPHID};
   $params->{bug_id}          = $params->{fields}->{'bugzilla.bug-id'};
   $params->{view_policy}     = $params->{fields}->{policy}->{view};
   $params->{edit_policy}     = $params->{fields}->{policy}->{edit};
@@ -354,6 +358,18 @@ sub _build_projects {
   }
 
   return $self->{projects} = \@projects;
+}
+
+sub _build_repository {
+  my ($self) = @_;
+  return $self->{repository} if $self->{repository};
+  my $repository
+    = Bugzilla::Extension::PhabBugz::Repository->new_from_query({
+    phids => [$self->repository_phid]
+    });
+  if ($repository) {
+    return $self->{repository} = $repository;
+  }
 }
 
 #########################

--- a/extensions/PhabBugz/lib/Types.pm
+++ b/extensions/PhabBugz/lib/Types.pm
@@ -12,7 +12,7 @@ use strict;
 use warnings;
 
 use Type::Library -base,
-  -declare => qw( Revision LinkedPhabUser PhabProject PhabUser Policy Project );
+  -declare => qw( Revision LinkedPhabUser PhabProject PhabUser Policy Project PhabRepo );
 use Type::Utils -all;
 use Types::Standard -all;
 
@@ -21,7 +21,7 @@ class_type Policy,      {class => 'Bugzilla::Extension::PhabBugz::Policy'};
 class_type Project,     {class => 'Bugzilla::Extension::PhabBugz::Project'};
 class_type PhabProject, {class => 'Bugzilla::Extension::PhabBugz::Project'};
 class_type PhabUser,    {class => 'Bugzilla::Extension::PhabBugz::User'};
+class_type PhabRepo     {class => 'Bugzilla::Extension::PhabBugz::Repository'};
 declare LinkedPhabUser, as PhabUser, where { is_Int($_->bugzilla_id) };
-
 
 1;

--- a/extensions/PhabBugz/lib/WebService.pm
+++ b/extensions/PhabBugz/lib/WebService.pm
@@ -193,10 +193,12 @@ sub bug_revisions {
     $revision_data->{reviews} = \@reviews;
 
     if ($revision_obj->view_policy ne 'public') {
-      $revision_data->{title} = '(secured)';
+      $revision_data->{title}     = '(secured)';
+      $revision_data->{call_sign} = '(secured)';
     }
     else {
-      $revision_data->{title} = $revision_obj->title;
+      $revision_data->{title}     = $revision_obj->title;
+      $revision_data->{call_sign} = $revision_obj->repository->call_sign;
     }
 
     $revision_data->{children} = [map { "D$_" } @{$children_map->{$id}}];

--- a/extensions/PhabBugz/lib/WebService.pm
+++ b/extensions/PhabBugz/lib/WebService.pm
@@ -197,8 +197,9 @@ sub bug_revisions {
       $revision_data->{call_sign} = '(secured)';
     }
     else {
-      $revision_data->{title}     = $revision_obj->title;
-      $revision_data->{call_sign} = $revision_obj->repository->call_sign;
+      $revision_data->{title} = $revision_obj->title;
+      $revision_data->{call_sign}
+        = $revision_obj->repository ? $revision_obj->repository->call_sign : 'N/A';
     }
 
     $revision_data->{children} = [map { "D$_" } @{$children_map->{$id}}];

--- a/extensions/PhabBugz/template/en/default/phabricator/table.html.tmpl
+++ b/extensions/PhabBugz/template/en/default/phabricator/table.html.tmpl
@@ -14,6 +14,7 @@
       <th>ID</th>
       <th>Status</th>
       <th>Reviewers</th>
+      <th>Repository</th>
       <th>Title</th>
     </tr>
   </thead>

--- a/extensions/PhabBugz/web/js/phabricator.js
+++ b/extensions/PhabBugz/web/js/phabricator.js
@@ -516,6 +516,12 @@ const Phabricator = {
       }
       tdReviewers.append(tableReviews);
 
+      // Repository Call Sign
+
+      const tdRepo = document.createElement("td");
+      tdRepo.classList.add("phabricator-repo");
+      tdRepo.append(rev.call_sign);
+
       // Revision Title
 
       const tdTitle = document.createElement("td");
@@ -539,6 +545,7 @@ const Phabricator = {
         tdId,
         tdRevisionStatus,
         tdReviewers,
+        tdRepo,
         tdTitle
       );
 


### PR DESCRIPTION
This PR allows a revision to get more detailed repository information than before by creating a new Repository class with accessors. The new class does not allow for creating or updating, just retrieving. This allows for a new column in the Phabricator Revisions table of show bug to show the call sign of the repo for the revision.