### PR TITLE
Bug 1886504 - Hide Duo as an option unless the current user is an employee

### DIFF
--- a/Bugzilla/MFA/Duo.pm
+++ b/Bugzilla/MFA/Duo.pm
@@ -14,6 +14,7 @@ use warnings;
 use base 'Bugzilla::MFA';
 
 use Bugzilla::DuoClient;
+use Bugzilla::Error;
 
 sub can_verify_inline {
   return 0;
@@ -21,6 +22,16 @@ sub can_verify_inline {
 
 sub enroll {
   my ($self, $params) = @_;
+
+  # Do not allow Duo enrollment unless required or user is a Mozilla employee
+  my $user = Bugzilla->user;
+  unless ($user->in_duo_required_group
+    || $user->in_group('mozilla-employee-confidential'))
+  {
+    ThrowUserError('duo_user_error',
+      {reason => 'You are not permitted to enroll Duo Security for this account.'});
+  }
+
   $self->property_set('user', $params->{username});
 }
 

--- a/template/en/default/account/prefs/mfa.html.tmpl
+++ b/template/en/default/account/prefs/mfa.html.tmpl
@@ -15,6 +15,11 @@
   </form>
 [% END %]
 
+[%# Do not show Duo options unless required or user is a Mozilla employee %]
+[% IF Param("duo_uri") && (user.in_duo_required_group || user.in_group('mozilla-employee-confidential')) %]
+  [% duo_allowed = 1 %]
+[% END %]
+
 [% IF NOT Bugzilla.feature('mfa') %]
   <input type="hidden" name="mfa_action" id="mfa-action" value="">
   <p>
@@ -195,7 +200,7 @@
         <p>You are a member of a group that requires Duo Security to be used for your MFA</p>
       [% END %]
 
-       [% IF Param("duo_uri")  %]
+       [% IF duo_allowed %]
         <button type="button" id="mfa-select-duo">Duo Security</button><br>
         <blockquote>
           <p>Requires a <a href="https://mana.mozilla.org/wiki/display/SD/DuoSecurity" target="_blank" rel="noopener noreferrer">Duo Security</a>
@@ -262,7 +267,7 @@
 
     </div>
 
-    [% IF Param("duo_uri") %]
+    [% IF duo_allowed %]
       [%# enable - duo %]
       <div id="mfa-enable-duo" style="display:none">
 


### PR DESCRIPTION
* Do not display the Duo Security option for MFA choices unless the user is 1) required to use Duo (config param) or 2) the user is a Mozilla employee (member of mozilla-employee-confidential group).
* Also block in enroll() in vase they try to bypass.