### PR TITLE
Bug 1802188 - Sitemap extension is not working due to XML content be disallowed by Mojoicious

### DIFF
--- a/Bugzilla/App/Static.pm
+++ b/Bugzilla/App/Static.pm
@@ -11,7 +11,7 @@ use Bugzilla::Constants qw(bz_locations);
 
 my $LEGACY_RE = qr{
     ^ (?:static/v(?<version>[0-9]+\.[0-9]+)/) ?
-    (?<file>(?:extensions/[^/]+/web|(?:image|skin|j|graph)s|data/webdot)/.+)
+    (?<file>(?:extensions/[^/]+/web|(?:image|skin|j|graph)s|data/webdot|data/SiteMapIndex)/.+)
     $
 }xs;
 

--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -299,9 +299,10 @@ sub _prevent_unsafe_response {
         (?: application/ (?: x(?: -javascript | ml (?: -dtd )? )
                            | (?: atom | rdf) \+ xml
                            | json )
-        # text/csv, text/calendar, text/plain, and text/html
+        # text/csv, text/calendar, text/plain, text/xml, and text/html
           | text/ (?: c (?: alendar | sv )
                     | plain
+                    | xml
                     | html )
         # used for HTTP push responses
           | multipart/x-mixed-replace)


### PR DESCRIPTION
This patch updates the Mojolicous framework specific parts of the BMO code to allow test/xml documents (needed for the SiteMap index file with links to the individual xml.gz files) and to allow static file serving from the data/SiteMapIndex directory. The index file is autogenerated from a link in the robots.txt file. All of which were not allowed before when we moved from Apache to Mojolicious so this feature has been broken now for almost 5 years :(