### PR TITLE
Bug 1887858 - What needs my attention: remove duplicate needinfos

### DIFF
--- a/extensions/BMO/lib/Reports/Attention.pm
+++ b/extensions/BMO/lib/Reports/Attention.pm
@@ -52,12 +52,10 @@ sub format_bug_list {
   my $datetime_now = DateTime->now(time_zone => $user->timezone);
 
   my @formatted_bugs;
-  my %local_seen;
   foreach my $row (@{$bugs}) {
 
-    # Skip if we have already seen this bug locally or globally
+    # Skip if we have already seen this bug globally
     my $bug_id = $row->{bug_id};
-    next if $local_seen{$bug_id};
     next if $global_seen->{$bug_id};
 
     my $bug = {
@@ -75,8 +73,7 @@ sub format_bug_list {
     $bug->{changeddate_epoch} = $datetime->epoch;
     $bug->{changeddate_fancy} = time_ago($datetime, $datetime_now);
 
-    # We only want to see a bug id once per page load so mark them seen
-    $local_seen{$bug_id} = 1;
+    # We only want to see a bug id once per page load so mark it as seen
     $global_seen->{$bug_id} = 1;
 
     push @formatted_bugs, $bug;

--- a/extensions/BMO/lib/Reports/Attention.pm
+++ b/extensions/BMO/lib/Reports/Attention.pm
@@ -433,10 +433,10 @@ sub report {
       . ' WHERE name LIKE \'%-security\'');
 
   # build bug lists
-  $vars->{critical_assigned_bugs}  = critical_assigned_bugs($who);
   $vars->{critical_needinfo_bugs}  = critical_needinfo_bugs($who);
-  $vars->{important_assigned_bugs} = important_assigned_bugs($who);
+  $vars->{critical_assigned_bugs}  = critical_assigned_bugs($who);
   $vars->{important_needinfo_bugs} = important_needinfo_bugs($who);
+  $vars->{important_assigned_bugs} = important_assigned_bugs($who);
   $vars->{other_needinfo_bugs}     = other_needinfo_bugs($who);
 
   # count number of unique bugs

--- a/extensions/BMO/lib/Reports/Attention.pm
+++ b/extensions/BMO/lib/Reports/Attention.pm
@@ -48,24 +48,37 @@ sub get_bug_list {
 
 sub format_bug_list {
   my ($bugs, $user) = @_;
-
+  my $global_seen  = Bugzilla->request_cache->{attention}->{global_seen};
   my $datetime_now = DateTime->now(time_zone => $user->timezone);
 
   my @formatted_bugs;
+  my %local_seen;
   foreach my $row (@{$bugs}) {
+
+    # Skip if we have already seen this bug locally or globally
+    my $bug_id = $row->{bug_id};
+    next if $local_seen{$bug_id};
+    next if $global_seen->{$bug_id};
+
     my $bug = {
-      id          => $row->{bug_id},
+      id          => $bug_id,
       status      => $row->{bug_status},
       priority    => $row->{priority},
       severity    => $row->{bug_severity},
       summary     => $row->{short_desc},
       changeddate => $row->{delta_ts},
     };
+
     my $datetime = datetime_from($bug->{changeddate});
     $datetime->set_time_zone($user->timezone);
     $bug->{changeddate}       = $datetime->strftime('%Y-%m-%d %T %Z');
     $bug->{changeddate_epoch} = $datetime->epoch;
     $bug->{changeddate_fancy} = time_ago($datetime, $datetime_now);
+
+    # We only want to see a bug id once per page load so mark them seen
+    $local_seen{$bug_id} = 1;
+    $global_seen->{$bug_id} = 1;
+
     push @formatted_bugs, $bug;
   }
 
@@ -382,31 +395,39 @@ sub report {
     = $input->{who} ? Bugzilla::User->check({name => $input->{who}}) : $user;
   $vars->{who} = $who->login;
 
+  # Create a global seen list of bugs (if not yet exists) to make sure
+  # we do not show a bug more than once across all lists. Request cache
+  # lasts for only this request.
+  my $request_cache = Bugzilla->request_cache;
+  $request_cache->{attention} = {};
+  $request_cache->{attention}->{global_seen} = {};
+
+  my $dbh = Bugzilla->dbh;
+
   # Here we load some values into cache that will be used later
-  # by the various queries.
-  my $cache = Bugzilla->process_cache->{attention} = {};
-  my $dbh   = Bugzilla->dbh;
+  # by the various queries. Process cache lasts til server restart.
+  my $process_cache = Bugzilla->process_cache->{attention} = {};
 
   # classifications
-  $cache->{classification_ids} ||= $dbh->selectcol_arrayref('
+  $process_cache->{classification_ids} ||= $dbh->selectcol_arrayref('
     SELECT id
       FROM classifications
      WHERE name IN (' . join(', ', map { $dbh->quote($_) } CLASSIFICATIONS) . ')');
 
   # needinfo flag
-  $cache->{needinfo_flag_id} ||= $dbh->selectrow_array("
+  $process_cache->{needinfo_flag_id} ||= $dbh->selectrow_array("
     SELECT id FROM flagtypes WHERE name = 'needinfo'");
 
   # keyword ids
-  $cache->{sec_critical_id} ||= $dbh->selectrow_array("
+  $process_cache->{sec_critical_id} ||= $dbh->selectrow_array("
     SELECT id FROM keyworddefs WHERE name = 'sec-critical'");
-  $cache->{sec_high_id} ||= $dbh->selectrow_array("
+  $process_cache->{sec_high_id} ||= $dbh->selectrow_array("
     SELECT id FROM keyworddefs WHERE name = 'sec-high'");
-  $cache->{regression_id} ||= $dbh->selectrow_array("
+  $process_cache->{regression_id} ||= $dbh->selectrow_array("
     SELECT id FROM keyworddefs WHERE name = 'regression'");
 
   # Get a list of group ids that end in -security
-  $cache->{sec_group_ids}
+  $process_cache->{sec_group_ids}
     ||= $dbh->selectcol_arrayref('SELECT id FROM '
       . $dbh->quote_identifier('groups')
       . ' WHERE name LIKE \'%-security\'');


### PR DESCRIPTION
This pull request uses caches to make sure that a bug is only displayed once per page load of the attention report. The local cache is for removing duplicates for a single section and the global cache is for all sections of the page. The way the cache works is the duplicates will be removed for the lower sections which are the least important and display them in the upper more critical sections.