### PR TITLE
Bug 1832408 - New user code in Phabbugz is failing on a specific account and starting over each time from the last successful id

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,13 @@
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
 sphinx:
   configuration: docs/en/rst/conf.py
 
 python:
-  version: 3.8
   install:
     - requirements: docs/en/rst/requirements.txt

--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -734,6 +734,11 @@ sub process_new_user {
 
   my $bug_user = $phab_user->bugzilla_user;
 
+  if (!$bug_user) {
+    WARN("SKIPPING: Bugzilla ID from Phabricator not found");
+    return;
+  }
+
   # Pre setup before querying DB
   my $restore_prev_user = set_phab_user();
 


### PR DESCRIPTION
While processing new users in Phabricator, phabbugz would hit an account in Phabricator that had a bugzilla user id stored that did not for some reason exist in the Bugzilla database. Phabbugz would die on this error and start over and then hit the same user again. This had been going on for quite some time :( This change will skip the bogus bugzilla user id and go to the next. 