### PR TITLE
Bug 1196291 - Prevent users without editbugs from commenting on resolved bugs, unless they are already involved in the bug

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/new_comment.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/new_comment.html.tmpl
@@ -12,10 +12,14 @@
   #%]
 
 <div id="add-comment">
-
-  [% IF !bug.check_can_change_field('longdesc', 0, 1).allowed %]
+  [% can_comment = bug.check_can_change_field('longdesc', 0, 1) %]
+  [% IF !can_comment.allowed %]
     <div id="new-comment-notice">
-      You are not allowed to make an additional comment on this [% terms.bug %].
+      [% IF can_comment.reason %]
+        [% can_comment.reason FILTER html %]
+      [% ELSE %]
+        You are not allowed to make an additional comment on this [% terms.bug %].
+      [% END %]
     </div>
     [% RETURN %]
   [% END %]

--- a/extensions/MozChangeField/Extension.pm
+++ b/extensions/MozChangeField/Extension.pm
@@ -17,6 +17,7 @@ use Bugzilla::Constants;
 use Bugzilla::Logging;
 
 use Bugzilla::Extension::MozChangeField::Pre::CanConfirm;
+use Bugzilla::Extension::MozChangeField::Pre::CommentClosedBugs;
 use Bugzilla::Extension::MozChangeField::Pre::CustomField;
 use Bugzilla::Extension::MozChangeField::Pre::Graveyard;
 use Bugzilla::Extension::MozChangeField::Pre::Reopen;
@@ -24,6 +25,7 @@ use Bugzilla::Extension::MozChangeField::Pre::TypePriSevEditbugs;
 
 my @pre_instances = (
   Bugzilla::Extension::MozChangeField::Pre::CanConfirm->new,
+  Bugzilla::Extension::MozChangeField::Pre::CommentClosedBugs->new,
   Bugzilla::Extension::MozChangeField::Pre::CustomField->new,
   Bugzilla::Extension::MozChangeField::Pre::Graveyard->new,
   Bugzilla::Extension::MozChangeField::Pre::Reopen->new,

--- a/extensions/MozChangeField/lib/Pre/CommentClosedBugs.pm
+++ b/extensions/MozChangeField/lib/Pre/CommentClosedBugs.pm
@@ -1,0 +1,46 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::Extension::MozChangeField::Pre::CommentClosedBugs;
+
+use 5.10.1;
+use Moo;
+
+use Bugzilla::Constants;
+
+sub evaluate_change {
+  my ($self, $args) = @_;
+
+  my $bug       = $args->{'bug'};
+  my $field     = $args->{'field'};
+  my $new_value = $args->{'new_value'};
+  my $old_value = $args->{'old_value'};
+  my $editbugs  = $args->{'editbugs'};
+  my $user      = Bugzilla->user;
+
+
+  # If this bug is closed and the current user has no role on the bug, then do
+  # not allow commenting on a bug that is not open.
+  if ($field =~ /^longdesc/ && !$bug->isopened && $new_value ne $old_value) {
+    my $has_role
+      = (  $editbugs
+        || $bug->reporter->id eq $user->id
+        || $bug->assigned_to->id eq $user->id
+        || ($bug->qa_contact && $bug->qa_contact->id eq $user->id)) ? 1 : 0;
+
+    return {result => PRIVILEGES_REQUIRED_NONE} if $has_role;
+
+    return {
+      result => PRIVILEGES_REQUIRED_EMPOWERED,
+      reason => 'You need permission to comment on this closed bug.',
+    };
+  }
+
+  return undef;
+}
+
+1;


### PR DESCRIPTION
This PR adds a new module that blocks adding a comment to a CLOSED bug if the user is not in editbugs, or does not have a direct role in the bug such as reporter, assignee, or qa contact. The template will show text in place of the comment field if they are blocked with a reason. This also blocks adding comments via the API if the user is not allowed. Let me know if you have any questions.