### PR TITLE
Bug 1824636 - change the search access key to avoid browser conflicts

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -262,18 +262,6 @@ window.addEventListener('load', detect_blocked_gravatars, { once: true });
 window.addEventListener('load', adjust_scroll_onload, { once: true });
 window.addEventListener('hashchange', adjust_scroll_onload);
 
-// Focus the quicksearch field in the header when ALT+s (or OPT+s on macOS) is
-// pressed.
-window.addEventListener('keydown', (event) => {
-    if (event.altKey && String.fromCharCode(event.which) === 'S') {
-        const qsElement = document.querySelector('#quicksearch_top');
-        if (qsElement) {
-            event.preventDefault();
-            qsElement.focus();
-        }
-    }
-});
-
 window.addEventListener('DOMContentLoaded', () => {
   const announcement = document.getElementById('new_announcement');
   if (announcement) {

--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -271,7 +271,7 @@
         <input role="searchbox" id="quicksearch_top" class="dropdown-button" name="quicksearch" autocomplete="off"
                value="[% quicksearch FILTER html %]" placeholder="Search [% terms.Bugs %]"
                title="Enter a [% terms.bug %] number or some search terms" aria-controls="header-search-dropdown"
-               aria-label="Quick Search">
+               accesskey="s" aria-label="Quick Search">
         [% PROCESS "global/header-search-dropdown.html.tmpl" %]
       </section>
     </form>


### PR DESCRIPTION
- change the access key to using the `accesskey` attribute
- this changes the access key from alt+s to alt+shift+s (win/lin) or ctrl+opt+s (macos)