### PR TITLE
Bug 1884724 - Standard bug entry form  for non-canconfirm users is missing fields that are available from the guided form

### DIFF
--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -5138,6 +5138,7 @@ sub check_can_change_field {
     if (
          $field eq 'short_desc'
       || $field eq 'component'
+      || $field eq 'version'
       || $field eq 'rep_platform'
       || $field eq 'op_sys'
       || ($field eq 'bug_type' && Bugzilla->params->{'require_bug_type'})

--- a/extensions/BugModal/template/en/default/bug_modal/create.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/create.html.tmpl
@@ -205,9 +205,10 @@
     [% INCLUDE bug_modal/field.html.tmpl
         field = bug_fields.version
         field_type = constants.FIELD_TYPE_SINGLE_SELECT
-        values = version
+        values = product.versions
+        value = bug.version
         help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#version"
-        advanced = 1
+        required = 1
     %]
 
     [%# platform %]


### PR DESCRIPTION
When a user who does not have canconfirm, normally they see the guided bug entry form by default. The guided form has a drop down for selecting product version. If they click the link at the bottom to switch over to the standard bug form, they are unable to select a version as it is hidden.

This PR changes the standard bug form to no longer consider the version drop down to be an *advanced* field and also make it required. Users without canconfirm cannot show advanced field so they always see a very simple version of the standard bug entry form.