### PR TITLE
Revert "Bug 1873447 - On the new bug form, can't use control-E on Mac to go to the end of fields"

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -1265,7 +1265,7 @@ $(function() {
                     if (event.shiftKey)
                         return;
                     // don't conflict with text input shortcut
-                    if (document.activeElement.matches('input, textarea'))
+                    if (document.activeElement.nodeNode == 'INPUT' || document.activeElement.nodeName == 'TEXTAREA')
                         return;
                     if ($('#cancel-btn:visible').length === 0) {
                         event.preventDefault();


### PR DESCRIPTION
Reverts mozilla-bteam/bmo#2163