### PR TITLE
Bug 1795748 - Add the `Fenix` product in BMO's "choose from the following selections" list

### DIFF
--- a/extensions/BMO/template/en/default/global/choose-product.html.tmpl
+++ b/extensions/BMO/template/en/default/global/choose-product.html.tmpl
@@ -92,7 +92,7 @@
       icon="firefox.png"
     %]
     [% INCLUDE easyproduct
-      name="Firefox for Android"
+      name="Fenix"
       icon="firefox_android.png"
     %]
     [% INCLUDE easyproduct

--- a/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
+++ b/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
@@ -157,13 +157,13 @@ tabbed browsing or the location bar)
       [% END %]
     [% END %]
   [% END %]
-    <li
+    <li>
+      <span class="product-item"
       [% IF onclick %]
       onclick="[% onclick FILTER html %]"
       [% ELSE %]
       onclick="product.select('[% name FILTER js %]')"
       [% END %]>
-      <span class="product-item">
       <img src="[% basepath FILTER none %]extensions/BMO/web/producticons/[% icon FILTER uri %]" class="product-icon">
       <a href="javascript:void(0)">[% caption FILTER html %]</a>
       <p>
@@ -174,6 +174,13 @@ tabbed browsing or the location bar)
         [% END %]
       </p>
       </span>
+      [% IF security_bug_link %]
+        <span class="product-item">
+          If you are reporting a security issue that puts users at risk,
+          <b><a href="[% security_bug_link FILTER none %]">use this form</a>
+          instead.</b>
+        </span>
+      [% END %]
     </li>
 [% END %]
 

--- a/extensions/GuidedBugEntry/template/en/default/guided/products.html.tmpl
+++ b/extensions/GuidedBugEntry/template/en/default/guided/products.html.tmpl
@@ -14,30 +14,16 @@ For [% terms.bugs %] in Firefox, the Mozilla Foundation's web browser.
 
 (<a href="https://www.mozilla.org/en-US/firefox/desktop/">more info</a>)
 [% END %]
-[% WRAPPER product_block
-   name="Firefox for Android"
+[% INCLUDE product_block
+   name="Fenix"
    icon="firefox_android.png"
-   onclick="document.location='https://github.com/mozilla-mobile/fenix/issues/'"
 %]
-Firefox for Android is the Firefox mobile experience developed for Android. [% terms.Bugs %] for
-this product are tracked on GitHub.
-
-<i>If you are reporting a security issue that puts users at risk,
-<b><a href="/enter_bug.cgi?format=guided#h=dupes|Fenix|Security%3A%20Android">use
-this form</a>.</b></i>
-[% END %]
-[% WRAPPER product_block
+[% INCLUDE product_block
    name="Firefox for iOS"
    icon="firefox_ios.png"
    onclick="document.location='https://github.com/mozilla-mobile/firefox-ios/issues'"
+   security_bug_link = "enter_bug.cgi?format=guided#h=dupes|Focus|Security%3A iOS"
 %]
-Firefox for iOS is the Firefox mobile experience developed for the iOS platform. [% terms.Bugs %] for
-this product are tracked on GitHub.
-
-<i>If you are reporting a security issue that puts users at risk,
-<b><a href="/enter_bug.cgi?format=guided#h=dupes|Focus|Security%3A iOS">use
-this form</a>.</b></i>
-[% END %]
 [% INCLUDE product_block
    name="Thunderbird"
    icon="thunderbird.png"
@@ -45,6 +31,7 @@ this form</a>.</b></i>
 [% WRAPPER product_block
    name="Other Products"
    icon="other.png"
-   onclick="guided.setStep('otherProducts')" %]
+   onclick="guided.setStep('otherProducts')"
+%]
 Other Mozilla products which aren't listed here
 [% END %]


### PR DESCRIPTION
This PR updates the Fenix (Firefox for Android) selections for the standard enter bug page as well as the Guided bug entry form that new, non-empowered users see. Fenix no longer uses Github issues and now just files all bugs in BMO. Firefox for iOS still uses Github issues for general bugs but uses BMO for security bugs. As part of this, I fixed a bug in the Firefox for iOS selection on the Guided bug page that would still redirect to Github even if a security bug was being entered.