### PR TITLE
Bug 1803867 - Add SMTP config options for enabling tls and specifying port number

### DIFF
--- a/Bugzilla/Config/MTA.pm
+++ b/Bugzilla/Config/MTA.pm
@@ -69,9 +69,11 @@ sub get_param_list {
       default => '',
       checker => \&check_smtp_auth
     },
-    {name => 'smtp_password', type => 'p', default => ''},
-    {name => 'smtp_debug',    type => 'b', default => 0},
-    {name => 'whinedays', type => 't', default => 7, checker => \&check_numeric},
+    {name => 'smtp_password',  type => 'p', default => ''},
+    {name => 'smtp_use_tls',   type => 'b', default => 0},
+    {name => 'smtp_port',      type => 't', default => 0, checker => \&check_numeric},
+    {name => 'smtp_debug',     type => 'b', default => 0},
+    {name => 'whinedays',      type => 't', default => 7, checker => \&check_numeric},
     {name => 'globalwatchers', type => 't', default => '',},
     {name => 'silent_users',   type => 't', default => '',},
   );

--- a/Bugzilla/Mailer.pm
+++ b/Bugzilla/Mailer.pm
@@ -198,13 +198,19 @@ sub MessageToMTA {
     $transport = Email::Sender::Transport::Sendmail->new;
   }
   elsif ($method eq 'SMTP') {
-    $transport = Email::Sender::Transport::SMTP::Persistent->new({
+    my $smtp_options = {
       hosts         => [Bugzilla->params->{smtpserver}],
       sasl_username => Bugzilla->params->{smtp_username},
       sasl_password => Bugzilla->params->{smtp_password},
       debug         => Bugzilla->params->{smtp_debug},
-      ssl           => 'maybestarttls'
-    });
+    };
+    if (Bugzilla->params->{smtp_use_tls}) {
+      $smtp_options->{ssl} = 'starttls';
+    }
+    if (Bugzilla->params->{smtp_port}) {
+      $smtp_options->{port} = Bugzilla->params->{smtp_port};
+    }
+    $transport = Email::Sender::Transport::SMTP::Persistent->new($smtp_options);
   }
 
   try {

--- a/template/en/default/admin/params/mta.html.tmpl
+++ b/template/en/default/admin/params/mta.html.tmpl
@@ -63,6 +63,10 @@
   smtp_password => "The password to pass to the SMTP server for SMTP authentication. " _
                    "This field has no effect if the smtp_username parameter is left empty.",
 
+  smtp_use_tls => "Use TLS for connection to SMTP server.",
+
+  smtp_port => "Port number used for connection to SMTP server. Leave as 0 to use default ports.",
+
   smtp_debug => "If enabled, this will print detailed information to your" _
                 " web server's error log about the communication between" _
                 " $terms.Bugzilla and your SMTP server. You can use this to" _


### PR DESCRIPTION
This allows for more configurability of SMTP for connecting to a remote server. Some require TLS and some do not and sometimes the port can be different than the standard. 