### PR TITLE
Bug 1783044 - Unable to link profile to People due to error page not being rendered properly

### DIFF
--- a/Bugzilla/Constants.pm
+++ b/Bugzilla/Constants.pm
@@ -802,6 +802,9 @@ sub DEFAULT_CSP {
     push @{$policy{form_action}}, Bugzilla->params->{phabricator_base_uri};
   }
 
+  # This is for people.mozilla.org authentication
+  push @{$policy{form_action}}, 'https://people.mozilla.org';
+
   return %policy;
 }
 

--- a/Bugzilla/Constants.pm
+++ b/Bugzilla/Constants.pm
@@ -802,7 +802,7 @@ sub DEFAULT_CSP {
     push @{$policy{form_action}}, Bugzilla->params->{phabricator_base_uri};
   }
 
-  # This is for people.mozilla.org authentication
+  # This is for people.mozilla.org authentication (bug 1783044)
   push @{$policy{form_action}}, 'https://people.mozilla.org';
 
   return %policy;


### PR DESCRIPTION
Adding https://people.mozilla.org to CSP form-action allow list of domains to see if this fixes the issue.