### PR TITLE
Bug 1827272 - Add Copy Name command to user's menu

### DIFF
--- a/extensions/BMO/web/js/edituser_menu.js
+++ b/extensions/BMO/web/js/edituser_menu.js
@@ -5,7 +5,7 @@
  * This Source Code Form is "Incompatible With Secondary Licenses", as
  * defined by the Mozilla Public License, v. 2.0. */
 
-function show_usermenu(id, email, show_edit, hide_profile) {
+function show_usermenu(id, email, name, show_edit, hide_profile) {
     var items = [
         {
             name: "Activity",
@@ -23,6 +23,19 @@ function show_usermenu(id, email, show_edit, hide_profile) {
             }
         }
     ];
+    if (name) {
+        items.unshift({
+            name: "Copy Name",
+            callback: function () {
+                $('#clip-container').show();
+                $('#clip').val(name).select();
+                $('#floating-message-text')
+                  .text(document.execCommand('copy') ? 'Name has been copied' : 'Could not copy name');
+                $('#floating-message').fadeIn(250).delay(2500).fadeOut();
+                $('#clip-container').hide();
+            }
+        });
+    }
     if (!hide_profile) {
         items.unshift({
             name: "Profile",
@@ -51,6 +64,6 @@ function show_usermenu(id, email, show_edit, hide_profile) {
 $(function() {
   $('.show_usermenu').on("click", function (event) {
     var $this = $(this);
-    return show_usermenu($this.data('user-id'), $this.data('user-email'), $this.data('show-edit'), $this.data('hide-profile'));
+    return show_usermenu($this.data('user-id'), $this.data('user-email'), $this.data('user-name'), $this.data('show-edit'), $this.data('hide-profile'));
   });
 });

--- a/extensions/BugModal/template/en/default/bug_modal/user.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/user.html.tmpl
@@ -45,6 +45,7 @@ END;
         <a class="email [%= "disabled" UNLESS u.is_enabled %] [% " show_usermenu" IF user.id %]"
           [% IF user.id %]
             href="mailto:[% u.email FILTER html %]"
+            data-user-name="[% u.name FILTER html %]"
             data-user-email="[% u.email FILTER html %]"
             data-user-id="[% u.id FILTER html %]"
             data-show-edit="[% user.in_group('editusers') || user.in_group('disableusers') || user.bless_groups.size > 0 ? 1 : 0 %]"

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -310,7 +310,7 @@ $(function() {
             );
             $('#cc-list .show_usermenu').click(function() {
                 const $this = $(this);
-                return show_usermenu($this.data('user-id'), $this.data('user-email'), $this.data('show-edit'),
+                return show_usermenu($this.data('user-id'), $this.data('user-email'), $this.data('user-name'), $this.data('show-edit'),
                     $this.data('hide-profile'));
             });
             $('#cc-list .cc-remove')

--- a/template/en/default/global/user.html.tmpl
+++ b/template/en/default/global/user.html.tmpl
@@ -27,7 +27,7 @@
   [% FILTER collapse %]
     [% IF user.id %]
       <a class="email [%= "bz_inactive" UNLESS who.is_enabled %]" href="mailto:[% who.email FILTER html %]"
-         onclick="return show_usermenu([% who.id FILTER none %], '[% who.email FILTER js %]',
+         onclick="return show_usermenu([% who.id FILTER none %], '[% who.email FILTER js %]', '[% who.name FILTER js %]',
                   [% user.in_group('editusers') || user.in_group('disableusers') || user.bless_groups.size > 0 ? "true" : "false" %]);"
         title="[% who.identity FILTER html %]">
     [%- END -%]


### PR DESCRIPTION
Adds a new entry in the user menu that drops down when you click on a user name on the show bug page. The menu entry simply copies the user's real name to the clipboard which can then pasted into the comment area. A notification is also displayed briefly that indicates the text was copied.