### PR TITLE
Bug 1825848 - LogActivityEntry is be called twice instead of once when the github push comment API code is executed

### DIFF
--- a/Bugzilla/API/V1/Github.pm
+++ b/Bugzilla/API/V1/Github.pm
@@ -308,8 +308,6 @@ sub push_comment {
       }
     };
 
-    # $bug->add_comment($comment_text);
-
     # If the commit is on the default branch and the bug does not have
     # the keyword 'leave-open', we can also close the bug as RESOLVED/FIXED.
     if ($ref =~ /refs\/heads\/$default_branch/ && !$bug->has_keyword('leave-open')
@@ -319,8 +317,6 @@ sub push_comment {
       # Set the bugs status to RESOLVED/FIXED
       $set_all->{bug_status} = 'RESOLVED';
       $set_all->{resolution} = 'FIXED';
-
-      #$bug->set_bug_status('RESOLVED', {resolution => 'FIXED'});
 
       # Update the qe-verify flag if not set and the bug was closed.
       my $found_flag;

--- a/Bugzilla/API/V1/Github.pm
+++ b/Bugzilla/API/V1/Github.pm
@@ -349,7 +349,7 @@ sub push_comment {
 
       # Update the milestone to the nightly branch if closing the bug.
       # Currently tailored for mozilla-mobile/firefox-android only
-      $self->_set_nightly_milestone($bug, $set_all, $branch) if $repository eq 'mozilla-mobile/firefox-android';
+      $self->_set_nightly_milestone($bug, $set_all) if $repository eq 'mozilla-mobile/firefox-android';
     }
 
     # Update the status flag to 'fixed' if one exists for the current branch

--- a/Bugzilla/API/V1/Github.pm
+++ b/Bugzilla/API/V1/Github.pm
@@ -407,12 +407,7 @@ sub _set_status_flag {
   # Return if the flag doesn't exist for some reason or the value fixed is already set
   return if (!$flag || $bug->$status_field eq 'fixed');
 
-  foreach my $value (@{$flag->values}) {
-    next if $value->value ne 'fixed';
-    last if !$flag->can_set_value($value->value);
-    $set_all->{$flag->name} = $value->value;
-    last;
-  }
+  $set_all->{$status_field} = 'fixed';
 }
 
 # If the bug is being closed, then we also need to set the appropriate

--- a/Bugzilla/API/V1/Github.pm
+++ b/Bugzilla/API/V1/Github.pm
@@ -289,8 +289,6 @@ sub push_comment {
   my $dbh = Bugzilla->dbh;
   $dbh->bz_start_transaction;
 
-  my $timestamp = $dbh->selectrow_array('SELECT LOCALTIMESTAMP(0)');
-  
   # Actually create the comments in this loop
   foreach my $bug_id (keys %update_bugs) {
     my $bug = Bugzilla::Bug->new({id => $bug_id, cache => 1});
@@ -303,7 +301,14 @@ sub push_comment {
       $comment_text .= $comment->{text} . "\n\n";
     }
 
-    $bug->add_comment($comment_text);
+    # Set all parameters
+    my $set_all = {
+      comment => {
+        body => $comment_text
+      }
+    };
+
+    # $bug->add_comment($comment_text);
 
     # If the commit is on the default branch and the bug does not have
     # the keyword 'leave-open', we can also close the bug as RESOLVED/FIXED.
@@ -312,7 +317,10 @@ sub push_comment {
       && $bug->status ne 'VERIFIED')
     {
       # Set the bugs status to RESOLVED/FIXED
-      $bug->set_bug_status('RESOLVED', {resolution => 'FIXED'});
+      $set_all->{bug_status} = 'RESOLVED';
+      $set_all->{resolution} = 'FIXED';
+
+      #$bug->set_bug_status('RESOLVED', {resolution => 'FIXED'});
 
       # Update the qe-verify flag if not set and the bug was closed.
       my $found_flag;
@@ -341,14 +349,15 @@ sub push_comment {
 
       # Update the milestone to the nightly branch if closing the bug.
       # Currently tailored for mozilla-mobile/firefox-android only
-      $self->_set_nightly_milestone($bug, $branch) if $repository eq 'mozilla-mobile/firefox-android';
+      $self->_set_nightly_milestone($bug, $set_all, $branch) if $repository eq 'mozilla-mobile/firefox-android';
     }
 
     # Update the status flag to 'fixed' if one exists for the current branch
     # Currently tailored for mozilla-mobile/firefox-android
-    $self->_set_status_flag($bug, $branch, $timestamp) if $repository eq 'mozilla-mobile/firefox-android';
+    $self->_set_status_flag($bug, $set_all, $branch) if $repository eq 'mozilla-mobile/firefox-android';
 
-    $bug->update($timestamp);
+    $bug->set_all($set_all);
+    $bug->update();
 
     my $comments       = $bug->comments({order => 'newest_to_oldest'});
     my $new_comment_id = $comments->[0]->id;
@@ -377,7 +386,7 @@ sub _verify_signature {
 # If the ref matches a certain branch pattern for the repo we are interested
 # in, then we also need to set the appropriate status flag to 'fixed'.
 sub _set_status_flag {
-  my ($self, $bug, $branch, $timestamp) = @_;
+  my ($self, $bug, $set_all, $branch) = @_;
 
   # In order to determine the appropriate status flag for the default
   # branch, we have to find out what the current *nightly* Firefox version is.
@@ -405,25 +414,7 @@ sub _set_status_flag {
   foreach my $value (@{$flag->values}) {
     next if $value->value ne 'fixed';
     last if !$flag->can_set_value($value->value);
-
-    my $added   = $value->value;
-    my $removed = $bug->$status_field;
-
-    if ($removed eq '---') {
-      Bugzilla::Extension::TrackingFlags::Flag::Bug->create({
-        tracking_flag_id => $flag->flag_id, bug_id => $bug->id, value => $added,
-      });
-    }
-    else {
-      $flag->bug_flag->set_value($added);
-      $flag->bug_flag->update($timestamp);
-    }
-
-    LogActivityEntry($bug->id, $flag->name, $removed, $added, Bugzilla->user->id,
-      $timestamp);
-
-    # Update the name/value pair in the bug object
-    $bug->{$flag->name} = $value->value;
+    $set_all->{$flag->name} = $value->value;
     last;
   }
 }
@@ -431,7 +422,7 @@ sub _set_status_flag {
 # If the bug is being closed, then we also need to set the appropriate
 # nightly milestone version.
 sub _set_nightly_milestone {
-  my ($self, $bug) = @_;
+  my ($self, $bug, $set_all) = @_;
 
   # In order to determine the appropriate status flag for the 'master/main'
   # branch, we have to find out what the current *nightly* Firefox version is.
@@ -449,7 +440,7 @@ sub _set_nightly_milestone {
   return if !$milestone;
 
   # Update the milestone
-  $bug->set_target_milestone($milestone->name);
+  $set_all->{target_milestone} = $milestone->name;
 }
 
 1;

--- a/qa/t/rest_github_push_comment.t
+++ b/qa/t/rest_github_push_comment.t
@@ -328,4 +328,33 @@ $t->get_ok($url
   ->json_is('/bugs/0/flags/0/name',         'qe-verify')
   ->json_is('/bugs/0/flags/0/status',       '+');
 
+# Change to make sure the flag change entry is recorded properly in the bug history
+$t->get_ok(
+  $url . "rest/bug/$bug_id_2/history" => {'X-Bugzilla-API-Key' => $api_key})
+  ->status_is(200)->json_is('/bugs/0/id', $bug_id_2);
+
+$result = $t->tx->res->json;
+
+my $history = $result->{bugs}->[0]->{history};
+
+my $found_status_flag_change = 0;
+foreach my $change_group (@{$history}) {
+  next if $change_group->{who} ne 'github-automation@bmo.tld';
+  foreach my $change (@{$change_group->{changes}}) {
+    if ( $change->{field_name} eq 'cf_status_firefox111'
+      && $change->{added} eq 'fixed')
+    {
+      $found_status_flag_change = 1;
+      next;
+    }
+    if ( $found_status_flag_change
+      && $change->{field_name} eq 'cf_status_firefox111')
+    {
+      ok(0, 'Found multiple changes for same flag');
+    }
+  }
+}
+
+ok($found_status_flag_change, 'Flag change found');
+
 done_testing();


### PR DESCRIPTION
* Update the test script to look for proper history entries to make sure we are adding them properly and no duplicates
* Switch to using $bug->set_all before $bug->update. This is how process_bug.cgi work and we should us that so as to not duplicate by performing update steps manually. This also allows to use the LogActivityEntry that is in TrackingFlags extension instead of logging ourselves as before causing the duplicate issue.