### PR TITLE
Bug 1830152: make the `stack_graph_raw` attribute a `Maybe`

### DIFF
--- a/extensions/PhabBugz/lib/Revision.pm
+++ b/extensions/PhabBugz/lib/Revision.pm
@@ -46,8 +46,10 @@ has view_policy      => (is => 'ro',   isa => Str);
 has edit_policy      => (is => 'ro',   isa => Str);
 has stack_graph_raw  => (
     is => 'ro',
-    isa => Dict [
-        slurpy Any
+    isa => Maybe [
+      Dict [
+          slurpy Any
+      ]
     ],
 );
 has subscriber_count => (is => 'ro',   isa => Int);


### PR DESCRIPTION
In suite it is possible to hit an edge case where the stack_graph_raw
attribute is not defined in the Phabricator API response. While we
investigate this problem we should make the stack_graph_raw attribute
a Maybe.
