### PR TITLE
Bug 1849069 - Real name change doesn't work if "New email address" is pre-filled with different email by password manager

### DIFF
--- a/template/en/default/account/prefs/account.html.tmpl
+++ b/template/en/default/account/prefs/account.html.tmpl
@@ -107,7 +107,7 @@
           <th align="right">Current password:</th>
           <td>
             <input type="hidden" name="old_login" value="[% user.login FILTER html %]">
-            <input autocomplete="off" type="password" name="old_password" id="old_password">
+            <input autocomplete="current-password" type="password" name="old_password" id="old_password">
             <a href="#" id="forgot-password">I forgot my password</a>
           </td>
         </tr>

--- a/template/en/default/account/prefs/account.html.tmpl
+++ b/template/en/default/account/prefs/account.html.tmpl
@@ -96,7 +96,7 @@
             <tr>
               <th align="right">New email address:</th>
               <td>
-                <input size="35" name="new_login_name" id="new_login_name">
+                <input size="35" name="new_login_name" id="new_login_name" autocomplete="off">
                 [% INCLUDE "mfa/protected.html.tmpl" %]
               </td>
             </tr>
@@ -107,7 +107,7 @@
           <th align="right">Current password:</th>
           <td>
             <input type="hidden" name="old_login" value="[% user.login FILTER html %]">
-            <input autocomplete="current-password" type="password" name="old_password" id="old_password">
+            <input autocomplete="off" type="password" name="old_password" id="old_password">
             <a href="#" id="forgot-password">I forgot my password</a>
           </td>
         </tr>

--- a/userprefs.cgi
+++ b/userprefs.cgi
@@ -129,7 +129,7 @@ sub SaveAccount {
     && Bugzilla->params->{"allowemailchange"}
     && $new_login_name)
   {
-    if ($user->login ne $new_login_name) {
+    if (lc($user->login) ne lc($new_login_name)) {
       $oldpassword || ThrowUserError("old_password_required");
 
       # Block multiple email changes for the same user.


### PR DESCRIPTION
To make it case insensitive like it is the case for login. See https://bugzilla.mozilla.org/show_bug.cgi?id=1849069