### PR TITLE
Bug 1882676 - enter bug page is not showing most frequently reported components properly

### DIFF
--- a/extensions/ProdCompSearch/lib/WebService.pm
+++ b/extensions/ProdCompSearch/lib/WebService.pm
@@ -165,12 +165,14 @@ sub list_frequent_components {
 
   my $dbh = Bugzilla->switch_to_shadow_db();
   my $sql = q{
-    SELECT products.name AS product, components.name AS component FROM bugs
-    INNER JOIN products ON bugs.product_id = products.id
-    INNER JOIN components ON bugs.component_id = components.id
-    WHERE bugs.reporter = ? AND bugs.creation_ts > ?
-      AND products.isactive = 1 AND components.isactive = 1
-    GROUP BY components.id ORDER BY count(bugs.bug_id) DESC LIMIT 10;
+    SELECT count(bugs.bug_id) AS bug_count, products.name AS product, components.name AS component 
+      FROM bugs
+           INNER JOIN products ON bugs.product_id = products.id
+           INNER JOIN components ON bugs.component_id = components.id
+     WHERE bugs.reporter = ? AND bugs.creation_ts > ?
+           AND products.isactive = 1 AND components.isactive = 1
+     GROUP BY products.name, components.name 
+     ORDER BY count(bugs.bug_id) DESC LIMIT 10
   };
   my $results = $dbh->selectall_arrayref($sql, {Slice => {}}, $user->id, $date);
 


### PR DESCRIPTION
At some point recently, something changed with MySQL in GCP that broke the query that returned the most often reported product/components to the UI. The results are displayed on the enter bug page before selecting a product. On Dec 11th, GCP upgraded from MySQL 8.0.18 to 8.0.26. It could be that the query we were using was not valid and the older version just dealt with it and the new one fails. I can post the exact error if needed. It was also failing locally using the latest 8.x of MySQL docker container. The new query in this PR works fine with recent versions of MySQL and also fixed the issue on bugzilla-dev.allizom.org. So without spending too much time going through change logs, lets just push this change.