### PR TITLE
Bug 1871414 - Update Selenium test suite to use a more recent version of Firefox to support new features

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,13 +24,26 @@ defaults:
 
   build_image: &build_image
     run:
-      name: Build Docker BMO image
+      name: Build Docker BMO Image
       command: |
         docker build \
           --build-arg CI="$CI" \
           --build-arg CIRCLE_SHA1="$CIRCLE_SHA1" \
           --build-arg CIRCLE_BUILD_URL="$CIRCLE_BUILD_URL" \
+          --target base \
           -t bmo .
+
+  build_image: &build_selenium_image
+    run:
+      name: Build Selenium Image
+      command: |
+        docker build \
+          --build-arg CI="$CI" \
+          --build-arg CIRCLE_SHA1="$CIRCLE_SHA1" \
+          --build-arg CIRCLE_BUILD_URL="$CIRCLE_BUILD_URL" \
+          --target test \
+          -t bmo .
+
 
   store_log: &store_log
     store_artifacts:
@@ -181,7 +194,7 @@ jobs:
       - setup_remote_docker
       - checkout
       - *docker_login
-      - *build_image
+      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -202,7 +215,7 @@ jobs:
       - setup_remote_docker
       - checkout
       - *docker_login
-      - *build_image
+      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -223,7 +236,7 @@ jobs:
       - setup_remote_docker
       - checkout
       - *docker_login
-      - *build_image
+      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -244,7 +257,7 @@ jobs:
       - setup_remote_docker
       - checkout
       - *docker_login
-      - *build_image
+      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -265,7 +278,7 @@ jobs:
       - setup_remote_docker
       - checkout
       - *docker_login
-      - *build_image
+      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build the Docker image
-        run: docker build -t bmo .
+        run: docker build -t bmo --target base .
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
       - name: Run sanity tests
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build the Docker image
-        run: docker build -t bmo .
+        run: docker build -t bmo --target base .
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
       - name: Run webservice tests
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build the Docker image
-        run: docker build -t bmo .
+        run: docker build -t bmo --target test .
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
       - name: Run bmo specific tests
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build the Docker image
-        run: docker build -t bmo .
+        run: docker build -t bmo --target test .
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
       - name: Run Selenium tests (1)
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build the Docker image
-        run: docker build -t bmo .
+        run: docker build -t bmo --target test .
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
       - name: Run Selenium tests (2)
@@ -64,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build the Docker image
-        run: docker build -t bmo .
+        run: docker build -t bmo --target test .
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
       - name: Run Selenium tests (3)
@@ -75,7 +75,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build the Docker image
-        run: docker build -t bmo .
+        run: docker build -t bmo --target test .
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
       - name: Run Selenium tests (4)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build the Docker image
-        run: docker build -t bmo .
+        run: docker build -t bmo --target base .
       - name: Create directory for artifacts
         run: mkdir build_info
       - name: Install docker-compose

