### PR TITLE
Bug 1792986 - Add Github API endpoint to be used for automatically linking PRs to bug attachments

### DIFF
--- a/Bugzilla/API/V1/Github.pm
+++ b/Bugzilla/API/V1/Github.pm
@@ -9,6 +9,7 @@ package Bugzilla::API::V1::Github;
 use 5.10.1;
 use Mojo::Base qw( Mojolicious::Controller );
 
+use Bugzilla::Attachment;
 use Bugzilla::Bug;
 use Bugzilla::Constants;
 use Bugzilla::Group;
@@ -55,13 +56,16 @@ sub pull_request {
   if ( !$payload
     || !$payload->{pull_request}
     || !$payload->{pull_request}->{html_url}
-    || !$payload->{pull_request}->{title})
+    || !$payload->{pull_request}->{title}
+    || !$payload->{pull_request}->{number})
   {
     return $self->code_error('github_pr_invalid_json');
   }
 
-  my $html_url = $payload->{pull_request}->{html_url};
-  my $title    = $payload->{pull_request}->{title};
+  my $html_url  = $payload->{pull_request}->{html_url};
+  my $title     = $payload->{pull_request}->{title};
+  my $pr_number = $payload->{pull_request}->{number};
+
   $title =~ BUG_RE;
   my $bug_id = $2;
   my $bug    = Bugzilla::Bug->new($bug_id);
@@ -90,7 +94,7 @@ sub pull_request {
     creation_ts => $timestamp,
     data        => $html_url,
     description => 'GitHub Pull Request',
-    filename    => 'file_' . $bug->id . '.txt',
+    filename    => "github-$pr_number-url.txt",
     ispatch     => 0,
     isprivate   => 0,
     mimetype    => 'text/x-github-pull-request',
@@ -106,6 +110,34 @@ sub pull_request {
     }
   );
   $bug->update($timestamp);
+
+  # fixup attachments with same github pull request but on different bugs
+  my %other_bugs;
+  my $other_attachments = Bugzilla::Attachment->match({
+    mimetype => 'text/x-github-pull-request',
+    filename => "github-$pr_number-url.txt",
+    WHERE    => {'bug_id != ? AND NOT isobsolete' => $bug->id}
+  });
+  foreach my $attachment (@$other_attachments) {
+    $other_bugs{$attachment->bug_id}++;
+    my $moved_comment
+      = "GitHub pull request attachment was moved to bug "
+      . $bug->id
+      . ". Setting attachment "
+      . $attachment->id
+      . " to obsolete.";
+    $attachment->set_is_obsolete(1);
+    $attachment->bug->add_comment(
+      $moved_comment,
+      {
+        type        => CMT_ATTACHMENT_UPDATED,
+        extra_data  => $attachment->id,
+        is_markdown => (Bugzilla->params->{use_markdown} ? 1 : 0)
+      }
+    );
+    $attachment->bug->update($timestamp);
+    $attachment->update($timestamp);
+  }
 
   # Return success
   return $self->render(json => {id => $attachment->id});

--- a/Bugzilla/API/V1/Github.pm
+++ b/Bugzilla/API/V1/Github.pm
@@ -111,7 +111,7 @@ sub pull_request {
   );
   $bug->update($timestamp);
 
