### PR TITLE
Bug 1901825 - Use of memcache causing intermittent errors in Bugzilla Reminders feature

### DIFF
--- a/Bugzilla/Reminder.pm
+++ b/Bugzilla/Reminder.pm
@@ -48,7 +48,7 @@ use constant VALIDATORS => {
 use constant AUDIT_CREATES => 1;
 use constant AUDIT_UPDATES => 1;
 use constant AUDIT_REMOVES => 1;
-use constant USE_MEMCACHED => 1;
+use constant USE_MEMCACHED => 0;
 
 # getters
 


### PR DESCRIPTION
Use of memcache needs to be disable for Bugzilla::Reminder as it is not appropriate use of the cache for that type of code. It is causing intermittent errors such as columns are not found during match, etc. I have tested disabling of memcache for the reminders table on bugilla-dev and the issue is no longer occurring.