### PR TITLE
Bug 1893924 - Tabular reports return blank tables

### DIFF
--- a/report.cgi
+++ b/report.cgi
@@ -337,15 +337,12 @@ sub check_value {
   my ($field, $result) = @_;
 
   my $value;
-  if (!defined $field) {
+  if (!defined $field || $field eq '') {
     $value = '';
-  }
-  elsif ($field eq '') {
-    $value = ' ';
   }
   else {
     $value = shift @$result;
-    $value = ' ' if (!defined $value || $value eq '');
+    $value = '' if (!defined $value || $value eq '');
     $value = '---' if ($field eq 'resolution' && $value eq ' ');
   }
   return $value;

--- a/template/en/default/reports/report-table.html.tmpl
+++ b/template/en/default/reports/report-table.html.tmpl
@@ -37,10 +37,6 @@
 [% col_field_disp = field_descs.$col_field || col_field %]
 [% row_field_disp = field_descs.$row_field || row_field %]
 
-[%# Fix an empty table name that can cause issues on CSS selectors, etc. %]
-[% IF tbl == " " %]
-  [% tbl = "" %]
-[% END %]
 [% urlbase = BLOCK %][% basepath FILTER none %]buglist.cgi?[% buglistbase FILTER html %][% END %]
 [% IF tbl == "-total-" %]
   [% IF tbl_vals %]


### PR DESCRIPTION
The previous removal of YUI javascript datatables broke rendering of values for tabular reports. This change fixes that.