### PR TITLE
Bug 1825899 - BMO push hook shouldn't set the status flag to fixed if the leave-open keyword is set

### DIFF
--- a/Bugzilla/API/V1/Github.pm
+++ b/Bugzilla/API/V1/Github.pm
@@ -338,17 +338,17 @@ sub push_comment {
         }
       }
 
-      # Update the milestone to the nightly branch if default branch
       # Currently tailored for mozilla-mobile/firefox-android only
-      if ($ref =~ /refs\/heads\/$default_branch/) {
-        $self->_set_nightly_milestone($bug, $branch)
-          if $repository eq 'mozilla-mobile/firefox-android';
-      }
+      if ($repository eq 'mozilla-mobile/firefox-android') {
 
-      # Update the status flag to 'fixed' if one exists for the current branch
-      # Currently tailored for mozilla-mobile/firefox-android
-      $self->_set_status_flag($bug, $branch, $timestamp)
-        if $repository eq 'mozilla-mobile/firefox-android';
+        # Update the milestone to the nightly branch if default branch
+        if ($ref =~ /refs\/heads\/$default_branch/) {
+          $self->_set_nightly_milestone($bug, $branch);
+        }
+
+        # Update the status flag to 'fixed' if one exists for the current branch
+        $self->_set_status_flag($bug, $branch, $timestamp);
+      }
     }
 
     $bug->update($timestamp);

--- a/Bugzilla/API/V1/Github.pm
+++ b/Bugzilla/API/V1/Github.pm
@@ -305,9 +305,8 @@ sub push_comment {
 
     $bug->add_comment($comment_text);
 
-    # If the commit is on the default branch and the bug does not have
-    # the keyword 'leave-open', we can also close the bug as RESOLVED/FIXED.
-    if ($ref =~ /refs\/heads\/$default_branch/ && !$bug->has_keyword('leave-open')
+    # If the bug does not have the keyword 'leave-open', we close the bug as RESOLVED/FIXED.
+    if (!$bug->has_keyword('leave-open')
       && $bug->status ne 'RESOLVED'
       && $bug->status ne 'VERIFIED')
     {
@@ -339,14 +338,18 @@ sub push_comment {
         }
       }
 
-      # Update the milestone to the nightly branch if closing the bug.
+      # Update the milestone to the nightly branch if default branch
       # Currently tailored for mozilla-mobile/firefox-android only
-      $self->_set_nightly_milestone($bug, $branch) if $repository eq 'mozilla-mobile/firefox-android';
-    }
+      if ($ref =~ /refs\/heads\/$default_branch/) {
+        $self->_set_nightly_milestone($bug, $branch)
+          if $repository eq 'mozilla-mobile/firefox-android';
+      }
 
-    # Update the status flag to 'fixed' if one exists for the current branch
-    # Currently tailored for mozilla-mobile/firefox-android
-    $self->_set_status_flag($bug, $branch, $timestamp) if $repository eq 'mozilla-mobile/firefox-android';
+      # Update the status flag to 'fixed' if one exists for the current branch
+      # Currently tailored for mozilla-mobile/firefox-android
+      $self->_set_status_flag($bug, $branch, $timestamp)
+        if $repository eq 'mozilla-mobile/firefox-android';
+    }
 
     $bug->update($timestamp);
 

--- a/qa/t/rest_github_push_comment.t
+++ b/qa/t/rest_github_push_comment.t
@@ -151,9 +151,13 @@ $t->get_ok(
 # the releases_v110 branch. Bug is left open as it was not a commit to the
 # master or main branch.
 $t->get_ok($url
-    . "rest/bug/$bug_id?include_fields=id,flags,status,resolution,_custom" =>
+    . "rest/bug/$bug_id?include_fields=id,flags,status,resolution,target_milestone,_custom" =>
     {'X-Bugzilla-API-Key' => $api_key})->status_is(200)
-  ->json_is('/bugs/0/id', $bug_id)->json_is('/bugs/0/status', 'CONFIRMED')
+  ->json_is('/bugs/0/id', $bug_id)->json_is('/bugs/0/status', 'RESOLVED')
+  ->json_is('/bugs/0/resolution',           'FIXED')
+  ->json_is('/bugs/0/flags/0/name',         'qe-verify')
+  ->json_is('/bugs/0/flags/0/status',       '+')
+  ->json_is('/bugs/0/target_milestone',     '---')
   ->json_is('/bugs/0/cf_status_firefox110', 'fixed');
 
 # Multiple commits with the same bug id should create a single comment


### PR DESCRIPTION
For a better idea of why this change is being made and what the flow should be now with the latest fix, see https://bugzilla.mozilla.org/show_bug.cgi?id=1825899#c1 Thanks!