### PR TITLE
Bug 1805681 - github pull request webhook returns 400

### DIFF
--- a/docs/en/rst/api/core/v1/github.rst
+++ b/docs/en/rst/api/core/v1/github.rst
@@ -65,14 +65,34 @@ name                       type     description
 
 **Response**
 
+Operation was completed successfully.
+
 .. code-block:: js
 
    {
+     "error": 0
      "id": 22
    }
 
-====  ====  ===================================================
-name  type  description
-====  ====  ===================================================
-id    int   ID of the pre-existing or newly-created attachment.
-====  ====  ===================================================
+=======  =======  ===================================================
+name     type     description
+=======  =======  ===================================================
+error    boolean  Whether the operation was successful or not.
+id       int      ID of the pre-existing or newly-created attachment.
+=======  =======  ===================================================
+
+An error condition occurred.
+
+.. code-block:: js
+
+   {
+     "error": 1
+     "message": "The pull request title did not contain a valid bug ID."
+   }
+
+=======  =======  ===================================================
+name     type     description
+=======  =======  ===================================================
+error    boolean  Whether the operation was successful or not.
+message  string   A message detailing what the error condition was.
+=======  =======  ===================================================

--- a/qa/t/rest_github_pull_request.t
+++ b/qa/t/rest_github_pull_request.t
@@ -88,7 +88,7 @@ $bad_signature
   = 'sha256=' . hmac_sha256_hex(encode_json($bad_payload), $github_secret);
 $t->post_ok($url
     . 'rest/github/pull_request' => {'X-Hub-Signature-256' => $bad_signature,
-    'X-GitHub-Event' => 'pull_request'} => json => $bad_payload)->status_is(400)
+    'X-GitHub-Event' => 'pull_request'} => json => $bad_payload)->status_is(200)
   ->json_like(
   '/message' => qr/The webhook sent a pull request event that was not an/);
 
@@ -108,7 +108,8 @@ $bad_signature
   = 'sha256=' . hmac_sha256_hex(encode_json($bad_payload), $github_secret);
 $t->post_ok($url
     . 'rest/github/pull_request' => {'X-Hub-Signature-256' => $bad_signature,
-    'X-GitHub-Event' => 'pull_request'} => json => $bad_payload)->status_is(400)
+    'X-GitHub-Event' => 'pull_request'} => json => $bad_payload)->status_is(200)
+  ->json_is('/error', 1)
   ->json_like(
   '/message' => qr/The pull request title did not contain a valid bug ID/);
 
@@ -163,7 +164,8 @@ $t->post_ok(
     'X-Hub-Signature-256' => $good_signature,
     'X-GitHub-Event'      => 'pull_request'
     } => json => $good_payload
-)->status_is(400)
+)->status_is(200)
+  ->json_is('/error', 1)
   ->json_like('/message' =>
     qr/The pull request contained a bug ID that already has an attachment/);
 
@@ -222,6 +224,6 @@ $good_signature
 $t->post_ok($url
     . 'rest/github/pull_request'                                           =>
     {'X-Hub-Signature-256' => $good_signature, 'X-GitHub-Event' => 'ping'} =>
-    json => $good_payload)->status_is(200)->json_has('/success');
+    json => $good_payload)->status_is(200)->json_is('/error' => 0);
 
 done_testing();


### PR DESCRIPTION
This PR changes to code to show 400 failures only if the JSON is invalid or the signature is invalid. All other errors should return 200 even though they are non-fatal errors. I have added a new key/value called `error` that is a boolean. If true, then a `message` is provided with the error message but the status code is 200. This should show green results in the webhook log in Github unless something serious happens.