### PR TITLE
Bug 1791629: teach `phab-bot` to set `#release-managers!` review when uplift form submitted

### DIFF
--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -400,7 +400,7 @@ sub process_revision_change {
     );
 
     # Get `#release-managers` review group.
-    my $release_managers_phid = Bugzilla::Extension::PhabBugz::Project
+    my $release_managers_group = Bugzilla::Extension::PhabBugz::Project
       ->new_from_query({name => 'release-managers'});
 
     if (!$release_managers_group) {

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -401,8 +401,17 @@ sub process_revision_change {
 
     # Get `#release-managers` review group.
     my $release_managers_phid = Bugzilla::Extension::PhabBugz::Project
-      ->new_from_query({name => 'release-managers'})
-      ->phid;
+      ->new_from_query({name => 'release-managers'});
+
+    if (!$release_managers_group) {
+      WARN(
+        "Uplift request change detected but `#release-managers` was " .
+        "not found on Phabricator."
+      );
+      return;
+    }
+    
+    my $release_managers_phid = $release_managers_group->phid;
 
     # Request `#release-managers` review on each revision.
     foreach my $stack_revision_phid (keys %{$revision->stack_graph_raw}) {

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -422,11 +422,6 @@ sub process_revision_change {
 
       # Add `#release-managers!` review and set revision status.
       $stack_revision->add_reviewer("blocking($release_managers_phid)");
-
-      if ($stack_revision->status ne 'needs-review') {
-        $stack_revision->set_status('request-review');
-      }
-
       $stack_revision->update();
 
       INFO("Requested #release-managers review of $stack_revision_phid.");

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -351,6 +351,13 @@ sub group_query {
   }
 }
 
+sub _is_uplift_request_form_change {
+  # Return `true` if the story text is an uplift request change.
+  my ($story_text) = @_;
+
+  return $story_text =~ /\s+uplift request field/;
+}
+
 sub process_revision_change {
   state $check = compile($Invocant, Revision, LinkedPhabUser, Str);
   my ($self, $revision, $changer, $story_text) = $check->(@_);
@@ -383,6 +390,41 @@ sub process_revision_change {
     $changer->name, $story_text
   );
   INFO($log_message);
+
+  # Change is a submission of the uplift request form.
+  if (_is_uplift_request_form_change($story_text)) {
+    my $revision_phid = $revision->phid;
+    INFO(
+      "Uplift request form submitted on $revision_phid, " .
+      "requesting `#release-managers` review."
+    );
+
+    # Get `#release-managers` review group.
+    my $release_managers_phid = Bugzilla::Extension::PhabBugz::Project
+      ->new_from_query({name => 'release-managers'})
+      ->phid;
+
+    # Request `#release-managers` review on each revision.
+    foreach my $stack_revision_phid (keys %{$revision->{stack_graph_raw}}) {
+      # Query Phabricator for each revision object related to the updated revision.
+      my $stack_revision = Bugzilla::Extension::PhabBugz::Revision->new_from_query(
+        {phids => [$stack_revision_phid]}
+      );
+
+      # Add `#release-managers!` review and set revision status.
+      $stack_revision->add_reviewer("blocking($release_managers_phid)");
+
+      if ($stack_revision->status ne 'needs-review') {
+        $stack_revision->set_status('request-review');
+      }
+
+      $stack_revision->update();
+
+      INFO("Requested relman review of $stack_revision_phid.");
+    }
+
+    return;
+  }
 
   # change to the phabricator user, which returns a guard that restores the previous user.
   my $restore_prev_user = set_phab_user();

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -405,7 +405,7 @@ sub process_revision_change {
       ->phid;
 
     # Request `#release-managers` review on each revision.
-    foreach my $stack_revision_phid (keys %{$revision->{stack_graph_raw}}) {
+    foreach my $stack_revision_phid (keys %{$revision->stack_graph_raw}) {
       # Query Phabricator for each revision object related to the updated revision.
       my $stack_revision = Bugzilla::Extension::PhabBugz::Revision->new_from_query(
         {phids => [$stack_revision_phid]}

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -420,7 +420,7 @@ sub process_revision_change {
 
       $stack_revision->update();
 
-      INFO("Requested relman review of $stack_revision_phid.");
+      INFO("Requested #release-managers review of $stack_revision_phid.");
     }
 
     return;

--- a/extensions/PhabBugz/lib/Revision.pm
+++ b/extensions/PhabBugz/lib/Revision.pm
@@ -44,6 +44,12 @@ has repository_phid  => (is => 'ro',   isa => Maybe[Str]);
 has bug_id           => (is => 'ro',   isa => Str);
 has view_policy      => (is => 'ro',   isa => Str);
 has edit_policy      => (is => 'ro',   isa => Str);
+has stack_graph_raw  => (
+    is => 'ro',
+    isa => Dict [
+        slurpy Any
+    ],
+);
 has subscriber_count => (is => 'ro',   isa => Int);
 has bug              => (is => 'lazy', isa => Object);
 has author           => (is => 'lazy', isa => Object);
@@ -120,6 +126,7 @@ sub BUILDARGS {
   $params->{bug_id}          = $params->{fields}->{'bugzilla.bug-id'};
   $params->{view_policy}     = $params->{fields}->{policy}->{view};
   $params->{edit_policy}     = $params->{fields}->{policy}->{edit};
+  $params->{stack_graph_raw} = $params->{fields}->{stackGraph};
   $params->{reviewers_raw}   = $params->{attachments}->{reviewers}->{reviewers}
     // [];
   $params->{subscribers_raw} = $params->{attachments}->{subscribers};
@@ -142,6 +149,15 @@ sub BUILDARGS {
 #       "type": "DREV",
 #       "phid": "PHID-DREV-uozm3ggfp7e7uoqegmc3",
 #       "fields": {
+#         "stackGraph": {
+#           "PHID-DREV-tzccv6pxtghpdkeutys2": [
+#             "PHID-DREV-rqndonx3itqv3ykz7tn6"
+#           ],
+#           "PHID-DREV-rqndonx3itqv3ykz7tn6": [
+#             "PHID-DREV-5jxsanssnzmhdtgxa33x"
+#           ],
+#           "PHID-DREV-5jxsanssnzmhdtgxa33x": []
+#         },
 #         "title": "Added .arcconfig",
 #         "authorPHID": "PHID-USER-4wigy3sh5fc5t74vapwm",
 #         "dateCreated": 1507666113,


### PR DESCRIPTION
Teaches `phab-bot` to set `#release-managers!` review when
the uplift request form is submitted. Parses feed story text
for an uplift request change and uses the `stackGraph` field
to request review on each revision in the stack.
