### PR TITLE
Bug 1795329 - Add dupe of and duplicates entries to bugs_activity table instead of just adding a comment

### DIFF
--- a/Bugzilla/Field.pm
+++ b/Bugzilla/Field.pm
@@ -387,7 +387,12 @@ use constant DEFAULT_FIELDS => (
     type           => FIELD_TYPE_BUG_ID,
     buglist        => 1,
   },
-
+  {
+    name           => 'dup_id',
+    desc           => 'Duplicate of',
+    type           => FIELD_TYPE_BUG_ID,
+    buglist        => 1,
+  },
   {
     name    => 'assignee_last_login',
     desc    => 'Assignee Last Login Date',

--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -346,9 +346,9 @@
       END;
 
       IF change.buglist;
-        IF change.fieldname == 'has_dupe';
+        IF change.fieldname == 'duplicates';
           label = "Duplicate of this " _ terms.bug;
-        ELSIF change.fieldname == 'dupe_of';
+        ELSIF change.fieldname == 'dup_id';
           label = "Duplicate of " _ terms.bug;
         ELSE;
           label = field_descs.${change.fieldname};


### PR DESCRIPTION
Before this, when a bug is resolved as a duplicate of another bug, a comment was added to the duplicated bug but an entry was not added to the bugs_activity table with the bug id of the dupe. If someone looking a bugs history using the UI or the API, it would not show the new bug id entry in the history and the client would need to also look in the comments to parse out the bug id from the comment. This PR adds the duplicate bug id to the activity table so it will show up properly in the history API. The comment text of a the comment stays the same.