### PR TITLE
Bug 1877294 - When adding a new version and mileston when new Firefox is released, disabled old versions and milestones 10 releases or older

### DIFF
--- a/qa/t/3_test_new_release.t
+++ b/qa/t/3_test_new_release.t
@@ -52,9 +52,16 @@ $sel->click_ok('link=New Firefox Release');
 $sel->wait_for_page_to_load_ok(WAIT_TIME);
 $sel->select_ok('milestone_products', 'label=Firefox');
 $sel->type_ok('new_milestone', '101');
+$sel->type_ok('old_milestone', '100');
 $sel->select_ok('version_products', 'label=Firefox');
 $sel->type_ok('new_version', '101');
+$sel->type_ok('old_version', '100');
 $sel->click_ok('submit', undef, 'Submit data');
+$sel->title_is('New Firefox Release');
+$sel->is_text_present_ok('Milestone 101 Branch was added to product Firefox.');
+$sel->is_text_present_ok('Milestone 100 Branch was disabled for product Firefox.');
+$sel->is_text_present_ok('Version Firefox 101 was added to product Firefox.');
+$sel->is_text_present_ok('Version Firefox 100 was disabled for product Firefox.');
 
 # Verify that the new milestone and version has been create and the proper sortkey is present
 

--- a/template/en/default/pages/new_release.html.tmpl
+++ b/template/en/default/pages/new_release.html.tmpl
@@ -17,17 +17,30 @@
 [% IF results %]
   [% FOREACH type = ['milestone', 'version'] %]
     <p><h4>[% type FILTER ucfirst FILTER html %]s Added</h4>
+    [% new_type = "new_" _ type %]
     [% FOREACH result = results %]
-      [% NEXT IF result.type != type %]
+      [% NEXT IF result.type != new_type %]
       [% IF result.success %]
         [% type FILTER ucfirst FILTER html %] <strong>[% result.value FILTER html %]</strong>
-        added to product <strong>[% result.product FILTER html %]</strong>.<br>
+        was added to product <strong>[% result.product FILTER html %]</strong>.<br>
       [% ELSE %]
         <span style="color:red;">[% type FILTER ucfirst FILTER html %] <strong>[% result.value FILTER html %]</strong>
         was not added to product <strong>[% result.product FILTER html %]</strong>.</span><br>
       [% END %]
     [% END %]
     </p>
+    <p><h4>[% type FILTER ucfirst FILTER html %]s Disabled</h4>
+    [% old_type = "old_" _ type %]
+    [% FOREACH result = results %]
+      [% NEXT IF result.type != old_type %]
+      [% IF result.success %]
+        [% type FILTER ucfirst FILTER html %] <strong>[% result.value FILTER html %]</strong>
+        was disabled for product <strong>[% result.product FILTER html %]</strong>.<br>
+      [% ELSE %]
+        <span style="color:red;">[% type FILTER ucfirst FILTER html %] <strong>[% result.value FILTER html %]</strong>
+        was not disabled for product <strong>[% result.product FILTER html %]</strong>.</span><br>
+      [% END %]
+    [% END %]
   [% END %]
 
   [% INCLUDE global/footer.html.tmpl %]
@@ -65,6 +78,14 @@
       Milestone will be added in the format of "XXX Branch"
     </td>
   </tr>
+  <tr>
+    <td>Disable Old Milestone</td>
+    <td>
+      <input type="text" name="old_milestone" id="old_milestone" required="true"
+             size="12" value="[% old_release FILTER html %]">
+      Leave blank to not disable old milestone
+    </td>
+  </tr>
   </table>
 
   <h4>Select Products for New Version</h4>
@@ -89,6 +110,14 @@
       <input type="text" name="new_version" id="new_version" required="true"
              size="10" value="[% next_release FILTER html %]">
       Version will be added in the format of "Firefox XXX"
+    </td>
+  </tr>
+  <tr>
+    <td>Disable Old Version</td>
+    <td>
+      <input type="text" name="old_version" id="old_version" required="true"
+             size="10" value="[% old_release FILTER html %]">
+      Leave blank to not disable old version
     </td>
   </tr>
   </table>


### PR DESCRIPTION
When adding new version and milestone using the admin new release UI, it should be able to automatically disabled the proper older ones at the same time.

- Adds new text fields for old milestone and version to disable. Automatically defaults values to new release - 10.
- Updates test script to test for disabling of old versions and milestones.