### PR TITLE
Bug 1825961: set `approval-mozilla-{repo}` flags on uplift revision attachments

### DIFF
--- a/extensions/PhabBugz/lib/Util.pm
+++ b/extensions/PhabBugz/lib/Util.pm
@@ -69,7 +69,6 @@ sub set_attachment_approval_flags {
     my $approval_flag = Bugzilla::FlagType->new({name => $approval_flag_name});
     if ($approval_flag) {
       push @new_flags, {
-        flagtype => $approval_flag,
         setter   => $user,
         status   => '?',
         type_id  => $approval_flag->id,


### PR DESCRIPTION
When a new Phabricator revision attachment is being added to a bug,
check if the repo associated with the revision is an uplift repo and
set the appropriate `approval-mozilla-{repo}` flag if necessary.

To determine if a repo is an uplift repository, we add the `projects`
attachment from Phabricator to the Conudit API query which returns
repository data. We add a `projects_raw` and `projects` field which
is the raw API response and an array of built `Project` objects in
Bugzilla, respectively. Then we add an `is_uplift_repo` function which
iterates over the `project` attribute and checks for a project with
the name matching `uplift`.
