### PR TITLE
Bug 1844801 - Updates charting UI to allow users in special chartpublicgroup to allow setting charts as public

### DIFF
--- a/Bugzilla/Config/GroupSecurity.pm
+++ b/Bugzilla/Config/GroupSecurity.pm
@@ -31,6 +31,14 @@ sub get_param_list {
     },
 
     {
+      name    => 'chartpublicgroup',
+      type    => 's',
+      choices => \&get_all_group_names,
+      default => 'admin',
+      checker => \&check_group
+    },
+
+    {
       name    => 'insidergroup',
       type    => 's',
       choices => \&get_all_group_names,

--- a/chart.cgi
+++ b/chart.cgi
@@ -99,7 +99,7 @@ $user->in_group(Bugzilla->params->{"chartgroup"}) || ThrowUserError(
 );
 
 # Only admins may create public queries
-$user->in_group('admin') || $cgi->delete('public');
+$user->in_group(Bugzilla->params->{chartpublicgroup}) || $cgi->delete('public');
 
 # All these actions relate to chart construction.
 if ($action =~ /^(assemble|add|remove|sum|subscribe|unsubscribe)$/) {

--- a/template/en/default/admin/params/groupsecurity.html.tmpl
+++ b/template/en/default/admin/params/groupsecurity.html.tmpl
@@ -33,6 +33,8 @@
                 "before enabling this for an untrusted population. If left blank, " _
                 "no users will be able to use New Charts.",
 
+  chartpublicgroup => "The name of the group of users who can make their charts publicly viewable.",
+
   insidergroup => "The name of the group of users who can see/change private " _
                   "comments and attachments.",
 

--- a/template/en/default/reports/series.html.tmpl
+++ b/template/en/default/reports/series.html.tmpl
@@ -72,9 +72,7 @@
         <input type="text" size="2" name="frequency"
                value="[% (default.frequency.0 OR 7) FILTER html %]">
         <span style="font-weight: bold;">&nbsp;day(s)</span><br>
-        [%# Change 'admin' here and in Series.pm, or remove the check
-            completely, if you want to change who can make series public. %]
-        [% IF user.in_group('admin') %]
+        [% IF user.in_group(Param('chartpublicgroup')) %]
           <input type="checkbox" name="public"
                  [%+ "checked='checked'" IF default.public.0 %]>
           <span style="font-weight: bold;">Visible to all<br>


### PR DESCRIPTION
Instead of only admin users being able to make a query public, we added a config parameter so any arbitrary group can be used. Now we can add additional users or groups to be able to make queries public. 