### PR TITLE
Bug 1892480 - Duo Security help link points to a non-existent page on the internal wiki site

### DIFF
--- a/extensions/BMO/template/en/default/bug/create/create-intern.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-intern.html.tmpl
@@ -246,7 +246,8 @@ $(document).ready(function() {
     <div class="row">
       <label class="required" for="job_description">
         Job Description
-        (<a target="_blank" rel="noopener noreferrer" href="https://mana.mozilla.org/wiki/display/globalstaffing/Intern+Job+Descriptions">more info</a>)
+        (<a target="_blank" rel="noopener noreferrer" 
+            href="https://mozilla-hub.atlassian.net/wiki/spaces/PR/pages/207814851/Early+Career+Program+at+Mozilla">more info</a>)
       </label>
       <textarea required name="job_description"
                 id="job_description" cols="80"  rows="10"

--- a/extensions/BMO/template/en/default/bug/create/create-recoverykey.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-recoverykey.html.tmpl
@@ -28,7 +28,7 @@
 
 <ul>
   <li>The Recovery Key will be displayed during the encryption process
-    (<a href="https://mana.mozilla.org/wiki/display/INFRASEC/Desktop+Security#DesktopSecurity-DiskencryptionFileVault">more info</a>)
+    (<a href="https://mozilla-hub.atlassian.net/wiki/spaces/SD/pages/26741084/FileVault+for+Mac">more info</a>)
   </li>
   <li>The asset tag number is located on a sticker typically on the bottom of the device.</li>
 </ul>

--- a/extensions/BMO/template/en/default/bug/create/create-recruiting.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-recruiting.html.tmpl
@@ -338,13 +338,13 @@ function jobDescToggle(what) {
             page. Please run your description through Textio before uploading
             it to your headcount request [% terms.bug %]. To learn more about
             Textio and learn how to create a Textio account,
-            <a href="https://mana.mozilla.org/wiki/display/globalstaffing/Diversity+Recruiting+Initiatives">
-              visit this Mana page</a>.<br><br>
+            <a href="https://mozilla-hub.atlassian.net/wiki/spaces/PR/pages/24449785/Job+Description+Resources">
+              visit this page</a>.<br><br>
             Please upload a draft of the Job Description you would like to be associated with this requisition
             (or <a href="javascript:jobDescToggle('text')">paste text as attachment</a>).</em><br>
           <input type="file" id="data" name="data" size="60"><br>
           <em>For job description formatting guidelines and help writing your job description please read the
-            <a href="https://mana.mozilla.org/wiki/display/globalstaffing/Best+Practices+Guide%3A+Writing+Job+Descriptions"
+            <a href="https://mozilla-hub.atlassian.net/wiki/spaces/PR/pages/24449785/Job+Description+Resources"
                target="_blank" rel="noopener noreferrer">Best Practices Guide</a>.</em>
         </td>
       </tr>
@@ -358,7 +358,7 @@ function jobDescToggle(what) {
             (or <a href="javascript:jobDescToggle('file')">attach a file</a>).</em><br>
           <textarea id="attach_text" name="attach_text" cols="60" rows="4"></textarea><br>
           <em>For job description formatting guidelines and help writing your job description please read the
-            <a href="https://mana.mozilla.org/wiki/display/globalstaffing/Best+Practices+Guide%3A+Writing+Job+Descriptions"
+            <a href="https://mozilla-hub.atlassian.net/wiki/spaces/PR/pages/24449785/Job+Description+Resources"
                target="_blank" rel="noopener noreferrer">Best Practices Guide</a>.</em>
         </td>
       </tr>

--- a/template/en/default/account/prefs/mfa.html.tmpl
+++ b/template/en/default/account/prefs/mfa.html.tmpl
@@ -203,7 +203,8 @@
        [% IF duo_allowed %]
         <button type="button" id="mfa-select-duo">Duo Security</button><br>
         <blockquote>
-          <p>Requires a <a href="https://mana.mozilla.org/wiki/display/SD/DuoSecurity" target="_blank" rel="noopener noreferrer">Duo Security</a>
+          <p>Requires a <a href="https://mozilla-hub.atlassian.net/wiki/spaces/SD/pages/26739600/DuoSecurity+Overviewi" 
+                           target="_blank" rel="noopener noreferrer">Duo Security</a>
           account (required for Mozilla employees).</p>
           <p>If this account is for automation and Duo 2FA is not appropriate, Please
           <a href="[% basepath FILTER none %]enter_bug.cgi?product=bugzilla.mozilla.org&component=Administration">
@@ -280,7 +281,8 @@
           <img src="[% basepath FILTER none %]images/duo.png" id="duo-logo" width="32" height="32">
           Verification with Duo Security will be performed before your account is updated.<br>
 
-          You must be <a href="https://mana.mozilla.org/wiki/display/SD/DuoSecurity" target="_blank" rel="noopener noreferrer">
+          You must be <a href="https://mozilla-hub.atlassian.net/wiki/spaces/SD/pages/26739600/DuoSecurity+Overview" 
+                         target="_blank" rel="noopener noreferrer">
           enrolled with Duo Security via login.mozilla.com</a> before you can use Duo 2FA.
         </p>
 

--- a/template/en/default/mfa/duo/not_enrolled.html.tmpl
+++ b/template/en/default/mfa/duo/not_enrolled.html.tmpl
@@ -45,7 +45,8 @@
 
   <p>
     Please ensure you are using your Mozilla LDAP username, and that you have
-    completed the <a href="https://mana.mozilla.org/wiki/display/SD/DuoSecurity" target="_blank" rel="noopener noreferrer">
+    completed the <a href="https://mozilla-hub.atlassian.net/wiki/spaces/SD/pages/26739600/DuoSecurity+Overview" 
+                     target="_blank" rel="noopener noreferrer">
       Duo Security enrollment process</a>.
   </p>
 


### PR DESCRIPTION
Update broken links to new locations on Mozilla Confluence.