### PR TITLE
Bug 1812606 - github pull request with the same number but from different repos get confused

### DIFF
--- a/Bugzilla/API/V1/Github.pm
+++ b/Bugzilla/API/V1/Github.pm
@@ -151,6 +151,7 @@ sub pull_request {
     WHERE    => {'bug_id != ? AND NOT isobsolete' => $bug->id}
   });
   foreach my $attachment (@$other_attachments) {
+    next if $attachment->data ne $html_url; # same pr number but different repo so skip it
     $other_bugs{$attachment->bug_id}++;
     my $moved_comment
       = "GitHub pull request attachment was moved to bug "


### PR DESCRIPTION
This pull request looks for attachments with the same pull request number in the filename but then also does a comparison of the attachment data containing the html url of the pull request. If they match then it is skipped, otherwise it moves the attachment to the different bug as before. Before this change we were only looking at the pull request number which causes issues when two repos have the same number. 