### PR TITLE
Bug 1873826 - Scrollbar gets hidden when opening dropdown menu

### DIFF
--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -337,6 +337,10 @@
  * Global
  */
 
+html {
+  scrollbar-gutter: stable both-edges;
+}
+
 body {
   font-size: var(--font-size-medium);
   line-height: var(--line-height-default);


### PR DESCRIPTION
[Bug 1873826 - Scrollbar gets hidden when opening dropdown menu](https://bugzilla.mozilla.org/show_bug.cgi?id=1873826)

This PR supersedes #2165 using a CSS-only approach. Tested on my macOS Sonoma + Firefox, and worked nicely.