### PR TITLE
Bug 1888524 - javascript error when creating and viewing some bugs: can't access property "querySelector", $overlay is null

### DIFF
--- a/extensions/BugModal/web/attachments_overlay.js
+++ b/extensions/BugModal/web/attachments_overlay.js
@@ -8,6 +8,12 @@
 window.addEventListener('DOMContentLoaded', () => {
   /** @type {HTMLDialogElement} */
   const $overlay = document.querySelector('#att-overlay');
+
+  // The overlay is available only on bugs with any attachment
+  if (!$overlay) {
+    return;
+  }
+
   /** @type {HTMLFormElement} */
   const $form = $overlay.querySelector('form');
   /** @type {HTMLHeadingElement} */


### PR DESCRIPTION
[Bug 1888524 - javascript error when creating and viewing some bugs: can't access property "querySelector", $overlay is null](https://bugzilla.mozilla.org/show_bug.cgi?id=1888524)

If the overlay doesn’t exist, the code shouldn’t be processed.