### PR TITLE
Bug 1886289 - Never attempt to send mail to nobody@mozilla.org

### DIFF
--- a/Bugzilla/BugMail.pm
+++ b/Bugzilla/BugMail.pm
@@ -299,7 +299,7 @@ sub Send {
       # this check needs to happen after the bugmail_recipients hook.
       if ( $user->email_enabled
         && $dep_ok
-        && ($user->login !~ /\.(?:bugs|tld)$/ && $user->login ne 'nobody@mozilla.org'))
+        && !is_fake_recipient_address($user->email)
       {
 
         # Don't show summaries for bugs the user can't access, and

--- a/Bugzilla/BugMail.pm
+++ b/Bugzilla/BugMail.pm
@@ -295,9 +295,12 @@ sub Send {
       }
 
       # Make sure the user isn't in the nomail list, and the dep check passed.
-      # BMO: never send emails to bugs or .tld addresses.  this check needs to
-      # happen after the bugmail_recipients hook.
-      if ($user->email_enabled && $dep_ok && ($user->login !~ /\.(?:bugs|tld)$/)) {
+      # BMO: never send emails to nobody@mozilla.org, .bugs, or .tld addresses.
+      # this check needs to happen after the bugmail_recipients hook.
+      if ( $user->email_enabled
+        && $dep_ok
+        && ($user->login !~ /\.(?:bugs|tld)$/ && $user->login ne 'nobody@mozilla.org'))
+      {
 
         # Don't show summaries for bugs the user can't access, and
         # provide a hook for extensions such as SecureMail to filter

--- a/Bugzilla/BugMail.pm
+++ b/Bugzilla/BugMail.pm
@@ -296,10 +296,10 @@ sub Send {
 
       # Make sure the user isn't in the nomail list, and the dep check passed.
       # BMO: never send emails to nobody@mozilla.org, .bugs, or .tld addresses.
-      # this check needs to happen after the bugmail_recipients hook.
+      # This check needs to happen after the bugmail_recipients hook.
       if ( $user->email_enabled
         && $dep_ok
-        && !is_fake_recipient_address($user->email)
+        && !is_fake_recipient_address($user->email))
       {
 
         # Don't show summaries for bugs the user can't access, and

--- a/Bugzilla/Mailer.pm
+++ b/Bugzilla/Mailer.pm
@@ -154,8 +154,10 @@ sub MessageToMTA {
       WARN("Attempted to send email to address in badhosts: $to");
       $email->header_set(to => '');
     }
-    elsif ($recipient->host =~ /\.(?:bugs|tld)$/) {
-      WARN("Attempted to send email to fake address: $to");
+    elsif ($recipient->host =~ /\.(?:bugs|tld)$/
+      || $recipient->address eq 'nobody@mozilla.org')
+    {
+      WARN("Attempted to send email to non-deliverable address: $to");
       $email->header_set(to => '');
     }
   }

--- a/Bugzilla/Mailer.pm
+++ b/Bugzilla/Mailer.pm
@@ -154,9 +154,7 @@ sub MessageToMTA {
       WARN("Attempted to send email to address in badhosts: $to");
       $email->header_set(to => '');
     }
-    elsif ($recipient->host =~ /\.(?:bugs|tld)$/
-      || $recipient->address eq 'nobody@mozilla.org')
-    {
+    elsif (is_fake_recipient_address($recipient->address)) {
       WARN("Attempted to send email to non-deliverable address: $to");
       $email->header_set(to => '');
     }

--- a/Bugzilla/Util.pm
+++ b/Bugzilla/Util.pm
@@ -28,7 +28,8 @@ use base qw(Exporter);
   validate_email_syntax clean_text
   get_text template_var disable_utf8
   enable_utf8 detect_encoding email_filter
-  round extract_nicks fetch_product_versions mojo_user_agent);
+  round extract_nicks fetch_product_versions mojo_user_agent
+  is_fake_recipient_address);
 use Bugzilla::Logging;
 use Bugzilla::Constants;
 use Bugzilla::RNG qw(irand);
@@ -1041,6 +1042,14 @@ sub mojo_user_agent {
   $ua->transactor->name('Bugzilla');
 
   return $ua;
+}
+
+sub is_fake_recipient_address {
+  my ($recipient) = @_;
+  if ($recipient =~ /\.(?:bugs|tld)$/ || $recipient eq 'nobody@mozilla.org') {
+    return 1;
+  }
+  return 0;
 }
 
 1;

--- a/t/007util.t
+++ b/t/007util.t
@@ -15,7 +15,7 @@ use warnings;
 
 use lib qw(. lib local/lib/perl5 t);
 use Support::Files;
-use Test::More tests => 17;
+use Test::More tests => 20;
 use DateTime;
 
 BEGIN {
@@ -94,6 +94,11 @@ ok(validate_email_syntax($ascii_email),
   'correctly formatted ASCII-only email address is valid');
 ok(!validate_email_syntax($utf8_email),
   'correctly formatted email address with non-ASCII characters is rejected');
+
+# is_fake_recipient_address
+ok(!is_fake_recipient_address('foo@example.com'), 'Non-fake email address is accepted');
+ok(is_fake_recipient_address('foo@example.tld'), 'Fake email address is denied');
+ok(is_fake_recipient_address('nobody@mozilla.org'), 'Fake default assignee for BMO is denied');
 
 # diff_arrays():
 my @old_array = qw(alpha beta alpha gamma gamma beta alpha delta epsilon gamma);


### PR DESCRIPTION
Similar to addresses @.(bugs|tld) we should also not send email to the [nobody@mozilla.org](mailto:nobody@mozilla.org) (default assignee, etc.) address as it is only a placeholder and isn't meant to be delivered to.