### PR TITLE
Bug 1903627 - "Remove reminder" button is still shown despite no reminders remaining on bug

### DIFF
--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -4644,8 +4644,8 @@ sub is_reminded {
   $user ||= Bugzilla->user;
 
   require Bugzilla::Reminder;
-  my $reminders
-    = Bugzilla::Reminder->match({bug_id => $self->id, user_id => $user->id});
+  my $reminders = Bugzilla::Reminder->match(
+    {bug_id => $self->id, user_id => $user->id, sent => 0});
   if (@{$reminders}) {
     return $self->{is_reminded} = 1;
   }


### PR DESCRIPTION
Need to filter out the reminder in is_reminded if sent = 1