-  # fixup attachments with same github pull request but on different bugs
+  # Fixup attachments with same github pull request but on different bugs
   my %other_bugs;
   my $other_attachments = Bugzilla::Attachment->match({
     mimetype => 'text/x-github-pull-request',
@@ -139,7 +139,7 @@ sub pull_request {
     $attachment->update($timestamp);
   }
 
-  # Return success
+  # Return new attachment id when successful
   return $self->render(json => {id => $attachment->id});
 }
 

--- a/Bugzilla/API/V1/Github.pm
+++ b/Bugzilla/API/V1/Github.pm
@@ -1,0 +1,127 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::API::V1::Github;
+use 5.10.1;
+use Mojo::Base qw( Mojolicious::Controller );
+
+use Bugzilla::Bug;
+use Bugzilla::Constants;
+use Bugzilla::Group;
+use Bugzilla::Logging;
+use Bugzilla::User;
+
+use Digest::SHA qw(hmac_sha256_hex);
+use Mojo::Util  qw(secure_compare);
+
+# Stolen from pylib/mozautomation/mozautomation/commitparser.py from
+# https://hg.mozilla.org/hgcustom/version-control-tools
+use constant BUG_RE => qr/
+  (
+    (?:
+      bug |
+      b= |
+      (?=\b\#?\d{5,}) |
+      ^(?=\d)
+    )
+    (?:\s*\#?)(\d+)(?=\b)
+  )/ix;
+
+sub setup_routes {
+  my ($class, $r) = @_;
+  $r->post('/github/pull_request')->to('V1::Github#pull_request');
+}
+
+sub pull_request {
+  my ($self) = @_;
+  Bugzilla->usage_mode(USAGE_MODE_MOJO_REST);
+
+  # Return early if not a pull_request event
+  my $event = $self->req->headers->header('X-GitHub-Event');
+  return $self->render(json => {error => 'Not pull request'}, status => 400)
+    if (!$event || $event ne 'pull_request');
+
+  # Verify that signature is correct based on shared secret
+  return $self->render(
+    json   => {error => 'Payload signatures did not match'},
+    status => 400
+  ) if !$self->verify_signature;
+
+  # Parse pull request title for bug ID
+  my $payload = $self->req->json;
+  if ( !$payload
+    || !$payload->{pull_request}
+    || !$payload->{pull_request}->{html_url}
+    || !$payload->{pull_request}->{title})
+  {
+    return $self->render(json => {error => 'Invalid JSON data'}, status => 400);
+  }
+
+  my $html_url = $payload->{pull_request}->{html_url};
+  my $title    = $payload->{pull_request}->{title};
+  $title =~ BUG_RE;
+  my $bug_id = $2;
+  my $bug    = Bugzilla::Bug->new($bug_id);
+  return $self->render(json => {error => 'Valid bug ID was not found'},
+    status => 400)
+    if !$bug;
+
+  # Check if bug already has this pull request attached
+  foreach my $attachment (@{$bug->attachments}) {
+    next if $attachment->content_type ne 'text/x-github-pull-request';
+    if ($attachment->data eq $html_url) {
+      return $self->render(
+        json   => {error => 'Pull request already attached'},
+        status => 400
+      );
+    }
+  }
+
+  # Create new attachment using pull request URL as attachment content
+  my $auto_user = Bugzilla::User->check({name => 'automation@bmo.tld'});
+  $auto_user->{groups}       = [Bugzilla::Group->get_all];
+  $auto_user->{bless_groups} = [Bugzilla::Group->get_all];
+  Bugzilla->set_user($auto_user);
+
+  my $timestamp = Bugzilla->dbh->selectrow_array("SELECT NOW()");
+
+  my $attachment = Bugzilla::Attachment->create({
+    bug         => $bug,
+    creation_ts => $timestamp,
+    data        => $html_url,
+    description => 'GitHub Pull Request',
+    filename    => 'file_' . $bug->id . '.txt',
+    ispatch     => 0,
+    isprivate   => 0,
+    mimetype    => 'text/x-github-pull-request',
+  });
+
+  # Insert a comment about the new attachment into the database.
+  $bug->add_comment(
+    '',
+    {
+      type        => CMT_ATTACHMENT_CREATED,
+      extra_data  => $attachment->id,
+      is_markdown => (Bugzilla->params->{use_markdown} ? 1 : 0)
+    }
+  );
+  $bug->update($timestamp);
+
+  # Return success
+  return $self->render(json => {id => $attachment->id});
+}
+
+sub verify_signature {
+  my ($self)             = @_;
+  my $payload            = $self->req->body;
+  my $secret             = Bugzilla->params->{github_pr_signature_secret};
+  my $received_signature = $self->req->headers->header('X-Hub-Signature-256');
+  my $expected_signature = 'sha256=' . hmac_sha256_hex($secret, $payload);
+  return secure_compare($expected_signature, $received_signature) ? 1 : 0;
+}
+
+1;

--- a/Bugzilla/Config/Attachment.pm
+++ b/Bugzilla/Config/Attachment.pm
@@ -34,14 +34,15 @@ sub get_param_list {
       checker => \&check_storage
     },
     {
-      name => 'attachment_s3_minsize',
-      type => 't',
+      name    => 'attachment_s3_minsize',
+      type    => 't',
       default => '20000',
       checker => \&check_numeric
     },
-    {name => 's3_bucket',             type => 't', default => '',},
-    {name => 'aws_access_key_id',     type => 't', default => '',},
-    {name => 'aws_secret_access_key', type => 't', default => '',},
+    {name => 's3_bucket',                  type => 't', default => '',},
+    {name => 'aws_access_key_id',          type => 't', default => '',},
+    {name => 'aws_secret_access_key',      type => 't', default => '',},
+    {name => 'github_pr_signature_secret', type => 't', default => ''},
   );
   return @param_list;
 }

--- a/qa/t/rest_github_pull_request.t
+++ b/qa/t/rest_github_pull_request.t
@@ -1,0 +1,87 @@
+#!/usr/bin/env perl
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+use strict;
+use warnings;
+use 5.10.1;
+use lib qw(lib ../../lib ../../local/lib/perl5);
+
+use Bugzilla;
+use Bugzilla::Logging;
+
+use Digest::SHA  qw(hmac_sha256_hex);
+use MIME::Base64 qw(decode_base64);
+use Mojo::JSON   qw(encode_json);
+use QA::Util     qw(get_config);
+use Test::Mojo;
+use Test::More;
+
+my $config        = get_config();
+my $api_key       = $config->{admin_user_api_key};
+my $url           = Bugzilla->localconfig->urlbase;
+my $github_secret = 'B1gS3cret!';
+
+my $t = Test::Mojo->new();
+
+# Create a new test bug for linking to PR
+
+my $new_bug = {
+  product     => 'Firefox',
+  component   => 'General',
+  summary     => 'Test GitHub PR Linking',
+  type        => 'defect',
+  version     => 'unspecified',
+  severity    => 'blocker',
+  description => 'This is a new test bug',
+};
+
+$t->post_ok(
+  $url . 'rest/bug' => {'X-Bugzilla-API-Key' => $api_key} => json => $new_bug)
+  ->status_is(200)->json_has('/id');
+
+my $bug_id = $t->tx->res->json->{id};
+
+# Create signature needed to be added to the GitHub header when
+# posting the PR update.
+
+# https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads
+my $payload = {
+  pull_request => {
+    html_url => 'https://github.com/mozilla-bteam/bmo/pull/1',
+    title    => "Bug $bug_id - Test GitHub PR Linking",
+  }
+};
+
+# https://docs.github.com/en/developers/webhooks-and-events/webhooks/securing-your-webhooks
+my $github_signature
+  = 'sha256=' . hmac_sha256_hex($github_secret, encode_json($payload));
+
+# Post the GitHub event to the rest/github/pull_request API endpoint
+
+$t->post_ok(
+  $url
+    . 'rest/github/pull_request' => {
+    'X-Hub-Signature-256' => $github_signature,
+    'X-GitHub-Event'      => 'pull_request'
+    } => json => $payload
+)->status_is(200)->json_has('/id');
+
+my $attach_id = $t->tx->res->json->{id};
+
+# Retrieve the attachment from the bug to make sure it was created correctly
+
+$t->get_ok(
+  $url . "rest/bug/attachment/$attach_id" => {'X-Bugzilla-API-Key' => $api_key})
+  ->status_is(200)->json_is("/attachments/$attach_id/content_type",
+  'text/x-github-pull-request')
+  ->json_is("/attachments/$attach_id/description", 'GitHub Pull Request');
+
+my $attach_data = $t->tx->res->json->{attachments}->{$attach_id}->{data};
+$attach_data = decode_base64($attach_data);
+ok($attach_data eq 'https://github.com/mozilla-bteam/bmo/pull/1');
+
+done_testing();

--- a/qa/t/rest_github_pull_request.t
+++ b/qa/t/rest_github_pull_request.t
@@ -15,7 +15,7 @@ use Bugzilla::Logging;
 
 use Digest::SHA  qw(hmac_sha256_hex);
 use MIME::Base64 qw(decode_base64);
-use Mojo::JSON   qw(encode_json);
+use Mojo::JSON   qw(encode_json true);
 use QA::Util     qw(get_config);
 use Test::Mojo;
 use Test::More;
@@ -77,6 +77,7 @@ $bad_payload = {
   pull_request => {
     html_url => 'https://github.com/mozilla-bteam/bmo/pull/1',
     title    => 'Bug 1000 - Test GitHub PR Linking',
+    number   => 1,
   }
 };
 $bad_signature
@@ -92,6 +93,7 @@ my $good_payload = {
   pull_request => {
     html_url => 'https://github.com/mozilla-bteam/bmo/pull/1',
     title    => "Bug $bug_id - Test GitHub PR Linking",
+    number   => 1
   }
 };
 
@@ -110,7 +112,7 @@ $t->post_ok(
 
 my $attach_id = $t->tx->res->json->{id};
 
-# Retrieve the attachment from the bug to make sure it was created correctly
+# Retrieve the new attachment from the bug to make sure it was created correctly
 $t->get_ok(
   $url . "rest/bug/attachment/$attach_id" => {'X-Bugzilla-API-Key' => $api_key})
   ->status_is(200)->json_is("/attachments/$attach_id/content_type",
@@ -131,5 +133,44 @@ $t->post_ok(
 )->status_is(400)
   ->json_like('/message' =>
     qr/The pull request contained a bug ID that already has an attachment/);
+
+# Create a second bug for testing attaching the same github pr but to a
+# different bug. For example if someone changes the bug ID in the title
+# of an existing pull request. The first attachment should be obsoleted
+# after creating the second one.
+$t->post_ok(
+  $url . 'rest/bug' => {'X-Bugzilla-API-Key' => $api_key} => json => $new_bug)
+  ->status_is(200)->json_has('/id');
+
+my $bug_id_2 = $t->tx->res->json->{id};
+
+# Post the valid GitHub event to the rest/github/pull_request API endpoint
+$good_payload->{pull_request}->{title} = "Bug $bug_id_2 - Test GitHub PR Linking";
+$good_signature = 'sha256=' . hmac_sha256_hex(encode_json($good_payload), $github_secret);
+$t->post_ok(
+  $url
+    . 'rest/github/pull_request' => {
+    'X-Hub-Signature-256' => $good_signature,
+    'X-GitHub-Event'      => 'pull_request'
+    } => json => $good_payload
+)->status_is(200)->json_has('/id');
+
+my $attach_id_2 = $t->tx->res->json->{id};
+
+# Retrieve the new attachment from the bug to make sure it was created correctly
+$t->get_ok(
+  $url . "rest/bug/attachment/$attach_id_2" => {'X-Bugzilla-API-Key' => $api_key})
+  ->status_is(200)->json_is("/attachments/$attach_id_2/content_type",
+  'text/x-github-pull-request')
+  ->json_is("/attachments/$attach_id_2/description", 'GitHub Pull Request');
+
+my $attach_data_2 = $t->tx->res->json->{attachments}->{$attach_id_2}->{data};
+$attach_data_2 = decode_base64($attach_data_2);
+ok($attach_data_2 eq 'https://github.com/mozilla-bteam/bmo/pull/1');
+
+# Retrieve the old attachment from the previous bug and make sure it was obsoleted.
+$t->get_ok(
+  $url . "rest/bug/attachment/$attach_id" => {'X-Bugzilla-API-Key' => $api_key})
+  ->status_is(200)->json_is("/attachments/$attach_id/is_obsolete", true);
 
 done_testing();

--- a/scripts/generate_bmo_data.pl
+++ b/scripts/generate_bmo_data.pl
@@ -589,6 +589,7 @@ my %set_params = (
     . '&long_desc_type=substring',
   defaultseverity      => 'normal',
   edit_comments_group  => 'editbugs',
+  github_pr_signature_secret => 'B1gS3cret!',
   insidergroup         => 'core-security-release',
   last_change_time_non_bot_skip_list => 'automation@bmo.tld',
   last_visit_keep_days => '28',

--- a/template/en/default/admin/params/attachment.html.tmpl
+++ b/template/en/default/admin/params/attachment.html.tmpl
@@ -52,5 +52,8 @@
     "value will be uploaded to S3 for performance reasons. Smaller attachments " _
     "will be stored in the database."
 
+  github_pr_signature_secret =>
+    "Shared secret needed for GitHub webhooks to post pull requests to Bugzilla " _
+    "creating an attachment linking the bug report to the pull request."
   }
 %]

--- a/template/en/default/global/code-error.html.tmpl
+++ b/template/en/default/global/code-error.html.tmpl
@@ -518,6 +518,22 @@
     Please contact a system administrator with details of what you
     were doing when the error occurred.
 
+  [% ELSIF error == "github_pr_not_pull_request" %]
+    The webhook event was not for a GitHub pull request.
+
+  [% ELSIF error == "github_pr_mismatch_signatures" %]
+    The webhook signature in the header did not match the expected value.
+
+  [% ELSIF error == "github_pr_invalid_json" %]
+    The webhook did not contain valid JSON or expected data was missing.
+
+  [% ELSIF error == "github_pr_bug_not_found" %]
+    The pull request title did not contain a valid [% terms.bug %] ID.
+
+  [% ELSIF error == "github_pr_attachment_exists" %]
+    The pull request contained a [% terms.bug %] ID that already has an attachment
+    with this pull request link.
+
   [% ELSE %]
     [%# Try to find hooked error messages %]
     [% error_message = Hook.process("errors") %]


### PR DESCRIPTION
Disregard the title changes in this PR as I was testing the webhooks with code on bugzilla-dev.allizom.org

This PR adds a new special API endpoint that can be used to add links to github pr to a bug report based on a bug id in the PR title. A webhook just needs to be created in the repository settings that points to https://bugzilla.mozilla.org/rest/github/pull_request for any pull request related changes. Also a shared secret will need to be obtained from the Bugzilla admin for authentication. A test script was added that tests to make sure the endpoint is working properly. Let me know if you have any questions or comments.