### PR TITLE
Bug 1820859 - Wrap code that looks for a latest nightly/stable versions of Firefox in try/catch block in case of failure

### DIFF
--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -2749,9 +2749,13 @@ sub search_date_pronoun {
   my $keys = ['LAST_MERGE_DATE', 'LAST_RELEASE_DATE', 'LAST_SOFTFREEZE_DATE'];
   return unless grep(/^$key$/, @$keys);
 
-  my $date = fetch_product_versions('firefox')->{$key};
-  ThrowUserError('product_date_pronouns_unavailable') unless $date;
-  $pronoun->{date} = $date;
+  my $versions = fetch_product_versions('firefox');
+  if (!%{$versions} || !$versions->{$key}) {
+    WARN("product_date_pronouns_unavailable");
+    ThrowUserError('product_date_pronouns_unavailable');
+  }
+
+  $pronoun->{date} = $versions->{$key};
 }
 
 sub tf_buglist_columns {


### PR DESCRIPTION
* Wrap the call to the product versions API in a try block.
* This allows bug page and search page to load properly in the even the endpoint is unavailable or misconfigured.
* Code in BMO extension needed updating to not check for a hash key before determining if the hash has values..