### PR TITLE
Bug 1726504 - Markdown tables are rendered incorrectly

### DIFF
--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -2683,8 +2683,9 @@ pre.comment-text {
 }
 
 .markdown-body table {
-  display: block;
-  width: 100%;
+  display: inline-block;
+  width: auto;
+  max-width: 100%;
   overflow: auto;
   border-top: 1px solid var(--grid-border-color);
 }


### PR DESCRIPTION
## Description 

Update markdown table CSS to render correctly in any width.

Final result:
![markdown-tables-desktop](https://user-images.githubusercontent.com/18278857/193605059-779eefe2-c865-4701-aafd-586130e6d61c.png)

