### PR TITLE
Bug 1847640 - Users cannot clear their needinfo in a bug that's closed, if they lack editbugs

### DIFF
--- a/extensions/MozChangeField/lib/Pre/CommentClosedBugs.pm
+++ b/extensions/MozChangeField/lib/Pre/CommentClosedBugs.pm
@@ -32,6 +32,18 @@ sub evaluate_change {
         || $bug->assigned_to->id eq $user->id
         || ($bug->qa_contact && $bug->qa_contact->id eq $user->id)) ? 1 : 0;
 
+    # If the current user has a needinfo flag requested of them,
+    # then allow commenting
+    foreach my $flag (@{$bug->flags}) {
+      next if $flag->type->name ne 'needinfo';
+      if ( $flag->status eq '?'
+        && $flag->requestee
+        && $flag->requestee->id == $user->id)
+      {
+        $has_role = 1;
+      }
+    }
+
     return {result => PRIVILEGES_REQUIRED_NONE} if $has_role;
 
     return {


### PR DESCRIPTION
* Updates the code that blocks commenting on closed bugs for those without editbugs
* Allow someone who is the needinfo on the bug to comment. 
* Once the comment is made that clears the needinfo, the same user cannot then comment again.