### PR TITLE
Bug 1861888 - Requiring Staff To Use Duo 2FA On Bugzilla

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -308,6 +308,20 @@ sub login {
       $authenticated_user->update();
     }
   }
+  
+  # Require Duo Security as MFA provider if user is in the duo_required_group
+  elsif (!i_am_webservice()
+    && Bugzilla->params->{duo_required_group}
+    && $authenticated_user->in_duo_required_group
+    && $authenticated_user->mfa ne 'duo')
+  {
+    my $on_mfa_page
+      = $script_name eq '/userprefs.cgi' && $cgi->param('tab') eq 'mfa';
+
+    if (!($on_mfa_page || $on_token_page || $do_logout)) {
+      $cgi->base_redirect('userprefs.cgi?tab=mfa');
+    }
+  }
 
   # We must now check to see if an sudo session is in progress.
   # For a session to be in progress, the following must be true:

--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -315,7 +315,7 @@ sub login {
     && Bugzilla->params->{duo_required_group}
     && ($authenticated_user->in_duo_required_group
       && !$authenticated_user->in_duo_excluded_group)
-    && $authenticated_user->mfa ne 'duo'
+    && $authenticated_user->mfa ne 'Duo'
     )
   {
     my $on_mfa_page

--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -310,10 +310,13 @@ sub login {
   }
 
   # Require Duo Security as MFA provider if user is in the duo_required_group
-  elsif (!i_am_webservice()
+  elsif (
+       !i_am_webservice()
     && Bugzilla->params->{duo_required_group}
-    && $authenticated_user->in_duo_required_group
-    && $authenticated_user->mfa ne 'duo')
+    && ($authenticated_user->in_duo_required_group
+      && !$authenticated_user->in_duo_excluded_group)
+    && $authenticated_user->mfa ne 'duo'
+    )
   {
     my $on_mfa_page
       = $script_name eq '/userprefs.cgi' && $cgi->param('tab') eq 'mfa';

--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -301,14 +301,14 @@ sub login {
     }
     else {
       my $dbh = Bugzilla->dbh_main;
-      my $date = $dbh->sql_date_math('NOW()', '+', '?', 'DAY');
+      my $sql_date = $dbh->sql_date_math('NOW()', '+', '?', 'DAY');
       my ($mfa_required_date)
-        = $dbh->selectrow_array("SELECT $date", undef, $grace_period);
+        = $dbh->selectrow_array("SELECT $sql_date", undef, $grace_period);
       $authenticated_user->set_mfa_required_date($mfa_required_date);
       $authenticated_user->update();
     }
   }
-  
+
   # Require Duo Security as MFA provider if user is in the duo_required_group
   elsif (!i_am_webservice()
     && Bugzilla->params->{duo_required_group}

--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -278,9 +278,30 @@ sub login {
       $cgi->base_redirect($redir_url->as_string);
     }
   }
-  elsif (!i_am_webservice()
-    && $authenticated_user->in_mfa_group
-    && !$authenticated_user->mfa)
+
+  # Require Duo Security as MFA provider if user is in the duo_required_group
+  elsif (
+       !i_am_webservice()
+    && Bugzilla->params->{duo_required_group}
+    && ($authenticated_user->in_duo_required_group
+      && !$authenticated_user->in_duo_excluded_group)
+    && $authenticated_user->mfa ne 'Duo'
+    )
+  {
+    my $on_mfa_page
+      = $script_name eq '/userprefs.cgi' && $cgi->param('tab') eq 'mfa';
+
+    if (!($on_mfa_page || $on_token_page || $do_logout)) {
+      $cgi->base_redirect('userprefs.cgi?tab=mfa');
+    }
+  }
+
+  # Next require MFA if grace period has expired
+  elsif (
+       !i_am_webservice()
+    && ($authenticated_user->in_mfa_group || $authenticated_user->mfa_required_date('UTC'))
+    && !$authenticated_user->mfa
+    )
   {
 
     # decide if the user needs a warning or to be blocked.
@@ -300,29 +321,12 @@ sub login {
       }
     }
     else {
-      my $dbh = Bugzilla->dbh_main;
+      my $dbh      = Bugzilla->dbh_main;
       my $sql_date = $dbh->sql_date_math('NOW()', '+', '?', 'DAY');
       my ($mfa_required_date)
         = $dbh->selectrow_array("SELECT $sql_date", undef, $grace_period);
       $authenticated_user->set_mfa_required_date($mfa_required_date);
       $authenticated_user->update();
-    }
-  }
-
-  # Require Duo Security as MFA provider if user is in the duo_required_group
-  elsif (
-       !i_am_webservice()
-    && Bugzilla->params->{duo_required_group}
-    && ($authenticated_user->in_duo_required_group
-      && !$authenticated_user->in_duo_excluded_group)
-    && $authenticated_user->mfa ne 'Duo'
-    )
-  {
-    my $on_mfa_page
-      = $script_name eq '/userprefs.cgi' && $cgi->param('tab') eq 'mfa';
-
-    if (!($on_mfa_page || $on_token_page || $do_logout)) {
-      $cgi->base_redirect('userprefs.cgi?tab=mfa');
     }
   }
 

