### PR TITLE
Bug 1875961 - Update attachment migration script by adding option to only update the class and not actually copy the data

### DIFF
--- a/Bugzilla/Net/Storage.pm
+++ b/Bugzilla/Net/Storage.pm
@@ -181,7 +181,13 @@ sub _send_request {
 
   if ($response->code =~ /^2\d\d$/) {
     if ($method eq 'GET') {
-      return $response->decoded_content;
+      my $data = $response->decoded_content();
+
+      if (utf8::is_utf8($data)) {
+        utf8::encode($data);
+      }
+
+      return $data;
     }
     else {
       return 1;

--- a/scripts/migrate-attachments.pl
+++ b/scripts/migrate-attachments.pl
@@ -16,16 +16,25 @@ $| = 1;
 use Bugzilla;
 use Bugzilla::Attachment;
 use Bugzilla::Install::Util qw(indicate_progress);
-use Getopt::Long qw(GetOptions);
+use Getopt::Long            qw(GetOptions);
 
 my @storage_names = Bugzilla::Attachment->get_storage_names();
 
 my %options;
-GetOptions(\%options, 'migrate=s@{2}', 'mirror=s@{2}', 'copy=s@{2}', 'delete=s') or exit 1;
-unless ($options{migrate} || $options{mirror} || $options{copy} || $options{delete}) {
+GetOptions(
+  \%options,    'migrate=s@{2}', 'class=s@{2}', 'mirror=s@{2}',
+  'copy=s@{2}', 'delete=s'
+) or exit 1;
+unless ($options{migrate}
+  || $options{class}
+  || $options{mirror}
+  || $options{copy}
+  || $options{delete})
+{
   die <<EOF;
 Syntax:
     migrate-attachments.pl --migrate source destination
+    migrate-attachments.pl --class source destination
     migrate-attachments.pl --mirror source destination
     migrate-attachments.pl --copy source destination
     migrate-attachments.pl --delete source
@@ -37,6 +46,14 @@ Syntax:
     new destination.
 
     e.g. migrate-attachments.pl --migrate database s3
+
+'class'
+    Only update the class value stored in the attachment_storage_class
+    from the source value to the destination value. This is useful for
+    when the data has been migrated using other means and you want the
+    data to be loaded from the new location instead of the old.
+
+    e.g. migrate-attachments.pl --class s3 google
 
 'mirror'
     Copies all attachments from the specified source to the destination.
@@ -75,21 +92,38 @@ if ($options{migrate}) {
   my ($source, $dest) = @{$options{migrate}};
 
   # Do not migrate from database to net storage if data is less than minsize
-  my $where;
-  if ($source eq 'database' && $dest eq 's3' && Bugzilla->params->{attachment_s3_minsize}) {
-    $where = 'WHERE attach_size > ' . int Bugzilla->params->{attachment_s3_minsize};
+  my $where = '';
+  if ( $source eq 'database'
+    && $dest eq 's3'
+    && Bugzilla->params->{attachment_s3_minsize})
+  {
+    $where .= ' AND attachments.attach_size > '
+      . int Bugzilla->params->{attachment_s3_minsize};
   }
-  elsif ($source eq 'database' && $dest eq 'google' && Bugzilla->params->{attachment_google_minsize}) {
-    $where = 'WHERE attach_size > ' . int Bugzilla->params->{attachment_google_minsize};
+  elsif ($source eq 'database'
+    && $dest eq 'google'
+    && Bugzilla->params->{attachment_google_minsize})
+  {
+    $where .= ' AND attachments.attach_size > '
+      . int Bugzilla->params->{attachment_google_minsize};
   }
 
-  my ($total) = $dbh->selectrow_array("SELECT COUNT(*) FROM attachments $where");
-  confirm(sprintf
-    'Migrate %s attachments from %s to %s?', $total, @{$options{migrate}});
+  my ($total) = $dbh->selectrow_array('
+    SELECT COUNT(*) 
+      FROM attachments 
+           JOIN attachment_storage_class ON attachments.attach_id = attachment_storage_class.id 
+     WHERE attachment_storage_class.storage_class = ? ' . $where, undef, $source);
 
-  my $sth
-    = $dbh->prepare("SELECT attach_id FROM attachments $where ORDER BY attach_id DESC");
-  $sth->execute();
+  confirm(sprintf 'Migrate %s attachments from %s to %s?',
+    $total, @{$options{migrate}});
+
+  my $sth = $dbh->prepare('
+      SELECT attach_id 
+        FROM attachments 
+             JOIN attachment_storage_class ON attachments.attach_id = attachment_storage_class.id 
+       WHERE attachment_storage_class.storage_class = ? ' . $where
+      . ' ORDER BY attach_id DESC');
+  $sth->execute($source);
   my ($count, $migrated) = (0, 0);
   while (my ($attach_id) = $sth->fetchrow_array()) {
     indicate_progress({total => $total, current => ++$count});
@@ -110,19 +144,63 @@ if ($options{migrate}) {
   print "Attachments migrated: $migrated\n";
 }
 
+if ($options{class}) {
+  if ($options{class}->[0] eq $options{class}->[1]) {
+    die "Source and destination must be different\n";
+  }
+  my ($source, $dest) = @{$options{class}};
+
+  my ($total) = $dbh->selectrow_array('
+    SELECT COUNT(*) 
+      FROM attachments 
+           JOIN attachment_storage_class ON attachments.attach_id = attachment_storage_class.id 
+     WHERE attachment_storage_class.storage_class = ?', undef, $source);
+
+  confirm(sprintf 'Update %d attachments class from %s to %s?',
+    $total, @{$options{class}});
+
+  my $sth = $dbh->prepare('
+      SELECT attach_id 
+        FROM attachments 
+             JOIN attachment_storage_class ON attachments.attach_id = attachment_storage_class.id 
+       WHERE attachment_storage_class.storage_class = ? ORDER BY attach_id DESC');
+  $sth->execute($source);
+  my ($count, $updated) = (0, 0);
+  while (my ($attach_id) = $sth->fetchrow_array()) {
+    indicate_progress({total => $total, current => ++$count});
+
+    my $attachment = Bugzilla::Attachment->new({id => $attach_id, cached => 1});
+
+    # Update the class of the attachment
+    $attachment->current_storage($dest)->set_class();
+
+    $updated++;
+  }
+  print "\n";
+  print "Attachments updated: $updated\n";
+}
+
 if ($options{mirror}) {
   if ($options{mirror}->[0] eq $options{mirror}->[1]) {
     die "Source and destination must be different\n";
   }
   my ($source, $dest) = @{$options{mirror}};
 
-  my ($total) = $dbh->selectrow_array("SELECT COUNT(*) FROM attachments");
-  confirm(sprintf
-    'Mirror %s attachments from %s to %s?', $total, @{$options{mirror}});
+  my ($total) = $dbh->selectrow_array('
+    SELECT COUNT(*) 
+      FROM attachments 
+           JOIN attachment_storage_class ON attachments.attach_id = attachment_storage_class.id 
+     WHERE attachment_storage_class.storage_class = ?', undef, $source);
 
-  my $sth
-    = $dbh->prepare("SELECT attach_id FROM attachments ORDER BY attach_id DESC");
-  $sth->execute();
+  confirm(sprintf 'Mirror %s attachments from %s to %s?',
+    $total, @{$options{mirror}});
+
+  my $sth = $dbh->prepare('
+      SELECT attach_id 
+        FROM attachments 
+             JOIN attachment_storage_class ON attachments.attach_id = attachment_storage_class.id 
+       WHERE attachment_storage_class.storage_class = ? ORDER BY attach_id DESC');
+  $sth->execute($source);
   my ($count, $deleted, $stored) = (0, 0, 0);
   while (my ($attach_id) = $sth->fetchrow_array()) {
     indicate_progress({total => $total, current => ++$count});
@@ -130,13 +208,16 @@ if ($options{mirror}) {
     my $attachment = Bugzilla::Attachment->new({id => $attach_id, cached => 1});
 
     # remove deleted attachments
-    if ($attachment->datasize == 0 && $attachment->current_storage($dest)->data_exists()) {
+    if ( $attachment->datasize == 0
+      && $attachment->current_storage($dest)->data_exists())
+    {
       $attachment->current_storage($dest)->remove_data();
       $deleted++;
     }
 
     # store attachments that don't already exist
-    elsif ($attachment->datasize != 0 && !$attachment->current_storage($dest)->data_exists())
+    elsif ($attachment->datasize != 0
+      && !$attachment->current_storage($dest)->data_exists())
     {
       if (my $data = $attachment->current_storage($source)->get_data()) {
         $attachment->current_storage($dest)->set_data($data);
@@ -155,17 +236,21 @@ elsif ($options{copy}) {
   }
   my ($source, $dest) = @{$options{copy}};
 
-  my ($total)
-    = $dbh->selectrow_array(
-    "SELECT COUNT(*) FROM attachments WHERE attach_size != 0");
-  confirm(sprintf
-    'Copy %s attachments from %s to %s?', $total, @{$options{copy}});
+  my ($total) = $dbh->selectrow_array('
+    SELECT COUNT(*) 
+      FROM attachments 
+           JOIN attachment_storage_class ON attachments.attach_id = attachment_storage_class.id 
+     WHERE attachment_storage_class.storage_class = ?', undef, $source);
 
-  my $sth
-    = $dbh->prepare(
-    "SELECT attach_id FROM attachments WHERE attach_size != 0 ORDER BY attach_id DESC"
-    );
-  $sth->execute();
+  confirm(sprintf 'Copy %s attachments from %s to %s?', $total,
+    @{$options{copy}});
+
+  my $sth = $dbh->prepare('
+      SELECT attach_id 
+        FROM attachments 
+             JOIN attachment_storage_class ON attachments.attach_id = attachment_storage_class.id 
+       WHERE attachment_storage_class.storage_class = ? ORDER BY attach_id DESC');
+  $sth->execute($source);
   my ($count, $stored) = (0, 0);
   while (my ($attach_id) = $sth->fetchrow_array()) {
     indicate_progress({total => $total, current => ++$count});
@@ -185,25 +270,32 @@ elsif ($options{copy}) {
 }
 
 elsif ($options{delete}) {
-  my $storage = $options{delete};
-  my ($total)
-    = $dbh->selectrow_array(
-    "SELECT COUNT(*) FROM attachments WHERE attach_size != 0");
+  my $source = $options{delete};
+
+  my ($total) = $dbh->selectrow_array('
+    SELECT COUNT(*) 
+      FROM attachments 
+           JOIN attachment_storage_class ON attachments.attach_id = attachment_storage_class.id 
+     WHERE attachment_storage_class.storage_class = ? AND attachments.attach_size != 0',
+    undef, $source);
+
   confirm(sprintf 'DELETE %s attachments from %s?', $total, $options{delete});
 
-  my $sth
-    = $dbh->prepare(
-    "SELECT attach_id FROM attachments WHERE attach_size != 0 ORDER BY attach_id DESC"
-    );
-  $sth->execute();
+  my $sth = $dbh->prepare('
+      SELECT attach_id 
+        FROM attachments 
+             JOIN attachment_storage_class ON attachments.attach_id = attachment_storage_class.id 
+       WHERE attachment_storage_class.storage_class = ? AND attachments.attach_size != 0 ORDER BY attach_id DESC'
+  );
+  $sth->execute($source);
   my ($count, $deleted) = (0, 0);
   while (my ($attach_id) = $sth->fetchrow_array()) {
     indicate_progress({total => $total, current => ++$count});
 
     my $attachment = Bugzilla::Attachment->new({id => $attach_id, cached => 1});
 
-    if ($attachment->current_storage($storage)->data_exists()) {
-      $attachment->current_storage($storage)->remove_data();
+    if ($attachment->current_storage($source)->data_exists()) {
+      $attachment->current_storage($source)->remove_data();
       $deleted++;
     }
   }


### PR DESCRIPTION
- Adds --class option to migrate-attachments.pl to just update the class names in the atachment_storage_class table from one value to another.
  - This is useful for when the data is already migrated from net storage to another using external means and we just want the data to be loaded from the new location
- Also made some fixes to the migration script that properly calculates the number of attachments that will be affected. Before if was mistakenly just counting all attachments regardless of source.
- Updated Storage.pm to properly encode the returned content into UTF8 to fix a bug with using the fake GCS server as test platform.