### PR TITLE
Bug 1877578 - Update sitemap extension and mining chart code to upload data to google cloud storage instead of aws s3

### DIFF
--- a/Bugzilla/Config/Reports.pm
+++ b/Bugzilla/Config/Reports.pm
@@ -18,40 +18,17 @@ our $sortkey = 1100;
 sub get_param_list {
   my $class      = shift;
   my @param_list = (
-    {
-      name    => 'report_secbugs_active',
-      type    => 'b',
-      default => 1,
-    },
+    {name => 'report_secbugs_active', type => 'b', default => 1,},
     {
       name    => 'report_secbugs_emails',
       type    => 't',
       default => 'bugzilla-admin@mozilla.org'
     },
-    {
-      name    => 'report_secbugs_teams',
-      type    => 'l',
-      default => '{}',
-    },
-    {
-      name    => 's3_mining_enabled',
-      type    => 'b',
-      default => 0,
-    },
-    {
-      name    => 's3_mining_access_key_id',
-      type    => 't',
-      default => '',
-    },
-    {
-      name    => 's3_mining_secret_access_key',
-      type    => 't',
-      default => '',
-    },
-    {
-      name    => 's3_mining_bucket',
-      type    => 't',
-      default => '',
-    }
+    {name => 'report_secbugs_teams',          type => 'l', default => '{}',},
+    {name => 'mining_enabled',                type => 'b', default => 0,},
+    {name => 'mining_google_bucket',          type => 't', default => '',},
+    {name => 'mining_google_host',            type => 't', default => '',},
+    {name => 'mining_google_service_account', type => 't', default => '',},
+
   );
 }

--- a/Bugzilla/Report/Net.pm
+++ b/Bugzilla/Report/Net.pm
@@ -13,7 +13,6 @@ use Moo;
 use Bugzilla;
 use Bugzilla::Error;
 use Bugzilla::Net::Google;
-use Bugzilla::Net::S3;
 
 has driver     => (is => 'lazy');
 has is_enabled => (is => 'lazy');
