### PR TITLE
Bug 1821386 - Set the Milestone field when resolving bugs after PR merges

### DIFF
--- a/qa/t/rest_github_push_comment.t
+++ b/qa/t/rest_github_push_comment.t
@@ -319,11 +319,12 @@ $t->get_ok(
 # Bug should have been closed since it did not have the leave-open keyword
 # and it should also have the status-firefox111 flag set to fixed.
 $t->get_ok($url
-    . "rest/bug/$bug_id_2?include_fields=id,flags,status,resolution,_custom" =>
+    . "rest/bug/$bug_id_2?include_fields=id,flags,status,resolution,target_milestone,_custom" =>
     {'X-Bugzilla-API-Key' => $api_key})->status_is(200)
   ->json_is('/bugs/0/id', $bug_id_2)->json_is('/bugs/0/status', 'RESOLVED')
   ->json_is('/bugs/0/resolution',           'FIXED')
   ->json_is('/bugs/0/cf_status_firefox111', 'fixed')
+  ->json_is('/bugs/0/target_milestone',     '111 Branch')
   ->json_is('/bugs/0/flags/0/name',         'qe-verify')
   ->json_is('/bugs/0/flags/0/status',       '+');
 

--- a/scripts/generate_bmo_data.pl
+++ b/scripts/generate_bmo_data.pl
@@ -281,8 +281,15 @@ my @products = (
     versions =>
       ['34 Branch', '35 Branch', '36 Branch', '37 Branch', 'Trunk', 'unspecified'],
     default_version  => 'unspecified',
-    milestones =>
-      ['Firefox 36', '---', 'Firefox 37', 'Firefox 38', 'Firefox 39', 'Future'],
+    milestones => [
+      'Firefox 36',
+      '---',
+      'Firefox 37',
+      'Firefox 38',
+      'Firefox 39',
+      '111 Branch',
+      'Future'
+    ],
     defaultmilestone => '---',
     components       => [{
       name        => 'General',


### PR DESCRIPTION
* If a bug is being closed and it is firefox-android, then we also set the milestone to the latest nightly branch
* generate_bmo_data.pl adds the 111 Branch milestone needed for testing.
* Update the test script to check that the milestone has been set properly if bug is closed.