### PR TITLE
Bug 1888481 - checkbox for NI is no longer automatically checked when picking myself or any other choice

### DIFF
--- a/extensions/Needinfo/template/en/default/bug/needinfo.html.tmpl
+++ b/extensions/Needinfo/template/en/default/bug/needinfo.html.tmpl
@@ -186,7 +186,7 @@ $(function() {
     <tr>
       <td class="needinfo-cb-td">
         [% IF bug.id %]
-          <input type="checkbox" name="needinfo" id="[% id_prefix FILTER html %]needinfo" value="1">
+          <input type="checkbox" name="needinfo" class="needinfo" id="[% id_prefix FILTER html %]needinfo" value="1">
         [% END %]
       </td>
       <td>

--- a/js/field.js
+++ b/js/field.js
@@ -623,6 +623,7 @@ $(function() {
 
     var options_user = {
         forceFixPosition: true,
+        orientation: 'auto',
         paramName: 'match',
         deferRequestBy: 250,
         minChars: 2,


### PR DESCRIPTION
[Bug 1157227 - redesign the "attachment details" page](https://bugzilla.mozilla.org/show_bug.cgi?id=1157227)

The `needinfo` class name was somehow missing in the template. Also, change the position of the user autocomplete dropdown to make sure it doesn’t go outside of the overlay.