### PR TITLE
Bug 1870044 -  Red star next to the Type field when viewing bugs

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
@@ -125,8 +125,10 @@ END;
 >
   [% IF label.defined && !no_label %]
     <div class="name">
-      [%~ IF required && !view_only %]
-        <span class="required_star" aria-label="Required Field">*</span>
+      [%# Single-select fields, such as Product or Type, are already selected on the show_bug page,
+        # so it doesn’t make sense to show an asterisk even if it’s a required field. %]
+      [%~ IF required && (mode != "show" || field_type != constants.FIELD_TYPE_SINGLE_SELECT) %]
+        <span class="required_star edit-show" style="display:none" aria-label="Required Field">*</span>
         [% " " %]
       [% END %]
       [%~ IF help.defined %]


### PR DESCRIPTION
Fix https://bugzilla.mozilla.org/show_bug.cgi?id=1870044

What the code comment says. We don’t need the asterisk for Type on the show_bug page.