### PR TITLE
Bug 1801343 - Need a way to disable the github PR linking if needed 

### DIFF
--- a/Bugzilla/API/V1/Github.pm
+++ b/Bugzilla/API/V1/Github.pm
@@ -40,6 +40,10 @@ sub pull_request {
   my ($self) = @_;
   Bugzilla->usage_mode(USAGE_MODE_MOJO_REST);
 
+  # Return early if linking is not allowed
+  return $self->code_error('github_pr_linking_disabled')
+    if !Bugzilla->params->{github_pr_linking_enabled};
+
   # Return early if not a pull_request or ping event
   my $event = $self->req->headers->header('X-GitHub-Event');
   if (!$event || ($event ne 'pull_request' && $event ne 'ping')) {

--- a/Bugzilla/Config/Attachment.pm
+++ b/Bugzilla/Config/Attachment.pm
@@ -42,6 +42,7 @@ sub get_param_list {
     {name => 's3_bucket',                  type => 't', default => '',},
     {name => 'aws_access_key_id',          type => 't', default => '',},
     {name => 'aws_secret_access_key',      type => 't', default => '',},
+    {name => 'github_pr_linking_enabled',  type => 'b', default => 0},
     {name => 'github_pr_signature_secret', type => 't', default => ''},
   );
   return @param_list;

--- a/scripts/generate_bmo_data.pl
+++ b/scripts/generate_bmo_data.pl
@@ -578,6 +578,7 @@ my %set_params = (
     . '&long_desc_type=substring',
   defaultseverity      => 'normal',
   edit_comments_group  => 'editbugs',
+  github_pr_linking_enabled => 1,
   github_pr_signature_secret => 'B1gS3cret!',
   insidergroup         => 'core-security-release',
   last_change_time_non_bot_skip_list => 'automation@bmo.tld',

--- a/template/en/default/admin/params/attachment.html.tmpl
+++ b/template/en/default/admin/params/attachment.html.tmpl
@@ -52,6 +52,10 @@
     "value will be uploaded to S3 for performance reasons. Smaller attachments " _
     "will be stored in the database."
 
+  github_pr_linking_enabled =>
+    "Enable the linking of Github pull requests as an attachment to the related " _
+    "bug report."
+
   github_pr_signature_secret =>
     "Shared secret needed for GitHub webhooks to post pull requests to Bugzilla " _
     "creating an attachment linking the bug report to the pull request."

--- a/template/en/default/global/code-error.html.tmpl
+++ b/template/en/default/global/code-error.html.tmpl
@@ -518,6 +518,9 @@
     Please contact a system administrator with details of what you
     were doing when the error occurred.
 
+  [% ELSIF error == "github_pr_linking_disabled" %]
+    Github linking of pull requests to attachments is not enabled for this site.
+
   [% ELSIF error == "github_pr_not_pull_request" %]
     The webhook event was not for a GitHub pull request.
 


### PR DESCRIPTION
Adds a config parameter to disable github pr linking if necessary.