### PR TITLE
Bug 1692222 - Show bug ids in reference fields when user has editbugs even if the user cannot see the actual bugs

### DIFF
--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -4478,8 +4478,9 @@ sub delta_ts_non_bot {
 sub list_relationship {
   my ($table, $my_field, $target_field, $bug_id, $exclude_resolved) = @_;
   my $cache = Bugzilla->request_cache->{"bug_$table"} ||= {};
+  my $user  = Bugzilla->user;
+  my $dbh   = Bugzilla->dbh;
 
-  my $dbh = Bugzilla->dbh;
   $exclude_resolved = $exclude_resolved ? 1 : 0;
   my $is_open_clause = $exclude_resolved ? 'AND is_open = 1' : '';
 
@@ -4496,8 +4497,14 @@ sub list_relationship {
     $cache->{"${target_field}_sth_$exclude_resolved"},
     undef, $bug_id);
 
-  # List only bugs visible to the user
-  return Bugzilla->user->visible_bugs(\@$bug_ids);
+  # If user has 'editbugs', show all bug ids.
+  # Otherwise list only bugs visible to the user
+  if ($user->in_group('editbugs')) {
+    return $bug_ids;
+  }
+  else {
+    return $user->visible_bugs(\@$bug_ids);
+  }
 }
 
 # Creates a lot of bug objects in the same order as the input array.
@@ -4716,8 +4723,11 @@ sub GetBugActivity {
         $added = _join_activity_entries($fieldname, $old_change->{'added'}, $added);
       }
 
-      # List only bugs visible to the user
-      if ($fieldname =~ /^(?:dependson|blocked|regress(?:ed_by|es))$/) {
+      # If user has 'editbugs', show all bug ids.
+      # Otherwise list only bugs visible to the user
+      if (!$user->in_group('editbugs')
+        && $fieldname =~ /^(?:dependson|blocked|regress(?:ed_by|es))$/)
+      {
         $removed = join(', ', @{$user->visible_bugs([split(/,\s*/, $removed)])});
         $added   = join(', ', @{$user->visible_bugs([split(/,\s*/, $added)])});
         next if !$removed && !$added;

--- a/qa/t/test_security.t
+++ b/qa/t/test_security.t
@@ -138,9 +138,9 @@ logout($sel);
 log_in($sel, $config, 'editbugs');
 go_to_bug($sel, $bug1_id);
 ok(!$sel->is_text_present("secret_qa_bug_$bug2_id"),
-  "The alias 'secret_qa_bug_$bug2_id' is not visible for unauthorized users");
-ok(!$sel->is_text_present($bug2_id),
-  "Even the bug ID is not visible for unauthorized users");
+  "The alias 'secret_qa_bug_$bug2_id' is not visible for editbugs users");
+ok($sel->is_text_present($bug2_id),
+  "But the bug ID is visible for editbugs users");
 logout($sel);
 
 go_to_bug($sel, $bug1_id, 1);

--- a/qa/t/webservice_bug_get.t
+++ b/qa/t/webservice_bug_get.t
@@ -16,7 +16,7 @@ use Data::Dumper;
 use DateTime;
 use QA::Util;
 use QA::Tests qw(bug_tests PRIVATE_BUG_USER);
-use Test::More tests => 1006;
+use Test::More tests => 1087;
 my ($config, @clients) = get_rpc_clients();
 
 my $xmlrpc = $clients[0];
@@ -107,7 +107,11 @@ sub post_success {
   is(scalar @{$call->result->{bugs}}, 1, "Got exactly one bug");
   my $bug = $call->result->{bugs}->[0];
   my $is_private_bug  = $bug->{id} == $private_bug->{id};
-  my $is_private_user = $t->{user} && $t->{user} eq PRIVATE_BUG_USER;
+  my $is_privileged_user
+    = $t->{user}
+    && ($t->{user} eq 'editbugs'
+    || $t->{user} eq 'admin'
+    || $t->{user} eq PRIVATE_BUG_USER);
 
   if ($t->{user} && $t->{user} eq 'admin') {
     ok(exists $bug->{estimated_time} && exists $bug->{remaining_time},
@@ -124,7 +128,7 @@ sub post_success {
   }
 
   # See also to a private bug should not display for the public bug
-  if (!$is_private_bug && !$is_private_user) {
+  if (!$is_private_bug && !$is_privileged_user) {
     ok(
       !exists $bug->{see_also} || !@{$bug->{see_also}},
       'See also to a private bug should not display for the public bug and normal user'
@@ -134,21 +138,13 @@ sub post_success {
   if (exists $bug->{depends_on}) {
     is_deeply(
       $bug->{depends_on},
-      $is_private_bug ? [] : $is_private_user ? [$private_id] : [],
-      $is_private_bug
-        ? 'depends_on value is correct'
-        : $is_private_user
-        ? 'Private bug ID in depends_on is returned to private bug user'
-        : 'Private bug ID in depends_on is not returned to non-private bug user'
+      $is_private_bug ? [] : $is_privileged_user ? [$private_id] : [],
+      $is_private_bug ? 'depends_on value is correct'
+      : $is_privileged_user
+      ? 'Private bug ID in depends_on is returned to privileged bug user'
+      : 'Private bug ID in depends_on is not returned to non-privileged bug user'
+        . ($t->{user} ? ' (' . $t->{user} . ')' : '')
     );
-  }
-
-  if ($t->{user}) {
-    ok($bug->{update_token}, 'Update token returned for logged-in user');
-  }
-  else {
-    ok(!exists $bug->{update_token},
-      'Update token not returned for logged-out users');
   }
 
   my $expect = $is_private_bug ? $private_bug : $public_bug;
@@ -177,6 +173,11 @@ my @tests = (
       exclude_fields => ['summary']
     },
     test => 'exclude_fields overrides include_fields'
+  },
+  {
+    user => 'editbugs',
+    args => {ids => [$public_id], include_fields => ['id', 'depends_on']},
+    test => 'editbugs can see private ids in bug references',
   },
 );
 

--- a/qa/t/webservice_bug_get_bugs.t
+++ b/qa/t/webservice_bug_get_bugs.t
@@ -16,7 +16,7 @@ use Data::Dumper;
 use DateTime;
 use QA::Util;
 use QA::Tests qw(bug_tests PRIVATE_BUG_USER);
-use Test::More tests => 1006;
+use Test::More tests => 979;
 my ($config, @clients) = get_rpc_clients();
 
 my $xmlrpc = $clients[0];
@@ -97,7 +97,11 @@ sub post_success {
   is(scalar @{$call->result->{bugs}}, 1, "Got exactly one bug");
   my $bug = $call->result->{bugs}->[0];
   my $is_private_bug  = $bug->{id} == $private_bug->{id};
-  my $is_private_user = $t->{user} && $t->{user} eq PRIVATE_BUG_USER;
+  my $is_privileged_user
+    = $t->{user}
+    && ($t->{user} eq 'editbugs'
+    || $t->{user} eq 'admin'
+    || $t->{user} eq PRIVATE_BUG_USER);
 
   if ($t->{user} && $t->{user} eq 'admin') {
     ok(
@@ -121,7 +125,7 @@ sub post_success {
   }
 
   # See also to a private bug should not display for the public bug
-  if (!$is_private_bug && !$is_private_user) {
+  if (!$is_private_bug && !$is_privileged_user) {
     ok(
       !exists $bug->{see_also} || !@{$bug->{see_also}},
       'See also to a private bug should not display for the public bug and normal user'
@@ -131,21 +135,13 @@ sub post_success {
   if (exists $bug->{depends_on}) {
     is_deeply(
       $bug->{depends_on},
-      $is_private_bug ? [] : $is_private_user ? [$private_id] : [],
-      $is_private_bug
-        ? 'depends_on value is correct'
-        : $is_private_user
-        ? 'Private bug ID in depends_on is returned to private bug user'
-        : 'Private bug ID in depends_on is not returned to non-private bug user'
+      $is_private_bug ? [] : $is_privileged_user ? [$private_id] : [],
+      $is_private_bug ? 'depends_on value is correct'
+      : $is_privileged_user
+      ? 'Private bug ID in depends_on is returned to privileged bug user'
+      : 'Private bug ID in depends_on is not returned to non-privileged bug user'
+        . ($t->{user} ? ' (' . $t->{user} . ')' : '')
     );
-  }
-
-  if ($t->{user}) {
-    ok($bug->{update_token}, 'Update token returned for logged-in user');
-  }
-  else {
-    ok(!exists $bug->{update_token},
-      'Update token not returned for logged-out users');
   }
 
   my $expect = $is_private_bug ? $private_bug : $public_bug;


### PR DESCRIPTION
This PR allows a user who has editbugs to still see private bugs in the dependencies/regressions lists even if they cannot see the full bugs. If the user does not have editbugs, then they don't display at all. This is true for the show activity page as well. Some adjustments were made to the test scripts to adapt to the new policy.