### PR TITLE
Bug 1832391 - Phabricator feed process crashes when a revision is in draft status and setting approval-mozilla-* flag on the new attachment

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,13 @@
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
 sphinx:
   configuration: docs/en/rst/conf.py
 
 python:
-  version: 3.8
   install:
     - requirements: docs/en/rst/requirements.txt

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -644,6 +644,7 @@ sub process_revision_change {
         'abandoned'       => '-',
         'accepted'        => '+',
         'changes-planned' => '?',
+        'draft'           => '?',
         'needs-review'    => '?',
         'needs-revision'  => '-',
       };

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -643,8 +643,8 @@ sub process_revision_change {
       my $revision_status_flag_map = {
         'abandoned'       => '-',
         'accepted'        => '+',
-        'changes-planned' => '?',
-        'draft'           => '?',
+        'changes-planned' => 'X',
+        'draft'           => 'X',
         'needs-review'    => '?',
         'needs-revision'  => '-',
       };

--- a/extensions/PhabBugz/lib/Util.pm
+++ b/extensions/PhabBugz/lib/Util.pm
@@ -67,7 +67,7 @@ sub set_attachment_approval_flags {
   }
 
   # If we didn't find an existing approval flag to update, add it now.
-  if (!@old_flags) {
+  if (!@old_flags && $status ne 'X') {
     my $approval_flag = Bugzilla::FlagType->new({name => $approval_flag_name});
     if ($approval_flag) {
       push @new_flags, {

--- a/extensions/PhabBugz/lib/WebService.pm
+++ b/extensions/PhabBugz/lib/WebService.pm
@@ -152,6 +152,7 @@ sub bug_revisions {
     'abandoned'       => 'Abandoned',
     'accepted'        => 'Accepted',
     'changes-planned' => 'Changes Planned',
+    'draft'           => 'Draft',
     'needs-review'    => 'Needs Review',
     'needs-revision'  => 'Needs Revision',
   };


### PR DESCRIPTION
This patch adds the '?' status for revisions that are also in the draft state which is the state the revision is set initially when it is first created. THis error occurred when a new revision was created against a repository (mozilla-beta) in Phabricator that had the uplift tag associated with it.