### PR TITLE
Bug 1832364 - Add support for AWS SES configuration sets to Mailer

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,13 @@
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
 sphinx:
   configuration: docs/en/rst/conf.py
 
 python:
-  version: 3.8
   install:
     - requirements: docs/en/rst/requirements.txt

--- a/Bugzilla/Mailer.pm
+++ b/Bugzilla/Mailer.pm
@@ -88,8 +88,12 @@ sub MessageToMTA {
 
   # We add this header to uniquely identify all email that we
   # send as coming from this Bugzilla installation.
-  #
   $email->header_set('X-Bugzilla-URL', Bugzilla->localconfig->urlbase);
+
+  # Support for AWS SES configuration sets
+  if ($ENV{'X-SES-CONFIGURATION-SET'}) {
+    $email->header_set('X-SES-CONFIGURATION-SET', $ENV{'X-SES-CONFIGURATION-SET'});
+  }
 
   # We add this header to mark the mail as "auto-generated" and
   # thus to hopefully avoid auto replies.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - LOG4PERL_CONFIG_FILE=log4perl-docker.conf
       - MOJO_LISTEN=http://*:8000
       - PORT=8000
+      - X-SES-CONFIGURATION-SET=ConfigSet
     depends_on:
       - bmo.db
       - memcached


### PR DESCRIPTION
Simple change that adds a special SES header to all emails that has a value that can be set with an environment variable. This allows for BMO emails to be uniquely identified in SES when grouped with other sites and dealing with bounces, etc.