### PR TITLE
Bug 1811786 - Unable to expand an attachment comment after it has been tagged with `admin`

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -306,21 +306,19 @@
     [% comment_tag = 'pre' %]
   [% END %]
 
-  [%# Description (Comment 0) can be empty %]
-  [% IF comment.body || comment.count == 0 %]
-    <[% comment_tag FILTER none %]
-        class="comment-text [%= "markdown-body" IF comment.is_markdown %] [%= "bz_private" IF comment.is_private %]
-               [% "empty" IF comment.body == "" %]"
-        id="ct-[% comment.count FILTER none %]" data-comment-id="[% comment.id FILTER none %]"
-        [% IF comment.is_markdown +%] data-ismarkdown="true" [% END ~%]
-        [% IF comment.collapsed +%] style="display:none"[% END ~%]>
-      [%~ IF comment.body != "" ~%]
-        [%~ comment.body_full({ exclude_attachment => 1 }) FILTER renderMarkdown(bug, comment) ~%]
-      [%~ ELSE ~%]
-        <em>No description provided.</em>
-      [%~ END ~%]
-    </[% comment_tag FILTER none %]>
-  [% END %]
+  <[% comment_tag FILTER none %]
+      class="comment-text [%= "markdown-body" IF comment.is_markdown %] [%= "bz_private" IF comment.is_private %]
+            [% "empty" IF comment.body == "" %]"
+      id="ct-[% comment.count FILTER none %]" data-comment-id="[% comment.id FILTER none %]"
+      [% IF comment.is_markdown +%] data-ismarkdown="true" [% END ~%]
+      [% IF comment.collapsed +%] style="display:none"[% END ~%]>
+    [%~ IF comment.body != "" ~%]
+      [%~ comment.body_full({ exclude_attachment => 1 }) FILTER renderMarkdown(bug, comment) ~%]
+    [%~ ELSIF comment.count == 0 ~%]
+      [%# Description (Comment 0) can be empty %]
+      <em>No description provided.</em>
+    [%~ END ~%]
+  </[% comment_tag FILTER none %]>
 [% END %]
 
 [%


### PR DESCRIPTION
The expand/collapse code needs for a `<pre id="ct-X"></pre>` to be present for the code to execute properly. So when we attach an attachment without a comment, the `<pre>` was missing. This patch adds it back but leaves it empty so that expand/collapse can still work properly.