### PR TITLE
Bug 1873913 - The request information feature no longer autofills the selected person's email into the text box

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -1586,7 +1586,7 @@ $(function() {
     });
 
     // dirty field tracking
-    $('#changeform select')
+    $('#changeform bz-select')
         .change(function() {
             var that = $(this);
             var dirty = $('#' + that.attr('id') + '-dirty');


### PR DESCRIPTION
[Bug 1873913 - The request information feature no longer autofills the selected person's email into the text box](https://bugzilla.mozilla.org/show_bug.cgi?id=1873913)

There are two “dirty field tracking” functions in `bug_modal.js`. I’m not fully understanding what’s happening there, but in #2157 I forgot to update one to match the custom element, and it caused  an error.

> Uncaught TypeError: that.data(...) is undefined at bug_modal.js:1609:47