### PR TITLE
Bug 1861260 - Update the Push extension to add additional status check code in order to restart the pod if an error is occurring

### DIFF
--- a/extensions/Push/lib/Daemon.pm
+++ b/extensions/Push/lib/Daemon.pm
@@ -14,6 +14,8 @@ use warnings;
 use Bugzilla::Constants;
 use Bugzilla::Extension::Push::Push;
 use Bugzilla::Extension::Push::Logger;
+use Bugzilla::Util qw(get_text);
+
 use Carp qw(confess);
 use Daemon::Generic;
 use File::Basename;
@@ -93,6 +95,17 @@ sub gd_run {
   $push->logger->{debug} = $self->{debug};
   $push->is_daemon(1);
   $push->start();
+}
+
+sub gd_check {
+  my $self = shift;
+  my $dbh = Bugzilla->dbh;
+
+  # Get a count of all the push jobs currently in the queue.
+  my $push_count    = $dbh->selectrow_array('SELECT COUNT(*) FROM push');
+  my $backlog_count = $dbh->selectrow_array('SELECT COUNT(*) FROM push_backlog');
+  print get_text('push_queue_depth', {count => $push_count}) . "\n";
+  print get_text('push_queue_backlog_depth', {count => $backlog_count}) . "\n";
 }
 
 1;

--- a/extensions/Push/template/en/default/hook/global/messages-messages.html.tmpl
+++ b/extensions/Push/template/en/default/hook/global/messages-messages.html.tmpl
@@ -13,4 +13,10 @@
 [% ELSIF message_tag == "push_message_deleted" %]
   The message has been deleted.
 
+[% ELSIF message_tag == "push_queue_depth" %]
+  [% count FILTER html %] push jobs in the queue.
+
+[% ELSIF message_tag == "push_queue_backlog_depth" %]
+  [% count FILTER html %] push jobs in the backlog queue.
+
 [% END %]


### PR DESCRIPTION
This adds additional checking code to the Push extension daemon. When running the command with the `check` parameter, instead of just returning a PID as is the default, we also check to make sure the database is up and accessible. In the recent past, the database disappeared and the daemon continued to run and checkout but the log was full of MySQL connection errors. This code change allows for Kubernetes to do a liveness check and restart the POD if the daemon can no longer access the database.