### PR TITLE
Bug 1828653 - relnote form is not added when setting the relnote flag for nomination

### DIFF
--- a/Bugzilla/Util.pm
+++ b/Bugzilla/Util.pm
@@ -979,8 +979,6 @@ sub fetch_product_versions {
   my ($product) = @_;
   my $key = "${product}_versions";
 
-  WARN($key);
-
   # First check to see if the values are stored in cache. If not
   # then we will call the end point to get the latest versions.
   my $versions = Bugzilla->request_cache->{$key}

--- a/extensions/BugModal/Extension.pm
+++ b/extensions/BugModal/Extension.pm
@@ -165,7 +165,7 @@ sub template_before_process {
   my $file = $args->{file};
   my $vars = $args->{vars};
 
-  return if $file ne 'bug_modal/edit.html.tmpl';
+  return if $file ne 'bug_modal/header.html.tmpl';
 
   if ($vars->{bug} && !$vars->{bugs}) {
     $vars->{bugs} = [$vars->{bug}];

--- a/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
@@ -70,7 +70,7 @@
 
 [% javascript = BLOCK %]
   [%# add tracking flags JSON if available %]
-  [% IF tracking_flags %]
+  [% IF tracking_flags_json %]
     [% javascript_urls.push("extensions/TrackingFlags/web/js/flags.js") %]
     var tracking_flags_str = "[% tracking_flags_json FILTER js %]";
     var TrackingFlags = $.parseJSON(tracking_flags_str);


### PR DESCRIPTION
- flags.js was not loading properly which controls the flag comments
- We need to run template_before_process when bug_modal/header.html.tmpl is loaded since the code that loads flags.js in in that template and not bug_modal/edit.html.tmpl.
- Removed an leftover debug statement from Bugzilla/Util.pm