### PR TITLE
Bug 1886266 - Change the number of old releases to go back and disable from 10 to 15

### DIFF
--- a/Bugzilla/App/BMO/NewRelease.pm
+++ b/Bugzilla/App/BMO/NewRelease.pm
@@ -63,7 +63,7 @@ sub new_release {
 
     my $vars = {
       next_release               => $current_nightly + 1,
-      old_release                => $current_nightly - 10,
+      old_release                => $current_nightly - 15,
       selectable_products        => $selectable_products,
       default_milestone_products => $default_milestone_products,
       default_version_products   => $default_version_products,


### PR DESCRIPTION
Disabling n-10 version/milestone was disabling releases that Thunderbird still cared about. So I am increasing to 15 as this should still be fine for other products as well such as Firefox.