### PR TITLE
Bug 1825961: set approval flags as the revision changer instead of author

### DIFF
--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -631,7 +631,14 @@ sub process_revision_change {
   INFO('If uplift repository we may need to set approval flags');
   if ($revision->repository && $revision->repository->is_uplift_repo()) {
     INFO('Uplift repository detected. Setting attachment approval flags');
-    set_attachment_approval_flags($attachment, $revision);
+
+    # The Bugzilla user for the user who initiated the change should be used to
+    # set the approval flags. This ensures that users who create revisions will
+    # set the flag to `?`, and only approvals from `mozilla-next-drivers` group
+    # members will set the flag to `+` or `-`.
+    my $flag_setter = $changer->bugzilla_user;
+
+    set_attachment_approval_flags($attachment, $revision, $flag_setter);
   }
 
   $attachment->update($timestamp);

--- a/extensions/PhabBugz/lib/Util.pm
+++ b/extensions/PhabBugz/lib/Util.pm
@@ -45,8 +45,8 @@ our @EXPORT = qw(
 
 # Set approval flags on Phabricator revision bug attachments.
 sub set_attachment_approval_flags {
-  my ($attachment, $revision) = @_;
-  my $submitter = $revision->author->bugzilla_user;
+  my ($attachment, $revision, $flag_setter) = @_;
+  my $flag_setter = $revision->author->bugzilla_user;
 
   my $revision_status_flag_map = {
     'abandoned'       => '-',
@@ -90,7 +90,7 @@ sub set_attachment_approval_flags {
     # Set the flag to it's new status. If it already has that status,
     # it will be a non-change. We also need to check to make sure the
     # flag change is allowed.
-    if ($submitter->can_change_flag($flag->type, $flag->status, $status)) {
+    if ($flag_setter->can_change_flag($flag->type, $flag->status, $status)) {
       INFO("Set existing `$approval_flag_name` flag to `$status`.");
       push @old_flags, {id => $flag->id, status => $status};
     }
@@ -108,10 +108,10 @@ sub set_attachment_approval_flags {
   if (!@old_flags && $status ne 'X') {
     my $approval_flag = Bugzilla::FlagType->new({name => $approval_flag_name});
     if ($approval_flag) {
-      if ($submitter->can_change_flag($approval_flag, 'X', $status)) {
+      if ($flag_setter->can_change_flag($approval_flag, 'X', $status)) {
         INFO("Creating new `$approval_flag_name` flag with status `$status`");
         push @new_flags,
-          {setter => $submitter, status => $status, type_id => $approval_flag->id,};
+          {setter => $flag_setter, status => $status, type_id => $approval_flag->id,};
       }
       else {
         INFO(

--- a/extensions/PhabBugz/lib/Util.pm
+++ b/extensions/PhabBugz/lib/Util.pm
@@ -46,7 +46,6 @@ our @EXPORT = qw(
 # Set approval flags on Phabricator revision bug attachments.
 sub set_attachment_approval_flags {
   my ($attachment, $revision, $flag_setter) = @_;
-  my $flag_setter = $revision->author->bugzilla_user;
 
   my $revision_status_flag_map = {
     'abandoned'       => '-',


### PR DESCRIPTION
Add a new positional argument to `set_attachment_approval_flags` that represents the
Bugzilla user making a change to the approval flag status. Use the Bugzilla user of
the revision changer instead of deriving the flag setter from the author of the
revision.
