### PR TITLE
Bug 1835941 - Create a new report for "What should I work on next?" to help engineers see bugs matching a specific search criteria

### DIFF
--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -257,6 +257,10 @@ sub page_before_template {
     require Bugzilla::Extension::BMO::Reports::ProductSecurity;
     Bugzilla::Extension::BMO::Reports::ProductSecurity::report($vars);
   }
+  elsif ($page eq 'whats_next.html') {
+    require Bugzilla::Extension::BMO::Reports::WhatsNext;
+    Bugzilla::Extension::BMO::Reports::WhatsNext::report($vars);
+  }
   elsif ($page eq 'fields.html') {
 
     # Recently global/field-descs.none.tmpl and bug/field-help.none.tmpl

--- a/extensions/BMO/lib/Reports/WhatsNext.pm
+++ b/extensions/BMO/lib/Reports/WhatsNext.pm
@@ -32,7 +32,7 @@ use constant CLASSIFICATIONS => (
 );
 
 use constant SELECT =>
-  'SELECT bugs.bug_id, bugs.bug_status, bugs.priority, bugs.short_desc, bugs.delta_ts';
+  'SELECT bugs.bug_id, bugs.bug_status, bugs.priority, bugs.bug_severity, bugs.short_desc, bugs.delta_ts';
 
 # Wrap the sql execution in a try block so we can see any SQL errors in debug output
 sub get_bug_list {
@@ -57,6 +57,7 @@ sub format_bug_list {
       id          => $row->{bug_id},
       status      => $row->{bug_status},
       priority    => $row->{priority},
+      severity    => $row->{bug_severity},
       summary     => $row->{short_desc},
       changeddate => $row->{delta_ts},
     };

--- a/extensions/BMO/lib/Reports/WhatsNext.pm
+++ b/extensions/BMO/lib/Reports/WhatsNext.pm
@@ -1,0 +1,377 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::Extension::BMO::Reports::WhatsNext;
+
+use 5.10.1;
+use strict;
+use warnings;
+
+use Bugzilla;
+use Bugzilla::Error;
+use Bugzilla::Logging;
+use Bugzilla::Search;
+use Bugzilla::Status qw(BUG_STATE_OPEN);
+use Bugzilla::User;
+use Bugzilla::Util qw(datetime_from fetch_product_versions time_ago);
+
+use DateTime;
+use Mojo::Util qw(dumper);
+use Try::Tiny;
+
+use constant CLASSIFICATIONS => (
+  'Client Software',
+  'Developer Infrastructure',
+  'Components',
+  'Server Software',
+  'Other',
+);
+
+use constant SELECT =>
+  "SELECT bugs.bug_id, bugs.bug_status, bugs.priority, bugs.short_desc, bugs.delta_ts";
+
+# Wrap the sql execution in a try block so we can see any SQL errors in debug output
+sub get_bug_list {
+  my ($query, @values) = @_;
+  try {
+    return Bugzilla->dbh->selectall_arrayref($query, {Slice => {}}, @values);
+  }
+  catch {
+    DEBUG($_);
+    return [];
+  };
+}
+
+sub format_bug_list {
+  my ($bugs, $user) = @_;
+
+  my $datetime_now = DateTime->now(time_zone => $user->timezone);
+
+  my @formatted_bugs;
+  foreach my $row (@{$bugs}) {
+    my $bug = {
+      id          => $row->{bug_id},
+      status      => $row->{bug_status},
+      priority    => $row->{priority},
+      summary     => $row->{short_desc},
+      changeddate => $row->{delta_ts},
+    };
+    my $datetime = datetime_from($bug->{changeddate});
+    $datetime->set_time_zone($user->timezone);
+    $bug->{changeddate}       = $datetime->strftime('%Y-%m-%d %T %Z');
+    $bug->{changeddate_fancy} = time_ago($datetime, $datetime_now);
+    push @formatted_bugs, $bug;
+  }
+
+  return \@formatted_bugs;
+}
+
+sub filter_secure_bugs {
+  my $bugs = shift;
+  my $user = Bugzilla->user;    # Must be the current user
+
+  # Running this will prime the visible bugs cache which
+  # makes each loop of $user->can_see_bug a fast operation
+  $user->visible_bugs([map { $_->{id} } @{$bugs}]);
+
+  my @filtered_bugs;
+  foreach my $bug (@{$bugs}) {
+    next if !$user->can_see_bug($bug->{id});
+    push @filtered_bugs, $bug;
+  }
+
+  return \@filtered_bugs;
+}
+
+# Here we fetch the latest versions so we can map then to
+# the appropriate tracking and status flags.
+sub get_tracking_status_flags {
+  my $versions = fetch_product_versions('firefox');
+  return {} unless $versions;
+
+  my $nightly_version = $versions->{FIREFOX_NIGHTLY};
+  my $beta_version    = $versions->{LATEST_FIREFOX_RELEASED_DEVEL_VERSION};
+  my $release_version = $versions->{LATEST_FIREFOX_VERSION};
+  return {} if !$nightly_version || !$beta_version || !$release_version;
+
+  # We just want the major versions number
+  my ($nightly_major) = $nightly_version =~ /^(\d+)/;
+  my ($beta_major)    = $beta_version    =~ /^(\d+)/;
+  my ($release_major) = $release_version =~ /^(\d+)/;
+  return {} if !$nightly_major && !$beta_major && !$release_major;
+
+  my $flag_data = {};
+
+  # Tracking Flags
+  my $nightly_name = "cf_tracking_firefox$nightly_major";
+  my $beta_name    = "cf_tracking_firefox$beta_major";
+  my $release_name = "cf_tracking_firefox$release_major";
+
+  my $nightly_field = Bugzilla::Extension::TrackingFlags::Flag->new({name => $nightly_name});
+  my $beta_field    = Bugzilla::Extension::TrackingFlags::Flag->new({name => $beta_name});
+  my $release_field = Bugzilla::Extension::TrackingFlags::Flag->new({name => $release_name});
+  return {} if !$nightly_field && !$beta_field && !$release_field;
+
+  $flag_data->{tracking} = {
+    nightly => $nightly_field,
+    beta    => $beta_field,
+    release => $release_field,
+  };
+
+  # Status Flags
+  $nightly_name = "cf_status_firefox$nightly_major";
+  $beta_name    = "cf_status_firefox$beta_major";
+  $release_name = "cf_status_firefox$release_major";
+
+  $nightly_field = Bugzilla::Extension::TrackingFlags::Flag->new({name => $nightly_name});
+  $beta_field    = Bugzilla::Extension::TrackingFlags::Flag->new({name => $beta_name});
+  $release_field = Bugzilla::Extension::TrackingFlags::Flag->new({name => $release_name});
+  return {} if !$nightly_field && !$beta_field && !$release_field;
+
+  $flag_data->{status} = {
+    nightly => $nightly_field,
+    beta    => $beta_field,
+    release => $release_field,
+  };
+
+  return $flag_data;
+}
+
+# S1 defects assigned to you
+sub s1_bugs {
+  my $user = shift;
+  my $dbh  = Bugzilla->dbh;
+
+  my $query = SELECT . '
+         FROM bugs JOIN products ON bugs.product_id = products.id
+        WHERE products.classification_id IN (SELECT id FROM classifications WHERE name IN ('
+    . join(', ', map { $dbh->quote($_) } CLASSIFICATIONS) . "))
+              AND bugs.bug_severity = 'S1'
+              AND bugs.bug_type = 'defect'
+              AND bugs.bug_status IN ("
+    . join(', ', map { $dbh->quote($_) } BUG_STATE_OPEN) . ')
+              AND bugs.assigned_to = ?
+     ORDER BY bugs.delta_ts DESC, bugs.bug_id';
+
+  my $bugs           = get_bug_list($query, $user->id);
+  my $formatted_bugs = format_bug_list($bugs, $user);
+  my $filtered_bugs  = filter_secure_bugs($formatted_bugs);
+
+  return $filtered_bugs;
+}
+
+# sec-crit bugs assigned to you (these should already be S1 defects, but just in case…)
+sub sec_crit_bugs {
+  my $user = shift;
+  my $dbh  = Bugzilla->dbh;
+
+  my $query = SELECT . '
+         FROM bugs JOIN products ON bugs.product_id = products.id
+              JOIN keywords ON bugs.bug_id = keywords.bug_id
+        WHERE products.classification_id IN (SELECT id FROM classifications WHERE name IN ('
+    . join(', ', map { $dbh->quote($_) } CLASSIFICATIONS) . "))
+              AND keywords.keywordid = (SELECT id FROM keyworddefs WHERE name = 'sec-critical')
+              AND bugs.bug_status IN ("
+    . join(', ', map { $dbh->quote($_) } BUG_STATE_OPEN) . ')
+              AND bugs.assigned_to = ?
+     ORDER BY bugs.delta_ts DESC, bugs.bug_id';
+
+  my $bugs           = get_bug_list($query, $user->id);
+  my $formatted_bugs = format_bug_list($bugs, $user);
+  my $filtered_bugs  = filter_secure_bugs($formatted_bugs);
+
+  return $filtered_bugs;
+}
+
+# Bugs that are needinfo? you and are marked as being tracked against or blocking the current nightly/beta/release
+sub important_needinfo_bugs {
+  my $user = shift;
+  my $dbh  = Bugzilla->dbh;
+
+  my $flags = get_tracking_status_flags();
+  return [] if !exists $flags->{tracking};
+
+  my $query = SELECT . '
+         FROM bugs JOIN products ON bugs.product_id = products.id
+              LEFT JOIN tracking_flags_bugs AS tracking_flags_bugs_1
+                ON bugs.bug_id = tracking_flags_bugs_1.bug_id
+                AND tracking_flags_bugs_1.tracking_flag_id = ' . $flags->{tracking}->{nightly}->flag_id . '
+              LEFT JOIN tracking_flags_bugs AS tracking_flags_bugs_2
+                ON bugs.bug_id = tracking_flags_bugs_2.bug_id
+                AND tracking_flags_bugs_2.tracking_flag_id = ' . $flags->{tracking}->{beta}->flag_id . '
+              LEFT JOIN tracking_flags_bugs AS tracking_flags_bugs_3
+                ON bugs.bug_id = tracking_flags_bugs_3.bug_id
+                AND tracking_flags_bugs_3.tracking_flag_id = ' . $flags->{tracking}->{release}->flag_id . '
+              LEFT JOIN flags AS requestees_login_name ON bugs.bug_id = requestees_login_name.bug_id
+                AND COALESCE(requestees_login_name.requestee_id, 0) = ?
+        WHERE products.classification_id IN (SELECT id FROM classifications WHERE name IN ('
+    . join(', ', map { $dbh->quote($_) } CLASSIFICATIONS) . "))
+              AND bugs.bug_status IN ("
+    . join(', ', map { $dbh->quote($_) } BUG_STATE_OPEN) . ")
+              AND (COALESCE(tracking_flags_bugs_1.value, '---') IN ('+', 'blocking')
+                    OR COALESCE(tracking_flags_bugs_2.value, '---') IN ('+', 'blocking')
+                    OR COALESCE(tracking_flags_bugs_3.value, '---') IN ('+', 'blocking'))
+              AND (requestees_login_name.bug_id IS NOT NULL
+                    AND requestees_login_name.type_id = (SELECT id FROM flagtypes WHERE name = 'needinfo'))
+            ORDER BY bugs.delta_ts DESC, bugs.bug_id";
+
+  my $bugs           = get_bug_list($query, $user->id);
+  my $formatted_bugs = format_bug_list($bugs, $user);
+  my $filtered_bugs  = filter_secure_bugs($formatted_bugs);
+
+  return $filtered_bugs;
+}
+
+# S2 defects assigned to you (for things that are not disabled in the current release)
+sub s2_bugs {
+  my $user = shift;
+  my $dbh  = Bugzilla->dbh;
+
+  my $flags = get_tracking_status_flags();
+  return [] if !exists $flags->{status};
+
+  my $query = SELECT . '
+         FROM bugs JOIN products ON bugs.product_id = products.id
+              LEFT JOIN tracking_flags_bugs AS tracking_flags_bugs_1
+                ON bugs.bug_id = tracking_flags_bugs_1.bug_id
+                AND tracking_flags_bugs_1.tracking_flag_id = ' . $flags->{status}->{nightly}->flag_id . '
+              LEFT JOIN tracking_flags_bugs AS tracking_flags_bugs_2
+                ON bugs.bug_id = tracking_flags_bugs_2.bug_id
+                AND tracking_flags_bugs_2.tracking_flag_id = ' . $flags->{status}->{beta}->flag_id . '
+              LEFT JOIN tracking_flags_bugs AS tracking_flags_bugs_3
+                ON bugs.bug_id = tracking_flags_bugs_3.bug_id
+                AND tracking_flags_bugs_3.tracking_flag_id = ' . $flags->{status}->{release}->flag_id . '
+        WHERE products.classification_id IN (SELECT id FROM classifications WHERE name IN ('
+    . join(', ', map { $dbh->quote($_) } CLASSIFICATIONS) . "))
+              AND bugs.bug_severity = 'S2'
+              AND bugs.bug_status IN ("
+    . join(', ', map { $dbh->quote($_) } BUG_STATE_OPEN) . ")
+              AND bugs.assigned_to = ?
+              AND COALESCE(tracking_flags_bugs_1.value, '---') != 'disabled'
+              AND COALESCE(tracking_flags_bugs_2.value, '---') != 'disabled'
+              AND COALESCE(tracking_flags_bugs_3.value, '---') != 'disabled'
+            ORDER BY bugs.delta_ts DESC, bugs.bug_id";
+
+  my $bugs           = get_bug_list($query, $user->id);
+  my $formatted_bugs = format_bug_list($bugs, $user);
+  my $filtered_bugs  = filter_secure_bugs($formatted_bugs);
+
+  return $filtered_bugs;
+}
+
+# sec-high bugs assigned to you (again, for things that are not disabled in the current release)
+sub sec_high_bugs {
+  my $user = shift;
+  my $dbh  = Bugzilla->dbh;
+
+  my $flags = get_tracking_status_flags();
+  return [] if !exists $flags->{status};
+
+  my $query = SELECT . '
+         FROM bugs JOIN products ON bugs.product_id = products.id
+              JOIN keywords ON bugs.bug_id = keywords.bug_id
+              LEFT JOIN tracking_flags_bugs AS tracking_flags_bugs_1
+                ON bugs.bug_id = tracking_flags_bugs_1.bug_id
+                AND tracking_flags_bugs_1.tracking_flag_id = ' . $flags->{status}->{nightly}->flag_id . '
+              LEFT JOIN tracking_flags_bugs AS tracking_flags_bugs_2
+                ON bugs.bug_id = tracking_flags_bugs_2.bug_id
+                AND tracking_flags_bugs_2.tracking_flag_id = ' . $flags->{status}->{beta}->flag_id . '
+              LEFT JOIN tracking_flags_bugs AS tracking_flags_bugs_3
+                ON bugs.bug_id = tracking_flags_bugs_3.bug_id
+                AND tracking_flags_bugs_3.tracking_flag_id = ' . $flags->{status}->{release}->flag_id . '
+        WHERE products.classification_id IN (SELECT id FROM classifications WHERE name IN ('
+    . join(', ', map { $dbh->quote($_) } CLASSIFICATIONS) . "))
+              AND keywords.keywordid = (SELECT id FROM keyworddefs WHERE name = 'sec-high')
+              AND bugs.bug_status IN ("
+    . join(', ', map { $dbh->quote($_) } BUG_STATE_OPEN) . ")
+              AND bugs.assigned_to = ?
+              AND COALESCE(tracking_flags_bugs_1.value, '---') != 'disabled'
+              AND COALESCE(tracking_flags_bugs_2.value, '---') != 'disabled'
+              AND COALESCE(tracking_flags_bugs_3.value, '---') != 'disabled'
+            ORDER BY bugs.delta_ts DESC, bugs.bug_id";
+
+  my $bugs           = get_bug_list($query, $user->id);
+  my $formatted_bugs = format_bug_list($bugs, $user);
+  my $filtered_bugs  = filter_secure_bugs($formatted_bugs);
+
+  return $filtered_bugs;
+}
+
+# Regressions
+sub regression_bugs {
+  my $user = shift;
+  my $dbh  = Bugzilla->dbh;
+
+  my $query = SELECT . '
+         FROM bugs JOIN products ON bugs.product_id = products.id
+              JOIN keywords ON bugs.bug_id = keywords.bug_id
+        WHERE products.classification_id IN (SELECT id FROM classifications WHERE name IN ('
+    . join(', ', map { $dbh->quote($_) } CLASSIFICATIONS) . "))
+              AND keywords.keywordid = (SELECT id FROM keyworddefs WHERE name = 'regression')
+              AND bugs.bug_status IN ("
+    . join(', ', map { $dbh->quote($_) } BUG_STATE_OPEN) . ')
+              AND bugs.assigned_to = ?
+     ORDER BY bugs.delta_ts DESC, bugs.bug_id';
+
+  my $bugs           = get_bug_list($query, $user->id);
+  my $formatted_bugs = format_bug_list($bugs, $user);
+  my $filtered_bugs  = filter_secure_bugs($formatted_bugs);
+
+  return $filtered_bugs;
+}
+
+# Other needinfos (needinfos for me but not set by me)
+sub other_needinfo_bugs {
+  my $user = shift;
+  my $dbh  = Bugzilla->dbh;
+
+  my $query = SELECT . '
+         FROM bugs JOIN products ON bugs.product_id = products.id
+              LEFT JOIN flags AS requestees_login_name ON bugs.bug_id = requestees_login_name.bug_id
+                AND COALESCE(requestees_login_name.requestee_id, 0) = ?
+                AND COALESCE(requestees_login_name.setter_id, 0) != ?
+        WHERE products.classification_id IN (SELECT id FROM classifications WHERE name IN ('
+    . join(', ', map { $dbh->quote($_) } CLASSIFICATIONS) . '))
+              AND bugs.bug_status IN ('
+    . join(', ', map { $dbh->quote($_) } BUG_STATE_OPEN) . ")
+              AND (requestees_login_name.bug_id IS NOT NULL
+                    AND requestees_login_name.type_id = (SELECT id FROM flagtypes WHERE name = 'needinfo'))
+        ORDER BY bugs.delta_ts DESC, bugs.bug_id";
+
+  my $bugs           = get_bug_list($query, $user->id, $user->id);
+  my $formatted_bugs = format_bug_list($bugs, $user);
+  my $filtered_bugs  = filter_secure_bugs($formatted_bugs);
+
+  return $filtered_bugs;
+}
+
+sub report {
+  my $vars  = shift;
+  my $user  = Bugzilla->user;
+  my $input = Bugzilla->input_params;
+
+  $user->in_group('editbugs')
+    || ThrowUserError('auth_failure',
+    {group => 'editbugs', action => 'run', object => 'whats_next'});
+
+  # If a username was not passed using the form, we default
+  # to the current user.
+  my $who
+    = $input->{who} ? Bugzilla::User->check({name => $input->{who}}) : $user;
+
+  $vars->{who} = $who->login;
+
+  $vars->{s1_bugs}                 = s1_bugs($who);
+  $vars->{sec_crit_bugs}           = sec_crit_bugs($who);
+  $vars->{important_needinfo_bugs} = important_needinfo_bugs($who);
+  $vars->{s2_bugs}                 = s2_bugs($who);
+  $vars->{sec_high_bugs}           = sec_high_bugs($who);
+  $vars->{regression_bugs}         = regression_bugs($who);
+  $vars->{other_needinfo_bugs}     = other_needinfo_bugs($who);
+}
+
+1;

--- a/extensions/BMO/lib/Reports/WhatsNext.pm
+++ b/extensions/BMO/lib/Reports/WhatsNext.pm
@@ -393,15 +393,6 @@ sub report {
   my $user  = Bugzilla->user;
   my $input = Bugzilla->input_params;
 
-  $user->in_group('mozilla-employee-confidential') || ThrowUserError(
-    'auth_failure',
-    {
-      group  => 'mozilla-employee-confidential',
-      action => 'run',
-      object => 'whats_next'
-    }
-  );
-
   # If a username was not passed using the form, we default
   # to the current user.
   my $who
@@ -413,21 +404,21 @@ sub report {
   my $dbh   = Bugzilla->dbh;
 
   # classifications
-  $cache->{classification_ids} = $dbh->selectcol_arrayref('
+  $cache->{classification_ids} ||= $dbh->selectcol_arrayref('
     SELECT id
       FROM classifications
      WHERE name IN (' . join(', ', map { $dbh->quote($_) } CLASSIFICATIONS) . ')');
 
   # needinfo flag
-  $cache->{needinfo_flag_id} = $dbh->selectrow_array("
+  $cache->{needinfo_flag_id} ||= $dbh->selectrow_array("
     SELECT id FROM flagtypes WHERE name = 'needinfo'");
 
   # keyword ids
-  $cache->{sec_critical_id} = $dbh->selectrow_array("
+  $cache->{sec_critical_id} ||= $dbh->selectrow_array("
     SELECT id FROM keyworddefs WHERE name = 'sec-critical'");
-  $cache->{sec_high_id} = $dbh->selectrow_array("
+  $cache->{sec_high_id} ||= $dbh->selectrow_array("
     SELECT id FROM keyworddefs WHERE name = 'sec-high'");
-  $cache->{regression_id} = $dbh->selectrow_array("
+  $cache->{regression_id} ||= $dbh->selectrow_array("
     SELECT id FROM keyworddefs WHERE name = 'regression'");
 
   $vars->{who}                     = $who->login;

--- a/extensions/BMO/lib/Reports/WhatsNext.pm
+++ b/extensions/BMO/lib/Reports/WhatsNext.pm
@@ -354,17 +354,21 @@ sub report {
   my $user  = Bugzilla->user;
   my $input = Bugzilla->input_params;
 
-  $user->in_group('editbugs')
-    || ThrowUserError('auth_failure',
-    {group => 'editbugs', action => 'run', object => 'whats_next'});
+  $user->in_group('mozilla-employee-confidential') || ThrowUserError(
+    'auth_failure',
+    {
+      group  => 'mozilla-employee-confidential',
+      action => 'run',
+      object => 'whats_next'
+    }
+  );
 
   # If a username was not passed using the form, we default
   # to the current user.
   my $who
     = $input->{who} ? Bugzilla::User->check({name => $input->{who}}) : $user;
 
-  $vars->{who} = $who->login;
-
+  $vars->{who}                     = $who->login;
   $vars->{s1_bugs}                 = s1_bugs($who);
   $vars->{sec_crit_bugs}           = sec_crit_bugs($who);
   $vars->{important_needinfo_bugs} = important_needinfo_bugs($who);

--- a/extensions/BMO/lib/Reports/WhatsNext.pm
+++ b/extensions/BMO/lib/Reports/WhatsNext.pm
@@ -32,7 +32,7 @@ use constant CLASSIFICATIONS => (
 );
 
 use constant SELECT =>
-  "SELECT bugs.bug_id, bugs.bug_status, bugs.priority, bugs.short_desc, bugs.delta_ts";
+  'SELECT bugs.bug_id, bugs.bug_status, bugs.priority, bugs.short_desc, bugs.delta_ts';
 
 # Wrap the sql execution in a try block so we can see any SQL errors in debug output
 sub get_bug_list {
@@ -209,8 +209,8 @@ sub important_needinfo_bugs {
               LEFT JOIN flags AS requestees_login_name ON bugs.bug_id = requestees_login_name.bug_id
                 AND COALESCE(requestees_login_name.requestee_id, 0) = ?
         WHERE products.classification_id IN (SELECT id FROM classifications WHERE name IN ('
-    . join(', ', map { $dbh->quote($_) } CLASSIFICATIONS) . "))
-              AND bugs.bug_status IN ("
+    . join(', ', map { $dbh->quote($_) } CLASSIFICATIONS) . '))
+              AND bugs.bug_status IN ('
     . join(', ', map { $dbh->quote($_) } BUG_STATE_OPEN) . ")
               AND (COALESCE(tracking_flags_bugs_1.value, '---') IN ('+', 'blocking')
                     OR COALESCE(tracking_flags_bugs_2.value, '---') IN ('+', 'blocking')

--- a/extensions/BMO/lib/Reports/WhatsNext.pm
+++ b/extensions/BMO/lib/Reports/WhatsNext.pm
@@ -136,9 +136,11 @@ sub get_tracking_status_flags {
     = Bugzilla::Extension::TrackingFlags::Flag->new({name => $release_name});
   return {} if !$nightly_field && !$beta_field && !$release_field;
 
-  $flag_data->{status}
-    = {nightly => $nightly_field, beta => $beta_field, release => $release_field,
-    };
+  $flag_data->{status} = {
+    nightly => $nightly_field,
+    beta    => $beta_field,
+    release => $release_field,
+  };
 
   return $flag_data;
 }
@@ -149,7 +151,7 @@ sub s1_bugs {
   my $dbh  = Bugzilla->dbh;
 
   # Preselected values for inserting into SQL
-  my $cache      = Bugzilla->request_cache->{whats_next};
+  my $cache      = Bugzilla->process_cache->{whats_next};
   my $class_ids  = join ',', @{$cache->{classification_ids}};
   my $bug_states = join ',', map { $dbh->quote($_) } BUG_STATE_OPEN;
 
@@ -175,7 +177,7 @@ sub sec_crit_bugs {
   my $dbh  = Bugzilla->dbh;
 
   # Preselected values for inserting into SQL
-  my $cache      = Bugzilla->request_cache->{whats_next};
+  my $cache      = Bugzilla->process_cache->{whats_next};
   my $keyword_id = $cache->{sec_critical_id};
   my $class_ids  = join ',', @{$cache->{classification_ids}};
   my $bug_states = join ',', map { $dbh->quote($_) } BUG_STATE_OPEN;
@@ -205,7 +207,7 @@ sub important_needinfo_bugs {
   return [] if !exists $flags->{tracking};
 
   # Preselected values for inserting into SQL
-  my $cache           = Bugzilla->request_cache->{whats_next};
+  my $cache           = Bugzilla->process_cache->{whats_next};
   my $needinfo_id     = $cache->{needinfo_flag_id};
   my $class_ids       = join ',', @{$cache->{classification_ids}};
   my $bug_states      = join ',', map { $dbh->quote($_) } BUG_STATE_OPEN;
@@ -244,14 +246,14 @@ sub important_needinfo_bugs {
 
 # S2 defects assigned to you (for things that are not disabled in the current release)
 sub s2_bugs {
-  my $user  = shift;
-  my $dbh   = Bugzilla->dbh;
+  my $user = shift;
+  my $dbh  = Bugzilla->dbh;
 
   my $flags = get_tracking_status_flags();
   return [] if !exists $flags->{status};
 
   # Preselected values for inserting into SQL
-  my $cache           = Bugzilla->request_cache->{whats_next};
+  my $cache           = Bugzilla->process_cache->{whats_next};
   my $class_ids       = join ',', @{$cache->{classification_ids}};
   my $bug_states      = join ',', map { $dbh->quote($_) } BUG_STATE_OPEN;
   my $nightly_flag_id = $flags->{status}->{nightly}->flag_id;
@@ -287,14 +289,14 @@ sub s2_bugs {
 
 # sec-high bugs assigned to you (again, for things that are not disabled in the current release)
 sub sec_high_bugs {
-  my $user  = shift;
-  my $dbh   = Bugzilla->dbh;
+  my $user = shift;
+  my $dbh  = Bugzilla->dbh;
 
   my $flags = get_tracking_status_flags();
   return [] if !exists $flags->{status};
 
   # Preselected values for inserting into SQL
-  my $cache           = Bugzilla->request_cache->{whats_next};
+  my $cache           = Bugzilla->process_cache->{whats_next};
   my $keyword_id      = $cache->{sec_high_id};
   my $class_ids       = join ',', @{$cache->{classification_ids}};
   my $bug_states      = join ',', map { $dbh->quote($_) } BUG_STATE_OPEN;
@@ -336,7 +338,7 @@ sub regression_bugs {
   my $dbh  = Bugzilla->dbh;
 
   # Preselected values for inserting into SQL
-  my $cache      = Bugzilla->request_cache->{whats_next};
+  my $cache      = Bugzilla->process_cache->{whats_next};
   my $keyword_id = $cache->{regression_id};
   my $class_ids  = join ',', @{$cache->{classification_ids}};
   my $bug_states = join ',', map { $dbh->quote($_) } BUG_STATE_OPEN;
@@ -363,7 +365,7 @@ sub other_needinfo_bugs {
   my $dbh  = Bugzilla->dbh;
 
   # Cached values for inserting into SQL
-  my $cache       = Bugzilla->request_cache->{whats_next};
+  my $cache       = Bugzilla->process_cache->{whats_next};
   my $needinfo_id = $cache->{needinfo_flag_id};
   my $class_ids   = join ',', @{$cache->{classification_ids}};
   my $bug_states  = join ',', map { $dbh->quote($_) } BUG_STATE_OPEN;
@@ -407,7 +409,7 @@ sub report {
 
   # Here we load some values into cache that will be used later
   # by the various queries.
-  my $cache = Bugzilla->request_cache->{whats_next} = {};
+  my $cache = Bugzilla->process_cache->{whats_next} = {};
   my $dbh   = Bugzilla->dbh;
 
   # classifications
@@ -425,7 +427,7 @@ sub report {
     SELECT id FROM keyworddefs WHERE name = 'sec-critical'");
   $cache->{sec_high_id} = $dbh->selectrow_array("
     SELECT id FROM keyworddefs WHERE name = 'sec-high'");
-   $cache->{regression_id} = $dbh->selectrow_array("
+  $cache->{regression_id} = $dbh->selectrow_array("
     SELECT id FROM keyworddefs WHERE name = 'regression'");
 
   $vars->{who}                     = $who->login;

--- a/extensions/BMO/lib/Reports/WhatsNext.pm
+++ b/extensions/BMO/lib/Reports/WhatsNext.pm
@@ -111,32 +111,34 @@ sub get_tracking_status_flags {
   my $beta_name    = "cf_tracking_firefox$beta_major";
   my $release_name = "cf_tracking_firefox$release_major";
 
-  my $nightly_field = Bugzilla::Extension::TrackingFlags::Flag->new({name => $nightly_name});
-  my $beta_field    = Bugzilla::Extension::TrackingFlags::Flag->new({name => $beta_name});
-  my $release_field = Bugzilla::Extension::TrackingFlags::Flag->new({name => $release_name});
+  my $nightly_field
+    = Bugzilla::Extension::TrackingFlags::Flag->new({name => $nightly_name});
+  my $beta_field
+    = Bugzilla::Extension::TrackingFlags::Flag->new({name => $beta_name});
+  my $release_field
+    = Bugzilla::Extension::TrackingFlags::Flag->new({name => $release_name});
   return {} if !$nightly_field && !$beta_field && !$release_field;
 
-  $flag_data->{tracking} = {
-    nightly => $nightly_field,
-    beta    => $beta_field,
-    release => $release_field,
-  };
+  $flag_data->{tracking}
+    = {nightly => $nightly_field, beta => $beta_field, release => $release_field,
+    };
 
   # Status Flags
   $nightly_name = "cf_status_firefox$nightly_major";
   $beta_name    = "cf_status_firefox$beta_major";
   $release_name = "cf_status_firefox$release_major";
 
-  $nightly_field = Bugzilla::Extension::TrackingFlags::Flag->new({name => $nightly_name});
-  $beta_field    = Bugzilla::Extension::TrackingFlags::Flag->new({name => $beta_name});
-  $release_field = Bugzilla::Extension::TrackingFlags::Flag->new({name => $release_name});
+  $nightly_field
+    = Bugzilla::Extension::TrackingFlags::Flag->new({name => $nightly_name});
+  $beta_field
+    = Bugzilla::Extension::TrackingFlags::Flag->new({name => $beta_name});
+  $release_field
+    = Bugzilla::Extension::TrackingFlags::Flag->new({name => $release_name});
   return {} if !$nightly_field && !$beta_field && !$release_field;
 
-  $flag_data->{status} = {
-    nightly => $nightly_field,
-    beta    => $beta_field,
-    release => $release_field,
-  };
+  $flag_data->{status}
+    = {nightly => $nightly_field, beta => $beta_field, release => $release_field,
+    };
 
   return $flag_data;
 }
@@ -146,16 +148,19 @@ sub s1_bugs {
   my $user = shift;
   my $dbh  = Bugzilla->dbh;
 
-  my $query = SELECT . '
+  # Preselected values for inserting into SQL
+  my $cache      = Bugzilla->request_cache->{whats_next};
+  my $class_ids  = join ',', @{$cache->{classification_ids}};
+  my $bug_states = join ',', map { $dbh->quote($_) } BUG_STATE_OPEN;
+
+  my $query = SELECT . "
          FROM bugs JOIN products ON bugs.product_id = products.id
-        WHERE products.classification_id IN (SELECT id FROM classifications WHERE name IN ('
-    . join(', ', map { $dbh->quote($_) } CLASSIFICATIONS) . "))
+        WHERE products.classification_id IN ($class_ids)
               AND bugs.bug_severity = 'S1'
               AND bugs.bug_type = 'defect'
-              AND bugs.bug_status IN ("
-    . join(', ', map { $dbh->quote($_) } BUG_STATE_OPEN) . ')
+              AND bugs.bug_status IN ($bug_states)
               AND bugs.assigned_to = ?
-     ORDER BY bugs.delta_ts DESC, bugs.bug_id';
+     ORDER BY bugs.delta_ts, bugs.bug_id";
 
   my $bugs           = get_bug_list($query, $user->id);
   my $formatted_bugs = format_bug_list($bugs, $user);
@@ -169,16 +174,20 @@ sub sec_crit_bugs {
   my $user = shift;
   my $dbh  = Bugzilla->dbh;
 
-  my $query = SELECT . '
+  # Preselected values for inserting into SQL
+  my $cache      = Bugzilla->request_cache->{whats_next};
+  my $keyword_id = $cache->{sec_critical_id};
+  my $class_ids  = join ',', @{$cache->{classification_ids}};
+  my $bug_states = join ',', map { $dbh->quote($_) } BUG_STATE_OPEN;
+
+  my $query = SELECT . "
          FROM bugs JOIN products ON bugs.product_id = products.id
               JOIN keywords ON bugs.bug_id = keywords.bug_id
-        WHERE products.classification_id IN (SELECT id FROM classifications WHERE name IN ('
-    . join(', ', map { $dbh->quote($_) } CLASSIFICATIONS) . "))
-              AND keywords.keywordid = (SELECT id FROM keyworddefs WHERE name = 'sec-critical')
-              AND bugs.bug_status IN ("
-    . join(', ', map { $dbh->quote($_) } BUG_STATE_OPEN) . ')
+        WHERE products.classification_id IN ($class_ids)
+              AND keywords.keywordid = $keyword_id
+              AND bugs.bug_status IN ($bug_states)
               AND bugs.assigned_to = ?
-     ORDER BY bugs.delta_ts DESC, bugs.bug_id';
+     ORDER BY bugs.delta_ts, bugs.bug_id";
 
   my $bugs           = get_bug_list($query, $user->id);
   my $formatted_bugs = format_bug_list($bugs, $user);
@@ -195,29 +204,36 @@ sub important_needinfo_bugs {
   my $flags = get_tracking_status_flags();
   return [] if !exists $flags->{tracking};
 
-  my $query = SELECT . '
+  # Preselected values for inserting into SQL
+  my $cache           = Bugzilla->request_cache->{whats_next};
+  my $needinfo_id     = $cache->{needinfo_flag_id};
+  my $class_ids       = join ',', @{$cache->{classification_ids}};
+  my $bug_states      = join ',', map { $dbh->quote($_) } BUG_STATE_OPEN;
+  my $nightly_flag_id = $flags->{tracking}->{nightly}->flag_id;
+  my $beta_flag_id    = $flags->{tracking}->{beta}->flag_id;
+  my $release_flag_id = $flags->{tracking}->{release}->flag_id;
+
+  my $query = SELECT . "
          FROM bugs JOIN products ON bugs.product_id = products.id
               LEFT JOIN tracking_flags_bugs AS tracking_flags_bugs_1
                 ON bugs.bug_id = tracking_flags_bugs_1.bug_id
-                AND tracking_flags_bugs_1.tracking_flag_id = ' . $flags->{tracking}->{nightly}->flag_id . '
+                AND tracking_flags_bugs_1.tracking_flag_id = $nightly_flag_id
               LEFT JOIN tracking_flags_bugs AS tracking_flags_bugs_2
                 ON bugs.bug_id = tracking_flags_bugs_2.bug_id
-                AND tracking_flags_bugs_2.tracking_flag_id = ' . $flags->{tracking}->{beta}->flag_id . '
+                AND tracking_flags_bugs_2.tracking_flag_id = $beta_flag_id
               LEFT JOIN tracking_flags_bugs AS tracking_flags_bugs_3
                 ON bugs.bug_id = tracking_flags_bugs_3.bug_id
-                AND tracking_flags_bugs_3.tracking_flag_id = ' . $flags->{tracking}->{release}->flag_id . '
+                AND tracking_flags_bugs_3.tracking_flag_id = $release_flag_id
               LEFT JOIN flags AS requestees_login_name ON bugs.bug_id = requestees_login_name.bug_id
                 AND COALESCE(requestees_login_name.requestee_id, 0) = ?
-        WHERE products.classification_id IN (SELECT id FROM classifications WHERE name IN ('
-    . join(', ', map { $dbh->quote($_) } CLASSIFICATIONS) . '))
-              AND bugs.bug_status IN ('
-    . join(', ', map { $dbh->quote($_) } BUG_STATE_OPEN) . ")
+        WHERE products.classification_id IN ($class_ids)
+              AND bugs.bug_status IN ($bug_states)
               AND (COALESCE(tracking_flags_bugs_1.value, '---') IN ('+', 'blocking')
                     OR COALESCE(tracking_flags_bugs_2.value, '---') IN ('+', 'blocking')
                     OR COALESCE(tracking_flags_bugs_3.value, '---') IN ('+', 'blocking'))
               AND (requestees_login_name.bug_id IS NOT NULL
-                    AND requestees_login_name.type_id = (SELECT id FROM flagtypes WHERE name = 'needinfo'))
-            ORDER BY bugs.delta_ts DESC, bugs.bug_id";
+                    AND requestees_login_name.type_id = $needinfo_id)
+            ORDER BY bugs.delta_ts, bugs.bug_id";
 
   my $bugs           = get_bug_list($query, $user->id);
   my $formatted_bugs = format_bug_list($bugs, $user);
@@ -228,33 +244,39 @@ sub important_needinfo_bugs {
 
 # S2 defects assigned to you (for things that are not disabled in the current release)
 sub s2_bugs {
-  my $user = shift;
-  my $dbh  = Bugzilla->dbh;
+  my $user  = shift;
+  my $dbh   = Bugzilla->dbh;
 
   my $flags = get_tracking_status_flags();
   return [] if !exists $flags->{status};
 
-  my $query = SELECT . '
+  # Preselected values for inserting into SQL
+  my $cache           = Bugzilla->request_cache->{whats_next};
+  my $class_ids       = join ',', @{$cache->{classification_ids}};
+  my $bug_states      = join ',', map { $dbh->quote($_) } BUG_STATE_OPEN;
+  my $nightly_flag_id = $flags->{status}->{nightly}->flag_id;
+  my $beta_flag_id    = $flags->{status}->{beta}->flag_id;
+  my $release_flag_id = $flags->{status}->{release}->flag_id;
+
+  my $query = SELECT . "
          FROM bugs JOIN products ON bugs.product_id = products.id
               LEFT JOIN tracking_flags_bugs AS tracking_flags_bugs_1
                 ON bugs.bug_id = tracking_flags_bugs_1.bug_id
-                AND tracking_flags_bugs_1.tracking_flag_id = ' . $flags->{status}->{nightly}->flag_id . '
+                AND tracking_flags_bugs_1.tracking_flag_id = $nightly_flag_id
               LEFT JOIN tracking_flags_bugs AS tracking_flags_bugs_2
                 ON bugs.bug_id = tracking_flags_bugs_2.bug_id
-                AND tracking_flags_bugs_2.tracking_flag_id = ' . $flags->{status}->{beta}->flag_id . '
+                AND tracking_flags_bugs_2.tracking_flag_id = $beta_flag_id
               LEFT JOIN tracking_flags_bugs AS tracking_flags_bugs_3
                 ON bugs.bug_id = tracking_flags_bugs_3.bug_id
-                AND tracking_flags_bugs_3.tracking_flag_id = ' . $flags->{status}->{release}->flag_id . '
-        WHERE products.classification_id IN (SELECT id FROM classifications WHERE name IN ('
-    . join(', ', map { $dbh->quote($_) } CLASSIFICATIONS) . "))
+                AND tracking_flags_bugs_3.tracking_flag_id = $release_flag_id
+        WHERE products.classification_id IN ($class_ids)
               AND bugs.bug_severity = 'S2'
-              AND bugs.bug_status IN ("
-    . join(', ', map { $dbh->quote($_) } BUG_STATE_OPEN) . ")
+              AND bugs.bug_status IN ($bug_states)
               AND bugs.assigned_to = ?
               AND COALESCE(tracking_flags_bugs_1.value, '---') != 'disabled'
               AND COALESCE(tracking_flags_bugs_2.value, '---') != 'disabled'
               AND COALESCE(tracking_flags_bugs_3.value, '---') != 'disabled'
-            ORDER BY bugs.delta_ts DESC, bugs.bug_id";
+            ORDER BY bugs.delta_ts, bugs.bug_id";
 
   my $bugs           = get_bug_list($query, $user->id);
   my $formatted_bugs = format_bug_list($bugs, $user);
@@ -265,34 +287,41 @@ sub s2_bugs {
 
 # sec-high bugs assigned to you (again, for things that are not disabled in the current release)
 sub sec_high_bugs {
-  my $user = shift;
-  my $dbh  = Bugzilla->dbh;
+  my $user  = shift;
+  my $dbh   = Bugzilla->dbh;
 
   my $flags = get_tracking_status_flags();
   return [] if !exists $flags->{status};
 
-  my $query = SELECT . '
+  # Preselected values for inserting into SQL
+  my $cache           = Bugzilla->request_cache->{whats_next};
+  my $keyword_id      = $cache->{sec_high_id};
+  my $class_ids       = join ',', @{$cache->{classification_ids}};
+  my $bug_states      = join ',', map { $dbh->quote($_) } BUG_STATE_OPEN;
+  my $nightly_flag_id = $flags->{status}->{nightly}->flag_id;
+  my $beta_flag_id    = $flags->{status}->{beta}->flag_id;
+  my $release_flag_id = $flags->{status}->{release}->flag_id;
+
+  my $query = SELECT . "
          FROM bugs JOIN products ON bugs.product_id = products.id
               JOIN keywords ON bugs.bug_id = keywords.bug_id
               LEFT JOIN tracking_flags_bugs AS tracking_flags_bugs_1
                 ON bugs.bug_id = tracking_flags_bugs_1.bug_id
-                AND tracking_flags_bugs_1.tracking_flag_id = ' . $flags->{status}->{nightly}->flag_id . '
+                AND tracking_flags_bugs_1.tracking_flag_id = $nightly_flag_id
               LEFT JOIN tracking_flags_bugs AS tracking_flags_bugs_2
                 ON bugs.bug_id = tracking_flags_bugs_2.bug_id
-                AND tracking_flags_bugs_2.tracking_flag_id = ' . $flags->{status}->{beta}->flag_id . '
+                AND tracking_flags_bugs_2.tracking_flag_id = $beta_flag_id
               LEFT JOIN tracking_flags_bugs AS tracking_flags_bugs_3
                 ON bugs.bug_id = tracking_flags_bugs_3.bug_id
-                AND tracking_flags_bugs_3.tracking_flag_id = ' . $flags->{status}->{release}->flag_id . '
-        WHERE products.classification_id IN (SELECT id FROM classifications WHERE name IN ('
-    . join(', ', map { $dbh->quote($_) } CLASSIFICATIONS) . "))
-              AND keywords.keywordid = (SELECT id FROM keyworddefs WHERE name = 'sec-high')
-              AND bugs.bug_status IN ("
-    . join(', ', map { $dbh->quote($_) } BUG_STATE_OPEN) . ")
+                AND tracking_flags_bugs_3.tracking_flag_id = $release_flag_id
+        WHERE products.classification_id IN ($class_ids)
+              AND keywords.keywordid = $keyword_id
+              AND bugs.bug_status IN ($bug_states)
               AND bugs.assigned_to = ?
               AND COALESCE(tracking_flags_bugs_1.value, '---') != 'disabled'
               AND COALESCE(tracking_flags_bugs_2.value, '---') != 'disabled'
               AND COALESCE(tracking_flags_bugs_3.value, '---') != 'disabled'
-            ORDER BY bugs.delta_ts DESC, bugs.bug_id";
+            ORDER BY bugs.delta_ts, bugs.bug_id";
 
   my $bugs           = get_bug_list($query, $user->id);
   my $formatted_bugs = format_bug_list($bugs, $user);
@@ -306,16 +335,20 @@ sub regression_bugs {
   my $user = shift;
   my $dbh  = Bugzilla->dbh;
 
-  my $query = SELECT . '
+  # Preselected values for inserting into SQL
+  my $cache      = Bugzilla->request_cache->{whats_next};
+  my $keyword_id = $cache->{regression_id};
+  my $class_ids  = join ',', @{$cache->{classification_ids}};
+  my $bug_states = join ',', map { $dbh->quote($_) } BUG_STATE_OPEN;
+
+  my $query = SELECT . "
          FROM bugs JOIN products ON bugs.product_id = products.id
               JOIN keywords ON bugs.bug_id = keywords.bug_id
-        WHERE products.classification_id IN (SELECT id FROM classifications WHERE name IN ('
-    . join(', ', map { $dbh->quote($_) } CLASSIFICATIONS) . "))
-              AND keywords.keywordid = (SELECT id FROM keyworddefs WHERE name = 'regression')
-              AND bugs.bug_status IN ("
-    . join(', ', map { $dbh->quote($_) } BUG_STATE_OPEN) . ')
+        WHERE products.classification_id IN ($class_ids)
+              AND keywords.keywordid = $keyword_id
+              AND bugs.bug_status IN ($bug_states)
               AND bugs.assigned_to = ?
-     ORDER BY bugs.delta_ts DESC, bugs.bug_id';
+     ORDER BY bugs.delta_ts, bugs.bug_id";
 
   my $bugs           = get_bug_list($query, $user->id);
   my $formatted_bugs = format_bug_list($bugs, $user);
@@ -329,18 +362,22 @@ sub other_needinfo_bugs {
   my $user = shift;
   my $dbh  = Bugzilla->dbh;
 
-  my $query = SELECT . '
+  # Cached values for inserting into SQL
+  my $cache       = Bugzilla->request_cache->{whats_next};
+  my $needinfo_id = $cache->{needinfo_flag_id};
+  my $class_ids   = join ',', @{$cache->{classification_ids}};
+  my $bug_states  = join ',', map { $dbh->quote($_) } BUG_STATE_OPEN;
+
+  my $query = SELECT . "
          FROM bugs JOIN products ON bugs.product_id = products.id
               LEFT JOIN flags AS requestees_login_name ON bugs.bug_id = requestees_login_name.bug_id
                 AND COALESCE(requestees_login_name.requestee_id, 0) = ?
                 AND COALESCE(requestees_login_name.setter_id, 0) != ?
-        WHERE products.classification_id IN (SELECT id FROM classifications WHERE name IN ('
-    . join(', ', map { $dbh->quote($_) } CLASSIFICATIONS) . '))
-              AND bugs.bug_status IN ('
-    . join(', ', map { $dbh->quote($_) } BUG_STATE_OPEN) . ")
+        WHERE products.classification_id IN ($class_ids)
+              AND bugs.bug_status IN ($bug_states)
               AND (requestees_login_name.bug_id IS NOT NULL
-                    AND requestees_login_name.type_id = (SELECT id FROM flagtypes WHERE name = 'needinfo'))
-        ORDER BY bugs.delta_ts DESC, bugs.bug_id";
+                    AND requestees_login_name.type_id = $needinfo_id)
+        ORDER BY bugs.delta_ts, bugs.bug_id";
 
   my $bugs           = get_bug_list($query, $user->id, $user->id);
   my $formatted_bugs = format_bug_list($bugs, $user);
@@ -367,6 +404,29 @@ sub report {
   # to the current user.
   my $who
     = $input->{who} ? Bugzilla::User->check({name => $input->{who}}) : $user;
+
+  # Here we load some values into cache that will be used later
+  # by the various queries.
+  my $cache = Bugzilla->request_cache->{whats_next} = {};
+  my $dbh   = Bugzilla->dbh;
+
+  # classifications
+  $cache->{classification_ids} = $dbh->selectcol_arrayref('
+    SELECT id
+      FROM classifications
+     WHERE name IN (' . join(', ', map { $dbh->quote($_) } CLASSIFICATIONS) . ')');
+
+  # needinfo flag
+  $cache->{needinfo_flag_id} = $dbh->selectrow_array("
+    SELECT id FROM flagtypes WHERE name = 'needinfo'");
+
+  # keyword ids
+  $cache->{sec_critical_id} = $dbh->selectrow_array("
+    SELECT id FROM keyworddefs WHERE name = 'sec-critical'");
+  $cache->{sec_high_id} = $dbh->selectrow_array("
+    SELECT id FROM keyworddefs WHERE name = 'sec-high'");
+   $cache->{regression_id} = $dbh->selectrow_array("
+    SELECT id FROM keyworddefs WHERE name = 'regression'");
 
   $vars->{who}                     = $who->login;
   $vars->{s1_bugs}                 = s1_bugs($who);

--- a/extensions/BMO/template/en/default/hook/reports/menu-end.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/reports/menu-end.html.tmpl
@@ -79,7 +79,13 @@
         <a href="[% basepath FILTER none %]page.cgi?id=internship_dashboard.html">Internship Dashboard</a>
       </strong> - Dashboard for open intern requisitions.
     </li>
-
+  [% END %]
+  [% IF user.in_group('editbugs') %]
+    <li>
+      <strong>
+        <a href="[% basepath FILTER none %]page.cgi?id=whats_next.html">What should I work on next?</a>
+      </strong> - As a Firefox developer, what should I work on next?
+    </li>
   [% END %]
 </ul>
 

--- a/extensions/BMO/template/en/default/hook/reports/menu-end.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/reports/menu-end.html.tmpl
@@ -80,12 +80,5 @@
       </strong> - Dashboard for open intern requisitions.
     </li>
   [% END %]
-  [% IF user.in_group('editbugs') %]
-    <li>
-      <strong>
-        <a href="[% basepath FILTER none %]page.cgi?id=whats_next.html">What should I work on next?</a>
-      </strong> - As a Firefox developer, what should I work on next?
-    </li>
-  [% END %]
 </ul>
 

--- a/extensions/BMO/template/en/default/pages/whats_next.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/whats_next.html.tmpl
@@ -16,7 +16,7 @@
 [% PROCESS global/variables.none.tmpl %]
 
 <div id="whats_next">
-  <h1>What should I work on next?</h1>
+  <h1>What Should I Work On Next?</h1>
 
   <div>
   </div>
@@ -58,14 +58,13 @@
 
   <p>These are the things you should drop everything else for (they’re in no particular order):</p>
 
-  <h3>S1 [% terms.bugs %] assigned to you</h3>
+  <h3>Your S1 [% terms.bugs %]</h3>
   [% INCLUDE bug_table bugs = s1_bugs %]
 
-  <h3>sec-crit [% terms.bugs %] assigned to you</h3>
-  (these should already be S1 [% terms.bugs %], but just in case…)
+  <h3>Your sec-crit [% terms.bugs %]</h3>
   [% INCLUDE bug_table bugs = sec_crit_bugs %]
 
-  <h3>[% terms.Bugs %] that are needinfo? you and are marked as being tracked against or blocking the current nightly, beta, or release versions.</h3>
+  <h3>Important needinfos</h3>
   [% INCLUDE bug_table bugs = important_needinfo_bugs %]
 
   <h2>High Priority Tasks</h2>
@@ -73,21 +72,16 @@
   <p>High priority tasks are also “drop everything”, except that in this case
     “everything” doesn’t include anything in the “Highest priority” list:</p>
 
-  <h3>S2 [% terms.bugs %] assigned to you</h3>
-  (for things that are not disabled in the current release)
+  <h3>Your S2 [% terms.bugs %]</h3>
   [% INCLUDE bug_table bugs = s2_bugs %]
 
-  <p>Some teams have very long lists of S2 [% terms.bugs %] - see notes below on “Long High Priority task lists”</p>
-
-  <h3>sec-high [% terms.bugs %] assigned to you</h3>
-  (again, for things that are not disabled in the current release)
+  <h3>Your sec-high [% terms.bugs %]</h3>
   [% INCLUDE bug_table bugs = sec_high_bugs %]
 
   <h3>Regressions</h3>
   [% INCLUDE bug_table bugs = regression_bugs %]
 
   <h3>Other needinfos</h3>
-  (needinfos for me but not set by me)
   [% INCLUDE bug_table bugs = other_needinfo_bugs %]
 </div>
 

--- a/extensions/BMO/template/en/default/pages/whats_next.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/whats_next.html.tmpl
@@ -94,6 +94,7 @@
       <tr>
         <th>[% terms.Bug %] ID</th>
         <th>Priority</th>
+        <th>Severity</th>
         <th>Status</th>
         <th>Summary</th>
         <th>Last Updated</th>
@@ -105,6 +106,7 @@
         <tr class="report_item [% count % 2 == 1 ? "report_row_odd" : "report_row_even" %]">
           <td><a href="[% basepath FILTER none %]show_bug.cgi?id=[% bug.id FILTER html %]">[% bug.id FILTER html %]</a></td>
           <td>[% bug.priority FILTER html %]</td>
+          <td>[% bug.severity FILTER html %]</td>
           <td>[% bug.status FILTER html %]</td>
           <td nowrap><a href="[% basepath FILTER none %]show_bug.cgi?id=[% bug.id FILTER html %]">[% bug.summary FILTER html %]</a></td>
           <td>

--- a/extensions/BMO/template/en/default/pages/whats_next.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/whats_next.html.tmpl
@@ -9,124 +9,87 @@
 [% INCLUDE global/header.html.tmpl
   title = "What should I work on next?"
   generate_api_token = 1
-  javascript_urls = [ "js/field.js" ]
+  javascript_urls = [ "js/field.js", "extensions/BMO/web/js/whats_next.js" ]
   style_urls = [ "extensions/BMO/web/styles/reports.css" ]
 %]
 
 [% PROCESS global/variables.none.tmpl %]
 
-<form id="whats_next_form" name="whats_next_form" action="[% basepath FILTER none %]page.cgi" method="get">
-<input type="hidden" name="id" value="whats_next.html">
-<input type="hidden" name="action" value="run">
-<table id="parameters">
-<tr>
-  <td>
-    <strong>Current User</strong>
+<div id="whats_next">
+  <h1>What should I work on next?</h1>
+
+  <div>
+  </div>
+
+  <form id="whats_next_form" name="whats_next_form" action="[% basepath FILTER none %]page.cgi" method="get">
+  <input type="hidden" name="id" value="whats_next.html">
+  <input type="hidden" name="action" value="run">
+  <table id="parameters">
+  <tr>
+    <td>
+      <strong>Current User</strong>
+    </td>
+    <td>
+      &nbsp;
+      [% INCLUDE global/userselect.html.tmpl
+         id = "who"
+         name = "who"
+         value = who
+         size = 40
+         emptyok = 0
+      %]
+      &nbsp;
+    </td>
+    <td>
+      <input type="submit" id="run" value="Change">
+    </td>
+  </tr>
+  <td colspan="2">
+    <label class="switch">
+      <input id="auto_refresh" type="checkbox" onchange="updateAutoRefresh();">
+      <span class="slider round"></span>
+    </label>
+    Auto-refresh every 10min
   </td>
-  <td>
-    &nbsp;
-    [% INCLUDE global/userselect.html.tmpl
-       id = "who"
-       name = "who"
-       value = who
-       size = 40
-       emptyok = 0
-    %]
-    &nbsp;
-  </td>
-  <td>
-    <input type="submit" id="run" value="Change">
-  </td>
-</tr>
-</table>
-</form>
+  </table>
+  </form>
 
-<h1>What should I work on next?</h1>
+  <h2>Highest Priority Tasks</h2>
 
-<p>We don’t always agree on top priority work. This can lead to us being inefficient
-  or missing simple tasks like replying to a critical problem for a release. So this
-  list takes steps to unify our definition of the highest levels of priority when it
-  comes to engineering work.</p>
+  <p>These are the things you should drop everything else for (they’re in no particular order):</p>
 
-<p>This list doesn’t attempt to prioritize normal work - it is just for the things
-  that are more important than the normal stuff. Also it’s about individual engineer
-  prioritization rather than team prioritization. It also doesn’t claim to include
-  all sources of high priority work (e.g. triage, responding to requests from HR, etc).</p>
+  <h3>S1 [% terms.bugs %] assigned to you</h3>
+  [% INCLUDE bug_table bugs = s1_bugs %]
 
-<p>So here are some rules of thumb about our priorities when it comes to [% terms.bug %] fixing.</p>
+  <h3>sec-crit [% terms.bugs %] assigned to you</h3>
+  (these should already be S1 [% terms.bugs %], but just in case…)
+  [% INCLUDE bug_table bugs = sec_crit_bugs %]
 
-<h2>Highest Priority Tasks</h2>
+  <h3>[% terms.Bugs %] that are needinfo? you and are marked as being tracked against or blocking the current nightly, beta, or release versions.</h3>
+  [% INCLUDE bug_table bugs = important_needinfo_bugs %]
 
-<p>These are the things you should drop everything else for (they’re in no particular order):</p>
+  <h2>High Priority Tasks</h2>
 
-<h3>S1 [% terms.bugs %] assigned to you</h3>
-[% INCLUDE bug_table bugs = s1_bugs %]
+  <p>High priority tasks are also “drop everything”, except that in this case
+    “everything” doesn’t include anything in the “Highest priority” list:</p>
 
-<h3>sec-crit [% terms.bugs %] assigned to you</h3>
-(these should already be S1 [% terms.bugs %], but just in case…)
-[% INCLUDE bug_table bugs = sec_crit_bugs %]
+  <h3>S2 [% terms.bugs %] assigned to you</h3>
+  (for things that are not disabled in the current release)
+  [% INCLUDE bug_table bugs = s2_bugs %]
 
-<h3>[% terms.Bugs %] that are needinfo? you and are marked as being tracked against or blocking the current nightly, beta, or release versions.</h3>
-[% INCLUDE bug_table bugs = important_needinfo_bugs %]
+  <p>Some teams have very long lists of S2 [% terms.bugs %] - see notes below on “Long High Priority task lists”</p>
 
-<h2>High Priority Tasks</h2>
+  <h3>sec-high [% terms.bugs %] assigned to you</h3>
+  (again, for things that are not disabled in the current release)
+  [% INCLUDE bug_table bugs = sec_high_bugs %]
 
-<p>High priority tasks are also “drop everything”, except that in this case
-  “everything” doesn’t include anything in the “Highest priority” list:</p>
+  <h3>Regressions</h3>
+  [% INCLUDE bug_table bugs = regression_bugs %]
 
-<h3>S2 [% terms.bugs %] assigned to you</h3>
-(for things that are not disabled in the current release)
-[% INCLUDE bug_table bugs = s2_bugs %]
-
-<p>Some teams have very long lists of S2 [% terms.bugs %] - see notes below on “Long High Priority task lists”</p>
-
-<h3>sec-high [% terms.bugs %] assigned to you</h3>
-(again, for things that are not disabled in the current release)
-[% INCLUDE bug_table bugs = sec_high_bugs %]
-
-<h3>Regressions</h3>
-[% INCLUDE bug_table bugs = regression_bugs %]
-
-<h3>Other needinfos</h3>
-(needinfos for me but not set by me)
-[% INCLUDE bug_table bugs = other_needinfo_bugs %]
-
-<h3>Notes:</h3>
-
-<ul>
-  <li>Long lists of High Priority tasks: For some people and teams, the list of
-    “High Priority” tasks is so long that you would never do normal work. If this
-    is you then you should schedule these tasks alongside normal work - However
-    making your task list manageable should still be a priority.</li>
-  <li>Severity is defined, but things get a bit hazy when it comes to how we define
-    severity for enhancements; this list is for serious [% terms.bugs %] only.</li>
-  <li>This list doesn’t include Review Requests as some engineers have a Review
-    Request load that would be impossible to manage with these strict rules.</li>
-  <li>There are indicators of severity not included here. To ensure traction with
-    engineers, ensure this priority is reflected in a [% terms.bugs %] severity.
-    Examples include:
-    <ul>
-      <li>Tracking Flags</li>
-      <li>access-s1/access-s2/access-s3</li>
-      <li>webcompat-p1</li>
-      <li>performance-p1</li>
-    </ul>
-  <li>You may have a long list of needinfos. Please don’t ignore them. If this list
-    is daunting, work with your manager to burn them down - for needinfos that are
-    older than 6 months you might consider declaring needinfo bankruptcy.</li>
-</ul>
-
-<h2>Everything Else</h2>
-
-<p>This list of things to work on deliberately doesn’t include “normal work”. That’s
-  because different teams and engineers at different levels will have very different
-  priorities. Over time we’d like to bring teams’ practices for prioritizing new work
-  more in line with each other, but that’s not the job of this note.</p>
-
-<p>If you find that most of your time is spent on high or highest priority tasks,
-  then it’s time to ask some questions to work out why - there’s likely to be a problem
-  behind this and it sounds like a recipe for burnout, and we should do everything we
-  can to even things out.</p>
+  <h3>Other needinfos</h3>
+  (needinfos for me but not set by me)
+  [% INCLUDE bug_table bugs = other_needinfo_bugs %]
+</div>
 
 [% INCLUDE global/footer.html.tmpl %]
 

--- a/extensions/BMO/template/en/default/pages/whats_next.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/whats_next.html.tmpl
@@ -1,0 +1,164 @@
+[%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  #
+  # This Source Code Form is "Incompatible With Secondary Licenses", as
+  # defined by the Mozilla Public License, v. 2.0.
+  #%]
+
+[% INCLUDE global/header.html.tmpl
+  title = "What should I work on next?"
+  generate_api_token = 1
+  javascript_urls = [ "js/field.js" ]
+  style_urls = [ "extensions/BMO/web/styles/reports.css" ]
+%]
+
+[% PROCESS global/variables.none.tmpl %]
+
+<form id="whats_next_form" name="whats_next_form" action="[% basepath FILTER none %]page.cgi" method="get">
+<input type="hidden" name="id" value="whats_next.html">
+<input type="hidden" name="action" value="run">
+<table id="parameters">
+<tr>
+  <td>
+    <strong>Current User</strong>
+  </td>
+  <td>
+    &nbsp;
+    [% INCLUDE global/userselect.html.tmpl
+       id = "who"
+       name = "who"
+       value = who
+       size = 40
+       emptyok = 0
+    %]
+    &nbsp;
+  </td>
+  <td>
+    <input type="submit" id="run" value="Change">
+  </td>
+</tr>
+</table>
+</form>
+
+<h1>What should I work on next?</h1>
+
+<p>We don’t always agree on top priority work. This can lead to us being inefficient
+  or missing simple tasks like replying to a critical problem for a release. So this
+  list takes steps to unify our definition of the highest levels of priority when it
+  comes to engineering work.</p>
+
+<p>This list doesn’t attempt to prioritize normal work - it is just for the things
+  that are more important than the normal stuff. Also it’s about individual engineer
+  prioritization rather than team prioritization. It also doesn’t claim to include
+  all sources of high priority work (e.g. triage, responding to requests from HR, etc).</p>
+
+<p>So here are some rules of thumb about our priorities when it comes to [% terms.bug %] fixing.</p>
+
+<h2>Highest Priority Tasks</h2>
+
+<p>These are the things you should drop everything else for (they’re in no particular order):</p>
+
+<h3>S1 [% terms.bugs %] assigned to you</h3>
+[% INCLUDE bug_table bugs = s1_bugs %]
+
+<h3>sec-crit [% terms.bugs %] assigned to you</h3>
+(these should already be S1 [% terms.bugs %], but just in case…)
+[% INCLUDE bug_table bugs = sec_crit_bugs %]
+
+<h3>[% terms.Bugs %] that are needinfo? you and are marked as being tracked against or blocking the current nightly, beta, or release versions.</h3>
+[% INCLUDE bug_table bugs = important_needinfo_bugs %]
+
+<h2>High Priority Tasks</h2>
+
+<p>High priority tasks are also “drop everything”, except that in this case
+  “everything” doesn’t include anything in the “Highest priority” list:</p>
+
+<h3>S2 [% terms.bugs %] assigned to you</h3>
+(for things that are not disabled in the current release)
+[% INCLUDE bug_table bugs = s2_bugs %]
+
+<p>Some teams have very long lists of S2 [% terms.bugs %] - see notes below on “Long High Priority task lists”</p>
+
+<h3>sec-high [% terms.bugs %] assigned to you</h3>
+(again, for things that are not disabled in the current release)
+[% INCLUDE bug_table bugs = sec_high_bugs %]
+
+<h3>Regressions</h3>
+[% INCLUDE bug_table bugs = regression_bugs %]
+
+<h3>Other needinfos</h3>
+(needinfos for me but not set by me)
+[% INCLUDE bug_table bugs = other_needinfo_bugs %]
+
+<h3>Notes:</h3>
+
+<ul>
+  <li>Long lists of High Priority tasks: For some people and teams, the list of
+    “High Priority” tasks is so long that you would never do normal work. If this
+    is you then you should schedule these tasks alongside normal work - However
+    making your task list manageable should still be a priority.</li>
+  <li>Severity is defined, but things get a bit hazy when it comes to how we define
+    severity for enhancements; this list is for serious [% terms.bugs %] only.</li>
+  <li>This list doesn’t include Review Requests as some engineers have a Review
+    Request load that would be impossible to manage with these strict rules.</li>
+  <li>There are indicators of severity not included here. To ensure traction with
+    engineers, ensure this priority is reflected in a [% terms.bugs %] severity.
+    Examples include:
+    <ul>
+      <li>Tracking Flags</li>
+      <li>access-s1/access-s2/access-s3</li>
+      <li>webcompat-p1</li>
+      <li>performance-p1</li>
+    </ul>
+  <li>You may have a long list of needinfos. Please don’t ignore them. If this list
+    is daunting, work with your manager to burn them down - for needinfos that are
+    older than 6 months you might consider declaring needinfo bankruptcy.</li>
+</ul>
+
+<h2>Everything Else</h2>
+
+<p>This list of things to work on deliberately doesn’t include “normal work”. That’s
+  because different teams and engineers at different levels will have very different
+  priorities. Over time we’d like to bring teams’ practices for prioritizing new work
+  more in line with each other, but that’s not the job of this note.</p>
+
+<p>If you find that most of your time is spent on high or highest priority tasks,
+  then it’s time to ask some questions to work out why - there’s likely to be a problem
+  behind this and it sounds like a recipe for burnout, and we should do everything we
+  can to even things out.</p>
+
+[% INCLUDE global/footer.html.tmpl %]
+
+[% BLOCK bug_table %]
+  [% IF bugs && bugs.size > 0 %]
+    <table id="report" class="standard">
+    <thead>
+      <tr>
+        <th>[% terms.Bug %] ID</th>
+        <th>Priority</th>
+        <th>Status</th>
+        <th>Summary</th>
+        <th>Last Updated</th>
+      </tr>
+    </thead>
+    <tbody>
+      [% FOREACH bug = bugs %]
+        [% count = loop.count() %]
+        <tr class="report_item [% count % 2 == 1 ? "report_row_odd" : "report_row_even" %]">
+          <td><a href="[% basepath FILTER none %]show_bug.cgi?id=[% bug.id FILTER html %]">[% bug.id FILTER html %]</a></td>
+          <td>[% bug.priority FILTER html %]</td>
+          <td>[% bug.status FILTER html %]</td>
+          <td nowrap><a href="[% basepath FILTER none %]show_bug.cgi?id=[% bug.id FILTER html %]">[% bug.summary FILTER html %]</a></td>
+          <td>
+            <span title="[% bug.changeddate FILTER time FILTER html %]">[% bug.changeddate_fancy FILTER html %]</span>
+          </td>
+        </tr>
+      [% END %]
+    </tbody>
+    </table>
+  [% ELSE %]
+    <p>No [% terms.bugs %] found.</p>
+  [% END %]
+  [% SET bugs = [] %]
+[% END %]

--- a/extensions/BMO/web/js/whats_next.js
+++ b/extensions/BMO/web/js/whats_next.js
@@ -1,0 +1,43 @@
+var auto_refresh_interval_id = null;
+
+function updateAutoRefresh() {
+  var auto_refresh_element = document.getElementById('auto_refresh');
+  if (auto_refresh_element.checked) {
+    setCookie('whats_next_auto_refresh', 1);
+    auto_refresh_interval_id = setInterval(() => {
+      window.location.reload();
+    }, 600000);
+  }
+  else {
+    setCookie('whats_next_auto_refresh', 0);
+    clearInterval(auto_refresh_interval_id);
+  }
+}
+
+function setCookie(name, value) {
+  document.cookie = name + "=" + (value ? 1 : 0)  + "; path=/";
+}
+
+function getCookie(name) {
+  var nameEQ = name + "=";
+  var ca = document.cookie.split(';');
+  for(var i=0; i < ca.length; i++) {
+    var c = ca[i];
+    while (c.charAt(0)==' ') {
+      c = c.substring(1, c.length);
+    }
+    if (c.indexOf(nameEQ) == 0) {
+      return c.substring(nameEQ.length, c.length);
+    }
+  }
+  return null;
+}
+
+window.addEventListener('load', () => {
+  var auto_refresh_element = document.getElementById('auto_refresh');
+  if (getCookie('whats_next_auto_refresh') == 1) {
+    auto_refresh_element.checked =  true;
+  }
+  updateAutoRefresh();
+  auto_refresh_element.onchange(updateAutoRefresh);
+});

--- a/extensions/BMO/web/styles/reports.css
+++ b/extensions/BMO/web/styles/reports.css
@@ -50,3 +50,62 @@
 .problem {
   color: var(--accent-color-red-1);
 }
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 30px;
+  height: 17px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--secondary-label-color);
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 13px;
+  width: 13px;
+  left: 2px;
+  bottom: 2px;
+  background-color: white;
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+input:checked + .slider {
+  background-color: #2196F3;
+}
+
+input:focus + .slider {
+  box-shadow: 0 0 1px #2196F3;
+}
+
+input:checked + .slider:before {
+  -webkit-transform: translateX(13px);
+  -ms-transform: translateX(13px);
+  transform: translateX(13px);
+}
+
+.slider.round {
+  border-radius: 17px;
+}
+
+.slider.round:before {
+  border-radius: 50%;
+}

--- a/qa/config/generate_test_data.pl
+++ b/qa/config/generate_test_data.pl
@@ -655,6 +655,14 @@ foreach my $user_group (@users_groups) {
   eval { $sth_add_mapping->execute($user->id, $group->id, 0, GRANT_DIRECT); };
 }
 
+# BMO: Add a couple of test users to the mozilla employee group for mozilla specific tests
+foreach my $name (qw(admin QA-Selenium-Test)) {
+  my $full_name = $name . '@mozilla.test';
+  my $user = Bugzilla::User->new({name => $full_name});
+  $user->set_groups({add => ['mozilla-employee-confidential']});
+  $user->update();
+}
+
 ##########################################################################
 # Associate Products with groups
 ##########################################################################

--- a/qa/t/1_test_whats_next.t
+++ b/qa/t/1_test_whats_next.t
@@ -154,11 +154,4 @@ ok(
 
 logout($sel);
 
-# Open what next report as an unprivileged user and make
-# sure the report is not visible.
-log_in($sel, $config, 'unprivileged');
-$sel->open_ok('/page.cgi?id=whats_next.html');
-$sel->title_is('Authorization Required');
-logout($sel);
-
 done_testing;

--- a/qa/t/1_test_whats_next.t
+++ b/qa/t/1_test_whats_next.t
@@ -83,7 +83,7 @@ $sel->is_text_present_ok('has been added to the database', 'Bug created');
 logout($sel);
 
 # Other needinfos (needinfos for me but not set by me)
-log_in($sel, $config, 'editbugs');
+log_in($sel, $config, 'QA_Selenium_TEST');
 file_bug_in_product($sel, 'Firefox');
 $sel->type_ok('short_desc', 'test bug for other needinfos not set by you');
 $sel->select_ok('component', 'General');
@@ -94,10 +94,7 @@ logout($sel);
 
 # Open the whats next report as admin
 log_in($sel, $config, 'admin');
-$sel->click_ok('header-tools-menu-button');
-$sel->click_ok('link=Reports');
-$sel->title_is('Reporting and Charting Kitchen');
-$sel->click_ok('link=What should I work on next?');
+$sel->open_ok('/page.cgi?id=whats_next.html');
 $sel->title_is('What should I work on next?');
 
 # Check for the existence of rows for each of the tables that we created bugs for
@@ -132,14 +129,11 @@ $sel->is_text_present_ok(
 
 logout($sel);
 
-# Open whats next report as editbugs user and make sure
+# Open whats next report as qa user and make sure
 # private bugs filed by admin user are not visible but
 # others are.
-log_in($sel, $config, 'editbugs');
-$sel->click_ok('header-tools-menu-button');
-$sel->click_ok('link=Reports');
-$sel->title_is('Reporting and Charting Kitchen');
-$sel->click_ok('link=What should I work on next?');
+log_in($sel, $config, 'QA_Selenium_TEST');
+$sel->open_ok('/page.cgi?id=whats_next.html');
 $sel->title_is('What should I work on next?');
 $sel->type_ok('who', $config->{admin_user_login});
 $sel->click_ok('run');
@@ -159,3 +153,12 @@ ok(
 );
 
 logout($sel);
+
+# Open what next report as an unprivileged user and make
+# sure the report is not visible.
+log_in($sel, $config, 'unprivileged');
+$sel->open_ok('/page.cgi?id=whats_next.html');
+$sel->title_is('Authorization Required');
+logout($sel);
+
+done_testing;

--- a/qa/t/1_test_whats_next.t
+++ b/qa/t/1_test_whats_next.t
@@ -1,0 +1,161 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is 'Incompatible With Secondary Licenses', as
+# defined by the Mozilla Public License, v. 2.0.
+
+use strict;
+use warnings;
+use lib qw(lib ../../lib ../../local/lib/perl5);
+
+use Test::More 'no_plan';
+
+use QA::Util;
+
+my ($sel, $config) = get_selenium();
+
+log_in($sel, $config, 'admin');
+
+# S1 bugs assigned to you
+file_bug_in_product($sel, 'Firefox');
+$sel->type_ok('short_desc', 'test bug for s1 bugs assigned to you');
+$sel->select_ok('component',    'General');
+$sel->select_ok('bug_severity', 'S1');
+$sel->select_ok('bug_status',   'ASSIGNED');
+$sel->type_ok('assigned_to', $config->{admin_user_login});
+$sel->click_ok('commit');
+$sel->is_text_present_ok('has been added to the database', 'Bug created');
+
+# sec-crit bugs assigned to you (private bug)
+file_bug_in_product($sel, 'Firefox');
+$sel->type_ok('short_desc', 'test bug for sec-critical bugs assigned to you');
+$sel->select_ok('component', 'General');
+$sel->type_ok('keywords', 'sec-critical');
+$sel->select_ok('bug_status', 'ASSIGNED');
+$sel->type_ok('assigned_to', $config->{admin_user_login});
+$sel->check_ok('//input[@name="groups" and @value="Master"]');
+$sel->click_ok('commit');
+$sel->is_text_present_ok('has been added to the database', 'Bug created');
+
+# Bugs that are needinfo? you and are marked as being tracked against
+# or blocking the current nightly, beta, or release versions.
+file_bug_in_product($sel, 'Firefox');
+$sel->type_ok('short_desc',
+  'test bug for needinfo you tracked against nightly beta release');
+$sel->select_ok('component', 'General');
+$sel->click_ok('//input[@value="Set bug flags"]');
+$sel->select_ok('cf_tracking_firefox111', 'blocking');
+$sel->type_ok('needinfo_from', $config->{admin_user_login});
+$sel->click_ok('commit');
+$sel->is_text_present_ok('has been added to the database', 'Bug created');
+
+# S2 bugs assigned to you
+file_bug_in_product($sel, 'Firefox');
+$sel->type_ok('short_desc', 'test bug for s2 bugs assigned to you');
+$sel->select_ok('component',    'General');
+$sel->select_ok('bug_severity', 'S2');
+$sel->select_ok('bug_status',   'ASSIGNED');
+$sel->type_ok('assigned_to', $config->{admin_user_login});
+$sel->click_ok('commit');
+$sel->is_text_present_ok('has been added to the database', 'Bug created');
+
+# sec-high bugs assigned to you (private bug)
+file_bug_in_product($sel, 'Firefox');
+$sel->type_ok('short_desc', 'test bug for sec-high bugs assigned to you');
+$sel->select_ok('component', 'General');
+$sel->type_ok('keywords', 'sec-high');
+$sel->select_ok('bug_status', 'ASSIGNED');
+$sel->type_ok('assigned_to', $config->{admin_user_login});
+$sel->check_ok('//input[@name="groups" and @value="Master"]');
+$sel->click_ok('commit');
+$sel->is_text_present_ok('has been added to the database', 'Bug created');
+
+# Regressions
+file_bug_in_product($sel, 'Firefox');
+$sel->type_ok('short_desc', 'test bug for regressions assigned to you');
+$sel->select_ok('component', 'General');
+$sel->type_ok('keywords', 'regression');
+$sel->select_ok('bug_status', 'ASSIGNED');
+$sel->type_ok('assigned_to', $config->{admin_user_login});
+$sel->click_ok('commit');
+$sel->is_text_present_ok('has been added to the database', 'Bug created');
+logout($sel);
+
+# Other needinfos (needinfos for me but not set by me)
+log_in($sel, $config, 'editbugs');
+file_bug_in_product($sel, 'Firefox');
+$sel->type_ok('short_desc', 'test bug for other needinfos not set by you');
+$sel->select_ok('component', 'General');
+$sel->type_ok('needinfo_from', $config->{admin_user_login});
+$sel->click_ok('commit');
+$sel->is_text_present_ok('has been added to the database', 'Bug created');
+logout($sel);
+
+# Open the whats next report as admin
+log_in($sel, $config, 'admin');
+$sel->click_ok('header-tools-menu-button');
+$sel->click_ok('link=Reports');
+$sel->title_is('Reporting and Charting Kitchen');
+$sel->click_ok('link=What should I work on next?');
+$sel->title_is('What should I work on next?');
+
+# Check for the existence of rows for each of the tables that we created bugs for
+$sel->is_text_present_ok(
+  'test bug for s1 bugs assigned to you',
+  'test bug for s1 bugs assigned to you'
+);
+$sel->is_text_present_ok(
+  'test bug for sec-critical bugs assigned to you',
+  'test bug for sec-critical bugs assigned to you'
+);
+$sel->is_text_present_ok(
+  'test bug for needinfo you tracked against nightly beta release',
+  'test bug for needinfo you tracked against nightly beta release'
+);
+$sel->is_text_present_ok(
+  'test bug for s2 bugs assigned to you',
+  'test bug for s2 bugs assigned to you'
+);
+$sel->is_text_present_ok(
+  'test bug for sec-high bugs assigned to you',
+  'test bug for sec-high bugs assigned to you'
+);
+$sel->is_text_present_ok(
+  'test bug for regressions assigned to you',
+  'test bug for regressions assigned to you'
+);
+$sel->is_text_present_ok(
+  'test bug for other needinfos not set by you',
+  'test bug for other needinfos not set by you'
+);
+
+logout($sel);
+
+# Open whats next report as editbugs user and make sure
+# private bugs filed by admin user are not visible but
+# others are.
+log_in($sel, $config, 'editbugs');
+$sel->click_ok('header-tools-menu-button');
+$sel->click_ok('link=Reports');
+$sel->title_is('Reporting and Charting Kitchen');
+$sel->click_ok('link=What should I work on next?');
+$sel->title_is('What should I work on next?');
+$sel->type_ok('who', $config->{admin_user_login});
+$sel->click_ok('run');
+$sel->title_is('What should I work on next?');
+
+$sel->is_text_present_ok(
+  'test bug for s1 bugs assigned to you',
+  'test bug for s1 bugs assigned to you'
+);
+ok(
+  !$sel->is_text_present('test bug for sec-critical bugs assigned to you'),
+  'test bug for sec-critical bugs assigned to you (not present)'
+);
+ok(
+  !$sel->is_text_present('test bug for sec-high bugs assigned to you'),
+  'test bug for sec-high bugs assigned to you (not present)'
+);
+
+logout($sel);

--- a/scripts/generate_bmo_data.pl
+++ b/scripts/generate_bmo_data.pl
@@ -908,6 +908,16 @@ my @keywords = (
     name        => 'checkin-needed-tb',
     description => 'Keyword searched on by the Thunderbird team to use to have your patch checked in, if you cant check it in yourself.'
   },
+  {
+    name        => 'sec-critical',
+    description => 'Exploitable vulnerabilities which can lead to the widespread compromise of many users.',
+  },
+  {
+    name        => 'sec-high',
+    description => 'Obtain confidential data from other sites the user is visiting or the local machine, or '
+    . 'inject data or code into those sites, requiring no more than normal browsing actions. Exploitable web '
+    . 'vulnerabilities that can lead to the targeted compromise of a small number of users.',
+  },
 );
 
 print "creating keywords...\n";
@@ -923,13 +933,23 @@ foreach my $kw (@keywords) {
 print "creating tracking flags...\n";
 my @tracking_flags = (
   {
+    name        => 'cf_status_firefox109',
+    description => 'status-firefox109',
+    sortkey     => 0,
+    type        => 'tracking',
+    enter_bug   => 1,
+    is_active   => 1,
+    values      => ['---', '?', 'affected', 'unaffected', 'fixed', 'wontfix', 'disabled'],
+    products    => ['Firefox'],
+  },
+  {
     name        => 'cf_status_firefox110',
     description => 'status-firefox110',
     sortkey     => 0,
     type        => 'tracking',
-    enter_bug   => 0,
+    enter_bug   => 1,
     is_active   => 1,
-    values      => ['---', '?', 'affected', 'unaffected', 'fixed', 'wontfix'],
+    values      => ['---', '?', 'affected', 'unaffected', 'fixed', 'wontfix', 'disabled'],
     products    => ['Firefox'],
   },
   {
@@ -937,9 +957,19 @@ my @tracking_flags = (
     description => 'status-firefox111',
     sortkey     => 0,
     type        => 'tracking',
-    enter_bug   => 0,
+    enter_bug   => 1,
     is_active   => 1,
-    values      => ['---', '?', 'affected', 'unaffected', 'fixed', 'wontfix'],
+    values      => ['---', '?', 'affected', 'unaffected', 'fixed', 'wontfix', 'disabled'],
+    products    => ['Firefox'],
+  },
+  {
+    name        => 'cf_tracking_firefox109',
+    description => 'tracking-firefox109',
+    sortkey     => 0,
+    type        => 'tracking',
+    enter_bug   => 1,
+    is_active   => 1,
+    values      => ['---', '?', '+', '-', 'blocking'],
     products    => ['Firefox'],
   },
   {
@@ -947,7 +977,7 @@ my @tracking_flags = (
     description => 'tracking-firefox110',
     sortkey     => 0,
     type        => 'tracking',
-    enter_bug   => 0,
+    enter_bug   => 1,
     is_active   => 1,
     values      => ['---', '?', '+', '-', 'blocking'],
     products    => ['Firefox'],
@@ -957,7 +987,7 @@ my @tracking_flags = (
     description => 'tracking-firefox111',
     sortkey     => 0,
     type        => 'tracking',
-    enter_bug   => 0,
+    enter_bug   => 1,
     is_active   => 1,
     values      => ['---', '?', '+', '-', 'blocking'],
     products    => ['Firefox'],
@@ -967,7 +997,7 @@ my @tracking_flags = (
     description => 'status-thunderbird_esr91',
     sortkey     => 0,
     type        => 'tracking',
-    enter_bug   => 0,
+    enter_bug   => 1,
     is_active   => 1,
     values      => ['---', '?', 'affected', 'unaffected', 'fixed', 'wontfix'],
     products    => ['Firefox'],
@@ -977,7 +1007,7 @@ my @tracking_flags = (
     description => 'status-thunderbird_esr102',
     sortkey     => 0,
     type        => 'tracking',
-    enter_bug   => 0,
+    enter_bug   => 1,
     is_active   => 1,
     values      => ['---', '?', 'affected', 'unaffected', 'fixed', 'wontfix'],
     products    => ['Firefox'],

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -1214,6 +1214,10 @@ input[type="radio"]:checked {
   content: '\E871';
 }
 
+#header .link-whats-next .icon::before {
+  content: '\E85D';
+}
+
 #header .dropdown {
   flex: none;
 }

--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -331,6 +331,16 @@
           [% END %]
         </ul>
       </div>
+      [% IF user.login && user.in_group('mozilla-employee-confidential') %]
+        <ul class="links">
+          <li class="link-whats-next">
+            <a href="[% basepath FILTER none %]page.cgi?id=whats_next.html" title="What Should I Work On Next?">
+              <span class="icon" aria-hidden="true"></span>
+              <span class="label">What's Next?</span>
+            </a>
+          </li>
+        </ul>
+      [% END %]
     </nav>
     [% Hook.process("badge") %]
     [% IF user.id %]

--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -336,7 +336,6 @@
           <li class="link-whats-next">
             <a href="[% basepath FILTER none %]page.cgi?id=whats_next.html" title="What Should I Work On Next?">
               <span class="icon" aria-hidden="true"></span>
-              <span class="label">What's Next?</span>
             </a>
           </li>
         </ul>


### PR DESCRIPTION
Follow goals for this PR:
* New report that shows several tables listing what bugs a developer should focus on next according to requirements laid out in https://docs.google.com/document/d/1X3VU0ggVKAFdnUSls3pcwpnrZa_Eb_-5tVj1rRvN1p8/edit#heading=h.8z0sho6pod67
* Report is accessible to users with editbugs or higher from the standard Reports page
* Each table is generated with a custom SQL instead of using Search.pm in order to match specific fields not possible with Search.pm
* The bugs are filtered based on permissions so nothing sensitive can be leaked.
* The report defaults to the current user, but another user can be entered and show their results instead.
* The SQL can be tweaked if we need finer detail or the results are not what is expected.
* There is a new qa/t/1_test_whats_next.t test script that makes sure that the report is working and that unprivileged users cannot see private bugs.

Let me know if you have any more questions. I will also upload this to bugzilla-dev.allizom.org for testing as well.

 Thanks! 