### PR TITLE
Bug 1803374 - Numbers in PR descriptions are considered bug numbers by the Bugzilla GitHub integration

### DIFF
--- a/Bugzilla/API/V1/Github.pm
+++ b/Bugzilla/API/V1/Github.pm
@@ -139,6 +139,7 @@ sub pull_request {
   foreach my $attachment (@$other_attachments) {
     # same pr number but different repo so skip it
     next if $attachment->data ne $html_url;
+
     $other_bugs{$attachment->bug_id}++;
     my $moved_comment
       = "GitHub pull request attachment was moved to bug "

--- a/docs/en/rst/api/core/v1/github.rst
+++ b/docs/en/rst/api/core/v1/github.rst
@@ -21,12 +21,12 @@ and be automatically redirected to the pull request.
 * Make sure at the bottom that "Active" is checked on.
 * Save the webhook.
 
-Note: Past pull requests will not automatically get a link created in the bug unless an
-edit event occurs on those older pull requests at some point. New pull requests should
-get the link automatically when the pull request is first created.
+Note: Past pull requests will not automatically get a link created in the bug. New pull
+requests should get the link automatically when the pull request is first created.
 
 Additional Note: The API endpoint looks at the pull request title for the bug id so
 make sure the title is formatted correctly to allow the bug id to be determined.
+Examples are, `Bug 1234:`, `Bug - 1234`, `bug 1234`, or `Bug 1234 - `.
 
 **Request**
 


### PR DESCRIPTION
This pull request gets rid of the more complex regex for finding IDs in commit titles and just simplifies it down to just looking for a specific format. In the past we were mistakenly linking to non bug IDs if an integer was found in the title such as a pull request id. This change will require the titles to contain "Bug XXX", "bug XXX", or "bug - XXX".