### PR TITLE
Bug 1895526 - Create Bugzilla/App/Controller directory where modules are auto loaded instead of being hard coded in the App.pm module

### DIFF
--- a/Bugzilla/App.pm
+++ b/Bugzilla/App.pm
@@ -201,16 +201,11 @@ sub setup_routes {
   # Load controller modules and their routes
   foreach my $module (find_modules('Bugzilla::App::Controller', {recursive => 1}))
   {
-    try {
-      require_module($module);
-      my $controller = $module->new;
-      if ($controller->can('setup_routes')) {
-        $controller->setup_routes($r);
-      }
+    require_module($module);
+    my $controller = $module->new;
+    if ($controller->can('setup_routes')) {
+      $controller->setup_routes($r);
     }
-    catch {
-      WARN("$module could not be loaded: $_");
-    };
   }
 
   $r->static_file('/__lbheartbeat__');

--- a/Bugzilla/App.pm
+++ b/Bugzilla/App.pm
@@ -206,6 +206,9 @@ sub setup_routes {
     if ($controller->can('setup_routes')) {
       $controller->setup_routes($r);
     }
+    else {
+      WARN("Could not execute setup_routes() for module: $module");
+    }
   }
 
   $r->static_file('/__lbheartbeat__');

--- a/Bugzilla/App.pm
+++ b/Bugzilla/App.pm
@@ -21,16 +21,7 @@ use Bugzilla::Constants;
 use Bugzilla::Extension             ();
 use Bugzilla::Install::Requirements ();
 use Bugzilla::Logging;
-use Bugzilla::App::API;
-use Bugzilla::App::BouncedEmails;
-use Bugzilla::App::CGI;
-use Bugzilla::App::Main;
-use Bugzilla::App::OAuth2::Provider::Clients;
-use Bugzilla::App::SES;
 use Bugzilla::App::Static;
-use Bugzilla::App::BMO::AntiSpam;
-use Bugzilla::App::BMO::NewRelease;
-use Bugzilla::App::MFA::Duo;
 use Mojo::Loader qw( find_modules );
 use Module::Runtime qw( require_module );
 use Bugzilla::Util ();
@@ -205,17 +196,22 @@ sub startup {
 
 sub setup_routes {
   my ($self) = @_;
-
   my $r = $self->routes;
-  Bugzilla::App::API->setup_routes($r);
-  Bugzilla::App::BouncedEmails->setup_routes($r);
-  Bugzilla::App::CGI->setup_routes($r);
-  Bugzilla::App::Main->setup_routes($r);
-  Bugzilla::App::OAuth2::Provider::Clients->setup_routes($r);
-  Bugzilla::App::SES->setup_routes($r);
-  Bugzilla::App::BMO::AntiSpam->setup_routes($r);
-  Bugzilla::App::BMO::NewRelease->setup_routes($r);
-  Bugzilla::App::MFA::Duo->setup_routes($r);
+
+  # Load controller modules and their routes
+  foreach my $module (find_modules('Bugzilla::App::Controller', {recursive => 1}))
+  {
+    try {
+      require_module($module);
+      my $controller = $module->new;
+      if ($controller->can('setup_routes')) {
+        $controller->setup_routes($r);
+      }
+    }
+    catch {
+      WARN("$module could not be loaded: $_");
+    };
+  }
 
   $r->static_file('/__lbheartbeat__');
   $r->static_file(

--- a/Bugzilla/App/Controller/API.pm
+++ b/Bugzilla/App/Controller/API.pm
@@ -5,7 +5,7 @@
 # This Source Code Form is "Incompatible With Secondary Licenses", as
 # defined by the Mozilla Public License, v. 2.0.
 
-package Bugzilla::App::API;
+package Bugzilla::App::Controller::API;
 
 use 5.10.1;
 use Mojo::Base qw( Mojolicious::Controller );

--- a/Bugzilla/App/Controller/BMO/AntiSpam.pm
+++ b/Bugzilla/App/Controller/BMO/AntiSpam.pm
@@ -5,7 +5,7 @@
 # This Source Code Form is "Incompatible With Secondary Licenses", as
 # defined by the Mozilla Public License, v. 2.0.
 
-package Bugzilla::App::BMO::AntiSpam;
+package Bugzilla::App::Controller::BMO::AntiSpam;
 
 use 5.10.1;
 use Mojo::Base 'Mojolicious::Controller';

--- a/Bugzilla/App/Controller/BMO/NewRelease.pm
+++ b/Bugzilla/App/Controller/BMO/NewRelease.pm
@@ -5,7 +5,7 @@
 # This Source Code Form is "Incompatible With Secondary Licenses", as
 # defined by the Mozilla Public License, v. 2.0.
 
-package Bugzilla::App::BMO::NewRelease;
+package Bugzilla::App::Controller::BMO::NewRelease;
 
 use 5.10.1;
 use Mojo::Base 'Mojolicious::Controller';

--- a/Bugzilla/App/Controller/BouncedEmails.pm
+++ b/Bugzilla/App/Controller/BouncedEmails.pm
@@ -5,7 +5,7 @@
 # This Source Code Form is "Incompatible With Secondary Licenses", as
 # defined by the Mozilla Public License, v. 2.0.
 
-package Bugzilla::App::BouncedEmails;
+package Bugzilla::App::Controller::BouncedEmails;
 
 use 5.10.1;
 use Mojo::Base qw( Mojolicious::Controller );

--- a/Bugzilla/App/Controller/CGI.pm
+++ b/Bugzilla/App/Controller/CGI.pm
@@ -5,7 +5,7 @@
 # This Source Code Form is "Incompatible With Secondary Licenses", as
 # defined by the Mozilla Public License, v. 2.0.
 
-package Bugzilla::App::CGI;
+package Bugzilla::App::Controller::CGI;
 use Mojo::Base 'Mojolicious::Controller';
 
 use CGI::Compile;

--- a/Bugzilla/App/Controller/MFA/Duo.pm
+++ b/Bugzilla/App/Controller/MFA/Duo.pm
@@ -5,7 +5,7 @@
 # This Source Code Form is "Incompatible With Secondary Licenses", as
 # defined by the Mozilla Public License, v. 2.0.
 
-package Bugzilla::App::MFA::Duo;
+package Bugzilla::App::Controller::MFA::Duo;
 
 use 5.10.1;
 use Mojo::Base 'Mojolicious::Controller';

--- a/Bugzilla/App/Controller/Main.pm
+++ b/Bugzilla/App/Controller/Main.pm
@@ -5,7 +5,7 @@
 # This Source Code Form is "Incompatible With Secondary Licenses", as
 # defined by the Mozilla Public License, v. 2.0.
 
-package Bugzilla::App::Main;
+package Bugzilla::App::Controller::Main;
 use Mojo::Base 'Mojolicious::Controller';
 
 use Bugzilla::Error;

--- a/Bugzilla/App/Controller/OAuth2/Provider/Clients.pm
+++ b/Bugzilla/App/Controller/OAuth2/Provider/Clients.pm
@@ -5,7 +5,7 @@
 # This Source Code Form is "Incompatible With Secondary Licenses", as
 # defined by the Mozilla Public License, v. 2.0.
 
-package Bugzilla::App::OAuth2::Provider::Clients;
+package Bugzilla::App::Controller::OAuth2::Provider::Clients;
 use 5.10.1;
 use Mojo::Base 'Mojolicious::Controller';
 

--- a/Bugzilla/App/Controller/SES.pm
+++ b/Bugzilla/App/Controller/SES.pm
@@ -1,11 +1,11 @@
-package Bugzilla::App::SES;
-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 # This Source Code Form is "Incompatible With Secondary Licenses", as
 # defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::App::Controller::SES;
 
 use 5.10.1;
 use Mojo::Base qw( Mojolicious::Controller );

--- a/Bugzilla/App/Plugin/Glue.pm
+++ b/Bugzilla/App/Plugin/Glue.pm
@@ -99,7 +99,7 @@ sub register {
       if (%add_params || !$stash->{Bugzilla_csp}) {
         my %params = DEFAULT_CSP();
         delete $params{report_only} if %add_params && !$add_params{report_only};
-        delete $params{report_only} if !$c->isa('Bugzilla::App::CGI');
+        delete $params{report_only} if !$c->isa('Bugzilla::App::Controller::CGI');
         foreach my $key (keys %add_params) {
           if (defined $add_params{$key}) {
             $params{$key} = $add_params{$key};

--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -411,7 +411,7 @@ sub header {
   $self->{_header_done} = 1;
 
   my $headers = $self->SUPER::header(%headers) || '';
-  if ($self->server_software eq 'Bugzilla::App::CGI') {
+  if ($self->server_software eq 'Bugzilla::App::Controller::CGI') {
     my $C = Bugzilla->request_cache->{mojo_controller};
     $C->res->headers->parse($headers);
     my $status = $C->res->headers->status;
@@ -428,7 +428,7 @@ sub header {
   }
   else {
     LOGDIE(
-      "Bugzilla::CGI->header() should only be called from inside Bugzilla::App::CGI!"
+      "Bugzilla::CGI->header() should only be called from inside Bugzilla::App::Controller::CGI!"
     );
   }
 }

--- a/Bugzilla/Error.pm
+++ b/Bugzilla/Error.pm
@@ -35,7 +35,7 @@ use Scalar::Util qw(blessed);
 sub _in_eval {
   my $in_eval = 0;
   for (my $stack = 1; my $sub = (caller($stack))[3]; $stack++) {
-    last if $sub =~ /^Bugzilla::App::CGI::try/;
+    last if $sub =~ /^Bugzilla::App::Controller::CGI::try/;
     $in_eval = 1 if $sub =~ /^\(eval\)/;
   }
   return $in_eval;

--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -521,7 +521,7 @@ sub process {
   my ($self, $input, $vars, $output) = @_;
   $vars //= {};
 
-  if (($ENV{SERVER_SOFTWARE} // '') eq 'Bugzilla::App::CGI') {
+  if (($ENV{SERVER_SOFTWARE} // '') eq 'Bugzilla::App::Controller::CGI') {
     $vars->{self} = $vars->{c} = Bugzilla->request_cache->{mojo_controller};
   }
 

--- a/extensions/BzAPI/Extension.pm
+++ b/extensions/BzAPI/Extension.pm
@@ -13,6 +13,8 @@ use warnings;
 
 use base qw(Bugzilla::Extension);
 
+use Bugzilla::App::Controller::CGI;
+
 use Bugzilla::Extension::BzAPI::Constants;
 use Bugzilla::Extension::BzAPI::Util qw(fix_credentials filter_wants_nocache);
 
@@ -286,7 +288,7 @@ sub app_startup {
   my $app = $args->{app};
   my $r   = $app->routes;
 
-  Bugzilla::App::CGI->load_one('bzapi_cgi', 'extensions/BzAPI/bin/rest.cgi');
+  Bugzilla::App::Controller::CGI->load_one('bzapi_cgi', 'extensions/BzAPI/bin/rest.cgi');
   $r->any('/extensions/BzAPI/bin/rest.cgi/*PATH_INFO')->to('CGI#bzapi_cgi');
   $r->any('/latest/*PATH_INFO')->to('CGI#bzapi_cgi');
   $r->any('/bzapi/*PATH_INFO')->to('CGI#bzapi_cgi');


### PR DESCRIPTION
Currently in Bugzilla/App.pm whenever a new Mojo controller module is added to add new functionality, we have to include the loading of the specific module and call its setup_routes() function. This bug is to create a new Bugzilla/App/Controller directory that we can place new controller modules and they will be loaded automatically instead of being hard coded. The change will create the code to auto load the modules as well as move the existing modules to the new location.