### PR TITLE
Bug 1848882 - Add a link to the quick search help from the main header drop down

### DIFF
--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -323,8 +323,12 @@
               <a href="[% basepath FILTER none %]admin.cgi" role="menuitem" tabindex="-1">Administration</a>
             </li>
           [% END %]
+          <li role="separator"></li>
+          <li role="presentation">
+            <a href="[% basepath FILTER html %]page.cgi?id=quicksearch.html" role="menuitem" tabindex="-1">
+              Quick Search Help</a>
+          </li>
           [% IF Param('docs_urlbase') %]
-            <li role="separator"></li>
             <li role="presentation">
               <a href="[% docs_urlbase FILTER html %]" role="menuitem" tabindex="-1">Documentation</a>
             </li>


### PR DESCRIPTION
Adds a new link to the main header drop down that takes user to page where there are quicksearch docs. We used to have these in  a different place and was removed without a new link added.