### PR TITLE
Bug 1801026 - 504 Gateway time-out while configuring Duo 2FA

### DIFF
--- a/userprefs.cgi
+++ b/userprefs.cgi
@@ -766,11 +766,11 @@ sub SaveMFAupdate {
 sub SaveMFAcallback {
   my $mfa_token = shift;
   my $user      = Bugzilla->user;
+  my $mfa       = Bugzilla->cgi->param('mfa');
+  my $provider  = Bugzilla::MFA->new_from($user, $mfa) // return;
+  my $event     = $provider->verify_token($mfa_token);
 
-  my $provider = Bugzilla::MFA->new_from($user, $mfa_token) // return;
-  my $event    = $provider->verify_token($mfa_token);
-
-  SaveMFAupdate($event->{action}, $mfa_token);
+  SaveMFAupdate($event->{action}, $mfa);
 }
 
 sub DoMFA {


### PR DESCRIPTION
Oh the careless mistakes :( This properly passes in the CGI param 'mfa' into `Bugzilla::MFA->new_from($user, $mfa)` instead of the value for $mfa_token which is totally different than what new_from is expecting. $mfa can only be 'TOTP' or 'Duo' and not a token hash string.

Same for `SaveMFAupdate($event->{action}, $mfa);`. It is expecting either 'TOTP' or 'Duo'. 

This fixes the issue locally and I will reconfirm on staging once it reaches it.