### PR TITLE
Bug 1873447 - On the new bug form, can't use control-E on Mac to go to the end of fields

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -1265,7 +1265,7 @@ $(function() {
                     if (event.shiftKey)
                         return;
                     // don't conflict with text input shortcut
-                    if (document.activeElement.nodeNode == 'INPUT' || document.activeElement.nodeName == 'TEXTAREA')
+                    if (document.activeElement.matches('input, textarea'))
                         return;
                     if ($('#cancel-btn:visible').length === 0) {
                         event.preventDefault();


### PR DESCRIPTION
[Bug 1873447 - On the new bug form, can't use control-E on Mac to go to the end of fields](https://bugzilla.mozilla.org/show_bug.cgi?id=1873447)

This is not actually a regression but due to a typo in `nodeName`. I’m simply replacing it with modern DOM 🙂 