### PR TITLE
Bug 1805179 - Expose `creation_time` in the `/rest/user` endpoint

### DIFF
--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -337,6 +337,7 @@ sub get {
       can_login          => $self->type('boolean',  $user->is_enabled ? 1 : 0),
       iam_username       => $self->type('string',   $user->iam_username),
       last_seen_date     => $self->type('dateTime', $user->last_seen_date),
+      creation_time      => $self->type('dateTime', $user->creation_ts),
       };
 
     if (Bugzilla->user->in_group('disableusers')) {

--- a/docs/en/rst/api/core/v1/user.rst
+++ b/docs/en/rst/api/core/v1/user.rst
@@ -385,6 +385,7 @@ saved_reports       array     User's saved reports, each having the following
                               Search object items described below.
 last_seen_date      datetime  The time when the user last loaded any page.
 last_activity_time  datetime  The time when the user last made a change to a bug.
+creation_time       datetime  The time when the user's account was created.
 ==================  ========  =====================================================
 
 Group object:


### PR DESCRIPTION
This is needed for https://github.com/mozilla/relman-auto-nag/issues/1807