--- a/Bugzilla/DaemonControl.pm
+++ b/Bugzilla/DaemonControl.pm
@@ -32,7 +32,7 @@ our @EXPORT_OK = qw(
   run_httpd run_cereal run_jobqueue
   run_cereal_and_httpd run_cereal_and_jobqueue
   catch_signal on_finish on_exception
-  assert_httpd assert_database assert_selenium
+  assert_httpd assert_database
 );
 
 our %EXPORT_TAGS = (
@@ -193,14 +193,6 @@ sub assert_httpd {
   return Future->wait_any($repeat, $timeout);
 }
 
-sub assert_selenium {
-  my ($host, $port) = @_;
-  $host //= 'localhost';
-  $port //= 4444;
-
-  return assert_connect($host, $port, 'assert_selenium');
-}
-
 sub assert_cereal {
   return assert_connect('localhost', $ENV{LOGGING_PORT} // 5880, 'assert_cereal');
 }
@@ -293,7 +285,7 @@ Bugzilla::DaemonControl - Utility functions for controlling daemons
 =head1 DESCRIPTION
 
 This module exports functions that either start daemons (L<run_httpd()>, L<run_cereal()>),
-check for running services (L<assert_httpd()>, L<assert_database()>, L<assert_selenium()>),
+check for running services (L<assert_httpd()>, L<assert_database()>,
 or help build more functions like the above (L<on_exception()>, L<on_finish()>).
 
 The C<run_> and C<assert_> functions return Futures, see L<Future> for details

--- a/Bugzilla/Test/Selenium.pm
+++ b/Bugzilla/Test/Selenium.pm
@@ -13,10 +13,10 @@ use Bugzilla::Util qw(trim);
 use Mojo::File;
 use Moo;
 use Test2::V0;
-use Test::Selenium::Remote::Driver;
+use Test::Selenium::Firefox;
 use Try::Tiny;
 
-has 'driver_class' => (is => 'ro', default => 'Test::Selenium::Remote::Driver');
+has 'driver_class' => (is => 'ro', default => 'Test::Selenium::Firefox');
 has 'driver_args' => (is => 'ro', required => 1,);
 has 'driver'      => (
   is      => 'lazy',

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mozillabteam/bmo-perl-slim:20231024.1
+FROM mozillabteam/bmo-perl-slim:20231024.1 AS base
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -39,3 +39,16 @@ EXPOSE 8000
 
 ENTRYPOINT ["/app/scripts/entrypoint.pl"]
 CMD ["httpd"]
+
+FROM base AS TEST
+
+USER root
+
+RUN apt-get install -y curl firefox-esr lsof
+
+RUN curl -L https://github.com/mozilla/geckodriver/releases/download/v0.33.0/geckodriver-v0.33.0-linux64.tar.gz -o /tmp/geckodriver.tar.gz \
+  && cd /tmp \
+  && tar zxvf geckodriver.tar.gz \
+  && mv geckodriver /usr/bin/geckodriver
+
+USER app

--- a/Dockerfile.bmo-slim
+++ b/Dockerfile.bmo-slim
@@ -6,7 +6,6 @@ RUN apt-get update \
     apt-file \
     build-essential \
     cmake \
-    curl \
     default-libmysqlclient-dev \
     git \
     libcairo-dev \
@@ -45,7 +44,6 @@ RUN cat /app/PACKAGES
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y \
-       curl \
        git \
        graphviz \
        libcap2-bin \

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -30,14 +30,10 @@ services:
       - LOG4PERL_CONFIG_FILE=log4perl-test.conf
       - LOGGING_PORT=5880
       - PORT=8000
-      - TWD_BROWSER=firefox
-      - TWD_HOST=selenium
-      - TWD_PORT=4444
     depends_on:
       - externalapi.test
       - bmo.db
       - memcached
-      - selenium
       - s3
       - gcs
 
@@ -59,12 +55,6 @@ services:
 
   memcached:
     image: ghcr.io/ghcr-library/memcached:latest
-
-  selenium:
-    image: selenium/standalone-firefox:3.141.59
-    shm_size: "512m"
-    ports:
-      - "59000:5900"
 
   s3:
     image: scireum/s3-ninja

--- a/qa/config/selenium_test.conf
+++ b/qa/config/selenium_test.conf
@@ -13,8 +13,6 @@
 
 {   'browser'                           => '*firefox',
     'experimental_browser_launcher'     => '*chrome',
-    'host'                              => 'localhost',
-    'port'                              => 4444,
     'browser_url'                       => 'http://bmo.test',
     'attachment_file'                   => '/app/qa/config/patch.diff',
     'bugzilla_path'                     => '/app',

--- a/qa/t/lib/QA/Util.pm
+++ b/qa/t/lib/QA/Util.pm
@@ -128,13 +128,17 @@ sub get_config {
 sub get_selenium {
   my $chrome_mode = shift;
   my $config      = get_config();
-
+ 
   my $sel = Bugzilla::Test::Selenium->new({
     driver_args => {
-      base_url   => $ENV{BZ_BASE_URL} || $config->{browser_url},
-      browser    => 'firefox',
-      version    => '',
-      javascript => 1
+      browser_name => 'firefox',
+      base_url     => $ENV{BZ_BASE_URL} || $config->{browser_url},
+      javascript   => 1,
+      extra_capabilities => {
+        'moz:firefoxOptions' => {
+          'args' => ['-headless'],
+        }
+      }
     }
   });
 

--- a/scripts/entrypoint.pl
+++ b/scripts/entrypoint.pl
@@ -11,7 +11,7 @@ use Bugzilla::Test::Util qw(create_user);
 use Bugzilla::DaemonControl qw(
   run_cereal_and_httpd
   run_cereal_and_jobqueue
-  assert_httpd assert_database assert_selenium
+  assert_httpd assert_database
   on_finish on_exception
 );
 
@@ -209,7 +209,6 @@ sub cmd_test_bmo {
   check_data_dir();
 
   assert_database()->get;
-  assert_selenium('selenium')->get;
 
   $ENV{BZ_TEST_NEWBIE}      = 'newbie@mozilla.example';
   $ENV{BZ_TEST_NEWBIE_PASS} = 'captain.space.bagel.ROBOT!';

--- a/t/bmo/bounced-emails.t
+++ b/t/bmo/bounced-emails.t
@@ -31,8 +31,6 @@ my @require_env = qw(
   BZ_BASE_URL
   BZ_TEST_NEWBIE
   BZ_TEST_NEWBIE_PASS
-  TWD_HOST
-  TWD_PORT
 );
 
 my @missing_env = grep { !exists $ENV{$_} } @require_env;

--- a/t/bmo/passwords.t
+++ b/t/bmo/passwords.t
@@ -74,8 +74,6 @@ my @require_env = qw(
   BZ_BASE_URL
   BZ_TEST_NEWBIE
   BZ_TEST_NEWBIE_PASS
-  TWD_HOST
-  TWD_PORT
 );
 
 my @missing_env = grep { !exists $ENV{$_} } @require_env;


### PR DESCRIPTION
This allows our tests to use Mozilla Firefox 115.5.0esr instead of the older version in selenium/standalone-firefox 