### PR TITLE
Bug 1881309 - Create new admin parameter to disabled new account creation

### DIFF
--- a/Bugzilla/Auth.pm
+++ b/Bugzilla/Auth.pm
@@ -490,7 +490,7 @@ Returns:     C<true> if users can log themselves out, C<false> otherwise.
 
 Description: Tells you whether or not users are allowed to manually create
              their own accounts, based on the current login system in use.
-             Note that this doesn't check the C<createemailregexp>
+             Note that this doesn't check the C<allow_account_creation>
              parameter--you have to do that by yourself in your code.
 Params:      None
 Returns:     C<true> if users are allowed to create new Bugzilla accounts,

--- a/Bugzilla/Config/Auth.pm
+++ b/Bugzilla/Config/Auth.pm
@@ -18,6 +18,8 @@ our $sortkey = 300;
 sub get_param_list {
   my $class      = shift;
   my @param_list = (
+    {name => 'allow_account_creation', type => 'b', default => '1',},
+
     {name => 'auth_env_id', type => 't', default => '',},
 
     {name => 'auth_env_email', type => 't', default => '',},
@@ -75,13 +77,6 @@ sub get_param_list {
     },
 
     {name => 'emailsuffix', type => 't', default => ''},
-
-    {
-      name    => 'createemailregexp',
-      type    => 't',
-      default => q:.*:,
-      checker => \&check_regexp
-    },
 
     {
       name    => 'password_complexity',

--- a/Bugzilla/User.pm
+++ b/Bugzilla/User.pm
@@ -2830,24 +2830,18 @@ sub is_available_username {
 sub check_account_creation_enabled {
   my $self = shift;
 
+  Bugzilla->params->{allow_account_creation}
+    || ThrowUserError('account_creation_disabled');
+
   # If we're using e.g. LDAP for login, then we can't create a new account.
   $self->authorizer->user_can_create_account
     || ThrowUserError('auth_cant_create_account');
-
-  Bugzilla->params->{'createemailregexp'}
-    || ThrowUserError('account_creation_disabled');
 }
 
 sub check_and_send_account_creation_confirmation {
   my ($self, $login) = @_;
 
   $login = $self->check_login_name_for_creation($login);
-  my $creation_regexp = Bugzilla->params->{'createemailregexp'};
-
-  if ($login !~ /$creation_regexp/i) {
-    ThrowUserError('account_creation_restricted');
-  }
-
   # BMO - add a hook to allow extra validation prior to account creation.
   Bugzilla::Hook::process("user_verify_login", {login => $login});
 

--- a/docs/en/rst/administering/parameters.rst
+++ b/docs/en/rst/administering/parameters.rst
@@ -79,6 +79,9 @@ whether to require users to login to browse bugs, the management
 of authentication cookies, and the regular expression used to
 validate email addresses. Some parameters are highlighted below.
 
+allow_account_creation
+    Allow new accounts to be created. If off, only administrators can create accounts.
+
 auth_env_id
     Environment variable used by external authentication system to store a unique identifier for each user. Leave it blank if there isn't one or if this method of authentication is not being used.
 
@@ -126,9 +129,6 @@ emailregexpdesc
 
 emailsuffix
     This is a string to append to any email addresses when actually sending mail to that address. It is useful if you have changed the :param:`emailregexp` param to only allow local usernames, but you want the mail to be delivered to username\@my.local.hostname.
-
-createemailregexp
-    This defines the (case-insensitive) regexp to use for email addresses that are permitted to self-register. The default (:paramval:`.*`) permits any account matching the emailregexp to be created. If this parameter is left blank, no users will be permitted to create their own accounts and all accounts will have to be created by an administrator.
 
 password_complexity
     Set the complexity required for passwords. In all cases must the passwords be at least 6 characters long.

--- a/docs/en/rst/administering/users.rst
+++ b/docs/en/rst/administering/users.rst
@@ -171,10 +171,8 @@ Self-Registration
 By default, users can create their own user accounts by clicking the
 ``New Account`` link at the bottom of each page (assuming
 they aren't logged in as someone else already). If you want to disable
-this self-registration, or if you want to restrict who can create their
-own user account, you have to edit the :param:`createemailregexp`
-parameter in the ``Configuration`` page; see
-:ref:`parameters`.
+this self-registration, you have to edit the :param:`allow_account_creation`
+parameter in the ``Configuration`` page; see :ref:`parameters`.
 
 .. _user-account-creation:
 

--- a/index.cgi
+++ b/index.cgi
@@ -50,7 +50,7 @@ if ($cgi->param('logout')) {
 my @etag_parts = (
   Bugzilla->VERSION,
   Bugzilla->params->{announcehtml},
-  Bugzilla->params->{createemailregexp},
+  Bugzilla->params->{allow_account_creation},
 );
 my $weak_etag     = q{W/"} . md5_hex(@etag_parts) . q{"};
 my $if_none_match = $cgi->http('If-None-Match');

--- a/qa/config/generate_test_data.pl
+++ b/qa/config/generate_test_data.pl
@@ -93,7 +93,6 @@ my %set_params = (
   defaultseverity            => '--',          # BMO CHANGE
   timetrackinggroup          => 'editbugs',    # BMO CHANGE
   letsubmitterchoosepriority => 1,             # BMO CHANGE
-  createemailregexp          => '.*',          # BMO CHANGE
 );
 
 my $params_modified;

--- a/template/en/default/account/auth/login.html.tmpl
+++ b/template/en/default/account/auth/login.html.tmpl
@@ -96,7 +96,7 @@
   # their password, assuming that our auth method allows that.
   #%]
 
-  [% IF Param("createemailregexp") && user.authorizer.user_can_create_account %]
+  [% IF Param("allow_account_creation") && user.authorizer.user_can_create_account %]
     <hr>
 
     <p>

--- a/template/en/default/account/create.html.tmpl
+++ b/template/en/default/account/create.html.tmpl
@@ -50,7 +50,7 @@
   at <a href="mailto:[% Param("maintainer") %]">[% Param("maintainer") %]</a>.
 </p>
 
-[% IF Param('createemailregexp') == '.*' && Param('emailsuffix') == '' %]
+[% IF Param('allow_account_creation') && Param('emailsuffix') == '' %]
 <p>
   <b>PRIVACY NOTICE:</b> [% terms.Bugzilla %] is an open [% terms.bug %]
   tracking system. Activity on most [% terms.bugs %], including email

--- a/template/en/default/account/email/request-new.txt.tmpl
+++ b/template/en/default/account/email/request-new.txt.tmpl
@@ -40,7 +40,7 @@ again by going to:
 
 [%+ urlbase %]createaccount.cgi
 
-[% IF Param('createemailregexp') == '.*' && Param('emailsuffix') == '' %]
+[% IF Param('allow_account_creation') && Param('emailsuffix') == '' %]
 PRIVACY NOTICE: [% terms.Bugzilla %] is an open [% terms.bug %] tracking system. Activity on most
 [%+ terms.bugs %], including email addresses, will be visible to the public. We recommend
 using a secondary account or free web email service (such as Gmail, Yahoo,

--- a/template/en/default/admin/params/auth.html.tmpl
+++ b/template/en/default/admin/params/auth.html.tmpl
@@ -25,6 +25,9 @@
 %]
 
 [% param_descs = {
+  allow_account_creation => "Allow new accounts to be created. " _
+                            "If off, only administrators can create accounts.",
+
   auth_env_id => "Environment variable used by external authentication system " _
                  "to store a unique identifier for each user. Leave it blank " _
                  "if there isn't one or if this method of authentication " _
@@ -125,13 +128,6 @@
                  "sending mail to that address. It is useful if you have changed " _
                  "the <tt>emailregexp</tt> param to only allow local usernames, " _
                  "but you want the mail to be delivered to username@my.local.hostname.",
-
-  createemailregexp => "This defines the (case-insensitive) regexp to use for email addresses that are " _
-                       "permitted to self-register using a 'New Account' feature. The " _
-                       "default (.*) permits any account matching the emailregexp " _
-                       "to be created. If this parameter is left blank, no users " _
-                       "will be permitted to create their own accounts and all accounts " _
-                       "will have to be created by an administrator.",
 
   password_complexity =>
     "Set the complexity required for passwords. In all cases must the passwords " _

--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -387,7 +387,7 @@
       </div>
     [% ELSE %]
       <ul id="header-login" class="links">
-        [% IF Param('createemailregexp') && user.authorizer.user_can_create_account %]
+        [% IF Param('allow_account_creation') && user.authorizer.user_can_create_account %]
           <li id="moz_new_account_container_top"><a href="[% basepath FILTER none %]createaccount.cgi">New Account</a></li>
         [% END %]
         [% IF user.authorizer.can_login %]

--- a/template/en/default/welcome-admin.html.tmpl
+++ b/template/en/default/welcome-admin.html.tmpl
@@ -53,14 +53,12 @@
     In other words, users who are not explicitly authenticated with a valid account
     cannot see any data. This is what you want if you want to keep your data private.</li>
 
-    <li><a href="[% basepath FILTER none %]editparams.cgi?section=auth#createemailregexp_desc">createemailregexp</a>
-    defines which users are allowed to create an account on this installation. If set
-    to ".*" (the default), everybody is free to create their own account. If set to
-    "@mycompany.com$", only users having an account @mycompany.com will be allowed to
-    create an account. If left blank, users will not be able to create accounts themselves;
-    only an administrator will be able to create one for them. If you want a private
-    installation, you must absolutely set this parameter to something different from
-    the default.</li>
+    <li><a href="[% basepath FILTER none %]editparams.cgi?section=auth#allow_account_creation_desc">allow_account_creation</a>
+    defines whether users are allowed to create an account on this installation. If set
+    to "on" (the default), everybody is free to create their own account. If set to "off",
+    users will not be able to create accounts themselves; only an administrator will be 
+    able to create one for them. If you want a private installation, you must absolutely
+    set this parameter to something different from the default.</li>
 
     <li><a href="[% basepath FILTER none %]editparams.cgi?section=mta#mail_delivery_method_desc">mail_delivery_method</a>
     defines the method used to send emails, such as sendmail or SMTP. You have to set


### PR DESCRIPTION
* Remove the unused createemailregex parameter which was originally also used for disabling new account creation.
* Added a new allow_account_creation parameter which is a boolean and defaults to on.
* Now we can disable quickly and re-enable quickly account creation when needed for spammers, etc.
* Update test cases to use the new parameter.