### PR TITLE
Bug 1831576 - Modify web bug bounty form

### DIFF
--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -2927,7 +2927,7 @@ sub app_startup {
   $r->any(
     '/:REWRITE_web_bounty' => [REWRITE_web_bounty => qr{form[\.:]web[\.:]bounty}])
     ->to(
-    'CGI#enter_bug_cgi' => {'format' => 'web-bounty', 'product' => 'mozilla.org'});
+    'CGI#enter_bug_cgi' => {'format' => 'web-bounty', 'product' => 'Websites'});
   $r->any(
     '/:REWRITE_blocklist_bug' => [REWRITE_blocklist_bug => qr{form[\.:]blocklist}])
     ->to(

--- a/extensions/BMO/template/en/default/bug/create/create-web-bounty.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-web-bounty.html.tmpl
@@ -66,6 +66,13 @@ function validateAndSubmit() {
 
 <h1>Web Bounty Form</h1>
 
+<div id="message">
+  We have migrated our web bug bounty program to HackerOne. Please submit your report to one of our programs:
+  <a href="https://hackerone.com/mozilla_critical_services">Mozilla Critical Services</a> and 
+  <a href="https://hackerone.com/mozilla_core_services">Mozilla Core Services</a>. If you do not prefer to 
+  use HackerOne, you can still submit the bug using this form.
+</div>
+
 <form id="web_bounty_form" method="post" action="[% basepath FILTER none %]post_bug.cgi" enctype="multipart/form-data"
       onSubmit="return validateAndSubmit();">
   <input type="hidden" name="filed_via" value="custom_form">

--- a/extensions/BMO/template/en/default/bug/create/create-web-bounty.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-web-bounty.html.tmpl
@@ -67,10 +67,10 @@ function validateAndSubmit() {
 <h1>Web Bounty Form</h1>
 
 <div id="message">
-  We have migrated our web bug bounty program to HackerOne. Please submit your report to one of our programs:
-  <a href="https://hackerone.com/mozilla_critical_services">Mozilla Critical Services</a> and 
+  We have migrated our web [% terms.bug %] bounty program to HackerOne. Please submit your report to one of 
+  our programs: <a href="https://hackerone.com/mozilla_critical_services">Mozilla Critical Services</a> and 
   <a href="https://hackerone.com/mozilla_core_services">Mozilla Core Services</a>. If you do not prefer to 
-  use HackerOne, you can still submit the bug using this form.
+  use HackerOne, you can still submit the [% terms.bug %] using this form.
 </div>
 
 <form id="web_bounty_form" method="post" action="[% basepath FILTER none %]post_bug.cgi" enctype="multipart/form-data"


### PR DESCRIPTION
Added messages (from bug report) to the web bounty form to inform about HackerOne. I also changed the product from mozilla.org to Websites in Extension.pm since Websites is not the proper product and was not changed when the restructuring happened a while back.