### PR TITLE
Bug 1874015 - Can no longer open-select-close bugzilla dropdowns in a single drag gesture

### DIFF
--- a/js/components/select.js
+++ b/js/components/select.js
@@ -712,7 +712,7 @@ class BzSelectElement extends HTMLElement {
 
   /**
    * Called whenever the mouse is moved over the {@link #listbox}. Update the active state if the
-   * the target is an option.
+   * target is an option.
    * @param {MouseEvent} event `mouseover` event.
    */
   #onListboxMouseOver(event) {

--- a/js/components/select.js
+++ b/js/components/select.js
@@ -609,7 +609,9 @@ class BzSelectElement extends HTMLElement {
   }
 
   /**
-   * Called whenever the {@link #dialog} is clicked. Hide the dropdown list.
+   * Called whenever the {@link #dialog} is clicked. Hide the dropdown list, and select a new option
+   * if possible. Usually {@link #onListboxMouseUp} handles selection, but the code is needed to
+   * pass the Selenium tests using `click` events.
    * @param {MouseEvent} event `click` event.
    */
   #onDialogClick(event) {
@@ -617,6 +619,11 @@ class BzSelectElement extends HTMLElement {
 
     if (target === this) {
       this.#hideDropdown();
+    } else if (target.matches('bz-option:not([disabled])')) {
+      this.#hideDropdown();
+      this.#canDispatchEvent = true;
+      this.value = target.value;
+      this.#canDispatchEvent = false;
     }
   }
 

--- a/js/components/select.js
+++ b/js/components/select.js
@@ -513,7 +513,7 @@ class BzSelectElement extends HTMLElement {
     this.#slot = this.shadowRoot.querySelector('slot');
     this.#noMatchMessage = this.shadowRoot.querySelector('.no-match');
 
-    this.#combobox.addEventListener('click', (event) => this.#onComboboxClick(event));
+    this.#combobox.addEventListener('mousedown', (event) => this.#onComboboxMouseDown(event));
     this.#combobox.addEventListener('keydown', (event) => this.#onComboboxKeyDown(event));
     this.#dialog.addEventListener('click', (event) => this.#onDialogClick(event));
     this.#dialog.addEventListener('keydown', (event) => this.#onDialogKeyDown(event));
@@ -521,6 +521,7 @@ class BzSelectElement extends HTMLElement {
     this.#searchBar.addEventListener('input', () => this.#onSearchbarInput(event));
     this.#clearButton.addEventListener('click', (event) => this.#onClearButtonClick(event));
     this.#listbox.addEventListener('mouseover', (event) => this.#onListboxMouseOver(event));
+    this.#listbox.addEventListener('mouseup', (event) => this.#onListboxMouseUp(event));
     this.#slot.addEventListener('slotchange', () => this.#onSlotChange());
 
     this.#setProps();
@@ -538,9 +539,11 @@ class BzSelectElement extends HTMLElement {
   }
 
   /**
-   * Called whenever the {@link #combobox} is clicked. Show the dropdown list.
+   * Called whenever a mouse button is pressed on the {@link #combobox}. Show the dropdown list.
+   * @param {MouseEvent} event `mousedown` event.
    */
-  #onComboboxClick() {
+  #onComboboxMouseDown(event) {
+    event.preventDefault();
     this.#showDropdown();
   }
 
@@ -606,8 +609,7 @@ class BzSelectElement extends HTMLElement {
   }
 
   /**
-   * Called whenever the {@link #dialog} is clicked. Hide the dropdown list, and select a new option
-   * if possible.
+   * Called whenever the {@link #dialog} is clicked. Hide the dropdown list.
    * @param {MouseEvent} event `click` event.
    */
   #onDialogClick(event) {
@@ -615,11 +617,6 @@ class BzSelectElement extends HTMLElement {
 
     if (target === this) {
       this.#hideDropdown();
-    } else if (target.matches('bz-option:not([disabled])')) {
-      this.#hideDropdown();
-      this.#canDispatchEvent = true;
-      this.value = target.value;
-      this.#canDispatchEvent = false;
     }
   }
 
@@ -707,12 +704,32 @@ class BzSelectElement extends HTMLElement {
   }
 
   /**
-   * Called whenever the mouse is moved over the {@link #listbox}. the active state if possible.
+   * Called whenever the mouse is moved over the {@link #listbox}. Update the active state if the
+   * the target is an option.
    * @param {MouseEvent} event `mouseover` event.
    */
   #onListboxMouseOver(event) {
-    if (event.target.matches('bz-option:not([disabled])')) {
-      this.#activeOption = event.target;
+    const { target } = event;
+
+    if (target.matches('bz-option:not([disabled])')) {
+      this.#activeOption = target;
+    }
+  }
+
+  /**
+   * Called whenever a mouse button is released on the {@link #listbox}. Select a new option if the
+   * target is an option.
+   * @param {MouseEvent} event `mouseup` event.
+   */
+  #onListboxMouseUp(event) {
+    const { target } = event;
+
+    if (target.matches('bz-option:not([disabled])')) {
+      event.preventDefault();
+      this.#hideDropdown();
+      this.#canDispatchEvent = true;
+      this.value = target.value;
+      this.#canDispatchEvent = false;
     }
   }
 


### PR DESCRIPTION
[Bug 1874015 - Can no longer open-select-close bugzilla dropdowns in a single drag gesture](https://bugzilla.mozilla.org/show_bug.cgi?id=1874015)

This mimics the behaviour of the native `<select>` element, allowing to select an option with mouse down + mouse move + mouse up, not just click + click.