### PR TITLE
Bug 1891527 - In Bugmail & Bug History for User Story edits, there's a warning about 'No newline at end of file' for user-entered values, even though the submitted value included a trailing newline

### DIFF
--- a/extensions/UserStory/Extension.pm
+++ b/extensions/UserStory/Extension.pm
@@ -68,11 +68,15 @@ sub bug_update_before_logging {
   my ($self, $args) = @_;
   my $changes = $args->{changes};
   return unless exists $changes->{cf_user_story};
-  my $diff = diff(
-    \$changes->{cf_user_story}->[0],
-    \$changes->{cf_user_story}->[1],
-    {CONTEXT => 0,},
-  );
+
+  my $old_value = $changes->{cf_user_story}->[0];
+  my $new_value = $changes->{cf_user_story}->[1];
+
+  # Add back newline to get rid of "No newline at end of file" error
+  $old_value .= "\n" if $old_value !~ /(?:\n|\r\n)$/;
+  $new_value .= "\n" if $new_value !~ /(?:\n|\r\n)$/;
+
+  my $diff = diff(\$old_value, \$new_value);
   $changes->{cf_user_story} = ['', $diff];
 }
 


### PR DESCRIPTION
I updated the code to add back the stripped newlines from the user story value before performing the diff if the newlines are missing. This fixes the issue with the warning being added to the diff output.