### PR TITLE
Bug 1870549 - When grabbing the next story id, sometimes it is invalid so we should try to grab the next one up to 5 tries

### DIFF
--- a/extensions/PhabBugz/t/feed-daemon-guts.t
+++ b/extensions/PhabBugz/t/feed-daemon-guts.t
@@ -57,8 +57,17 @@ my @bad_response = (
   ['HTTP error',   mock_useragent_tx("doesn't matter", sub { $_->code(500) })],
   ['invalid JSON', mock_useragent_tx('<xml>foo</xml>')],
   [
-    'JSON containing error code',
-    mock_useragent_tx(encode_json({error_code => 1234}))
+    'JSON containing error code (non-object error)',
+    mock_useragent_tx(
+      encode_json({error_code => 1234, error_info => 'Some random error'})
+    )
+  ],
+  [
+    'JSON containing error code (error)',
+    mock_useragent_tx(encode_json({
+      error_code => 1234,
+      error_info => 'does not identify a valid object in query'
+    }))
   ],
 );
 


### PR DESCRIPTION
This PR updates the subroutine that is used to get the next list of feed stories from Phabricator based on the last successful feed ID stored. It will try the next ID but if it fails with the familiar `does not identify a valid object` then it will increment and try the next ID up to 5 increments. If after 5 then it will just return an empty list like we do currently and an admin will need to step in.