### PR TITLE
Bug 1821251 - fix accessibilty to search field in header, and add a shortcut to focus it

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -262,6 +262,18 @@ window.addEventListener('load', detect_blocked_gravatars, { once: true });
 window.addEventListener('load', adjust_scroll_onload, { once: true });
 window.addEventListener('hashchange', adjust_scroll_onload);
 
+// Focus the quicksearch field in the header when ALT+s (or OPT+s on macOS) is
+// pressed.
+window.addEventListener('keydown', (event) => {
+    if (event.altKey && String.fromCharCode(event.which) === 'S') {
+        const qsElement = document.querySelector('#quicksearch_top');
+        if (qsElement) {
+            event.preventDefault();
+            qsElement.focus();
+        }
+    }
+});
+
 window.addEventListener('DOMContentLoaded', () => {
   const announcement = document.getElementById('new_announcement');
   if (announcement) {

--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -264,9 +264,9 @@
   <div class="inner">
     <h1 id="header-title" class="title"><a href="[% urlbase _ 'home' FILTER none %]" title="Go to home page">[% terms.Bugzilla %]</a></h1>
     <form role="search" id="header-search" class="quicksearch" action="[% basepath FILTER none %]buglist.cgi" data-no-csrf>
+      <h2 id="header-search-label">Quick Search</h2>
       <section class="searchbox-outer dropdown" role="combobox" aria-expanded="false" aria-haspopup="listbox"
                aria-labelledby="header-search-label" aria-owns="header-search-dropdown">
-        <h2 id="header-search-label">Quick Search</h2>
         <span class="icon" aria-hidden="true"></span>
         <input role="searchbox" id="quicksearch_top" class="dropdown-button" name="quicksearch" autocomplete="off"
                value="[% quicksearch FILTER html %]" placeholder="Search [% terms.Bugs %]"


### PR DESCRIPTION
- move `<h2>` outside of the quicksearch combo role; it being there breaks the ability for screen readers to navigate to the search field
- add a keyboard shortcut to focus quicksearch: alt+s / opt+s