@@ -21,26 +20,25 @@ has is_enabled => (is => 'lazy');
 sub _build_driver {
   my $self = shift;
 
-  my $driver = Bugzilla::Net::S3->new({
-    client_id  => Bugzilla->params->{s3_mining_access_key_id},
-    secret_key => Bugzilla->params->{s3_mining_secret_access_key},
-    bucket     => Bugzilla->params->{s3_mining_bucket},
-    host       => Bugzilla->params->{aws_host},
-    secure     => 1,
-    retry      => 1,
+  my $driver = Bugzilla::Net::Google->new({
+    bucket          => Bugzilla->params->{mining_google_bucket},
+    host            => Bugzilla->params->{mining_google_host},
+    service_account => Bugzilla->params->{mining_google_service_account},
+    secure          => 1,
+    retry           => 1,
   });
 
   return $driver;
 }
 
 sub _build_is_enabled {
-  return Bugzilla->params->{s3_mining_enabled} ? 1 : 0;
+  return Bugzilla->params->{mining_enabled} ? 1 : 0;
 }
 
 sub set_data {
   my ($self, $product, $data) = @_;
   unless ($self->driver->add_key($product, $data)) {
-    warn "Failed to add data for product $product to S3: "
+    warn "Failed to add data for product $product to net storage: "
       . $self->driver->error_string . "\n";
     ThrowCodeError('net_mining_add_failed',
       {product => $product, reason => $self->driver->error_string});
@@ -52,7 +50,7 @@ sub get_data {
   my ($self, $product) = @_;
   my $data = $self->driver->get_key($product);
   if (!$data) {
-    warn "Failed to retrieve data for product $product from S3: "
+    warn "Failed to retrieve data for product $product from net storage: "
       . $self->driver->error_string . "\n";
     ThrowCodeError('net_mining_get_failed',
       {product => $product, reason => $self->driver->error_string});
@@ -63,7 +61,7 @@ sub get_data {
 sub remove_data {
   my ($self, $product) = @_;
   $self->driver->delete_key($product)
-    or warn "Failed to remove data for product $product from S3: "
+    or warn "Failed to remove data for product $product from net storage: "
     . $self->driver->error_string . "\n";
   return $self;
 }

--- a/conf/checksetup_answers.txt
+++ b/conf/checksetup_answers.txt
@@ -50,3 +50,13 @@ $answer{'google_storage_host'}            = 'gcs';
 $answer{'google_storage_bucket'}          = 'attachments';
 $answer{'google_storage_service_account'} = 'test';
 $answer{'attachment_google_minsize'}      = '10';
+
+$answer{'mining_enabled'}                 = 1;
+$answer{'mining_google_host'}            = 'gcs';
+$answer{'mining_google_bucket'}          = 'mining';
+$answer{'mining_google_service_account'} = 'test';
+
+$answer{'sitemapindex_enabled'}                = 1;
+$answer{'sitemapindex_google_host'}            = 'gcs';
+$answer{'sitemapindex_google_bucket'}          = 'sitemapindex';
+$answer{'sitemapindex_google_service_account'} = 'test';

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -64,3 +64,5 @@ services:
     command: "-scheme http"
     volumes:
       - ./docker/gcs/attachments:/data/attachments
+      - ./docker/gcs/sitemapindex:/data/sitemapindex
+      - ./docker/gcs/mining:/data/mining

--- a/docker-compose.yml.orig
+++ b/docker-compose.yml.orig
@@ -26,7 +26,7 @@ services:
       - BMO_memcached_servers=memcached:11211
       - BMO_ses_username=ses@mozilla.bugs
       - BMO_ses_password=password123456789!
-      - BMO_urlbase=http://bmo.test/
+      - BMO_urlbase=http://localhost:8000/
       - BUGZILLA_ALLOW_INSECURE_HTTP=1
       - BZ_ANSWERS_FILE=/app/conf/checksetup_answers.txt
       - HTTP_BACKEND=morbo
@@ -130,14 +130,6 @@ services:
       - bmo-gcs-attachments:/data/attachments
       - bmo-gcs-sitemapindex:/data/sitemapindex
       - bmo-gcs-mining:/data/mining
-
-  proxy:
-    image: haproxytech/haproxy-alpine
-    volumes:
-      - ./docker/proxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
-    ports:
-      - "1080:1080"
-    restart: always
 
 volumes:
   bmo-mysql-db:

--- a/docker-compose.yml.rej
+++ b/docker-compose.yml.rej
@@ -1,0 +1,14 @@
+--- docker-compose.yml
++++ docker-compose.yml
+@@ -38,10 +38,9 @@ services:
+     depends_on:
+       - bmo.db
+       - memcached
++      - proxy
+       - s3
+       - gcs
+-    ports:
+-      - 8000:8000
+ 
+   bmo.jobqueue:
+     build: *bmo_build

--- a/extensions/SiteMapIndex/Extension.pm
+++ b/extensions/SiteMapIndex/Extension.pm
@@ -54,9 +54,12 @@ sub before_robots_txt {
   return if !Bugzilla->params->{sitemapindex_enabled};
 
   my $sitemap_url
-      = 'https://s3.us-west-2.amazonaws.com/'
-      . Bugzilla->params->{sitemapindex_s3_bucket}
-    . '/sitemap_index.xml';
+    = 'https://'
+    . Bugzilla->params->{sitemapindex_google_host}
+    . '/storage/v1/b/'
+    . Bugzilla->params->{sitemapindex_google_bucket} . '/o/'
+    . 'sitemap_index.xml';
+
   $args->{vars}{SITEMAP_URL} = $sitemap_url;
 }
 

--- a/extensions/SiteMapIndex/lib/Config.pm
+++ b/extensions/SiteMapIndex/lib/Config.pm
@@ -19,11 +19,10 @@ sub get_param_list {
   my ($class) = @_;
 
   my @params = (
-    {name => 'sitemapindex_enabled',           type => 'b', default => 0,},
-    {name => 'sitemapindex_s3_bucket',         type => 't', default => '',},
-    {name => 'sitemapindex_aws_region',        type => 't', default => 'us-west-2'},
-    {name => 'sitemapindex_aws_client_id',     type => 't', default => '',},
-    {name => 'sitemapindex_aws_client_secret', type => 't', default => '',},
+    {name => 'sitemapindex_enabled',                type => 'b', default => 0,},
+    {name => 'sitemapindex_google_bucket',          type => 't', default => '',},
+    {name => 'sitemapindex_google_host',            type => 't', default => '',},
+    {name => 'sitemapindex_google_service_account', type => 't', default => '',},
   );
 
   return @params;

--- a/extensions/SiteMapIndex/template/en/default/admin/params/sitemapindex.html.tmpl
+++ b/extensions/SiteMapIndex/template/en/default/admin/params/sitemapindex.html.tmpl
@@ -14,9 +14,8 @@
 [%
    param_descs = {
       sitemapindex_enabled => "Enable SiteMapIndex",
-      sitemapindex_s3_bucket => "S3 bucket name to access sitemapindex files",
-      sitemapindex_aws_region => "SiteMapIndex AWS Region (default: us-west-2)",
-      sitemapindex_aws_client_id => "SiteMapIndex AWS Client ID",
-      sitemapindex_aws_client_secret => "SiteMapIndex AWS Client Secret"
+      sitemapindex_google_bucket => "Google Cloud Storage bucket name for sitemapindex files",
+      sitemapindex_google_host => "Google Cloud Storage host for sitemapindex files",
+      sitemapindex_google_service_account => "Google Cloud Storage service account for sitemapindex files",
    }
 %]

--- a/template/en/default/admin/params/reports.html.tmpl
+++ b/template/en/default/admin/params/reports.html.tmpl
@@ -16,13 +16,13 @@
       "Comma delimited list of the email addresses that the security $terms.bugs report will be sent to.",
     report_secbugs_teams =>
       "A one team per line list of the teams the security $terms.bugs report will report on.",
-    s3_mining_enabled =>
-      "Use AWS S3 bucket to store mining data for graph reports. Otherwise store on local filesystem.",
-    s3_mining_access_key_id =>
-      "Access key ID for AWS S3 account used to store mining data for graph reports.",
-    s3_mining_secret_access_key =>
-      "Secret access key for AWS S3 account used to store mining data for graph reports.",
-    s3_mining_bucket =>
-      "Name of AWS S3 bucket to store mining data for graph reports."
+    mining_enabled =>
+      "Use Google Cloud Storage bucket to store mining data for graph reports. Otherwise store on local filesystem.",
+    mining_google_bucket =>
+      "Google Cloud Storage bucket used to store mining data for graph reports.",
+    mining_google_host =>
+      "Google Cloud Storage host used to store mining data for graph reports.",
+    mining_google_service_account =>
+      "Google Cloud Storage service account used to store mining data for graph reports."
   }
 %]


### PR DESCRIPTION
This pull requests converts the settings and code responsible for uploading specific data to AWS S3 to instead upload to Google Cloud Storage. 