### PR TITLE
no bug - Update Selenium headless Firefox to latest

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -62,7 +62,7 @@ services:
 
   selenium:
     image: selenium/standalone-firefox:102.0.1
-    shm_size: "512m"
+    shm_size: "2gb"
     ports:
       - "59000:5900"
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -61,7 +61,7 @@ services:
     image: ghcr.io/ghcr-library/memcached:latest
 
   selenium:
-    image: selenium/standalone-firefox:3.141.59
+    image: selenium/standalone-firefox:latest
     shm_size: "512m"
     ports:
       - "59000:5900"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -61,7 +61,7 @@ services:
     image: ghcr.io/ghcr-library/memcached:latest
 
   selenium:
-    image: selenium/standalone-firefox:latest
+    image: selenium/standalone-firefox:102.0.1
     shm_size: "512m"
     ports:
       - "59000:5900"


### PR DESCRIPTION
Not sure if this will work but we need to update [selenium/standalone-firefox](https://registry.hub.docker.com/r/selenium/standalone-firefox/tags) to a newer version as per #2157. If `latest` doesn’t work, we could try an older version, maybe Firefox 115 ESR.