### PR TITLE
Bug 1805453: implement Bugzilla-updating logic from Phab uplift extension in Phab Feed reader

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -49,6 +49,7 @@ severity = 2
 [-ValuesAndExpressions::ProhibitNoisyQuotes]
 [-ValuesAndExpressions::ProhibitVersionStrings]
 [-ValuesAndExpressions::ProhibitImplicitNewlines]
+[-ValuesAndExpressions::RequireInterpolationOfMetachars]
 [-Variables::ProhibitLocalVars]
 [-Variables::ProhibitPackageVars]
 

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -458,14 +458,14 @@ sub process_uplift_request_form_change {
       INFO("Found `qe-verify` flag to update.");
       $qe_verify_flag = $flag;
 
-      if ($qe_verify_flag->status ne '?') {
+      if ($qe_verify_flag->status ne '+') {
         # Set the flag to `?`.
         $bug->set_flags([{
           id     => $qe_verify_flag->id,
-          status => '?',
+          status => '+',
         }], []);
 
-        INFO("Set `qe-verify` flag to `?`.");
+        INFO("Set `qe-verify` flag to `+`.");
       }
 
       last;

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -366,19 +366,19 @@ sub readable_answer {
     return $answer;
   }
 
-  # Return "yes" for `1`.
+  # Return 'yes' for `1`.
   if ($answer) {
-    return "yes";
+    return 'yes';
   }
 
-  # Return "no" for `0`.
-  return "no";
+  # Return 'no' for `0`.
+  return 'no';
 }
 
 sub format_uplift_request_as_markdown {
   my ($question_answers_mapping) = @_;
 
-  my $comment = "# Uplift Approval Request\n";
+  my $comment = '# Uplift Approval Request\n';
 
   while (my ($question, $answer) = each %{$question_answers_mapping}) {
     my $answer_string = readable_answer($answer);
@@ -393,19 +393,19 @@ sub process_uplift_request_form_change {
   # Process an uplift request form change for the passed revision object.
   my ($revision, $bug) = @_;
 
-  my ($timestamp) = Bugzilla->dbh->selectrow_array("SELECT NOW()");
+  my ($timestamp) = Bugzilla->dbh->selectrow_array('SELECT NOW()');
   my $phab_bot_user = Bugzilla::User->new({name => PHAB_AUTOMATION_USER});
 
   # Take no action if the form is empty.
   if (!$revision->uplift_request) {
-    INFO("Uplift request form field cleared, ignoring.");
+    INFO('Uplift request form field cleared, ignoring.');
     return;
   }
 
   my $revision_phid = $revision->phid;
   INFO(
     "Uplift request form submitted on $revision_phid, " .
-    "requesting `#release-managers` review."
+    'requesting `#release-managers` review.'
   );
 
   # Get `#release-managers` review group.
@@ -414,8 +414,8 @@ sub process_uplift_request_form_change {
 
   if (!$release_managers_group) {
     WARN(
-      "Uplift request change detected but `#release-managers` was " .
-      "not found on Phabricator."
+      'Uplift request change detected but `#release-managers` was ' .
+      'not found on Phabricator.'
     );
     return;
   }
@@ -436,7 +436,7 @@ sub process_uplift_request_form_change {
     INFO("Requested #release-managers review of $stack_revision_phid.");
   }
 
-  INFO("Commenting the uplift form on the bug.");
+  INFO('Commenting the uplift form on the bug.');
 
   my $comment_content = format_uplift_request_as_markdown($revision->uplift_request);
   my $comment_params = {
@@ -446,8 +446,8 @@ sub process_uplift_request_form_change {
   $bug->add_comment($comment_content, $comment_params);
 
   # If manual QE is required, set the Bugzilla flag.
-  if ($revision->uplift_request->{"Needs manual QE test"}) {
-    INFO("Needs manual QE test is set.");
+  if ($revision->uplift_request->{'Needs manual QE test'}) {
+    INFO('Needs manual QE test is set.');
 
     my @old_flags;
     my @new_flags;
@@ -458,15 +458,15 @@ sub process_uplift_request_form_change {
 
       # Ignore for all flags except `qe-verify`.
       next if $flag->type->name ne 'qe-verify';
-      INFO("Found `qe-verify` flag.");
+      INFO('Found `qe-verify` flag.');
 
       if ($flag->status ne '+') {
-        INFO("Setting status to `+` for qe-verify.");
+        INFO('Setting status to `+` for qe-verify.');
 
         # Set the flag to `?`.
         push @old_flags, {id => $flag->id, status => '+'};
 
-        INFO("Set `qe-verify` flag to `+`.");
+        INFO('Set `qe-verify` flag to `+`.');
       }
 
       last;
@@ -474,7 +474,6 @@ sub process_uplift_request_form_change {
 
     # If we didn't find an existing `qe-verify` flag to update, add it now.
     if (!@old_flags) {
-      FATAL("CREATING NEW QE-VERIFY FLAG");
       my $qe_flag = Bugzilla::FlagType->new({name => 'qe-verify'});
       if ($qe_flag) {
         push @new_flags, {

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -358,7 +358,23 @@ sub _is_uplift_request_form_change {
   return $story_text =~ /\s+uplift request field/;
 }
 
-# TODO test
+sub readable_answer {
+  my ($answer) = @_;
+
+  # Return the value itself if it is not a number.
+  if ($answer ne '0' && $answer ne '1') {
+    return $answer;
+  }
+
+  # Return "yes" for `1`.
+  if ($answer) {
+    return "yes";
+  }
+
+  # Return "no" for `0`.
+  return "no";
+}
+
 sub format_uplift_request_as_markdown {
   my ($question_answers_mapping) = @_;
 

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -359,76 +359,76 @@ sub _is_uplift_request_form_change {
 }
 
 sub process_uplift_request_form_change {
-    # Process an uplift request form change for the passed revision object.
-    my ($revision) = @_;
+  # Process an uplift request form change for the passed revision object.
+  my ($revision) = @_;
 
-    # Take no action if the form is empty.
-    # TODO test
-    if ($revision->uplift_form->is_empty) {
-        INFO("Uplift request form field cleared, ignoring.");
-        return;
-    }
+  # Take no action if the form is empty.
+  # TODO test
+  if ($revision->uplift_form->is_empty) {
+    INFO("Uplift request form field cleared, ignoring.");
+    return;
+  }
 
-    my $revision_phid = $revision->phid;
-    INFO(
-      "Uplift request form submitted on $revision_phid, " .
-      "requesting `#release-managers` review."
+  my $revision_phid = $revision->phid;
+  INFO(
+    "Uplift request form submitted on $revision_phid, " .
+    "requesting `#release-managers` review."
+  );
+
+  # Get `#release-managers` review group.
+  my $release_managers_group = Bugzilla::Extension::PhabBugz::Project
+    ->new_from_query({name => 'release-managers'});
+
+  if (!$release_managers_group) {
+    WARN(
+      "Uplift request change detected but `#release-managers` was " .
+      "not found on Phabricator."
+    );
+    return;
+  }
+
+  my $release_managers_phid = $release_managers_group->phid;
+
+  # Request `#release-managers` review on each revision.
+  foreach my $stack_revision_phid (keys %{$revision->stack_graph_raw}) {
+    # Query Phabricator for each revision object related to the updated revision.
+    my $stack_revision = Bugzilla::Extension::PhabBugz::Revision->new_from_query(
+      {phids => [$stack_revision_phid]}
     );
 
-    # Get `#release-managers` review group.
-    my $release_managers_group = Bugzilla::Extension::PhabBugz::Project
-      ->new_from_query({name => 'release-managers'});
+    # Add `#release-managers!` review and set revision status.
+    $stack_revision->add_reviewer("blocking($release_managers_phid)");
+    $stack_revision->update();
 
-    if (!$release_managers_group) {
-      WARN(
-        "Uplift request change detected but `#release-managers` was " .
-        "not found on Phabricator."
-      );
-      return;
-    }
+    INFO("Requested #release-managers review of $stack_revision_phid.");
+  }
 
-    my $release_managers_phid = $release_managers_group->phid;
+  # Comment the uplift form rendered on Bugzilla
+  # TODO add rendered form to storage on Phabricator side.
+  # TODO test
+  my $comment_data = {
+    'bug_id' => $revision->bug->id,
+    'is_markdown' => 1,
+  };
+  my $comment = Bugzilla::Comment->insert_create_data($comment_data);
 
-    # Request `#release-managers` review on each revision.
-    foreach my $stack_revision_phid (keys %{$revision->stack_graph_raw}) {
-      # Query Phabricator for each revision object related to the updated revision.
-      my $stack_revision = Bugzilla::Extension::PhabBugz::Revision->new_from_query(
-        {phids => [$stack_revision_phid]}
-      );
-
-      # Add `#release-managers!` review and set revision status.
-      $stack_revision->add_reviewer("blocking($release_managers_phid)");
-      $stack_revision->update();
-
-      INFO("Requested #release-managers review of $stack_revision_phid.");
-    }
-
-    # Comment the uplift form rendered on Bugzilla
-    # TODO add rendered form to storage on Phabricator side.
-    # TODO test
-    my $comment_data = {
-        'bug_id' => $revision->bug->id,
-        'is_markdown' => 1,
+  # If manual QE is required, set the Bugzilla flag
+  # TODO test
+  if ($revision->uplift_form->{"Needs manual QE test"}) {
+    # TODO how to set bug flags?
+    # TODO set the `qe-verify` flag to `?` here.
+    my $new_flags = {
+      type_id  => $flagtype->id,
+      status   => '?',
+      setter   => $setter,
+      flagtype => $flagtype,
     };
-    my $comment = Bugzilla::Comment->insert_create_data($comment_data);
 
-    # If manual QE is required, set the Bugzilla flag
-    # TODO test
-    if ($revision->uplift_form->{"Needs manual QE test"}) {
-        # TODO how to set bug flags?
-        # TODO set the `qe-verify` flag to `?` here.
-        my $new_flags = {
-            type_id  => $flagtype->id,
-            status   => '?',
-            setter   => $setter,
-            flagtype => $flagtype,
-        };
-
-        $revision->bug->set_flags($revision->bug->flags, $new_flags);
-        $revision->bug->update();
-    }
-    
-    # TODO commit here?
+    $revision->bug->set_flags($revision->bug->flags, $new_flags);
+    $revision->bug->update();
+  }
+  
+  # TODO commit here?
 }
 
 sub process_revision_change {

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -464,7 +464,7 @@ sub process_uplift_request_form_change {
         INFO("Setting status to `+` for qe-verify.");
 
         # Set the flag to `?`.
-        push(@old_flags, {id => $flag->id, status => '+'});
+        push @old_flags, {id => $flag->id, status => '+'};
 
         INFO("Set `qe-verify` flag to `+`.");
       }
@@ -477,12 +477,12 @@ sub process_uplift_request_form_change {
       FATAL("CREATING NEW QE-VERIFY FLAG");
       my $qe_flag = Bugzilla::FlagType->new({name => 'qe-verify'});
       if ($qe_flag) {
-        push(@new_flags, {
+        push @new_flags, {
           flagtype => $qe_flag,
           setter => $phab_bot_user,
           status => '+',
           type_id => $qe_flag->id,
-        });
+        };
       }
     }
 

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -441,7 +441,7 @@ sub process_uplift_request_form_change {
   my $comment_content = format_uplift_request_as_markdown($revision->uplift_request);
   my $comment_params = {
     'is_markdown' => 1,
-    'isprivate' => 0,
+    'isprivate'   => 0,
   };
   $bug->add_comment($comment_content, $comment_params);
 
@@ -478,9 +478,9 @@ sub process_uplift_request_form_change {
       if ($qe_flag) {
         push @new_flags, {
           flagtype => $qe_flag,
-          setter => $phab_bot_user,
-          status => '+',
-          type_id => $qe_flag->id,
+          setter   => $phab_bot_user,
+          status   => '+',
+          type_id  => $qe_flag->id,
         };
       }
     }

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -437,6 +437,7 @@ sub process_uplift_request_form_change {
   }
 
   INFO("Commenting the uplift form on the bug.");
+
   my $comment_content = format_uplift_request_as_markdown($revision->uplift_request);
   my $comment_params = {
     'is_markdown' => 1,

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -380,7 +380,8 @@ sub format_uplift_request_as_markdown {
 
   my $comment = '# Uplift Approval Request\n';
 
-  while (my ($question, $answer) = each %{$question_answers_mapping}) {
+  foreach my $question (keys %{$question_answers_mapping}) {
+    my $answer = $question_answers_mapping->{$question};
     my $answer_string = readable_answer($answer);
 
     $comment .= "- **$question**: $answer_string\n";

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -515,8 +515,7 @@ sub process_revision_change {
 
   # Change is a submission of the uplift request form.
   if (_is_uplift_request_form_change($story_text)) {
-    process_uplift_request_form_change($revision, $bug);
-    return;
+    return process_uplift_request_form_change($revision, $bug);
   }
 
   # Check to make sure bug id is valid and author can see it

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -362,10 +362,12 @@ sub _is_uplift_request_form_change {
 sub format_uplift_request_as_markdown {
   my ($question_answers_mapping) = @_;
 
-  my $comment = "";
+  my $comment = "# Uplift Approval Request\n";
 
   while (my ($question, $answer) = each %{$question_answers_mapping}) {
-    $comment .= "- **$question** $answer\n";
+    my $answer_string = readable_answer($answer);
+
+    $comment .= "- **$question**: $answer_string\n";
   }
 
   return $comment;

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -488,7 +488,7 @@ sub process_uplift_request_form_change {
     # Set the flags.
     $bug->set_flags(\@old_flags, \@new_flags);
   }
-  
+
   $bug->update($timestamp);
   INFO("Finished processing uplift request form change for $revision_phid.");
 }

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -378,7 +378,7 @@ sub readable_answer {
 sub format_uplift_request_as_markdown {
   my ($question_answers_mapping) = @_;
 
-  my $comment = '# Uplift Approval Request\n';
+  my $comment = "# Uplift Approval Request\n";
 
   foreach my $question (keys %{$question_answers_mapping}) {
     my $answer = $question_answers_mapping->{$question};

--- a/extensions/PhabBugz/lib/Revision.pm
+++ b/extensions/PhabBugz/lib/Revision.pm
@@ -52,7 +52,7 @@ has stack_graph_raw  => (
 );
 has subscriber_count => (is => 'ro',   isa => Int);
 has bug              => (is => 'lazy', isa => Object);
-has uplift_request   => (is => 'ro',   isa => ArrayRef | Dict [ slurpy Any ]);
+has uplift_request   => (is => 'ro',   isa => Maybe[ArrayRef | Dict [ slurpy Any ]]);
 has author           => (is => 'lazy', isa => Object);
 has repository       => (is => 'lazy', isa => Maybe[PhabRepo]);
 has reviews =>

--- a/extensions/PhabBugz/lib/Revision.pm
+++ b/extensions/PhabBugz/lib/Revision.pm
@@ -52,6 +52,7 @@ has stack_graph_raw  => (
 );
 has subscriber_count => (is => 'ro',   isa => Int);
 has bug              => (is => 'lazy', isa => Object);
+has uplift_request   => (is => 'ro',   isa => Dict [ slurpy Any ]);
 has author           => (is => 'lazy', isa => Object);
 has repository       => (is => 'lazy', isa => Maybe[PhabRepo]);
 has reviews =>
@@ -124,6 +125,7 @@ sub BUILDARGS {
   $params->{diff_phid}       = $params->{fields}->{diffPHID};
   $params->{repository_phid} = $params->{fields}->{repositoryPHID};
   $params->{bug_id}          = $params->{fields}->{'bugzilla.bug-id'};
+  $params->{uplift_request}  = $params->{fields}->{'uplift.request'};
   $params->{view_policy}     = $params->{fields}->{policy}->{view};
   $params->{edit_policy}     = $params->{fields}->{policy}->{edit};
   $params->{stack_graph_raw} = $params->{fields}->{stackGraph};
@@ -166,7 +168,18 @@ sub BUILDARGS {
 #           "view": "public",
 #           "edit": "admin"
 #         },
-#         "bugzilla.bug-id": "1154784"
+#         "bugzilla.bug-id": "1154784",
+#         "uplift.request": {
+#             "User impact if declined": "Some impact.",
+#             "Code covered by automated testing": true,
+#             "Fix verified in Nightly": true,
+#             "Needs manual QE test": false,
+#             "Steps to reproduce for manual QE testing": "none",
+#             "Risk associated with taking this patch": "low",
+#             "Explanation of risk level": "Affects only nondefault configurations.",
+#             "String changes made/needed": "none",
+#             "Is Android affected?": true
+#         }
 #       },
 #       "attachments": {
 #         "reviewers": {

--- a/extensions/PhabBugz/lib/Revision.pm
+++ b/extensions/PhabBugz/lib/Revision.pm
@@ -52,7 +52,9 @@ has stack_graph_raw  => (
 );
 has subscriber_count => (is => 'ro',   isa => Int);
 has bug              => (is => 'lazy', isa => Object);
-has uplift_request   => (is => 'ro',   isa => Dict [ slurpy Any ]);
+# TODO the uplift request shouldn't be an `ArrayRef` - Phab should return `{}`
+# instead of `[]`. I think this is because PHP uses `array()` for both?
+has uplift_request   => (is => 'ro',   isa => ArrayRef | Dict [ slurpy Any ]);
 has author           => (is => 'lazy', isa => Object);
 has repository       => (is => 'lazy', isa => Maybe[PhabRepo]);
 has reviews =>

--- a/extensions/PhabBugz/lib/Revision.pm
+++ b/extensions/PhabBugz/lib/Revision.pm
@@ -52,8 +52,6 @@ has stack_graph_raw  => (
 );
 has subscriber_count => (is => 'ro',   isa => Int);
 has bug              => (is => 'lazy', isa => Object);
-# TODO the uplift request shouldn't be an `ArrayRef` - Phab should return `{}`
-# instead of `[]`. I think this is because PHP uses `array()` for both?
 has uplift_request   => (is => 'ro',   isa => ArrayRef | Dict [ slurpy Any ]);
 has author           => (is => 'lazy', isa => Object);
 has repository       => (is => 'lazy', isa => Maybe[PhabRepo]);


### PR DESCRIPTION
Re-implements the Bugzilla updating logic in the Phabricator Uplifts extension into BMO PhabBugz feed reader.

First add the uplift request form to `Revision.pm` so it is accessible from the feed. The form is either an empty
array or a `Dict` of `Any` keys, where the keys are the form questions and the values are the answers.
Move uplift request form processing into its own function to avoid a massive `process_revision_change` function.
Add A function `format_uplift_request_as_markdown` to render the form as a markdown comment, and add a
`readable_answer` function to convert `1` and `0` values to `yes` and `no` respectively. Use the markdown rendering
function as the contents of a comment on the bug when the form is submitted. Add a check for the `Needs manual QE test` question to set `qe-verify` to `+` if the users reponse is `true`.