### PR TITLE
Bug 1828677 - Invalid regex in BMO feed reader: `The regular expression you provided ':?:phab\\-bot[[:>:]]' is not valid`

### DIFF
--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -717,7 +717,7 @@ sub process_new_user {
   # CHECK AND WARN FOR POSSIBLE USERNAME SQUATTING
   INFO("Checking for username squatters");
   my $dbh     = Bugzilla->dbh;
-  my $regexp  = $dbh->quote(":?:" . quotemeta($phab_user->name) . "[[:>:]]");
+  my $regexp  = $dbh->quote($dbh->WORD_START . ':?:' . quotemeta($phab_user->name) . $dbh->WORD_END);
   my $results = $dbh->selectall_arrayref("
         SELECT userid, login_name, realname
           FROM profiles


### PR DESCRIPTION
https://stackoverflow.com/questions/59998409/error-code-3685-illegal-argument-to-a-regular-expression

"This question will probably become more popular as adoption of MySQL 8.0 increases and previously-stored SQL queries using REGEXP start to break.

According to [MySQL 8.0 Reference Manual / ... / Regular Expressions](https://dev.mysql.com/doc/refman/8.0/en/regexp.html), "MySQL implements regular expression support using International Components for Unicode (ICU)."

According to [MySQL 5.6 Reference Manual / ... / Regular Expressions](https://dev.mysql.com/doc/refman/5.6/en/regexp.html), "MySQL uses Henry Spencer's implementation of regular expressions."

Therefore, since you are using MySQL 8.0, rather than using [[:<:]] and [[:>:]], you can now use \b."

We are using 8.0 now with the move to GCP so I just updated the regexp to use `\b`.