### PR TITLE
Bug 1893924 - Tabular reports return blank tables

### DIFF
--- a/report.cgi
+++ b/report.cgi
@@ -337,13 +337,16 @@ sub check_value {
   my ($field, $result) = @_;
 
   my $value;
-  if (!defined $field || $field eq '') {
+  if (!defined $field) {
     $value = '';
+  }
+  elsif ($field eq '') {
+    $value = 'single';
   }
   else {
     $value = shift @$result;
-    $value = '' if (!defined $value || $value eq '');
-    $value = '---' if ($field eq 'resolution' && $value eq ' ');
+    $value = 'single' if (!defined $value || $value eq '');
+    $value = '---' if ($field eq 'resolution' && $value eq 'single');
   }
   return $value;
 }

--- a/template/en/default/reports/report-table.html.tmpl
+++ b/template/en/default/reports/report-table.html.tmpl
@@ -37,6 +37,9 @@
 [% col_field_disp = field_descs.$col_field || col_field %]
 [% row_field_disp = field_descs.$row_field || row_field %]
 
+[%# Class and ID names need to have whitespace removed. %]
+[% tbl_id = tbl FILTER css_class_quote %]
+
 [% urlbase = BLOCK %][% basepath FILTER none %]buglist.cgi?[% buglistbase FILTER html %][% END %]
 [% IF tbl == "-total-" %]
   [% IF tbl_vals %]
@@ -47,34 +50,33 @@
 [% END %]
 
 <script [% script_nonce FILTER none %]>
-function bz_encode (str, decode) {
+function bz_encode (str) {
   if (typeof str !== 'string') {
     str = String(str);
   }
 
-  // First decode HTML entities, if requested.
-  if (decode)
-    str = str.replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&quot;/g, '"')
-             .replace(/&nbsp;/g, " ").replace(/&amp;/g, "&").replace(/\s+$/,"");
+  // First decode HTML entities.
+  str = str.replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&quot;/g, '"')
+           .replace(/&nbsp;/g, " ").replace(/&amp;/g, "&").replace(/\s+$/,"");
 
   // encodeURIComponent() doesn't escape single quotes.
   return encodeURIComponent(str).replace(/'/g, escape);
 };
 
 window.addEventListener('DOMContentLoaded', () => {
-  const linkify = ({ value, data }) => {
+  const linkify = ({ $column, value, data }) => {
     if (value === '.') {
       return '.';
     }
 
     if (data.row_title === 'Total') {
       return '<a href="[% urlbase FILTER js %]&amp;[% col_field FILTER uri FILTER js %]='
-        + bz_encode(data.field) + '[% "&amp;" _ row_vals IF row_vals %]">' + value + '</a>';
+        + bz_encode($column.dataset.key) + '[% "&amp;" _ row_vals IF row_vals %]">' + encodeURIComponent(value) + '</a>';
     }
 
     return '<a href="[% urlbase FILTER js %]&amp;[% row_field FILTER uri FILTER js %]='
-      + bz_encode(data.row_title, 1) + '&amp;[% col_field FILTER uri FILTER js %]='
-      + bz_encode(data.field) + '">' + value + '</a>';
+      + bz_encode(data.row_title) + '&amp;[% col_field FILTER uri FILTER js %]='
+      + bz_encode($column.dataset.key) + '">' + encodeURIComponent(value) + '</a>';
   };
 
   const linkifyTotal = ({ value, data }) => {
@@ -88,7 +90,7 @@ window.addEventListener('DOMContentLoaded', () => {
     }
 
     return '<a href="[% urlbase FILTER js %]&amp;[% row_field FILTER uri FILTER js %]='
-      + bz_encode(data.row_title, 1) + '[% "&amp;" _ col_vals IF col_vals %]">' + value + '</a>';
+      + bz_encode(data.row_title) + '[% "&amp;" _ col_vals IF col_vals %]">' + encodeURIComponent(value) + '</a>';
   };
 
   const totalRowFormatter = ({ $row, data }) => {
@@ -145,7 +147,7 @@ window.addEventListener('DOMContentLoaded', () => {
     },
   ];
 
-  const rows = [...document.querySelectorAll('#tabular_report tbody tr')];
+  const rows = [...document.querySelectorAll('#tabular_report_[% tbl_id FILTER js %] tbody tr')];
 
   const data = rows.map(($tr) => Object.fromEntries(
     [...$tr.querySelectorAll('td')].map(($td, index) => {
@@ -154,10 +156,10 @@ window.addEventListener('DOMContentLoaded', () => {
     })
   ));
 
-  document.querySelector('#tabular_report').remove();
+  document.querySelector('#tabular_report_[% tbl_id FILTER js %]').remove();
 
   new Bugzilla.DataTable({
-    container: '#tabular_report_container_[% tbl FILTER js %]',
+    container: '#tabular_report_container_[% tbl_id FILTER js %]',
     columns,
     data,
     options: { formatRow: totalRowFormatter },
@@ -189,8 +191,8 @@ window.addEventListener('DOMContentLoaded', () => {
 [% col_idx = 0 %]
 [% row_idx = 0 %]
 [% grand_total = 0 %]
-<div id="tabular_report_container_[% tbl FILTER html %]">
-<table id="tabular_report" border="1">
+<div id="tabular_report_container_[% tbl_id FILTER html %]">
+<table id="tabular_report_[% tbl_id FILTER html %]" border="1">
   [% IF col_field %]
     <thead>
     <tr>


### PR DESCRIPTION
Second try at fixing this the correct way. 

What was happening is when a single table of the report was being rendered, report.cgi was setting the table name to " " which the JS changes didn't like. So I now set the table name to "single" and look for that instead of " ". This fixes one issue occurring. On the same note there was also an issue with table identifiers have spaces in the names which I had to remove otherwise the tables were misrendered.

Another issue was that linkify and linkifyTotal formatters were not getting the column name value properly and only the row name and count. By passing in $column element (a <td>) to the formatters I am able to access the column and name and remove the undefined values showing up in the links to buglist.cgi.

And lastly, a third issue was when displaying multiple tables on a single report. The tables had data appearing in the wrong places when the JS was rendering them since each table was not distinct and was using the same "report_table" identifier. Changing to "report_table_[% tbl_id FILTER html %]" made each one distinct and all were rendered properly.