### PR TITLE
Bug 1870891 - Replace native <select> with custom element with search bar

### DIFF
--- a/Bugzilla/Test/Selenium.pm
+++ b/Bugzilla/Test/Selenium.pm
@@ -194,7 +194,7 @@ sub get_text {
 sub selected_label_is {
   my ($self, $id, $label) = @_;
   TRACE("selected_label_is: $id, $label");
-  my $locator = qq{//*[self::select|self::bz-select][\@id="$id"]};
+  my $locator = qq{//*[local-name()="select" or local-name()="bz-select"][\@id="$id"]};
   my $element = $self->find_element($locator);
   if (!$element) {
     $locator =~ s/\@id/\@name/;
@@ -202,7 +202,7 @@ sub selected_label_is {
   }
   my @options;
   try {
-    @options = $self->driver->find_elements($locator . '/*[self::option|self::bz-option]');
+    @options = $self->driver->find_elements($locator . '/*[local-name()="option" or local-name()="bz-option"]');
   };
   foreach my $option (@options) {
     my $text = trim($option->get_text());
@@ -220,7 +220,7 @@ sub get_selected_labels {
   $locator = $self->_fix_locator($locator);
   my @elements;
   try {
-    @elements = $self->driver->find_elements($locator . '/*[self::option|self::bz-option]');
+    @elements = $self->driver->find_elements($locator . '/*[local-name()="option" or local-name()="bz-option"]');
   };
   if (@elements) {
     my @selected;
@@ -239,7 +239,7 @@ sub get_select_options {
   $locator = $self->_fix_locator($locator);
   my @elements;
   try {
-    @elements = $self->driver->find_elements($locator . '/*[self::option|self::bz-option]');
+    @elements = $self->driver->find_elements($locator . '/*[local-name()="option" or local-name()="bz-option"]');
   };
   if (@elements) {
     my @options;
@@ -302,7 +302,7 @@ sub select_ok {
   }
   my @options;
   try {
-    @options = $self->driver->find_elements($locator . '/*[self::option|self::bz-option]');
+    @options = $self->driver->find_elements($locator . '/*[local-name()="option" or local-name()="bz-option"]');
   };
   my ($is_label, $is_value);
   if ($label =~ /^label=(.*)$/) {

--- a/Bugzilla/Test/Selenium.pm
+++ b/Bugzilla/Test/Selenium.pm
@@ -14,6 +14,7 @@ use Mojo::File;
 use Moo;
 use Test2::V0;
 use Test::Selenium::Firefox;
+use Time::HiRes;
 use Try::Tiny;
 
 has 'driver_class' => (is => 'ro', default => 'Test::Selenium::Firefox');
@@ -52,6 +53,7 @@ sub click_ok {
     TRACE("click_ok new locator: $locator");
   }
   $self->driver->click_element_ok($locator, 'xpath', $arg1, $desc);
+  Time::HiRes::sleep(0.5); # FIXME: Delay for slow page performance
 }
 
 sub open_ok {
@@ -337,7 +339,7 @@ sub select_ok {
         # Don’t use `$option->click()` here because it only works for visible
         # elements, doesn’t work for custom elements
         $self->driver->execute_script('arguments[0].click();', $option);
-        sleep(1);
+        Time::HiRes::sleep(0.5); # FIXME: Delay for slow page performance
         ok($option->get_property('selected'), "Set selected: $label");
       }
       else {

--- a/Bugzilla/Test/Selenium.pm
+++ b/Bugzilla/Test/Selenium.pm
@@ -186,7 +186,7 @@ sub get_text {
   $locator = $self->_fix_locator($locator);
   my $element = $self->find_element($locator);
   if ($element) {
-    return $element->get_property('textContent');
+    return trim($element->get_property('textContent'));
   }
   return '';
 }
@@ -228,7 +228,7 @@ sub get_selected_labels {
     my @selected;
     foreach my $element (@elements) {
       next if !$element->is_selected();
-      push @selected, $element->get_property('textContent');
+      push @selected, trim($element->get_property('textContent'));
     }
     return @selected;
   }
@@ -247,7 +247,7 @@ sub get_select_options {
   if (@elements) {
     my @options;
     foreach my $element (@elements) {
-      push @options, $element->get_property('textContent');
+      push @options, trim($element->get_property('textContent'));
     }
     return @options;
   }
@@ -330,11 +330,15 @@ sub select_ok {
         ok(1, "Set selected: $label");
       }
       else {
-        # Don’t use `$option->click()` here because it only works for visible
-        # elements, doesn’t work for custom elements
-        $self->driver->execute_script('arguments[0].click();', $option);
-        sleep(1);
-        ok($option->get_property('selected') ? 1 : 0, "Set selected: $label");
+        if ($option->get_tag_name() eq 'bz-option') {
+          # Don’t use `$option->click()` here because it only works for visible
+          # elements, doesn’t work for custom elements
+          $self->driver->execute_script('arguments[0].click();', $option);
+          sleep(1);
+          ok($option->get_property('selected'), "Set selected: $label");
+        } else {
+          ok($option->click(), "Set selected: $label");
+        }
       }
       return;
     }

--- a/Bugzilla/Test/Selenium.pm
+++ b/Bugzilla/Test/Selenium.pm
@@ -194,7 +194,7 @@ sub get_text {
 sub selected_label_is {
   my ($self, $id, $label) = @_;
   TRACE("selected_label_is: $id, $label");
-  my $locator = qq{//*[local-name()="select" or local-name()="bz-select"][\@id="$id"]};
+  my $locator = qq{//*[self::select|self::bz-select][\@id="$id"]};
   my $element = $self->find_element($locator);
   if (!$element) {
     $locator =~ s/\@id/\@name/;
@@ -202,7 +202,7 @@ sub selected_label_is {
   }
   my @options;
   try {
-    @options = $self->driver->find_elements($locator . '/*[local-name()="option" or local-name()="bz-option"]');
+    @options = $self->driver->find_elements($locator . '/*[self::option|self::bz-option]');
   };
   foreach my $option (@options) {
     my $text = trim($option->get_text());
@@ -220,7 +220,7 @@ sub get_selected_labels {
   $locator = $self->_fix_locator($locator);
   my @elements;
   try {
-    @elements = $self->driver->find_elements($locator . '/*[local-name()="option" or local-name()="bz-option"]');
+    @elements = $self->driver->find_elements($locator . '/*[self::option|self::bz-option]');
   };
   if (@elements) {
     my @selected;
@@ -239,7 +239,7 @@ sub get_select_options {
   $locator = $self->_fix_locator($locator);
   my @elements;
   try {
-    @elements = $self->driver->find_elements($locator . '/*[local-name()="option" or local-name()="bz-option"]');
+    @elements = $self->driver->find_elements($locator . '/*[self::option|self::bz-option]');
   };
   if (@elements) {
     my @options;
@@ -302,7 +302,7 @@ sub select_ok {
   }
   my @options;
   try {
-    @options = $self->driver->find_elements($locator . '/*[local-name()="option" or local-name()="bz-option"]');
+    @options = $self->driver->find_elements($locator . '/*[self::option|self::bz-option]');
   };
   my ($is_label, $is_value);
   if ($label =~ /^label=(.*)$/) {

--- a/Bugzilla/Test/Selenium.pm
+++ b/Bugzilla/Test/Selenium.pm
@@ -202,7 +202,8 @@ sub selected_label_is {
   }
   my @options;
   try {
-    @options = $self->driver->find_elements($locator . '/*[self::option|self::bz-option]');
+    @options = $self->driver->find_elements(
+      $locator . '/*[self::option|self::bz-option]');
   };
   foreach my $option (@options) {
     my $text = trim($option->get_property('textContent'));
@@ -220,7 +221,8 @@ sub get_selected_labels {
   $locator = $self->_fix_locator($locator);
   my @elements;
   try {
-    @elements = $self->driver->find_elements($locator . '/*[self::option|self::bz-option]');
+    @elements = $self->driver->find_elements(
+      $locator . '/*[self::option|self::bz-option]');
   };
   if (@elements) {
     my @selected;
@@ -239,7 +241,8 @@ sub get_select_options {
   $locator = $self->_fix_locator($locator);
   my @elements;
   try {
-    @elements = $self->driver->find_elements($locator . '/*[self::option|self::bz-option]');
+    @elements = $self->driver->find_elements(
+      $locator . '/*[self::option|self::bz-option]');
   };
   if (@elements) {
     my @options;
@@ -302,7 +305,8 @@ sub select_ok {
   }
   my @options;
   try {
-    @options = $self->driver->find_elements($locator . '/*[self::option|self::bz-option]');
+    @options = $self->driver->find_elements(
+      $locator . '/*[self::option|self::bz-option]');
   };
   my ($is_label, $is_value);
   if ($label =~ /^label=(.*)$/) {

--- a/Bugzilla/Test/Selenium.pm
+++ b/Bugzilla/Test/Selenium.pm
@@ -194,7 +194,7 @@ sub get_text {
 sub selected_label_is {
   my ($self, $id, $label) = @_;
   TRACE("selected_label_is: $id, $label");
-  my $locator = qq{//select[\@id="$id"]};
+  my $locator = qq{//*[self::select|self::bz-select][\@id="$id"]};
   my $element = $self->find_element($locator);
   if (!$element) {
     $locator =~ s/\@id/\@name/;
@@ -202,7 +202,7 @@ sub selected_label_is {
   }
   my @options;
   try {
-    @options = $self->driver->find_elements($locator . '/option');
+    @options = $self->driver->find_elements($locator . '/*[self::option|self::bz-option]');
   };
   foreach my $option (@options) {
     my $text = trim($option->get_text());
@@ -220,7 +220,7 @@ sub get_selected_labels {
   $locator = $self->_fix_locator($locator);
   my @elements;
   try {
-    @elements = $self->driver->find_elements($locator . '/option');
+    @elements = $self->driver->find_elements($locator . '/*[self::option|self::bz-option]');
   };
   if (@elements) {
     my @selected;
@@ -239,7 +239,7 @@ sub get_select_options {
   $locator = $self->_fix_locator($locator);
   my @elements;
   try {
-    @elements = $self->driver->find_elements($locator . '/option');
+    @elements = $self->driver->find_elements($locator . '/*[self::option|self::bz-option]');
   };
   if (@elements) {
     my @options;
@@ -302,7 +302,7 @@ sub select_ok {
   }
   my @options;
   try {
-    @options = $self->driver->find_elements($locator . '/option');
+    @options = $self->driver->find_elements($locator . '/*[self::option|self::bz-option]');
   };
   my ($is_label, $is_value);
   if ($label =~ /^label=(.*)$/) {

--- a/Bugzilla/Test/Selenium.pm
+++ b/Bugzilla/Test/Selenium.pm
@@ -186,7 +186,7 @@ sub get_text {
   $locator = $self->_fix_locator($locator);
   my $element = $self->find_element($locator);
   if ($element) {
-    return trim($element->get_property('textContent'));
+    return trim($element->get_text() || $element->get_property('textContent'));
   }
   return '';
 }
@@ -206,7 +206,8 @@ sub selected_label_is {
       $locator . '/*[self::option|self::bz-option]');
   };
   foreach my $option (@options) {
-    my $text = trim($option->get_property('textContent'));
+    my $text
+      = trim($element->get_text() || $option->get_property('textContent'));
     if ($text eq $label && $option->get_property('selected')) {
       ok(1, "Selected label is: $label");
       return;
@@ -228,7 +229,8 @@ sub get_selected_labels {
     my @selected;
     foreach my $element (@elements) {
       next if !$element->is_selected();
-      push @selected, trim($element->get_property('textContent'));
+      push @selected,
+        trim($element->get_text() || $element->get_property('textContent'));
     }
     return @selected;
   }
@@ -247,7 +249,8 @@ sub get_select_options {
   if (@elements) {
     my @options;
     foreach my $element (@elements) {
-      push @options, trim($element->get_property('textContent'));
+      push @options,
+        trim($element->get_text() || $element->get_property('textContent'));
     }
     return @options;
   }

--- a/Bugzilla/Test/Selenium.pm
+++ b/Bugzilla/Test/Selenium.pm
@@ -333,16 +333,15 @@ sub select_ok {
       if ($option->get_property('selected')) {
         ok(1, "Set selected: $label");
       }
+      elsif ($option->get_tag_name() eq 'bz-option') {
+        # Don’t use `$option->click()` here because it only works for visible
+        # elements, doesn’t work for custom elements
+        $self->driver->execute_script('arguments[0].click();', $option);
+        sleep(1);
+        ok($option->get_property('selected'), "Set selected: $label");
+      }
       else {
-        if ($option->get_tag_name() eq 'bz-option') {
-          # Don’t use `$option->click()` here because it only works for visible
-          # elements, doesn’t work for custom elements
-          $self->driver->execute_script('arguments[0].click();', $option);
-          sleep(1);
-          ok($option->get_property('selected'), "Set selected: $label");
-        } else {
-          ok($option->click(), "Set selected: $label");
-        }
+        ok($option->click(), "Set selected: $label");
       }
       return;
     }

--- a/Bugzilla/Test/Selenium.pm
+++ b/Bugzilla/Test/Selenium.pm
@@ -186,7 +186,8 @@ sub get_text {
   $locator = $self->_fix_locator($locator);
   my $element = $self->find_element($locator);
   if ($element) {
-    return trim($element->get_text() || $element->get_property('textContent'));
+    return trim($element->get_text())
+      || trim($element->get_property('textContent'));
   }
   return '';
 }
@@ -206,8 +207,8 @@ sub selected_label_is {
       $locator . '/*[self::option|self::bz-option]');
   };
   foreach my $option (@options) {
-    my $text
-      = trim($element->get_text() || $option->get_property('textContent'));
+    my $text = trim($option->get_text())
+      || trim($option->get_property('textContent'));
     if ($text eq $label && $option->get_property('selected')) {
       ok(1, "Selected label is: $label");
       return;
@@ -229,8 +230,8 @@ sub get_selected_labels {
     my @selected;
     foreach my $element (@elements) {
       next if !$element->is_selected();
-      push @selected,
-        trim($element->get_text() || $element->get_property('textContent'));
+      push @selected, trim($element->get_text())
+        || trim($element->get_property('textContent'));
     }
     return @selected;
   }
@@ -249,8 +250,8 @@ sub get_select_options {
   if (@elements) {
     my @options;
     foreach my $element (@elements) {
-      push @options,
-        trim($element->get_text() || $element->get_property('textContent'));
+      push @options, trim($element->get_text())
+        || trim($element->get_property('textContent'));
     }
     return @options;
   }

--- a/Bugzilla/Test/Selenium.pm
+++ b/Bugzilla/Test/Selenium.pm
@@ -186,7 +186,7 @@ sub get_text {
   $locator = $self->_fix_locator($locator);
   my $element = $self->find_element($locator);
   if ($element) {
-    return $element->get_text();
+    return $element->get_property('textContent');
   }
   return '';
 }
@@ -205,7 +205,7 @@ sub selected_label_is {
     @options = $self->driver->find_elements($locator . '/*[self::option|self::bz-option]');
   };
   foreach my $option (@options) {
-    my $text = trim($option->get_text());
+    my $text = trim($option->get_property('textContent'));
     if ($text eq $label && $option->get_property('selected')) {
       ok(1, "Selected label is: $label");
       return;
@@ -226,7 +226,7 @@ sub get_selected_labels {
     my @selected;
     foreach my $element (@elements) {
       next if !$element->is_selected();
-      push @selected, $element->get_text();
+      push @selected, $element->get_property('textContent');
     }
     return @selected;
   }
@@ -244,7 +244,7 @@ sub get_select_options {
   if (@elements) {
     my @options;
     foreach my $element (@elements) {
-      push @options, $element->get_text();
+      push @options, $element->get_property('textContent');
     }
     return @options;
   }
@@ -314,23 +314,23 @@ sub select_ok {
     $is_value = 1;
   }
   foreach my $option (@options) {
-    my $value;
-    if ($is_label) {
-      $value = $option->get_text();
-    }
-    elsif ($is_value) {
-      $value = $option->get_value();
-    }
-    else {
-      $value = $option->get_text();
-    }
+    my $value
+      = $is_value
+      ? $option->get_value()
+      # Don’t use `$option->get_text()` here because it only works for visible
+      # element, doesn’t work for custom elements
+      : $option->get_property('textContent');
     $value = trim($value);
     if ($value eq $label) {
       if ($option->get_property('selected')) {
         ok(1, "Set selected: $label");
       }
       else {
-        ok($option->click(), "Set selected: $label");
+        # Don’t use `$option->click()` here because it only works for visible
+        # elements, doesn’t work for custom elements
+        $self->driver->execute_script('arguments[0].click();', $option);
+        sleep(1);
+        ok($option->get_property('selected') ? 1 : 0, "Set selected: $label");
       }
       return;
     }

--- a/extensions/BugModal/template/en/default/bug_modal/create.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/create.html.tmpl
@@ -47,7 +47,6 @@
   END;
 
   # expose all the values required in `create.js` through `data` attributes on the `<form>`
-  component_descriptions = [];
   description_templates = [];
   default_bug_types = [];
   default_assignees = [];
@@ -59,7 +58,6 @@
   FOREACH c = product.components;
     NEXT IF NOT c.is_active;
 
-    component_descriptions.push(c.description);
     default_bug_types.push(c.default_bug_type);
     default_assignees.push(c.default_assignee.login);
     default_ccs.push(c.initial_cc.login);
@@ -92,7 +90,6 @@
 
 <form name="changeform" id="create-form" class="enter_bug_form" method="post"
       action="[% basepath FILTER none %]post_bug.cgi" enctype="multipart/form-data"
-      data-component-descriptions="[% json_encode(component_descriptions) FILTER html %]"
       data-description-templates="[% json_encode(description_templates) FILTER html %]"
       data-default-bug-types="[% json_encode(default_bug_types) FILTER html %]"
       data-default-assignees="[% json_encode(default_assignees) FILTER html %]"
@@ -185,12 +182,10 @@
             field_type = constants.FIELD_TYPE_SINGLE_SELECT
             values = product.components
             value = bug.component_
-            select_size = 7
             inline = 1
             no_indent = 1
             required = 1
         %]
-        <div id="component-description"></div>
       </div>
       <div id="component-tip">
         Not sure which component to choose? Use the

--- a/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
@@ -22,6 +22,7 @@
   # prefix: (string) string to prepend to 'name' and 'id' attributes (default: empty)
   # value: (string) visible value (default: bug.$name)
   # values: (array of string) list of value objects (FIELD_TYPE_SINGLE_SELECT and _BUG_URLS only) (default: lazy-load on edit)
+  # select_size: (integer) the size attribute for <select> (FIELD_TYPE_MULTI_SELECT only)
   # inline: (boolean) output field as a table-cell instead of as a stand-alone div (default: false)
   # no_indent: (boolean) don't indent the field (left-padding) (default: false)
   # full_width: (boolean) the field takes up the complete page width (default: false)
@@ -285,16 +286,16 @@ END;
         [% CASE constants.FIELD_TYPE_MULTI_SELECT %]
           [%# multi value select %]
           <input type="hidden" id="[% name FILTER html %]-dirty">
-          <bz-select name="[% name FILTER html %]" id="[% name FILTER html %]" multiple
-                  [% aria_labelledby_html FILTER none %]>
+          <select name="[% name FILTER html %]" id="[% name FILTER html %]" multiple
+                  size="[% select_size || 5 FILTER html %]" [% aria_labelledby_html FILTER none %]>
             [% IF values.defined %]
               [%# not implemented %]
             [% ELSE %]
               [% FOREACH v IN value %]
-                <bz-option value="[% v FILTER html %]" selected>[% v FILTER html %]</bz-option>
+                <option value="[% v FILTER html %]" selected>[% v FILTER html %]</option>
               [% END %]
             [% END %]
-          </bz-select>
+          </select>
 
         [% CASE constants.FIELD_TYPE_FREETEXT %]
           [%# normal input field %]

--- a/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/field.html.tmpl
@@ -22,7 +22,6 @@
   # prefix: (string) string to prepend to 'name' and 'id' attributes (default: empty)
   # value: (string) visible value (default: bug.$name)
   # values: (array of string) list of value objects (FIELD_TYPE_SINGLE_SELECT and _BUG_URLS only) (default: lazy-load on edit)
-  # select_size: (integer) the size attribute for <select> (FIELD_TYPE_SINGLE_SELECT and FIELD_TYPE_MULTI_SELECT only)
   # inline: (boolean) output field as a table-cell instead of as a stand-alone div (default: false)
   # no_indent: (boolean) don't indent the field (left-padding) (default: false)
   # full_width: (boolean) the field takes up the complete page width (default: false)
@@ -90,13 +89,6 @@ ELSIF field_type == constants.FIELD_TYPE_MULTI_SELECT || field_type == constants
   has_value = value.size > 0;
 ELSE;
   has_value = value != "";
-END;
-IF !select_size.defined;
-  IF field_type == constants.FIELD_TYPE_SINGLE_SELECT;
-    select_size = 0;
-  ELSE;
-    select_size = 5;
-  END;
 END;
 # switch to view mode if edit-only and the current user cannot edit
 IF !editable && edit_only;
@@ -271,37 +263,38 @@ END;
             [% END %]
           </div>
           [% ELSE %]
-          <select name="[% name FILTER html %]" id="[% name FILTER html %]"
-                  [% IF select_size > 1 %] size="[% select_size FILTER html %]"[% END %]
+          <bz-select name="[% name FILTER html %]" id="[% name FILTER html %]"
                   [% aria_labelledby_html FILTER none %] [% aria_required FILTER none %]>
             [% IF values.defined %]
               [% FOREACH v IN values %]
                 [% NEXT IF NOT v.is_active AND NOT value.contains(v.name).size %]
                 [% NEXT IF NOT bug.check_can_change_field(name, bug.${field_name}, v.name).allowed %]
-                <option value="[% v.name FILTER html %]"
+                <bz-option value="[% v.name FILTER html %]"
                         id="v[% v.id FILTER html %]_[% name FILTER html %]"
-                        [% " selected" IF value.contains(v.name).size %]
-                >[% v.name FILTER html %]</option>
+                        aria-description="[% v.description || '' FILTER html %]"
+                        [% " selected" IF value.contains(v.name).size %]>
+                  [% v.name FILTER html %]
+                </bz-option>
               [% END %]
             [% ELSE %]
-              <option value="[% value FILTER html %]" selected>[% value FILTER html %]</option>
+              <bz-option value="[% value FILTER html %]" selected>[% value FILTER html %]</bz-option>
             [% END %]
-          </select>
+          </bz-select>
           [% END %]
 
         [% CASE constants.FIELD_TYPE_MULTI_SELECT %]
           [%# multi value select %]
           <input type="hidden" id="[% name FILTER html %]-dirty">
-          <select name="[% name FILTER html %]" id="[% name FILTER html %]" multiple
-                  size="[% select_size FILTER html %]" [% aria_labelledby_html FILTER none %]>
+          <bz-select name="[% name FILTER html %]" id="[% name FILTER html %]" multiple
+                  [% aria_labelledby_html FILTER none %]>
             [% IF values.defined %]
               [%# not implemented %]
             [% ELSE %]
               [% FOREACH v IN value %]
-                <option value="[% v FILTER html %]" selected>[% v FILTER html %]</option>
+                <bz-option value="[% v FILTER html %]" selected>[% v FILTER html %]</bz-option>
               [% END %]
             [% END %]
-          </select>
+          </bz-select>
 
         [% CASE constants.FIELD_TYPE_FREETEXT %]
           [%# normal input field %]

--- a/extensions/BugModal/template/en/default/bug_modal/flags.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/flags.html.tmpl
@@ -130,7 +130,7 @@
 
     <td class="flag-value">
       <input type="hidden" id="[% flag_id FILTER html %]-dirty">
-      <select id="[% flag_id FILTER html %]" name="[% flag_id FILTER html %]"
+      <bz-select id="[% flag_id FILTER html %]" name="[% flag_id FILTER html %]"
         title="[% t.description FILTER html %]"
         [% UNLESS (t.is_requestable && user.can_request_flag(t))
                    || user.can_set_flag(t)
@@ -139,22 +139,22 @@
         [% END %]
         class="bug-flag">
         [% IF !f || (user.can_unset_flag(t, f.status) && user.can_request_flag(t)) || f.setter_id == user.id %]
-          <option value="X"></option>
+          <bz-option value="X"></bz-option>
         [% END %]
         [% IF t.is_active %]
           [% IF (!f && t.is_requestable && user.can_request_flag(t)) || (f && (user.can_unset_flag(t, f.status) || f.status == "?")) %]
-            <option value="?" [% "selected" IF f && f.status == "?" %]>?</option>
+            <bz-option value="?" [% "selected" IF f && f.status == "?" %]>?</bz-option>
           [% END %]
           [% IF user.can_set_flag(t) || (f && f.status == "+") %]
-            <option value="+" [% "selected" IF f && f.status == "+" %]>+</option>
+            <bz-option value="+" [% "selected" IF f && f.status == "+" %]>+</bz-option>
           [% END %]
           [% IF user.can_set_flag(t) || (f && f.status == "-") %]
-            <option value="-" [% "selected" IF f && f.status == "-" %]>-</option>
+            <bz-option value="-" [% "selected" IF f && f.status == "-" %]>-</bz-option>
           [% END %]
         [% ELSE %]
-          <option value="[% f.status FILTER html %]" selected>[% f.status FILTER html %]</option>
+          <bz-option value="[% f.status FILTER html %]" selected>[% f.status FILTER html %]</bz-option>
         [% END %]
-      </select>
+      </bz-select>
     </td>
 
     [% IF (t.is_requestable && t.is_requesteeble) || (f && f.requestee) %]

--- a/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
@@ -64,6 +64,7 @@
     "extensions/BugModal/web/comments.js",
     "extensions/ComponentWatching/web/js/overlay.js",
     "js/bugzilla-readable-status-min.js",
+    "js/components/select.js",
     "js/field.js",
     "js/comments.js"
   );

--- a/extensions/BugModal/template/en/default/bug_modal/tracking_flags.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/tracking_flags.html.tmpl
@@ -92,7 +92,7 @@
 [% BLOCK tf_select %]
   [% RETURN UNLESS flag %]
   <input type="hidden" id="[% flag.name FILTER html %]-dirty">
-  <select id="[% flag.name FILTER html %]" name="[% flag.name FILTER html %]">
+  <bz-select id="[% flag.name FILTER html %]" name="[% flag.name FILTER html %]">
     [%
       flag_bug_value = flag.bug_flag(bug_id).value;
       FOREACH value IN flag.values;
@@ -100,12 +100,12 @@
           NEXT IF !value.is_active || !flag.can_set_value(value.name);
         END;
     %]
-        <option value="[% value.name FILTER html %]"
+        <bz-option value="[% value.name FILTER html %]"
           id="v[% value.id FILTER html %]_[% flag.name FILTER html %]"
           [% " selected" IF flag_bug_value == value.name %]
         >
           [% value.name FILTER html %]
-        </option>
+        </bz-option>
     [% END %]
-  </select>
+  </bz-select>
 [% END %]

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -1411,27 +1411,7 @@ a.lightbox-icon.markdown {
 
 #component {
   width: auto !important;
-}
-
-#component-description {
-  overflow: auto;
-  overscroll-behavior: contain;
-  margin: 4px 0;
-  max-height: 150px;
-  font-size: var(--font-size-small);
-  overflow-wrap: anywhere;
-}
-
-#component-description > :first-child {
-  margin-top: 0;
-}
-
-#component-description > :last-child {
-  margin-bottom: 0;
-}
-
-#component-description ul {
-  padding: 0 0 0 16px;
+  min-width: 160px;
 }
 
 #component-tip {

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -619,7 +619,7 @@ $(function() {
     //
 
     // dirty field tracking
-    $('#changeform select').each(function() {
+    $('#changeform bz-select').each(function() {
         var that = $(this);
         var dirty = $('#' + that.attr('id') + '-dirty');
         if (!dirty) return;
@@ -627,15 +627,15 @@ $(function() {
 
         // store the option that had the selected attribute when we
         // initially loaded
-        var value = that.find('option[selected]').map(function() { return this.value; }).toArray();
+        var value = that.find('bz-option[selected]').map(function() { return this.value; }).toArray();
         if (value.length === 0 && !that.attr('multiple'))
-            value = that.find('option:first').map(function() { return this.value; }).toArray();
+            value = that.find('bz-option:first').map(function() { return this.value; }).toArray();
         that.data('preselected', value);
 
         // if the user hasn't touched a field, override the browser's choice
         // with Bugzilla's
         if (!dirty.val())
-            that.val(value);
+            that.val(value[0]);
     });
 
     // edit/save mode button
@@ -702,7 +702,7 @@ $(function() {
                             `);
                         } else {
                             $select.insertAdjacentHTML('beforeend', `
-                              <option value="${name}" ${name === selected ? 'selected' : ''}>${name}</option>
+                              <bz-option value="${name}" ${name === selected ? 'selected' : ''}>${name}</bz-option>
                             `);
                         }
                     }
@@ -1002,7 +1002,7 @@ $(function() {
             other.val(that.val());
         });
 
-    // bug flag value <select>
+    // bug flag value <bz-select>
     $('.bug-flag')
         .change(function(event) {
             var target = $(event.target);
@@ -1018,7 +1018,7 @@ $(function() {
         });
 
     // tracking flags
-    $('.tracking-flags select')
+    $('.tracking-flags bz-select')
         .change(function(event) {
             tracking_flag_change(event.target);
         });
@@ -1133,7 +1133,7 @@ $(function() {
         });
 
     // show "save changes" button if there are any immediately editable elements
-    if ($('.module select:visible').length || $('.module input:visible').length) {
+    if ($('.module bz-select:visible').length || $('.module input:visible').length) {
         $('#top-save-btn').show();
     }
 
@@ -1400,7 +1400,7 @@ $(function() {
                     el.empty();
                     var selected = el.data('preselect');
                     $(value).each(function(i, v) {
-                        el.append($('<option>', { value: v.name, text: v.name }));
+                        el.append($('<bz-option>', { value: v.name, text: v.name }));
                         if (typeof selected === 'undefined' && v.selected)
                             selected = v.name;
                     });

--- a/extensions/BugModal/web/create.js
+++ b/extensions/BugModal/web/create.js
@@ -3,14 +3,11 @@
 window.addEventListener('DOMContentLoaded', () => {
   const $form = document.querySelector('#create-form');
   const $toggleAdvanced = document.querySelector('#toggle-advanced');
-  const $componentDescription = document.querySelector('#component-description');
   const $defaultCcField = document.querySelector('#field-default-cc');
   const $defaultCcValue = document.querySelector('#field-value-default-cc');
   const $triageOwner = document.querySelector('#triage-owner');
   const $flagRows = document.querySelectorAll('#bug-flags tr, #attachment_flags .bz_flag_type');
 
-  /** @type {string[]} */
-  const componentDescriptions = JSON.parse($form.dataset.componentDescriptions);
   /** @type {string[]} */
   const descriptionTemplates = JSON.parse($form.dataset.descriptionTemplates);
   /** @type {string[]} */
@@ -204,15 +201,11 @@ window.addEventListener('DOMContentLoaded', () => {
     $defaultCcValue.innerHTML = defaultCcs[index] || '<em>None</em>';
     $triageOwner.innerHTML = triageOwners[index] || '<em>None</em>';
 
-    $componentDescription.innerHTML = componentDescriptions[index];
-    $form.component.querySelector('[aria-describedby]')?.removeAttribute('aria-describedby');
-    $form.component.options[index].setAttribute('aria-describedby', 'component-description');
-
     // We show or hide the available flags depending on the selected component.
     $flagRows.forEach(($row) => {
       // Each flag table row should have one flag form select element
       // We get the flag type id from the id attribute of the select.
-      const $select = $row.querySelector('select');
+      const $select = $row.querySelector('select, bz-select');
       const canShow = availableFlags.includes(Number($select.id.split('-')[1]));
       const canSet = $select.options.length > 1;
 
@@ -306,7 +299,7 @@ window.addEventListener('DOMContentLoaded', () => {
       $form.contenttypemethod.checked = true;
       $form.contenttypeselection.selectedIndex = 0;
       $form.contenttypeentry.value = '';
-      document.querySelectorAll('#attachment_flags select').forEach(($select) => {
+      document.querySelectorAll('#attachment_flags :is(select, bz-select)').forEach(($select) => {
         $select.selectedIndex = 0;
       });
       updatedRequiredFields(false);

--- a/js/components/select.js
+++ b/js/components/select.js
@@ -1,0 +1,1242 @@
+// @ts-check
+
+/**
+ * Implement a `<select>` element alternative that shows a searchbar for easier data input. This
+ * partially implements the {@link HTMLSelectElement} DOM API and the `combobox` WAI-ARIA role.
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement
+ * @see https://w3c.github.io/aria/#combobox
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/combobox/
+ */
+class BzSelectElement extends HTMLElement {
+  /**
+   * Make it the custom element part of the outer form.
+   * @type {boolean}
+   */
+  static formAssociated = true;
+
+  /**
+   * A list of attributes to be captured with {@link attributeChangedCallback}.
+   * @type {string[]}
+   */
+  static get observedAttributes() {
+    return ['name', 'disabled', 'required', 'aria-required', 'aria-invalid', 'aria-errormessage'];
+  }
+
+  /**
+   * Whether to allow selecting multiple options. This component doesn’t support multiple selection,
+   * so the value is fixed with `false`.
+   * @type {boolean}
+   */
+  multiple = false;
+
+  /**
+   * The `type` property. This component doesn’t support multiple selection, so the value is fixed.
+   * @type {string}
+   */
+  type = 'select-one';
+
+  /**
+   * The internal field ID.
+   * @type {string}
+   */
+  #id;
+
+  /**
+   * The internal field label.
+   * @type {string}
+   */
+  #label;
+
+  /**
+   * A reference to the element with the `combobox` role.
+   * @type {HTMLElement}
+   */
+  #combobox;
+
+  /**
+   * A reference to the label element inside the {@link #combobox},
+   * @type {HTMLElement}
+   */
+  #comboboxLabel;
+
+  /**
+   * A reference to the `<dialog>` element that shows the dropdown list.
+   * @type {HTMLDialogElement}
+   */
+  #dialog;
+
+  /**
+   * A reference to the `<input>` element that serves as a searchbar.
+   * @type {HTMLInputElement}
+   */
+  #searchBar;
+
+  /**
+   * A reference to the `<button>` element that clears the {@link #searchBar} value.
+   * @type {HTMLInputElement}
+   */
+  #clearButton;
+
+  /**
+   * A reference to the element with the `listbox` role showing options.
+   * @type {HTMLElement}
+   */
+  #listbox;
+
+  /**
+   * A reference to the element with the no match message.
+   * @type {HTMLElement}
+   */
+  #noMatchMessage;
+
+  /**
+   * A reference to the `<slot>` element.
+   * @type {HTMLSlotElement}
+   */
+  #slot;
+
+  /**
+   * Hold DOM properties to be synced with the HTML attributes.
+   * @type {{ [key: string]: string }}
+   */
+  #props = {};
+
+  /**
+   * The element internals required for form association.
+   * @type {ElementInternals}
+   */
+  #internals;
+
+  /**
+   * Hold the characters typed on the {@link #combobox} to enable a quick value search.
+   * @type {string}
+   */
+  #typeAheadFindChars = '';
+
+  /**
+   * Hold a timeout to reset the {@link #typeAheadFindChars} value.
+   * @type {number}
+   */
+  #typeAheadFindTimer = 0;
+
+  /**
+   * Whether to dispatch the `change` event within {@link #selectedOption}. This has to be changed
+   * to `true` when updating {@link value} or {@link #selectedOption} within an event handler.
+   * @type {boolean}
+   */
+  #canDispatchEvent = false;
+
+  /**
+   * Whether the element is disabled.
+   * @type {boolean}
+   */
+  get disabled() {
+    return this.matches('[disabled]');
+  }
+
+  /**
+   * Enable or disable the element.
+   * @param {boolean} disabled The new state.
+   */
+  set disabled(disabled) {
+    if (disabled) {
+      if (!this.disabled) {
+        this.setAttribute('disabled', 'disabled');
+      }
+    } else {
+      if (this.disabled) {
+        this.removeAttribute('disabled');
+      }
+    }
+
+    this.#combobox.setAttribute('aria-disabled', disabled);
+    this.#combobox.tabIndex = disabled ? -1 : 0;
+  }
+
+  /**
+   * A list of the options.
+   * @type {BzOptionElement[]}
+   */
+  get options() {
+    return [...this.querySelectorAll('bz-option')];
+  }
+
+  /**
+   * Whether the selection is required.
+   * @type {boolean}
+   */
+  get required() {
+    return this.matches('[required]');
+  }
+
+  /**
+   * Enable or disable the selection requirement.
+   * @param {boolean} required The new state.
+   */
+  set required(required) {
+    if (required) {
+      if (!this.required) {
+        this.setAttribute('required', 'required');
+      }
+    } else {
+      if (this.required) {
+        this.removeAttribute('required');
+      }
+    }
+
+    this.#combobox.setAttribute('aria-required', required);
+  }
+
+  /**
+   * The currently selected option’s index.
+   * @type {number}
+   */
+  get selectedIndex() {
+    return this.options.findIndex((option) => option.selected);
+  }
+
+  /**
+   * Select a new option by index.
+   * @param {number} index A new index.
+   */
+  set selectedIndex(index) {
+    this.#selectedOption = this.options[index];
+  }
+
+  /**
+   * A reference to the currently selected option.
+   * @type {BzOptionElement}
+   */
+  get #selectedOption() {
+    return this.options.find((option) => option.selected);
+  }
+
+  /**
+   * Select a new option.
+   * @param {HTMLElement | undefined} newOption A new option to be selected. If
+   * `undefined`, the selection will be cleared.
+   */
+  set #selectedOption(newOption) {
+    const currentOption = this.#selectedOption;
+
+    if (currentOption && currentOption !== newOption) {
+      currentOption.selected = false;
+    }
+
+    if (newOption) {
+      if (!newOption.selected) {
+        newOption.selected = true;
+      }
+
+      this.#comboboxLabel.textContent = newOption.label;
+      this.#internals.setFormValue(newOption.value);
+      this.#comboboxLabel.classList.remove('no-value');
+    } else {
+      this.#comboboxLabel.textContent = 'Select...';
+      this.#comboboxLabel.classList.add('no-value');
+      this.#internals.setFormValue('');
+    }
+
+    if (this.#canDispatchEvent) {
+      this.dispatchEvent(new Event('change'));
+    }
+  }
+
+  /**
+   * A list of currently selected options. It only includes 0 or 1 option because this custom
+   * element doesn’t support multiple selection.
+   * @type {BzOptionElement[]}
+   */
+  get selectedOptions() {
+    return this.options.filter((option) => option.selected);
+  }
+
+  /**
+   * A list of options that are not disabled.
+   * @type {BzOptionElement[]}
+   */
+  get #enabledOptions() {
+    return this.options.filter((option) => option.matches(':not([disabled])'));
+  }
+
+  /**
+   * A list of options that are not disabled or hidden.
+   * @type {BzOptionElement[]}
+   */
+  get #availableOptions() {
+    return this.options.filter((option) => option.matches(':not([disabled], [hidden])'));
+  }
+
+  /**
+   * A reference to the currently active option.
+   * @type {BzOptionElement | undefined}
+   */
+  get #activeOption() {
+    return this.options.find((option) => option.matches('.active'));
+  }
+
+  /**
+   * Make a new option active.
+   * @param {BzOptionElement | undefined} newOption A new option to be an active descendant of the
+   * listbox, or `undefined` to reset the active state.
+   */
+  set #activeOption(newOption) {
+    const currentOption = this.#activeOption;
+
+    if (newOption) {
+      if (currentOption) {
+        currentOption.classList.remove('active');
+
+        if (currentOption.id === `${this.#id}-active-option`) {
+          currentOption.removeAttribute('id');
+        }
+      }
+
+      newOption.id ||= `${this.#id}-active-option`;
+      newOption.classList.add('active');
+      newOption.scrollIntoView();
+      this.#combobox.setAttribute('aria-activedescendant', newOption.id);
+    } else {
+      this.#combobox.removeAttribute('aria-activedescendant');
+    }
+  }
+
+  /**
+   * The currently selected option’s value, or an empty string if no option is selected.
+   * @type {string}
+   */
+  get value() {
+    return this.#selectedOption?.value || '';
+  }
+
+  /**
+   * Select a new option by value.
+   * @param {string} value
+   */
+  set value(value) {
+    this.#selectedOption = this.options.find((option) => option.value === value);
+  }
+
+  /**
+   * Initialize a new `BzSelectElement` instance.
+   */
+  constructor() {
+    super();
+
+    this.#internals = this.attachInternals();
+    this.#id = `select-${Math.random().toString(36).split('.')[1]}`;
+  }
+
+  /**
+   * Called when the element is added to the document. Initialize the internals including the shadow
+   * DOM and event handers.
+   */
+  connectedCallback() {
+    this.#label =
+      (this.hasAttribute('aria-labelledby')
+        ? document
+            .getElementById(this.getAttribute('aria-labelledby'))
+            ?.textContent?.trim()
+            .replace(/:$/, '')
+        : this.getAttribute('aria-label')) || this.getAttribute('name');
+
+    this.attachShadow({ mode: 'open' }).innerHTML = `
+      <style>
+        :host {
+          display: inline-block;
+          min-width: 80px;
+          max-width: 240px;
+          white-space: nowrap;
+          -webkit-user-select: none;
+          user-select: none;
+        }
+
+        :host([disabled]) * {
+          opacity: 0.5;
+          pointer-events: none;
+        }
+
+        [role="combobox"] {
+          display: flex;
+          align-items: center;
+          box-sizing: border-box;
+          outline: 0;
+          border: 1px solid var(--control-border-color);
+          border-radius: var(--control-border-radius);
+          padding: 0 24px 0 8px;
+          width: 100%;
+          height: 28px;
+          color: var(--control-foreground-color);
+          background-color: var(--control-background-color);
+          background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="rgb(90, 91, 92)" d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"/><path fill="none" d="M0 0h24v24H0V0z"/></svg>');
+          background-position: calc(100% - 4px) center;
+          background-repeat: no-repeat;
+          background-size: 16px;
+          cursor: pointer;
+          pointer-events: auto;
+        }
+
+        [role="combobox"] .label {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        [role="combobox"] .label.no-value {
+          font-style: italic;
+        }
+
+        dialog {
+          flex-direction: column;
+          inset: 0 auto auto 0;
+          outline: 0;
+          margin: 0;
+          border: 1px solid var(--control-border-color);
+          border-radius: var(--control-border-radius);
+          padding: 0;
+          width: min-content;
+          max-width: 100%;
+          max-height: 600px;
+          color: var(--menu-foreground-color);
+          background-color: var(--menu-background-color);
+          box-shadow: var(--menu-box-shadow);
+        }
+
+        dialog[open] {
+          display: flex;
+        }
+
+        dialog::backdrop {
+          background: transparent;
+        }
+
+        [role="search"] {
+          flex: none;
+          box-sizing: border-box;
+          outline: 0;
+          margin: 8px;
+          border: 1px solid var(--control-border-color);
+          border-radius: var(--control-border-radius);
+          padding: var(--control-padding);
+          width: calc(100% - 16px);
+          min-width: 80px;
+          color: var(--control-foreground-color);
+          background-color: var(--control-background-color);
+          box-shadow: none;
+          font-family: var(--font-family-sans-serif);
+          font-size: var(--font-size-medium);
+        }
+
+        [role="search"][aria-hidden="true"] {
+          display: none;
+        }
+
+        [role="combobox"]:focus,
+        [role="search"]:focus {
+          border-color: var(--focused-control-border-color);
+        }
+
+        [role="listbox"] {
+          flex: auto;
+          outline: 0;
+          margin: 8px 0;
+          overflow-y: auto;
+          overscroll-behavior: contain;
+        }
+
+        [role="search"][aria-hidden="false"] ~ [role="listbox"] {
+          margin-top: 0;
+        }
+
+        button:not([hidden]) {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          gap: 4px;
+          margin: 0;
+          border-width: 0;
+          border-style: solid;
+          border-color: transparent;
+          padding: 0;
+          color: inherit;
+          background-color: transparent;
+          box-shadow: none;
+          font-family: inherit;
+          font-size: inherit;
+          line-height: inherit;
+          font-weight: normal;
+          text-align: left;
+          white-space: nowrap;
+          cursor: pointer;
+        }
+
+        button.clear {
+          position: absolute;
+          inset: 9px 9px auto auto;
+          border-radius: 4px;
+          width: 28px;
+          height: 28px;
+          font-size: 24px;
+        }
+
+        .no-match {
+          margin: 0 8px;
+        }
+      </style>
+      <div id="${this.#id}-combobox" tabindex="0" role="combobox" aria-readonly="true"
+          aria-autocomplete="list" aria-haspopup="dialog" aria-expanded="false"
+          aria-controls="${this.#id}-dialog">
+        <span class="label no-value">Select...</span>
+      </div>
+      <dialog id="${this.#id}-dialog" aria-label="Select ${this.#label}">
+        <input type="text" role="search" aria-label="Filter ${this.#label} options" />
+        <button type="button" class="clear" aria-label="Clear Filtering" hidden>×</button>
+        <div id="${this.#id}-listbox" role="listbox" aria-label="Available ${this.#label} options">
+          <slot></slot>
+        </div>
+        <div class="no-match" role="status" hidden>
+          <em>No matching options.</em>
+        </div>
+      </dialog>
+    `;
+
+    this.#combobox = this.shadowRoot.querySelector('[role="combobox"]');
+    this.#comboboxLabel = this.#combobox.querySelector('.label');
+    this.#dialog = this.shadowRoot.querySelector('dialog');
+    this.#searchBar = this.shadowRoot.querySelector('[role="search"]');
+    this.#clearButton = this.shadowRoot.querySelector('button.clear');
+    this.#listbox = this.shadowRoot.querySelector('[role="listbox"]');
+    this.#slot = this.shadowRoot.querySelector('slot');
+    this.#noMatchMessage = this.shadowRoot.querySelector('.no-match');
+
+    this.#combobox.addEventListener('click', (event) => this.#onComboboxClick(event));
+    this.#combobox.addEventListener('keydown', (event) => this.#onComboboxKeyDown(event));
+    this.#dialog.addEventListener('click', (event) => this.#onDialogClick(event));
+    this.#dialog.addEventListener('keydown', (event) => this.#onDialogKeyDown(event));
+    this.#dialog.addEventListener('close', () => this.#onDialogClose(event));
+    this.#searchBar.addEventListener('input', () => this.#onSearchbarInput(event));
+    this.#clearButton.addEventListener('click', (event) => this.#onClearButtonClick(event));
+    this.#listbox.addEventListener('mouseover', (event) => this.#onListboxMouseOver(event));
+    this.#slot.addEventListener('slotchange', () => this.#onSlotChange());
+
+    this.#setProps();
+  }
+
+  /**
+   * Called whenever attributes are changed. Sync the values with corresponding properties.
+   * @param {string} name Attribute name.
+   * @param {string} oldValue Old attribute value.
+   * @param {string} value New attribute value.
+   */
+  attributeChangedCallback(name, oldValue, value) {
+    this.#props[name] = value;
+    this.#setProps();
+  }
+
+  /**
+   * Called whenever the {@link #combobox} is clicked. Show the dropdown list.
+   */
+  #onComboboxClick() {
+    this.#showDropdown();
+  }
+
+  /**
+   * Called whenever a key is pressed on the {@link #combobox}. Mimic the native `<select>`
+   * element’s behavior, including arrow key selection and type ahead find.
+   * @param {KeyboardEvent} event `keydown` event.
+   */
+  #onComboboxKeyDown(event) {
+    const { key } = event;
+    /** @type {BzOptionElement | undefined} */
+    let newOption;
+
+    if ([' ', 'ArrowUp', 'ArrowDown'].includes(key)) {
+      event.stopPropagation();
+      this.#showDropdown();
+    } else if (['ArrowRight', 'ArrowLeft'].includes(key)) {
+      event.stopPropagation();
+
+      const selectedOptionIndex = this.#selectedOption
+        ? this.#enabledOptions.findIndex((option) => option === this.#selectedOption)
+        : -1;
+
+      if (key === 'ArrowRight') {
+        const startIndex = this.#selectedOption ? selectedOptionIndex + 1 : 0;
+
+        newOption = this.#enabledOptions.find((_, index) => index >= startIndex);
+      } else {
+        const endIndex = this.#selectedOption
+          ? selectedOptionIndex - 1
+          : this.#enabledOptions.length - 1;
+
+        newOption = this.#enabledOptions.findLast((_, index) => index <= endIndex);
+      }
+    } else if (key.length === 1) {
+      event.stopPropagation();
+
+      if (this.#typeAheadFindChars !== key) {
+        this.#typeAheadFindChars += key;
+      }
+
+      clearTimeout(this.#typeAheadFindTimer);
+
+      this.#typeAheadFindTimer = window.setTimeout(() => {
+        this.#typeAheadFindChars = '';
+      }, 1000);
+
+      const regex = new RegExp(`^${this.#typeAheadFindChars}`, 'i');
+      const startIndex = this.#selectedOption?.label.match(regex)
+        ? this.#enabledOptions.findIndex((option) => option === this.#selectedOption) + 1
+        : 0;
+
+      newOption = this.#enabledOptions.find(
+        (option, index) => index >= startIndex && option.label.match(regex),
+      );
+    }
+
+    if (newOption) {
+      this.#canDispatchEvent = true;
+      this.#selectedOption = newOption;
+      this.#canDispatchEvent = false;
+    }
+  }
+
+  /**
+   * Called whenever the {@link #dialog} is clicked. Hide the dropdown list, and select a new option
+   * if possible.
+   * @param {MouseEvent} event `click` event.
+   */
+  #onDialogClick(event) {
+    const { target } = event;
+
+    if (target === this) {
+      this.#hideDropdown();
+    } else if (target.matches('bz-option:not([disabled])')) {
+      this.#hideDropdown();
+      this.#canDispatchEvent = true;
+      this.value = target.value;
+      this.#canDispatchEvent = false;
+    }
+  }
+
+  /**
+   * Called whenever a key is pressed on the {@link #dialog}. Change the active state when an arrow
+   * key is pressed, or select a new option when the Enter key is pressed.
+   * @param {KeyboardEvent} event `keydown` event.
+   */
+  #onDialogKeyDown(event) {
+    const { key } = event;
+    const options = this.#availableOptions;
+    const currentOption = this.#activeOption;
+    /** @type {BzOptionElement | undefined} */
+    let newActiveOption;
+
+    if (key === 'ArrowDown') {
+      event.preventDefault();
+      newActiveOption = currentOption ? options[options.indexOf(currentOption) + 1] : options[0];
+    }
+
+    if (key === 'ArrowUp') {
+      event.preventDefault();
+      newActiveOption = currentOption
+        ? options[options.indexOf(currentOption) - 1]
+        : options[options.length - 1];
+    }
+
+    if (key === 'Enter') {
+      event.preventDefault();
+      this.#hideDropdown();
+
+      if (currentOption) {
+        this.#canDispatchEvent = true;
+        this.value = currentOption.value;
+        this.#canDispatchEvent = false;
+      }
+    }
+
+    this.#activeOption = newActiveOption;
+  }
+
+  /**
+   * Called whenever the {@link #dialog} is closed with the Escape key. Hide the dropdown list.
+   */
+  #onDialogClose() {
+    this.#hideDropdown();
+  }
+
+  /**
+   * Called whenever a key is pressed on the {@link #searchBar}. Filter the options based on the
+   * input.
+   */
+  #onSearchbarInput() {
+    const value = this.#searchBar.value.trim();
+    const terms = value.split(/\s+/).map((term) => term.toLocaleLowerCase());
+    /** @type {BzOptionElement | undefined} */
+    let newActiveOption;
+
+    this.#enabledOptions.forEach((option) => {
+      if (terms.every((term) => option.label.toLocaleLowerCase().includes(term))) {
+        newActiveOption ??= option;
+        option.removeAttribute('hidden');
+      } else {
+        option.setAttribute('hidden', 'hidden');
+      }
+    });
+
+    const hasAvailableOptions = !!this.#availableOptions.length;
+
+    this.#activeOption = newActiveOption;
+    this.#listbox.hidden = !hasAvailableOptions;
+    this.#noMatchMessage.hidden = hasAvailableOptions;
+    this.#clearButton.hidden = !value;
+  }
+
+  /**
+   * Whenever the {@link #clearButton} is clicked. Clear the filter value.
+   * @param {MouseEvent} event `click` event.
+   */
+  #onClearButtonClick(event) {
+    event.stopPropagation();
+
+    this.#searchBar.value = '';
+    this.#onSearchbarInput();
+  }
+
+  /**
+   * Called whenever the mouse is moved over the {@link #listbox}. the active state if possible.
+   * @param {MouseEvent} event `mouseover` event.
+   */
+  #onListboxMouseOver(event) {
+    if (event.target.matches('bz-option:not([disabled])')) {
+      this.#activeOption = event.target;
+    }
+  }
+
+  /**
+   * Called whenever the slot content is updated. Show or hide the {@link #searchBar} depending on
+   * the number of options.
+   */
+  #onSlotChange() {
+    this.#searchBar.setAttribute('aria-hidden', this.options.length < 10);
+  }
+
+  /**
+   * Sync properties with attributes added to {@link #props}.
+   */
+  #setProps() {
+    if (!this.#combobox) {
+      return;
+    }
+
+    Object.entries(this.#props).forEach(([name, value]) => {
+      if (['name'].includes(name)) {
+        this[name] = value;
+      }
+
+      if (['disabled', 'required'].includes(name)) {
+        this[name] = value !== null;
+      }
+
+      if (name.startsWith('aria-') && value !== null) {
+        this.#combobox.setAttribute(name, value);
+        this.removeAttribute(name);
+      }
+    });
+
+    this.#props = {};
+  }
+
+  /**
+   * Show the dropdown list.
+   */
+  #showDropdown() {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(({ intersectionRect, rootBounds }) => {
+        if (!intersectionRect) {
+          return;
+        }
+
+        const { scrollHeight: contentHeight, scrollWidth: contentWidth } = this.#dialog;
+        const topMargin = intersectionRect.top - 8;
+        const bottomMargin = rootBounds.height - intersectionRect.bottom - 8;
+        let showAtTop = false;
+        let height = 'auto';
+
+        if (contentHeight > bottomMargin) {
+          if (topMargin > bottomMargin) {
+            height = `${Math.min(topMargin, contentHeight)}px`;
+            showAtTop = true;
+          } else {
+            height = `${Math.min(bottomMargin, contentHeight)}px`;
+          }
+        }
+
+        const top = showAtTop ? 'auto' : `${intersectionRect.bottom}px`;
+        const right = 'auto';
+        const bottom = showAtTop ? `${rootBounds.height - intersectionRect.top}px` : 'auto';
+        const left = `${intersectionRect.left}px`;
+
+        this.#dialog.style.inset = [top, right, bottom, left].join(' ');
+        this.#dialog.style.height = height;
+        this.#dialog.style.opacity = 1;
+
+        observer.disconnect();
+      });
+    });
+
+    this.#dialog.style.opacity = 0;
+    this.#dialog.showModal();
+    this.#combobox.setAttribute('aria-expanded', 'true');
+    document.body.style.setProperty('overflow', 'hidden');
+
+    window.requestAnimationFrame(() => {
+      observer.observe(this);
+    });
+
+    const selected = this.#selectedOption;
+
+    if (selected) {
+      selected.classList.add('active');
+      selected.scrollIntoView();
+    }
+  }
+
+  /**
+   * Hide the dropdown list and reset the states.
+   */
+  #hideDropdown() {
+    if (this.#dialog.open) {
+      this.#dialog.close();
+    }
+
+    document.body.style.removeProperty('overflow');
+    this.#dialog.style = '';
+    this.#searchBar.value = '';
+    this.#combobox.setAttribute('aria-expanded', 'false');
+    this.#combobox.removeAttribute('aria-activedescendant');
+
+    this.options.forEach((option) => {
+      option.removeAttribute('hidden');
+      option.classList.remove('active');
+
+      if (option.id === `${this.#id}-active-option`) {
+        option.removeAttribute('id');
+      }
+    });
+  }
+}
+
+/**
+ * Implement an `<option>` alternative that can display a tooltip. This partially implements the
+ * {@link HTMLOptionElement} DOM API and the `option` WAI-ARIA role.
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLOptionElement
+ * @see https://w3c.github.io/aria/#option
+ */
+class BzOptionElement extends HTMLElement {
+  /**
+   * A list of attributes to be captured with {@link attributeChangedCallback}.
+   * @type {string[]}
+   */
+  static get observedAttributes() {
+    return ['class', 'value', 'selected', 'disabled', 'hidden', 'aria-description'];
+  }
+
+  /**
+   * The option’s value.
+   * @type {string}
+   */
+  value = '';
+
+  /**
+   * A reference to the element with the `option` role.
+   * @type {HTMLElement}
+   */
+  #option;
+
+  /**
+   * A reference to the `<slot>` element.
+   * @type {HTMLSlotElement}
+   */
+  #slot;
+
+  /**
+   * A reference to the `<dialog>` element that shows a tooltip.
+   * @type {HTMLDialogElement}
+   */
+  #dialog;
+
+  /**
+   * Hold a timeout to reset the {@link #dialog} opener.
+   * @type {number}
+   */
+  #dialogOpenTimer = 0;
+
+  /**
+   * Hold DOM properties to be synced with the HTML attributes.
+   * @type {{ [key: string]: string }}
+   */
+  #props = {};
+
+  /**
+   * Whether to element is selected by default. Note that the `selected` attribute is not updated
+   * when the selection is updated; it always indicates the default selection.
+   * @type {boolean}
+   */
+  get defaultSelected() {
+    return this.matches('[selected]');
+  }
+
+  /**
+   * Whether the element is disabled.
+   * @type {boolean}
+   */
+  get disabled() {
+    return this.matches('[disabled]');
+  }
+
+  /**
+   * Enable or disable the element.
+   * @param {boolean} disabled The new state.
+   */
+  set disabled(disabled) {
+    if (disabled) {
+      if (!this.disabled) {
+        this.setAttribute('disabled', 'disabled');
+      }
+    } else {
+      if (this.disabled) {
+        this.removeAttribute('disabled');
+      }
+    }
+
+    this.#option.setAttribute('aria-disabled', disabled);
+  }
+
+  /**
+   * Whether the element is hidden.
+   * @type {boolean}
+   */
+  get hidden() {
+    return this.matches('[hidden]');
+  }
+
+  /**
+   * Show or hide the element.
+   * @param {boolean} hidden The new state.
+   */
+  set hidden(hidden) {
+    if (hidden) {
+      if (!this.hidden) {
+        this.setAttribute('hidden', 'hidden');
+      }
+    } else {
+      if (this.hidden) {
+        this.removeAttribute('hidden');
+      }
+    }
+
+    this.#option.setAttribute('aria-hidden', hidden);
+  }
+
+  /**
+   * The position of the option within the parent `<bz-select>` element’s option list.
+   * @type {number}
+   */
+  get index() {
+    return this.closest('bz-select').options.indexOf(this);
+  }
+
+  /**
+   * The option’s displayed label.
+   * @type {string}
+   */
+  get label() {
+    return this.#slot.assignedNodes()[0]?.textContent.trim() ?? '';
+  }
+
+  /**
+   * A reference to the parent `<bz-select>` element.
+   * @type {BzSelectElement}
+   */
+  get #select() {
+    return this.closest('bz-select');
+  }
+
+  /**
+   * Whether the option is currently selected. Note that, as mentioned in the comment for
+   * {@link defaultSelected}, the `selected` attribute cannot be used to determine the selection.
+   * @type {boolean}
+   */
+  get selected() {
+    return this.#option.matches('[aria-selected="true"]');
+  }
+
+  /**
+   * Select or deselect the option.
+   * @param {boolean} selected The new state.
+   */
+  set selected(selected) {
+    if (selected) {
+      if (!this.selected) {
+        this.#option.setAttribute('aria-selected', 'true');
+      }
+
+      if (this.#select.value !== this.value) {
+        this.#select.value = this.value;
+      }
+    } else {
+      if (this.selected) {
+        this.#option.setAttribute('aria-selected', 'false');
+      }
+
+      if (this.#select.value !== '') {
+        this.#select.value = '';
+      }
+    }
+  }
+
+  /**
+   * The option’s displayed label. An alias of {@link label}.
+   * @type {string}
+   */
+  get text() {
+    return this.label;
+  }
+
+  /**
+   * Initialize a new `BzOptionElement` instance.
+   */
+  constructor() {
+    super();
+  }
+
+  /**
+   * Called when the element is added to the document. Initialize the internals including the shadow
+   * DOM and event handers.
+   */
+  connectedCallback() {
+    this.attachShadow({ mode: 'open' }).innerHTML = `
+      <style>
+        :host {
+          display: block;
+          white-space: nowrap;
+          -webkit-user-select: none;
+          user-select: none;
+        }
+
+        :host([hidden]) {
+          display: none;
+        }
+
+        :host([disabled]) * {
+          opacity: 0.5;
+          pointer-events: none;
+        }
+
+        [role="option"] {
+          position: relative;
+          display: flex;
+          align-items: center;
+          padding: 0 16px 0 32px;
+          height: 28px;
+          cursor: pointer;
+        }
+
+        [role="option"][aria-selected="true"] {
+          background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path fill="rgb(170, 171, 172)" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>');
+          background-position: 8px center;
+          background-repeat: no-repeat;
+          background-size: 16px;
+        }
+
+        :host(.active),
+        [role="option"]:hover {
+          background-color: var(--hovered-menuitem-background-color);
+        }
+
+        dialog {
+          position: fixed;
+          outline: 0;
+          margin: 0;
+          border: 1px solid var(--control-border-color);
+          border-radius: var(--control-border-radius);
+          padding: 12px;
+          width: 240px;
+          max-width: 100%;
+          max-height: 100%;
+          color: var(--secondary-label-color);
+          background-color: var(--menu-background-color);
+          box-shadow: var(--menu-box-shadow);
+          font-size: var(--font-size-small);
+          line-height: var(--line-height-comfortable);
+          white-space: normal;
+        }
+
+        dialog :is(p, ul) {
+          margin: 8px 0;
+          padding: 0;
+        }
+
+        dialog li {
+          margin: 4px 0 4px 16px;
+          padding: 0;
+        }
+
+        dialog :first-child {
+          margin-top: 0;
+        }
+
+        dialog :last-child {
+          margin-bottom: 0;
+        }
+      </style>
+      <div role="option" aria-selected="${this.hasAttribute('selected')}">
+        <slot></slot>
+        <dialog role="none">
+          ${
+            // Assume `aria-description` is sanitized
+            this.getAttribute('aria-description') || ''
+          }
+        </dialog>
+      </div>
+    `;
+
+    this.#option = this.shadowRoot.querySelector('[role="option"]');
+    this.#slot = this.shadowRoot.querySelector('slot');
+    this.#dialog = this.shadowRoot.querySelector('dialog');
+
+    this.#slot.addEventListener('slotchange', (event) => this.#onSlotChange(event));
+
+    this.#setProps();
+  }
+
+  /**
+   * Called when attributes are changed. Sync the values with corresponding properties.
+   * @param {string} name Attribute name.
+   * @param {string} oldValue Old attribute value.
+   * @param {string} value New attribute value.
+   */
+  attributeChangedCallback(name, oldValue, value) {
+    this.#props[name] = value;
+    this.#setProps();
+  }
+
+  /**
+   * Scroll the parent `<bz-select>` element to make the option visible.
+   */
+  scrollIntoView() {
+    if (super.scrollIntoViewIfNeeded) {
+      super.scrollIntoViewIfNeeded();
+    } else {
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach(({ intersectionRect, intersectionRatio }) => {
+          if (!intersectionRect) {
+            return;
+          }
+
+          if (intersectionRatio < 1) {
+            super.scrollIntoView(false);
+          }
+
+          observer.disconnect();
+        });
+      });
+
+      observer.observe(this);
+    }
+  }
+
+  /**
+   * Sync properties with attributes added to {@link #props}.
+   */
+  #setProps() {
+    if (!this.#option) {
+      return;
+    }
+
+    Object.entries(this.#props).forEach(([name, value]) => {
+      if (['value'].includes(name)) {
+        this[name] = value;
+      }
+
+      if (['selected', 'disabled', 'hidden'].includes(name)) {
+        this[name] = value !== null;
+      }
+
+      if (name.startsWith('aria-') && value !== null) {
+        this.#option.setAttribute(name, value);
+        this.removeAttribute(name);
+      }
+
+      if (name === 'class') {
+        if (this.#dialog.textContent.trim()) {
+          if (value.match(/\bactive\b/)) {
+            this.#showTooltip();
+          } else {
+            this.#hideTooltip();
+          }
+        }
+      }
+    });
+
+    this.#props = {};
+  }
+
+  /**
+   * Show the tooltip.
+   */
+  #showTooltip() {
+    if (this.#dialog.open) {
+      return;
+    }
+
+    this.#dialogOpenTimer = window.setTimeout(() => {
+      const optionRect = this.getBoundingClientRect();
+
+      // Avoid autofocus with `inert`
+      this.#dialog.inert = true;
+      this.#dialog.style.top = `${optionRect.top + 4}px`;
+      this.#dialog.style.left = `${optionRect.right - 4}px`;
+      this.#dialog.style.opacity = 0;
+      this.#dialog.show();
+      this.#dialog.inert = false;
+
+      // Adjust the position
+      window.requestAnimationFrame(() => {
+        const dialogRect = this.#dialog.getBoundingClientRect();
+        const rootRect = document.body.getBoundingClientRect();
+
+        if (dialogRect.bottom > rootRect.bottom) {
+          this.#dialog.style.top = 'auto';
+          this.#dialog.style.bottom = '4px';
+        }
+
+        this.#dialog.style.opacity = 1;
+      });
+    }, 250);
+  }
+
+  /**
+   * Hide the tooltip.
+   */
+  #hideTooltip() {
+    window.clearTimeout(this.#dialogOpenTimer);
+
+    if (this.#dialog.open) {
+      this.#dialog.close();
+    }
+  }
+
+  /**
+   * Called whenever the slot content is updated. Update the parent `<bz-select>` element’s value if
+   * it’s selected by default.
+   */
+  #onSlotChange() {
+    if (this.defaultSelected) {
+      this.#select.value = this.value;
+    }
+  }
+}
+
+window.customElements.define('bz-select', BzSelectElement);
+window.customElements.define('bz-option', BzOptionElement);

--- a/js/components/select.js
+++ b/js/components/select.js
@@ -356,6 +356,10 @@ class BzSelectElement extends HTMLElement {
           pointer-events: none;
         }
 
+        :host(.attention) [role="combobox"] {
+          border-color: var(--invalid-control-border-color);
+        }
+
         [role="combobox"] {
           display: flex;
           align-items: center;

--- a/qa/t/1_test_bmo_retire_values.t
+++ b/qa/t/1_test_bmo_retire_values.t
@@ -124,7 +124,7 @@ $sel->selected_label_is("component", 'TempComponent');
 file_bug_in_product($sel, "TestProduct");
 ok(
   !$sel->is_element_present(
-    q#//select[@id='component']/option[@value='TempComponent']#),
+    q#//bz-select[@id='component']/bz-option[@value='TempComponent']#),
   'TempComponent is missing from create'
 );
 
@@ -133,7 +133,7 @@ ok(
 go_to_bug($sel, $clean_bug_id);
 ok(
   !$sel->is_element_present(
-    q#//select[@id='component']/option[@value='TempComponent']#),
+    q#//bz-select[@id='component']/bz-option[@value='TempComponent']#),
   'TempComponent is missing from update'
 );
 
@@ -255,7 +255,7 @@ $sel->is_text_present_ok("Changes submitted for bug $bug_id");
 file_bug_in_product($sel, "TestProduct");
 ok(
   !$sel->is_element_present(
-    q#//select[@id='version']/option[@value='TempVersion']#),
+    q#//bz-select[@id='version']/bz-option[@value='TempVersion']#),
   'TempVersion is missing from create'
 );
 
@@ -264,7 +264,7 @@ ok(
 go_to_bug($sel, $clean_bug_id);
 ok(
   !$sel->is_element_present(
-    q#//select[@id='version']/option[@value='TempVersion']#),
+    q#//bz-select[@id='version']/bz-option[@value='TempVersion']#),
   'TempVersion is missing from update'
 );
 
@@ -383,7 +383,7 @@ $sel->selected_label_is("target_milestone", 'TempMilestone');
 file_bug_in_product($sel, "TestProduct");
 ok(
   !$sel->is_element_present(
-    q#//select[@id='target_milestone']/option[@value='TempMilestone']#),
+    q#//bz-select[@id='target_milestone']/bz-option[@value='TempMilestone']#),
   'TempMilestone is missing from create'
 );
 
@@ -392,7 +392,7 @@ ok(
 go_to_bug($sel, $clean_bug_id);
 ok(
   !$sel->is_element_present(
-    q#//select[@id='target_milestone']/option[@value='TempMilestone']#),
+    q#//bz-select[@id='target_milestone']/bz-option[@value='TempMilestone']#),
   'TempMilestone is missing from update'
 );
 

--- a/qa/t/1_test_bug_edit.t
+++ b/qa/t/1_test_bug_edit.t
@@ -69,11 +69,11 @@ $sel->select_ok("op_sys",       "label=Other");
 
 # QA_Selenium_TEST does not have editbugs so we make sure
 # the following fields are not editable
-ok(!$sel->is_element_present('//select[@name="priority"]'),
+ok(!$sel->is_element_present('//bz-select[@name="priority"]'),
   'Priority field not editable');
-ok(!$sel->is_element_present('//select[@name="bug_type"]'),
+ok(!$sel->is_element_present('//bz-select[@name="bug_type"]'),
   'Bug type field not editable');
-ok(!$sel->is_element_present('//select[@name="bug_severity"]'),
+ok(!$sel->is_element_present('//bz-select[@name="bug_severity"]'),
   'Severity field not editable');
 
 $sel->type_ok("bug_file_loc",      "foo.cgi?action=bar");
@@ -230,17 +230,17 @@ log_in($sel, $config, 'unprivileged');
 go_to_bug($sel, $bug1_id);
 $sel->type_ok("comment",
   "I have no privs, I can only comment (and remove myself from the CC list)");
-ok(!$sel->is_element_present('//select[@name="product"]'),
+ok(!$sel->is_element_present('//bz-select[@name="product"]'),
   "Product field not editable");
-ok(!$sel->is_element_present('//select[@name="bug_type"]'),
+ok(!$sel->is_element_present('//bz-select[@name="bug_type"]'),
   "Type field not editable");
-ok(!$sel->is_element_present('//select[@name="bug_severity"]'),
+ok(!$sel->is_element_present('//bz-select[@name="bug_severity"]'),
   "Severity field not editable");
-ok(!$sel->is_element_present('//select[@name="priority"]'),
+ok(!$sel->is_element_present('//bz-select[@name="priority"]'),
   "Priority field not editable");
-ok(!$sel->is_element_present('//select[@name="op_sys"]'),
+ok(!$sel->is_element_present('//bz-select[@name="op_sys"]'),
   "OS field not editable");
-ok(!$sel->is_element_present('//select[@name="rep_platform"]'),
+ok(!$sel->is_element_present('//bz-select[@name="rep_platform"]'),
   "Hardware field not editable");
 $sel->click_ok("cc-summary");
 

--- a/qa/t/1_test_choose_priority.t
+++ b/qa/t/1_test_choose_priority.t
@@ -20,11 +20,11 @@ set_parameters($sel,
   {"Bug Change Policies" => {"letsubmitterchoosepriority-off" => undef}});
 file_bug_in_product($sel, "TestProduct");
 ok(!$sel->is_text_present("Priority"), "The Priority label is not present");
-ok(!$sel->is_element_present("//select[\@name='priority']"),
+ok(!$sel->is_element_present("//bz-select[\@name='priority']"),
   "The Priority drop-down menu is not present");
 set_parameters($sel,
   {"Bug Change Policies" => {"letsubmitterchoosepriority-on" => undef}});
 file_bug_in_product($sel, "TestProduct");
 $sel->is_text_present_ok("Priority");
-$sel->is_element_present_ok("//select[\@name='priority']");
+$sel->is_element_present_ok("//bz-select[\@name='priority']");
 logout($sel);

--- a/qa/t/2_test_flags.t
+++ b/qa/t/2_test_flags.t
@@ -418,7 +418,7 @@ $sel->title_is("Create New Attachment for Bug #$bug1_id");
 $sel->attach_file('//input[@name="data"]', $config->{attachment_file});
 $sel->type_ok('//input[@name="description"]', "patch, v3");
 $sel->click_ok('//input[@name="contenttypemethod" and @value="list"]');
-$sel->select_ok('//bz-select[@name="contenttypeselection"]',
+$sel->select_ok('//select[@name="contenttypeselection"]',
   "label=plain text (text/plain)");
 $sel->select_ok("flag_type-$aflagtype1_id", "label=+");
 $sel->type_ok("comment", "one +, the other one blank");
@@ -485,7 +485,7 @@ $sel->click_ok(
 $sel->wait_for_page_to_load_ok(WAIT_TIME);
 $sel->title_like(qr/^Attachment $attachment2_id Details for Bug $bug1_id/);
 $sel->is_element_present_ok(
-  '//bz-select[@title="attachmentflag2"][@disabled]',
+  '//select[@title="attachmentflag2"][@disabled]',
   "Attachment flags are not editable by a powerless user"
 );
 
@@ -504,7 +504,7 @@ $sel->type_ok('//input[@name="description"]', "patch, v4");
 # canconfirm/editbugs privs are required to edit this flag.
 
 $sel->is_element_present_ok(
-  qq{//bz-select[\@id="flag_type-$aflagtype1_id"][\@disabled]},
+  qq{//select[\@id="flag_type-$aflagtype1_id"][\@disabled]},
   "Flag type non editable by powerless user");
 
 # No privs are required to edit this flag.
@@ -529,7 +529,7 @@ $sel->click_ok(
   "//a[contains(\@href,'/attachment.cgi?id=${attachment3_id}&action=edit')]");
 $sel->wait_for_page_to_load_ok(WAIT_TIME);
 $sel->title_like(qr/^Attachment $attachment3_id Details for Bug $bug1_id/);
-$sel->select_ok('//bz-select[@title="attachmentflag1"]', "label=+");
+$sel->select_ok('//select[@title="attachmentflag1"]', "label=+");
 $sel->click_ok("update");
 $sel->wait_for_page_to_load_ok(WAIT_TIME);
 $sel->is_text_present_ok(

--- a/qa/t/2_test_flags.t
+++ b/qa/t/2_test_flags.t
@@ -248,8 +248,8 @@ $sel->is_text_present_ok('has been added to the database',
 go_to_bug($sel, $bug1_id);
 $sel->is_text_present_ok("SeleniumBugFlag1Test");
 
-# We specify //select or //input, just to be sure. This is not required, though.
-$sel->is_element_present_ok("//select[\@id='flag_type-$flagtype1_id']");
+# We specify //bz-select or //input, just to be sure. This is not required, though.
+$sel->is_element_present_ok("//bz-select[\@id='flag_type-$flagtype1_id']");
 $sel->is_element_present_ok("//input[\@id='requestee_type-$flagtype1_id']");
 
 # If fields are of the correct type above, we assume this is still true below.
@@ -283,17 +283,17 @@ go_to_bug($sel, $bug1_id);
 $sel->is_element_present_ok(
   qq{//div[\@id="bug-flags"]/table/tbody/tr/td[\@class="flag-setter"]/div/a[\@data-user-email="$config->{admin_user_login}"]/../../../td[\@class="flag-name"]/*[text()="SeleniumBugFlag1Test"]}
 );
-my $flag1_1_id = $sel->get_attribute('//select[@title="bugflag1"]@id');
+my $flag1_1_id = $sel->get_attribute('//bz-select[@title="bugflag1"]@id');
 $flag1_1_id =~ s/flag-//;
 $sel->is_element_present_ok(
   qq{//div[\@id="bug-flags"]/table/tbody/tr/td[\@class="flag-setter"]/div/a[\@data-user-email="$config->{admin_user_login}"]/../../../td[\@class="flag-name"]/*[text()="SeleniumBugFlag2Test"]}
 );
-my $flag2_1_id = $sel->get_attribute('//select[@title="bugflag2"]@id');
+my $flag2_1_id = $sel->get_attribute('//bz-select[@title="bugflag2"]@id');
 $flag2_1_id =~ s/flag-//;
 $sel->is_element_present_ok(
   qq{//div[\@id="bug-flags"]/table/tbody/tr/td[\@class="flag-setter"]/div/a[\@data-user-email="$config->{admin_user_login}"]/../../../td[\@class="flag-name"]/a[normalize-space(text())="SeleniumBugFlag3Test"]}
 );
-my $flag3_1_id = $sel->get_attribute('//select[@title="bugflag3"]@id');
+my $flag3_1_id = $sel->get_attribute('//bz-select[@title="bugflag3"]@id');
 $flag3_1_id =~ s/flag-//;
 
 $sel->is_text_present_ok("addl. SeleniumBugFlag1Test");
@@ -418,7 +418,7 @@ $sel->title_is("Create New Attachment for Bug #$bug1_id");
 $sel->attach_file('//input[@name="data"]', $config->{attachment_file});
 $sel->type_ok('//input[@name="description"]', "patch, v3");
 $sel->click_ok('//input[@name="contenttypemethod" and @value="list"]');
-$sel->select_ok('//select[@name="contenttypeselection"]',
+$sel->select_ok('//bz-select[@name="contenttypeselection"]',
   "label=plain text (text/plain)");
 $sel->select_ok("flag_type-$aflagtype1_id", "label=+");
 $sel->type_ok("comment", "one +, the other one blank");
@@ -485,7 +485,7 @@ $sel->click_ok(
 $sel->wait_for_page_to_load_ok(WAIT_TIME);
 $sel->title_like(qr/^Attachment $attachment2_id Details for Bug $bug1_id/);
 $sel->is_element_present_ok(
-  '//select[@title="attachmentflag2"][@disabled]',
+  '//bz-select[@title="attachmentflag2"][@disabled]',
   "Attachment flags are not editable by a powerless user"
 );
 
@@ -504,7 +504,7 @@ $sel->type_ok('//input[@name="description"]', "patch, v4");
 # canconfirm/editbugs privs are required to edit this flag.
 
 $sel->is_element_present_ok(
-  qq{//select[\@id="flag_type-$aflagtype1_id"][\@disabled]},
+  qq{//bz-select[\@id="flag_type-$aflagtype1_id"][\@disabled]},
   "Flag type non editable by powerless user");
 
 # No privs are required to edit this flag.
@@ -529,7 +529,7 @@ $sel->click_ok(
   "//a[contains(\@href,'/attachment.cgi?id=${attachment3_id}&action=edit')]");
 $sel->wait_for_page_to_load_ok(WAIT_TIME);
 $sel->title_like(qr/^Attachment $attachment3_id Details for Bug $bug1_id/);
-$sel->select_ok('//select[@title="attachmentflag1"]', "label=+");
+$sel->select_ok('//bz-select[@title="attachmentflag1"]', "label=+");
 $sel->click_ok("update");
 $sel->wait_for_page_to_load_ok(WAIT_TIME);
 $sel->is_text_present_ok(

--- a/qa/t/2_test_flags2.t
+++ b/qa/t/2_test_flags2.t
@@ -172,7 +172,7 @@ $sel->is_element_present_ok(
   qq{//div[\@id="bug-flags"]/table/tbody/tr/td[\@class="flag-setter"]/div/a[\@data-user-email="$config->{admin_user_login}"]/../../../td[\@class="flag-name"]/*[text()="selenium"]}
 );
 my $flag1_id = $sel->get_attribute(
-  '//select[@title="Available in TestProduct and Another Product/c1"]@id');
+  '//bz-select[@title="Available in TestProduct and Another Product/c1"]@id');
 $flag1_id =~ s/flag-//;
 $sel->selected_label_is("flag-$flag1_id", "+");
 $sel->is_element_present_ok(
@@ -221,11 +221,11 @@ file_bug_in_product($sel, 'Another Product');
 $sel->select_ok("component", "label=c2");
 $sel->type_ok("assigned_to", $config->{unprivileged_user_login});
 $sel->is_element_present_ok(
-  qq{//select[\@id="flag_type-$flagtype1_id"][\@disabled]},
+  qq{//bz-select[\@id="flag_type-$flagtype1_id"][\@disabled]},
   "The selenium bug flag type is not editable");
 $sel->select_ok("component", "label=c1");
 $sel->is_element_present_ok(
-  qq{//select[\@id="flag_type-$flagtype1_id"][not(\@disabled)]},
+  qq{//bz-select[\@id="flag_type-$flagtype1_id"][not(\@disabled)]},
   "The selenium bug flag type is now editable");
 $sel->select_ok("flag_type-$flagtype1_id", "label=?");
 $sel->type_ok("requestee_type-$flagtype1_id", $config->{admin_user_login});
@@ -243,7 +243,7 @@ $sel->is_element_present_ok(
   qq{//div[\@id="bug-flags"]/table/tbody/tr/td[\@class="flag-setter"]/div/a[\@data-user-email="$config->{admin_user_login}"]/../../../td[\@class="flag-name"]/*[text()="selenium"]}
 );
 my $flag2_id = $sel->get_attribute(
-  '//select[@title="Available in TestProduct and Another Product/c1"]@id');
+  '//bz-select[@title="Available in TestProduct and Another Product/c1"]@id');
 $flag2_id =~ s/flag-//;
 $sel->selected_label_is("flag-$flag2_id", '?');
 
@@ -325,7 +325,7 @@ $sel->is_text_present_ok("Changes submitted for bug $bug2_id");
 go_to_bug($sel, $bug2_id);
 ok(!$sel->is_element_present("flag-$flag2_id"), "Flag $flag2_id deleted");
 $sel->is_element_present_ok(
-  qq{//select[\@id="flag_type-$flagtype1_id"][\@disabled]},
+  qq{//bz-select[\@id="flag_type-$flagtype1_id"][\@disabled]},
   "Flag type 'selenium' not editable by powerless users"
 );
 ok(!$sel->is_element_present("flag_type-$flagtype2_id"),


### PR DESCRIPTION
[Bug 1870891 - Replace native `<select>` with custom element with search bar](https://bugzilla.mozilla.org/show_bug.cgi?id=1870891)

This PR replaces most of the native `<select>` elements on the enter_bug and show_bug pages with new custom elements. A search bar appears when there are 10 or more options for easier filtering. The component dropdown displays the component description in a popover.

Implementation note: These dropdown lists and popovers are created using `<dialog>` (modal [top layer](https://developer.chrome.com/blog/what-is-the-top-layer)) instead of the [Popover API](https://developer.chrome.com/blog/introducing-popover-api/) (non-modal top layer) because the latter is [not yet enabled](https://bugzilla.mozilla.org/show_bug.cgi?id=1866993) in Firefox other than Nightly. It’s not a problem but just in case some wonder.

<img width="326" alt="image" src="https://github.com/mozilla-bteam/bmo/assets/2929505/1ad807a6-d03a-4316-ad3c-7c6ab060614c">

<img width="730" alt="image" src="https://github.com/mozilla-bteam/bmo/assets/2929505/460a306f-08c8-4570-8131-e3e7b367135f">
