### PR TITLE
Bug 1814226 - create a custom API endpoint for uplift automation bug changes

### DIFF
--- a/extensions/PhabBugz/lib/API/V1/Lando.pm
+++ b/extensions/PhabBugz/lib/API/V1/Lando.pm
@@ -48,13 +48,14 @@ sub get {
 
   my $bug = Bugzilla::Bug->check($id);
 
-  my $result = {id => $bug->id, whiteboard => $bug->status_whiteboard,};
+  my $result
+    = {bugs => [{id => $bug->id, whiteboard => $bug->status_whiteboard,},]};
 
   my $flags = Bugzilla::Extension::TrackingFlags::Flag->match(
     {bug_id => $bug->id, is_active => 1});
   foreach my $flag (@{$flags}) {
     my $flag_name = $flag->name;
-    $result->{$flag_name} = $bug->$flag_name;
+    $result->{bugs}->[0]->{$flag_name} = $bug->$flag_name;
   }
 
   $self->render(json => $result);

--- a/extensions/PhabBugz/lib/API/V1/Lando.pm
+++ b/extensions/PhabBugz/lib/API/V1/Lando.pm
@@ -1,0 +1,100 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::Extension::PhabBugz::API::V1::Lando;
+
+use 5.10.1;
+use Mojo::Base qw( Mojolicious::Controller );
+
+use JSON::Validator::Joi 'joi';
+use Mojo::JSON qw(true false);
+
+use Bugzilla::Constants;
+use Bugzilla::Group;
+
+use Bugzilla::Extension::PhabBugz::Constants;
+use Bugzilla::Extension::TrackingFlags::Flag;
+use Bugzilla::Extension::TrackingFlags::Flag::Bug;
+
+our %api_field_names = reverse %{Bugzilla::Bug::FIELD_MAP()};
+$api_field_names{'bug_group'} = 'groups';
+
+sub setup_routes {
+  my ($class, $r) = @_;
+  $r->put('/lando/uplift')->to('PhabBugz::API::V1::Lando#uplift');
+}
+
+sub uplift {
+  my ($self) = @_;
+  Bugzilla->usage_mode(USAGE_MODE_MOJO_REST);
+
+  my $user = $self->bugzilla->login;
+  $user->id || return $self->user_error('login_required');
+
+  # Must be lando automation user to access this endpoint
+  ($user->login eq LANDO_AUTOMATION_USER)
+    || return $self->user_error('login_required');
+
+  # Upgrade Lando user permissions to make changes to any bug
+  $user->{groups}       = [Bugzilla::Group->get_all];
+  $user->{bless_groups} = [Bugzilla::Group->get_all];
+
+  my $params = $self->req->json;
+  $params = Bugzilla::Bug::map_fields($params);
+
+  my $ids = delete $params->{ids};
+  defined $ids || ThrowCodeError('param_required', {param => 'ids'});
+
+  my @bugs = map { Bugzilla::Bug->check($_) } @$ids;
+
+  # Strictly prohibit the lando user from changing any fields
+  # other than whiteboard and status flags
+  foreach my $field (keys %{$params}) {
+    if ($field ne 'status_whiteboard' && $field !~ /^cf_status_firefox/) {
+      delete $params->{$field};
+    }
+  }
+
+  # Update each bug
+  foreach my $bug (@bugs) {
+    $bug->set_all($params);
+  }
+
+  my %all_changes;
+
+  my $dbh = Bugzilla->dbh;
+  $dbh->bz_start_transaction();
+  foreach my $bug (@bugs) {
+    $all_changes{$bug->id} = $bug->update();
+  }
+  $dbh->bz_commit_transaction();
+
+  foreach my $bug (@bugs) {
+    $bug->send_changes($all_changes{$bug->id});
+  }
+
+  my @result;
+  foreach my $bug (@bugs) {
+    my %hash = (id => $bug->id, last_change_time => $bug->delta_ts, changes => {},);
+    my %changes = %{$all_changes{$bug->id}};
+    foreach my $field (keys %changes) {
+      my $change    = $changes{$field};
+      my $api_field = $api_field_names{$field} || $field;
+      $change->[0] = '' if !defined $change->[0];
+      $change->[1] = '' if !defined $change->[1];
+      $hash{changes}->{$api_field} = {
+        removed => $change->[0],
+        added   => $change->[1],
+      };
+    }
+    push @result, \%hash;
+  }
+
+  $self->render(json => {bugs => \@result});
+}
+
+1;

--- a/qa/config/selenium_test.conf
+++ b/qa/config/selenium_test.conf
@@ -27,6 +27,8 @@
     'admin_user_nick'                   => 'admin',
     'automation_user_login'             => 'automation@bmo.tld',
     'automation_user_api_key'           => '4fut0aBEfW260ULXEP1pvOqj7lwnhHoSB16wfpLP',
+    'lando_user_login'                  => 'lobot@bmo.tld',
+    'lando_user_api_key'                => 'hqPlbNFAtbGhBC7O68DfMBNE5wu7e18Ssviatizl',
     'permanent_user_login'              => 'permanent_user@mozilla.test',
     'permanent_user_passwd'             => 'bo6aazeKohch',
     'unprivileged_user_login'           => 'no-privs@mozilla.test',

--- a/qa/t/rest_lando_uplift.t
+++ b/qa/t/rest_lando_uplift.t
@@ -51,9 +51,9 @@ $t->get_ok(
 # Make sure the Lando user can see a limit amount of bug data through the custom endpoint
 $t->get_ok(
   $url . "rest/lando/uplift/$bug_id" => {'X-Bugzilla-API-Key' => $lando_api_key})
-  ->status_is(200)->json_is('/id', $bug_id)
-  ->json_is('/whiteboard',           $new_bug->{status_whiteboard})
-  ->json_is('/cf_status_firefox111', '---');
+  ->status_is(200)->json_is('/bugs/0/id', $bug_id)
+  ->json_is('/bugs/0/whiteboard',           $new_bug->{status_whiteboard})
+  ->json_is('/bugs/0/cf_status_firefox111', '---');
 
 # As Lando user, update the bug and clear checkin needed text from whiteboard and set the
 # status-firefox111 flag. This should work even if Lando cannot see the bug.
@@ -67,7 +67,8 @@ $t->put_ok($url
 
 $t->get_ok(
   $url . "rest/lando/uplift/$bug_id" => {'X-Bugzilla-API-Key' => $lando_api_key})
-  ->status_is(200)->json_is('/id', $bug_id)->json_is('/whiteboard', '')
-  ->json_is('/cf_status_firefox111', 'fixed');
+  ->status_is(200)->json_is('/bugs/0/id', $bug_id)
+  ->json_is('/bugs/0/whiteboard',           '')
+  ->json_is('/bugs/0/cf_status_firefox111', 'fixed');
 
 done_testing();

--- a/qa/t/rest_lando_uplift.t
+++ b/qa/t/rest_lando_uplift.t
@@ -1,0 +1,61 @@
+#!/usr/bin/env perl
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+use strict;
+use warnings;
+use 5.10.1;
+use lib qw(lib ../../lib ../../local/lib/perl5);
+
+use Bugzilla;
+use QA::Util qw(get_config);
+
+use Test::Mojo;
+use Test::More;
+
+my $config        = get_config();
+my $admin_api_key = $config->{'admin_user_api_key'};
+my $lando_api_key = $config->{lando_user_api_key};
+my $url           = Bugzilla->localconfig->urlbase;
+
+my $t = Test::Mojo->new();
+
+# Create a new private test bug for testing Lando uplift
+# The bug should not be visible to the Lando user.
+my $new_bug = {
+  product           => 'Firefox',
+  component         => 'General',
+  summary           => 'Test Lando Uplift',
+  type              => 'defect',
+  version           => 'unspecified',
+  severity          => 'blocker',
+  description       => 'This is a new test bug',
+  groups            => ['Master'],
+  status_whiteboard => '[checkin-needed-mozilla-central]',
+};
+
+$t->post_ok($url
+    . 'rest/bug' => {'X-Bugzilla-API-Key' => $admin_api_key} => json => $new_bug)
+  ->status_is(200)->json_has('/id');
+
+my $bug_id = $t->tx->res->json->{id};
+
+# Make sure Lando user cannot see bug
+$t->get_ok(
+  $url . "rest/bug/$bug_id" => {'X-Bugzilla-API-Key' => $lando_api_key})
+  ->status_is(401);
+
+# As Lando user, update the bug and clear checkin needed text from whiteboard and set the
+# status-firefox111 flag. This should work even if Lando cannot see the bug.
+my $update
+  = {ids => [$bug_id], 'whiteboard' => '', 'cf_status_firefox111' => 'fixed'};
+$t->put_ok($url
+    . 'rest/lando/uplift' => {'X-Bugzilla-API-Key' => $lando_api_key} => json =>
+    $update)->status_is(200)->json_is('/bugs/0/id', $bug_id)
+  ->json_is('/bugs/0/changes/cf_status_firefox111/added', 'fixed')
+  ->json_is('/bugs/0/changes/whiteboard/added',           '');
+
+done_testing();

--- a/scripts/generate_bmo_data.pl
+++ b/scripts/generate_bmo_data.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perlgenerate
+#!/usr/bin/env perl
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/scripts/generate_bmo_data.pl
+++ b/scripts/generate_bmo_data.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/env perlgenerate
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -187,6 +187,14 @@ my @users = (
     password => '*',
     api_key  => '4fut0aBEfW260ULXEP1pvOqj7lwnhHoSB16wfpLP'
   },
+  {
+    login    => 'lobot@bmo.tld',
+    realname => 'Lando Automation',
+    password => 'password123456789!',
+    api_key  => 'hqPlbNFAtbGhBC7O68DfMBNE5wu7e18Ssviatizl'
+  },
+
+
   map { {login => $_, realname => (split(/@/, $_, 2))[0], password => '*',} }
     map {
     map {@$_}
@@ -863,6 +871,71 @@ print "creating keywords...\n";
 foreach my $kw (@keywords) {
   next if new Bugzilla::Keyword({name => $kw->{name}});
   Bugzilla::Keyword->create($kw);
+}
+
+###########################################################
+# Create Tracking Flags
+###########################################################
+
+print "creating tracking flags...\n";
+my @tracking_flags = (
+  {
+    name        => 'cf_status_firefox110',
+    description => 'status-firefox110',
+    sortkey     => 0,
+    type        => 'tracking',
+    enter_bug   => 0,
+    is_active   => 1,
+    values      => ['?', 'affected', 'unaffected', 'fixed', 'wontfix'],
+    products    => ['Firefox'],
+  },
+  {
+    name        => 'cf_status_firefox111',
+    description => 'status-firefox111',
+    sortkey     => 0,
+    type        => 'tracking',
+    enter_bug   => 0,
+    is_active   => 1,
+    values      => ['?', 'affected', 'unaffected', 'fixed', 'wontfix'],
+    products    => ['Firefox'],
+  },
+
+);
+
+my $setter_group = Bugzilla::Group->new({name => 'editbugs'});
+
+foreach my $flag_data (@tracking_flags) {
+  my $values   = delete $flag_data->{values};
+  my $products = delete $flag_data->{products};
+
+  my $flag_obj = Bugzilla::Extension::TrackingFlags::Flag->create($flag_data);
+
+  # Add values for the new tracking flag
+  my $sortkey = 0;
+  foreach my $value (@{$values}) {
+    $sortkey += 1;
+
+    my $value_data = {
+      value           => $value,
+      setter_group_id => $setter_group->id,
+      is_active       => 1,
+      sortkey         => $sortkey,
+      comment          => '',
+      tracking_flag_id => $flag_obj->flag_id,
+    };
+
+    Bugzilla::Extension::TrackingFlags::Flag::Value->create($value_data);
+  }
+
+  # Make if visible to the products listed
+  foreach my $product (@{$products}) {
+    my $product_obj = Bugzilla::Product->new({name => $product});
+    Bugzilla::Extension::TrackingFlags::Flag::Visibility->create({
+      tracking_flag_id => $flag_obj->flag_id,
+      product_id       => $product_obj->id,
+      component_id     => undef,
+    });
+  }
 }
 
 print "installation and configuration complete!\n";

--- a/scripts/generate_conduit_data.pl
+++ b/scripts/generate_conduit_data.pl
@@ -106,24 +106,6 @@ if (!Bugzilla::User->new({name => $phab_login})) {
 }
 
 ##########################################################################
-# Create Lando Automation Bot
-##########################################################################
-
-my $lando_login    = $ENV{LANDO_BOT_LOGIN}    || 'lobot@bmo.tld';
-my $lando_password = $ENV{LANDO_BOT_PASSWORD} || 'password123456789!';
-
-print "creating lando automation account...\n";
-if (!Bugzilla::User->new({name => $lando_login})) {
-  my $new_user = Bugzilla::User->create(
-    {
-      login_name    => $lando_login,
-      realname      => 'Lando Automation',
-      cryptpassword => $lando_password
-    },
-  );
-}
-
-##########################################################################
 # Add Users to Groups
 ##########################################################################
 my @users_groups = (

--- a/template/en/default/global/code-error.html.tmpl
+++ b/template/en/default/global/code-error.html.tmpl
@@ -391,6 +391,13 @@
     that you set one of the following parameters:
     <code>[% params.join(', ') FILTER html %]</code>
 
+  [% ELSIF error == "too_many_params" %]
+    [% title = "Too Many Parameters" %]
+    More parameters were provided that what are allowed.
+    [% IF allowed_params %]
+      Only the following parameters are allowed: [% allowed_params.join(', ') FILTER html %].
+    [% END %]
+
   [% ELSIF error == "product_empty_group_controls" %]
     [% title = "Missing Group Controls" %]
     New settings must be defined to edit group controls for


### PR DESCRIPTION
I tried to keep the API the same as what you code currently expects so that all you would need to do is update the actual endpoint and nothing else. 

Implemented GET and PUT functions. The first should return the id, the whiteboard, and current tracking flag values. The PUT just allows updating the whiteboard and status flags. The return data from both should be the same as the normal API endpoints. 

Let me know if you want me to throw this on bugzilla-dev.allizom.org for testing.