### PR TITLE
Bug 1831632 - Update group membership report to more prominently display users are in groups that not Mozilla email addresses (i.e. personal accounts)

### DIFF
--- a/Bugzilla/Group.pm
+++ b/Bugzilla/Group.pm
@@ -135,7 +135,7 @@ sub members_complete {
   }
 
   # If we want a list of users that are members but do not match the regexp
-  # if the current group, then we need to filter the user list.
+  # of the current group, then we need to filter the user list.
   # Regexp are normally used to automatically add users to a group such
   # as mozilla-employee-confidential, etc.
   if ($type eq 'non-mozilla' && $self->user_regexp) {

--- a/Bugzilla/Group.pm
+++ b/Bugzilla/Group.pm
@@ -110,7 +110,7 @@ sub members_non_inherited {
 # returns all possible members of groups, keyed by the group name or _direct
 # a user present in multiple groups will be returned multiple times
 sub members_complete {
-  my ($self) = @_;
+  my ($self, $type) = @_;
   my $dbh = Bugzilla->dbh;
   require Bugzilla::User;
 
@@ -119,13 +119,36 @@ sub members_complete {
     "SELECT DISTINCT user_id FROM user_group_map WHERE isbless = 0 AND group_id = ?"
     );
 
-  my $result = {_direct => $self->members_direct()};
+  my $result = {};
+
+  if ($type eq 'all' || $type eq 'direct' || $type eq 'non-mozilla') {
+    $result->{_direct} = $self->members_direct();
+    # Return early if we only want direct users
+    return $result if $type eq 'direct';
+  }
+
   foreach my $group_id (@{$self->flatten_group_membership($self->id)}) {
     next if $group_id == $self->id;
     my $group_name = Bugzilla::Group->new({id => $group_id, cache => 1})->name;
     my $user_ids = $dbh->selectcol_arrayref($sth, undef, $group_id);
     $result->{$group_name} = Bugzilla::User->new_from_list($user_ids);
   }
+
+  # If we want a list of users that are members but do not match the regexp
+  # if the current group, then we need to filter the user list.
+  # Regexp are normally used to automatically add users to a group such
+  # as mozilla-employee-confidential, etc.
+  if ($type eq 'non-mozilla' && $self->user_regexp) {
+    my $regexp = $self->user_regexp;
+    foreach my $type (keys %{$result}) {
+      my @filtered;
+      foreach my $user (@{$result->{$type}}) {
+        push @filtered, $user if $user->login !~ m/$regexp/i;
+      }
+      $result->{$type} = \@filtered;
+    }
+  }
+
   return $result;
 }
 

--- a/extensions/BMO/lib/Reports/Groups.pm
+++ b/extensions/BMO/lib/Reports/Groups.pm
@@ -198,7 +198,7 @@ sub members_report {
   $vars->{'include_disabled'} = $include_disabled;
 
   my $search_type = $cgi->param('search_type') || 'all';
-  if (none { $search_type eq $_ } ('all', 'direct', 'indirect', 'non-mozilla')) {
+  if (none { $search_type eq $_ } qw(all direct indirect non-mozilla)) {
     ThrowUserError('report_invalid_parameter', {name => 'search type'});
   }
   $vars->{search_type} = $search_type;

--- a/extensions/BMO/lib/Reports/Groups.pm
+++ b/extensions/BMO/lib/Reports/Groups.pm
@@ -16,7 +16,9 @@ use Bugzilla::Error;
 use Bugzilla::Group;
 use Bugzilla::User;
 use Bugzilla::Util qw(trim datetime_from);
+
 use JSON qw(encode_json);
+use List::MoreUtils qw(none);
 
 sub admins_report {
   my ($vars) = @_;
@@ -196,6 +198,9 @@ sub members_report {
   $vars->{'include_disabled'} = $include_disabled;
 
   my $search_type = $cgi->param('search_type') || 'all';
+  if (none { $search_type eq $_ } ('all', 'direct', 'indirect', 'non-mozilla')) {
+    ThrowUserError('report_invalid_parameter', {name => 'search type'});
+  }
   $vars->{search_type} = $search_type;
 
   # load selected group

--- a/extensions/BMO/template/en/default/pages/group_members.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/group_members.html.tmpl
@@ -18,19 +18,39 @@
   <tr>
     <th>Group</th>
     <td>
-      <select name="group">
+      <select name="group" id="group">
         [% FOREACH group_name = groups %]
           <option value="[% group_name FILTER html %]"
                   [% "selected" IF group_name == group.name %]>
             [% group_name FILTER html %]</option>
         [% END %]
       </select>
+    </td>
+  </tr><tr>
+    <th>
+      Search
+    </th>
+    <td>
+      <select name="search_type" id="search_type">
+        <option value="all" [% "selected" IF !search_type OR search_type == "all" %]>All</option>
+        <option value="direct" [% "selected" IF search_type == "direct" %]>Direct Membership</option>
+        <option value="indirect" [% "selected" IF search_type == "indirect" %]>Indirect Membership (inherited)</option>
+        <option value="non-mozilla" [% "selected" IF search_type == "non-mozilla" %]>Non-Mozilla Accounts</option>
+      </select>
+    </td>
+  </tr><tr>
+    <td></td>
+    <td>
       <input type="checkbox" name="include_disabled" id="include_disabled"
              value="1" [% "checked" IF include_disabled %]>
       <label for="include_disabled">
         Include disabled users
       </label>
-      <input type="submit" value="Generate">
+    </td>
+  </tr><tr>
+    <td></td>
+    <td>
+      <input type="submit" value="Generate" id="generate">
     </td>
   </tr>
   </table>


### PR DESCRIPTION
* Some cleanup of the group member report by adding a table for the different query fields
* Extend Bugzilla::Group->members_complete to take an argument that will filter results based on search type
* non-mozilla search type filters the users to only show email addresses that do not match the groups regex if one exists.
* The regex is used by Mozilla to automatically place users in specific confidential groups.
* Figured this would be better than hard-coding '.*@mozilla(foundation)?\.(org|com)' and all of the other possibilities.