### PR TITLE
Bug 1887999 - Approval request dropdowns sometimes not visible with modal Details dialog

### DIFF
--- a/extensions/BugModal/web/attachments_overlay.js
+++ b/extensions/BugModal/web/attachments_overlay.js
@@ -543,7 +543,7 @@ window.addEventListener('DOMContentLoaded', () => {
    * @param {HTMLElement} $row `<tbody>` element.
    * @param {object} flag Flag object from the API.
    * @param {object} [options] Options.
-   * @param {object} [options.cloned] Whether the row is cloned. We need to reactivate user
+   * @param {boolean} [options.cloned] Whether the row is cloned. We need to reactivate user
    * autocomplete for the requestee field because the event listener is not cloned.
    * @param {boolean} [options.additional] Whether to show an `addl.` label in the setter column.
    * This only applies if the flag is multi-requestable, and there is one or more existing

--- a/js/field.js
+++ b/js/field.js
@@ -19,6 +19,18 @@
  *                 Reed Loden <reed@reedloden.com>
  */
 
+/**
+ * Reference or define the Bugzilla app namespace.
+ * @namespace
+ */
+var Bugzilla = Bugzilla || {}; // eslint-disable-line no-var
+
+/**
+ * Reference or define the Field namespace.
+ * @namespace
+ */
+Bugzilla.Field = Bugzilla.Field || {};
+
 /* This library assumes that the needed YUI libraries have been loaded
    already. */
 
@@ -688,21 +700,28 @@ $(function() {
         onSearchError: searchComplete
     };
 
+    /**
+     * Activate user autocomplete on the given input field.
+     * @param {HTMLInputElement} $input `<input class="bz_autocomplete_user">`.
+     */
+    Bugzilla.Field.activateUserAutocomplete = ($input) => {
+        const is_multiple = !!$input.getAttribute('data-multiple');
+        const options = { ...options_user, appendTo: $input.closest('dialog, #main-inner') };
+
+        options.delimiter = is_multiple ? /,\s*/ : undefined;
+        // Override `this` in the relevant functions
+        options.formatResult = options.formatResult.bind($input);
+        options.onSelect = options.onSelect.bind($input);
+
+        $input.dataset.counter = 0;
+        $input.classList.add('bz_autocomplete');
+        $($input).devbridgeAutocomplete(options);
+    };
+
     // init user autocomplete fields
     $('.bz_autocomplete_user')
         .each(function() {
-            const $input = this;
-            const is_multiple = !!$input.getAttribute('data-multiple');
-            const options = { ...options_user, appendTo: this.closest('dialog, #main-inner') };
-
-            options.delimiter = is_multiple ? /,\s*/ : undefined;
-            // Override `this` in the relevant functions
-            options.formatResult = options.formatResult.bind($input);
-            options.onSelect = options.onSelect.bind($input);
-
-            $input.dataset.counter = 0;
-            $input.classList.add('bz_autocomplete');
-            $(this).devbridgeAutocomplete(options);
+            Bugzilla.Field.activateUserAutocomplete(this);
         });
 
     // init autocomplete fields with array of values


### PR DESCRIPTION
[Bug 1887999 - Approval request dropdowns sometimes not visible with modal Details dialog](https://bugzilla.mozilla.org/show_bug.cgi?id=1887999)

The problem could be reproduced if there were multiple attachments with and without flags.

Remove an unnecessary check for cloned rows, which is actually done by `foundTypeIds`. Also, fix user autocomplete on requestee fields not working on these cloned rows.