--- a/Bugzilla/Config/Auth.pm
+++ b/Bugzilla/Config/Auth.pm
@@ -99,14 +99,14 @@ sub get_param_list {
     {name => 'duo_skey', type => 't', default => '',},
     {
       name    => 'duo_required_group',
-      type    => 't',
+      type    => 's',
       default => '',
       choices => \&get_all_group_names,
       checker => \&check_group,
     },
     {
-      name => 'duo_required_excluded_group',
-      type => 't',
+      name    => 'duo_required_excluded_group',
+      type    => 's',
       default => '',
       choices => \&get_all_group_names,
       checker => \&check_group,

--- a/Bugzilla/Config/Auth.pm
+++ b/Bugzilla/Config/Auth.pm
@@ -97,6 +97,20 @@ sub get_param_list {
     {name => 'duo_akey', type => 't', default => '',},
     {name => 'duo_ikey', type => 't', default => '',},
     {name => 'duo_skey', type => 't', default => '',},
+    {
+      name    => 'duo_required_group',
+      type    => 't',
+      default => '',
+      choices => \&get_all_group_names,
+      checker => \&check_group,
+    },
+    {
+      name => 'duo_required_excluded_group',
+      type => 't',
+      default => '',
+      choices => \&get_all_group_names,
+      checker => \&check_group,
+    },
 
     {
       name    => 'mfa_group',

--- a/Bugzilla/User.pm
+++ b/Bugzilla/User.pm
@@ -320,7 +320,9 @@ sub update {
     if ($self->mfa eq 'Duo') {
       $self->set_mfa('');
       $self->set_password('*');
-      my ($mfa_required_date) = Bugzilla->dbh->selectrow_array('SELECT NOW()');
+      my ($mfa_required_date)
+        = $dbh->selectrow_array(
+        "SELECT " . $dbh->sql_date_math('NOW()', '-', '1', 'DAY'));
       $self->set_mfa_required_date($mfa_required_date);
       $self->SUPER::update();
     }

--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -215,7 +215,7 @@ sub suggest {
 sub get {
   my ($self, $params)
     = validate(@_, 'names', 'ids', 'match', 'group_ids', 'groups', 'ldap_emails');
-  my $user = Bugzilla->user;
+  my $api_user = Bugzilla->user;
 
   Bugzilla->switch_to_shadow_db();
 
@@ -229,21 +229,21 @@ sub get {
   my (@user_objects, @faults);
   if ($params->{names}) {
     foreach my $name (@{$params->{names}}) {
-      my $user;
+      my $user_obj;
       # If permissive mode, then we do not kill the whole
       # request if there is an error with user lookup.
       # We store the errors in 'faults' array.
       if ($params->{permissive}) {
         my $old_error_mode = Bugzilla->error_mode;
         Bugzilla->error_mode(ERROR_MODE_DIE);
-        eval { $user = Bugzilla::User->check({name => $name}); };
+        eval { $user_obj = Bugzilla::User->check({name => $name}); };
         Bugzilla->error_mode($old_error_mode);
         if ($@) {
           push @faults, {name => $name, error => true, message => $@->message};
           undef $@;
           next;
         }
-        push @user_objects, $user;
+        push @user_objects, $user_obj;
       }
       else {
         push @user_objects, Bugzilla::User->check({name => $name});
@@ -252,7 +252,7 @@ sub get {
   }
 
   # Allow users in mozilla-employee-confidential to search by ldap_email
-  if ($user->in_group('mozilla-employee-confidential') && $params->{ldap_emails})
+  if ($api_user->in_group('mozilla-employee-confidential') && $params->{ldap_emails})
   {
     foreach my $email (@{$params->{ldap_emails}}) {
       # There could be more than one match per ldap email if the user has multiple accounts
@@ -280,7 +280,7 @@ sub get {
 
   # If the user is not logged in: Return an error if they passed any user ids.
   # Otherwise, return a limited amount of information based on login names.
-  if (!$user->id) {
+  if (!$api_user->id) {
     if ($params->{ids}) {
       ThrowUserError("user_access_by_id_denied");
     }
@@ -307,7 +307,7 @@ sub get {
   # obj_by_ids are only visible to the user if they can see
   # the otheruser, for non visible otheruser throw an error
   foreach my $obj (@$obj_by_ids) {
-    if ($user->can_see_user($obj)) {
+    if ($api_user->can_see_user($obj)) {
       if (!$unique_users{$obj->id}) {
         push(@user_objects, $obj);
         $unique_users{$obj->id} = $obj;
@@ -337,60 +337,60 @@ sub get {
   my $exclude_disabled = $params->{'include_disabled'} ? 0 : 1;
   foreach my $match_string (@{$params->{'match'} || []}) {
     my $matched = Bugzilla::User::match($match_string, $limit, $exclude_disabled);
-    foreach my $user (@$matched) {
-      if (!$unique_users{$user->id}) {
-        push(@user_objects, $user);
-        $unique_users{$user->id} = $user;
+    foreach my $user_obj (@$matched) {
+      if (!$unique_users{$user_obj->id}) {
+        push @user_objects, $user_obj;
+        $unique_users{$user_obj->id} = $user_obj;
       }
     }
   }
 
   my $in_group = $self->_filter_users_by_group(\@user_objects, $params);
-  foreach my $user (@$in_group) {
+  foreach my $user_obj (@$in_group) {
     my $user_info = filter $params,
       {
-      id                 => $self->type('int',      $user->id),
-      real_name          => $self->type('string',   $user->name),
-      nick               => $self->type('string',   $user->nick),
-      name               => $self->type('email',    $user->login),
-      email              => $self->type('email',    $user->email),
-      can_login          => $self->type('boolean',  $user->is_enabled ? 1 : 0),
-      last_seen_date     => $self->type('dateTime', $user->last_seen_date),
-      creation_time      => $self->type('dateTime', $user->creation_ts),
+      id                 => $self->type('int',      $user_obj->id),
+      real_name          => $self->type('string',   $user_obj->name),
+      nick               => $self->type('string',   $user_obj->nick),
+      name               => $self->type('email',    $user_obj->login),
+      email              => $self->type('email',    $user_obj->email),
+      can_login          => $self->type('boolean',  $user_obj->is_enabled ? 1 : 0),
+      last_seen_date     => $self->type('dateTime', $user_obj->last_seen_date),
+      creation_time      => $self->type('dateTime', $user_obj->creation_ts),
       };
 
-    if (Bugzilla->user->in_group('disableusers')) {
+    if ($api_user->in_group('disableusers')) {
       if (filter_wants($params, 'email_enabled')) {
-        $user_info->{email_enabled} = $self->type('boolean', $user->email_enabled);
+        $user_info->{email_enabled} = $self->type('boolean', $user_obj->email_enabled);
       }
       if (filter_wants($params, 'login_denied_text')) {
-        $user_info->{login_denied_text} = $self->type('string', $user->disabledtext);
+        $user_info->{login_denied_text} = $self->type('string', $user_obj->disabledtext);
       }
     }
 
-    if (Bugzilla->user->id == $user->id) {
+    if ($api_user->id == $user_obj->id) {
       if (filter_wants($params, 'saved_searches')) {
         $user_info->{saved_searches}
-          = [map { $self->_query_to_hash($_) } @{$user->queries}];
+          = [map { $self->_query_to_hash($_) } @{$user_obj->queries}];
       }
     }
 
     # If calling user is member of mozilla-employee-confidential,
     # return ldap_email value as well
-    if (Bugzilla->user->in_group('mozilla-employee-confidential')
-      && $user->ldap_email)
+    if ($api_user->in_group('mozilla-employee-confidential')
+      && $user_obj->ldap_email)
     {
-      $user_info->{ldap_email} = $user->ldap_email;
+      $user_info->{ldap_email} = $user_obj->ldap_email;
     }
 
     if (filter_wants($params, 'groups')) {
-      if ( Bugzilla->user->id == $user->id
-        || Bugzilla->user->in_group('mozilla-employee-confidential'))
+      if ( $api_user->id == $user_obj->id
+        || $api_user->in_group('mozilla-employee-confidential'))
       {
-        $user_info->{groups} = [map { $self->_group_to_hash($_) } @{$user->groups}];
+        $user_info->{groups} = [map { $self->_group_to_hash($_) } @{$user_obj->groups}];
       }
       else {
-        $user_info->{groups} = $self->_filter_bless_groups($user->groups);
+        $user_info->{groups} = $self->_filter_bless_groups($user_obj->groups);
       }
     }
 

--- a/Bugzilla/WebService/User.pm
+++ b/Bugzilla/WebService/User.pm
@@ -352,6 +352,14 @@ sub get {
       }
     }
 
+    # If calling user is member of mozilla-employee-confidential,
+    # return ldap_email value as well
+    if (Bugzilla->user->in_group('mozilla-employee-confidential')
+      && $user->ldap_email)
+    {
+      $user_info->{ldap_email} = $user->ldap_email;
+    }
+
     if (filter_wants($params, 'groups')) {
       if ( Bugzilla->user->id == $user->id
         || Bugzilla->user->in_group('mozilla-employee-confidential'))

--- a/qa/t/1_test_duo_requirement.t
+++ b/qa/t/1_test_duo_requirement.t
@@ -175,8 +175,9 @@ $t->put_ok(Bugzilla->localconfig->urlbase
     {'X-Bugzilla-API-Key' => $config->{admin_user_api_key}} => json =>
     $user_update)->status_is(200)->json_has('/users');
 
-# User just removed from duo required must add MFA to theimyr
-# account once they have logged in
+# User just removed from duo required must add MFA
+# to their account once they have logged in
+$sel->open_ok('/enter_bug.cgi', undef, 'Try to enter a new bug');
 $sel->type_ok(
   'Bugzilla_login',
   $config->{duo_user_login},

--- a/qa/t/1_test_duo_requirement.t
+++ b/qa/t/1_test_duo_requirement.t
@@ -234,8 +234,10 @@ log_in($sel, $config, 'admin');
 set_parameters(
   $sel,
   {
-    'User Authentication' =>
-      {'duo_required_group' => undef, 'duo_required_excluded_group' => undef,}
+    'User Authentication' => {
+      'duo_required_group'          => {type => 'select', value => ''},
+      'duo_required_excluded_group' => {type => 'select', value => ''},
+    }
   }
 );
 logout($sel);

--- a/template/en/default/account/prefs/mfa.html.tmpl
+++ b/template/en/default/account/prefs/mfa.html.tmpl
@@ -180,8 +180,11 @@
       [% IF Param("duo_host")  %]
         <button type="button" id="mfa-select-duo">Duo Security</button><br>
         <blockquote>
-          Requires a <a href="https://mana.mozilla.org/wiki/display/SD/DuoSecurity" target="_blank" rel="noopener noreferrer">Duo Security</a>
-          account (required for Mozilla employees).
+          <p>Requires a <a href="https://mana.mozilla.org/wiki/display/SD/DuoSecurity" target="_blank" rel="noopener noreferrer">Duo Security</a>
+          account (required for Mozilla employees).</p>
+          <p>If this account is for automation and Duo 2FA is not appropriate, Please
+          <a href="[% basepath FILTER none %]enter_bug.cgi?product=bugzilla.mozilla.org&component=Administration">file a bug</a>
+          with details of your bot and requirements.</p>
         </blockquote>
       [% END %]
     </div>

--- a/template/en/default/account/prefs/mfa.html.tmpl
+++ b/template/en/default/account/prefs/mfa.html.tmpl
@@ -175,6 +175,8 @@
           <a href="https://support.google.com/accounts/answer/1066447" target="_blank" rel="noopener noreferrer">Google Authenticator</a>
           or <a href="https://freeotp.github.io/" target="_blank" rel="noopener noreferrer">Red Hat FreeOTP</a>),
         </blockquote>
+      [% ELSE %]
+        <p>You are a member of a group that requires Duo Security to be used for your MFA</p>
       [% END %]
 
       [% IF Param("duo_host")  %]

--- a/template/en/default/account/prefs/mfa.html.tmpl
+++ b/template/en/default/account/prefs/mfa.html.tmpl
@@ -183,8 +183,8 @@
           <p>Requires a <a href="https://mana.mozilla.org/wiki/display/SD/DuoSecurity" target="_blank" rel="noopener noreferrer">Duo Security</a>
           account (required for Mozilla employees).</p>
           <p>If this account is for automation and Duo 2FA is not appropriate, Please
-          <a href="[% basepath FILTER none %]enter_bug.cgi?product=bugzilla.mozilla.org&component=Administration">file a bug</a>
-          with details of your bot and requirements.</p>
+          <a href="[% basepath FILTER none %]enter_bug.cgi?product=bugzilla.mozilla.org&component=Administration">
+            file a [% terms.bug %]</a> with details of your bot and requirements.</p>
         </blockquote>
       [% END %]
     </div>

--- a/template/en/default/account/prefs/mfa.html.tmpl
+++ b/template/en/default/account/prefs/mfa.html.tmpl
@@ -61,10 +61,12 @@
     <input type="hidden" name="mfa_action" id="mfa-action" value="disable">
 
     <div class="mfa-buttons">
-      <div>
-        <button type="button" id="mfa-disable">Disable Two-factor Authentication</button>
-        [% INCLUDE "mfa/protected.html.tmpl" %]
-      </div>
+      [% IF user.mfa != 'Duo' || (user.mfa == 'Duo' && !user.in_duo_required_group) %]
+        <div>
+          <button type="button" id="mfa-disable">Disable Two-factor Authentication</button>
+          [% INCLUDE "mfa/protected.html.tmpl" %]
+        </div>
+      [% END %]
       <div>
         <button type="button" id="mfa-recovery">Generate Printable Recovery Codes</button>
         [% INCLUDE "mfa/protected.html.tmpl" %]
@@ -162,22 +164,24 @@
     <input type="hidden" name="mfa" id="mfa">
 
     <div id="mfa-select" class="mfa-buttons">
-      <p>
-        Select the two-factor system you want to use:
-      </p>
+      [% IF !user.in_duo_required_group %]
+        <p>
+          Select the two-factor system you want to use:
+        </p>
 
-      <button type="button" id="mfa-select-totp">Time-based One-Time Password (TOTP)</button><br>
-      <blockquote>
-        Requires a smartphone and a TOTP app (such as
-        <a href="https://support.google.com/accounts/answer/1066447" target="_blank" rel="noopener noreferrer">Google Authenticator</a>
-        or <a href="https://freeotp.github.io/" target="_blank" rel="noopener noreferrer">Red Hat FreeOTP</a>),
-      </blockquote>
+        <button type="button" id="mfa-select-totp">Time-based One-Time Password (TOTP)</button><br>
+        <blockquote>
+          Requires a smartphone and a TOTP app (such as
+          <a href="https://support.google.com/accounts/answer/1066447" target="_blank" rel="noopener noreferrer">Google Authenticator</a>
+          or <a href="https://freeotp.github.io/" target="_blank" rel="noopener noreferrer">Red Hat FreeOTP</a>),
+        </blockquote>
+      [% END %]
 
       [% IF Param("duo_host")  %]
         <button type="button" id="mfa-select-duo">Duo Security</button><br>
         <blockquote>
           Requires a <a href="https://mana.mozilla.org/wiki/display/SD/DuoSecurity" target="_blank" rel="noopener noreferrer">Duo Security</a>
-          account (recommended for Mozilla employees).
+          account (required for Mozilla employees).
         </blockquote>
       [% END %]
     </div>

--- a/template/en/default/admin/params/auth.html.tmpl
+++ b/template/en/default/admin/params/auth.html.tmpl
@@ -175,6 +175,13 @@
     "The 'secret key' for Duo 2FA. This value is provided by your " _
     "Duo Security administrator.",
 
+  duo_required_group =>
+    "Members of this group must use Duo Security as their choice of MFA."
+
+  duo_required_excluded_group =>
+    "Members of this group will not be required to use Duo Security as their " _
+    "choice of MFA. For example, bot accounts."
+
   mfa_group =>
     "Members of this group must enable MFA. If the grace period is set, " _
     "users will receive a warning on every page until end of the grace period. " _

--- a/template/en/default/global/messages.html.tmpl
+++ b/template/en/default/global/messages.html.tmpl
@@ -43,14 +43,12 @@
     canceled.
 
   [% ELSIF message_tag == "account_updated" %]
-    [% IF changed_fields.size
-          + groups_added_to.size + groups_removed_from.size
-          + groups_granted_rights_to_bless.size + groups_denied_rights_to_bless.size %]
+    [% IF changes.keys.size %]
       [% title = "User $loginold updated" %]
       The following changes have been made to the user account
       [%+ loginold FILTER html %]:
       <ul>
-        [% FOREACH field = changed_fields %]
+        [% FOREACH field = changes.keys %]
           <li>
             [% IF    field == 'login_name' %]
               The login is now [% otheruser.login FILTER html %].
@@ -80,35 +78,29 @@
               The user [% otheruser.password_change_required ? "must" : "no longer needs to" %] update their password.
             [% ELSIF field == 'password_change_reason' %]
               The password change reason has been modified.
+            [% ELSIF field == 'groups' %]
+              [% IF changes.groups.0.size %]
+                The account has been removed from the
+                [%+ changes.groups.0.join(', ') FILTER html %]
+                group[% 's' IF changes.groups.0.size > 1 %].
+              [% END %]
+              [% IF changes.groups.1.size %]
+                The account has been added to the
+                [%+ changes.groups.1.join(', ') FILTER html %]
+                group[% 's' IF changes.groups.1.size > 1 %].
+              [% END %]
+            [% ELSIF field == 'bless_groups' %]
+              [% IF changes.bless_groups.0.size %]
+                The account has been denied rights to bless the
+                [%+ changes.bless_groups.0.join(', ') FILTER html %]
+                group[% 's' IF changes.bless_groups.0.size > 1 %].
+              [% END %]
+              [% IF changes.bless_groups.1.size %]
+                The account has been granted rights to bless the
+                [%+ changes.bless_groups.1.join(', ') FILTER html %]
+                group[% 's' IF changes.bless_groups.1.size > 1 %].
+              [% END %]
             [% END %]
-          </li>
-        [% END %]
-        [% IF groups_added_to.size %]
-          <li>
-            The account has been added to the
-            [%+ groups_added_to.join(', ') FILTER html %]
-            group[% 's' IF groups_added_to.size > 1 %].
-          </li>
-        [% END %]
-        [% IF groups_removed_from.size %]
-          <li>
-            The account has been removed from the
-            [%+ groups_removed_from.join(', ') FILTER html %]
-            group[% 's' IF groups_removed_from.size > 1 %].
-          </li>
-        [% END %]
-        [% IF groups_granted_rights_to_bless.size %]
-          <li>
-            The account has been granted rights to bless the
-            [%+ groups_granted_rights_to_bless.join(', ') FILTER html %]
-            group[% 's' IF groups_granted_rights_to_bless.size > 1 %].
-          </li>
-        [% END %]
-        [% IF groups_denied_rights_to_bless.size %]
-          <li>
-            The account has been denied rights to bless the
-            [%+ groups_denied_rights_to_bless.join(', ') FILTER html %]
-            group[% 's' IF groups_denied_rights_to_bless.size > 1 %].
           </li>
         [% END %]
       </ul>

--- a/template/en/default/global/user-error.html.tmpl
+++ b/template/en/default/global/user-error.html.tmpl
@@ -1240,6 +1240,10 @@
     You are already enrolled in two-factor authentication and cannot enroll
     again. To generate a new enrollment, first remove the current one.
 
+  [% ELSIF error == "duo_exclude_only_bots" %]
+    [% title = "Only Bot Accounts Excluded" %]
+    Only Bot related accounts should be excluded from Duo MFA requirement.
+
   [% ELSIF error == "migrate_config_created" %]
     The file <kbd>[% file FILTER html %]</kbd> contains configuration
     variables that must be set before continuing with the migration.
@@ -1888,6 +1892,11 @@
     Logged-out users cannot use the "match" argument to this function
     to access any user information.
 
+  [% ELSIF error == "user_access_by_ldap_denied" %]
+    [% title = "Matching by LDAP email denied" %]
+    Logged-out users cannot use the "ldap_emails" argument to this function
+    to access any user information.
+  
   [% ELSIF error == "user_login_required" %]
     [% title = "Login Name Required" %]
     [% admindocslinks = {'useradmin.html' => 'User administration'} %]

--- a/userprefs.cgi
+++ b/userprefs.cgi
@@ -739,6 +739,8 @@ sub SaveMFAupdate {
     $settings->{api_key_only}->set('on');
     clear_settings_cache(Bugzilla->user->id);
 
+    $user->set_mfa_required_date(''); # Clear requirement date if set
+
     $user->update({keep_session => 1, keep_tokens => 1});
     $dbh->bz_commit_transaction;
   }


### PR DESCRIPTION
* This pull request adds two new config parameters, `duo_required_group` and `duo_required_excluded_group`. 
* Any user that is added to the `duo_required_group` will automatically be redirected to the MFA preferences page if their current MFA is not set to `Duo`.
* There they will be able to configure `Duo` for their account using the standard enrollment procedure.
* If the user account is a member of the `duo_required_excluded_group`, then they will not be redirected to the MFA page and will operate normally.
* Only bot accounts (addresses ending in tld or bugs) should be allowed to be added to the excluded group.
* If a member of the required group is removed from that group, they are logged out, their password is cleared, and their MFA is cleared. They can then reset their password and setup TOTP instead.
* If they were previously not a member and are added, then they are logged out and the next time they log in they, they are redirected to the MFA page if they are not already Duo enrolled. Otherwise the operate normally.