### PR TITLE
Bug 1888810 - Hide editing option of user profiles for users without corresponding authorization

### DIFF
--- a/extensions/BMO/web/js/edituser_menu.js
+++ b/extensions/BMO/web/js/edituser_menu.js
@@ -47,7 +47,7 @@ function show_usermenu(vcard) {
             }
         });
     }
-    if (hide_profile == 0) {
+    if (hide_profile === "0") {
         items.unshift({
             name: "Profile",
             callback: function () {
@@ -56,7 +56,7 @@ function show_usermenu(vcard) {
             }
         });
     }
-    if (show_edit) {
+    if (show_edit === "1") {
         items.push({
             name: "Edit",
             callback: function () {


### PR DESCRIPTION
Since the values are now considered strings instead of boolean values from vcard.dataset, we use strict value checking to see if the value is "0' or "1". 