### PR TITLE
Bug 1882734 - Use new CVE website for linking CVE-IDs

### DIFF
--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -600,7 +600,7 @@ sub bug_format_comment {
         my $args  = shift;
         my $match = html_quote($args->{matches}->[0]);
         return
-          qq{<a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=$match">$match</a>};
+          qq{<a href="https://www.cve.org/CVERecord?id=$match">$match</a>};
       }
     }
   );

--- a/qa/t/1_test_bmo_autolinkification.t
+++ b/qa/t/1_test_bmo_autolinkification.t
@@ -40,7 +40,7 @@ $sel->wait_for_page_to_load_ok(WAIT_TIME);
 $sel->title_like(qr/\d+ \S $bug_summary/, "cve added");
 go_to_bug($sel, $bug_id);
 attribute_is($sel, 'CVE-2010-2884',
-  'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2010-2884');
+  'https://www.cve.org/CVERecord?id=CVE-2010-2884');
 
 $sel->type_ok("comment", "r12345");
 $sel->click_ok("bottom-save-btn");


### PR DESCRIPTION
The new CVE website from mitre is https://www.cve.org/, replacing https://cve.mitre.org/. From https://cve.mitre.org/:

>    NOTICE: Transition to the all-new CVE website at WWW.CVE.ORG and CVE Record Format JSON are underway.
>
>    NOTICE: Legacy CVE download formats deprecation is now underway and will end on June 30, 2024. New CVE List download format is available now.

As far as I know, new CVEs also have a delay before they appear on https://cve.mitre.org/, while they appear instantly on https://www.cve.org/. The autolinks from BMO for CVE-IDs should probably be updated to that new site.