### PR TITLE
Bug 1844801 - Updates charting UI to allow users in special chartpublicgroup to allow setting charts as public

### DIFF
--- a/Bugzilla/Series.pm
+++ b/Bugzilla/Series.pm
@@ -160,11 +160,12 @@ sub initFromCGI {
     "query_format"
   );
 
-  $self->{'public'} = $cgi->param('public') ? 1 : 0;
-
-  # Change 'admin' here and in series.html.tmpl, or remove the check
-  # completely, if you want to change who can make series public.
-  $self->{'public'} = 0 unless Bugzilla->user->in_group('admin');
+  if (Bugzilla->user->in_group(Bugzilla->params->{chartpublicgroup})) {
+    $self->{'public'} = $cgi->param('public') ? 1 : 0;
+  }
+  else {
+    $self->{'public'} = 0;
+  }
 }
 
 sub writeToDatabase {


### PR DESCRIPTION
* additional place where the code needed to be changed to allow non-admins to make a chart series publicly viewable.