### PR TITLE
Bug 1200286 - The permissions section in user preferences should distinguish between assigned and inherited groups

### DIFF
--- a/template/en/default/account/prefs/permissions.html.tmpl
+++ b/template/en/default/account/prefs/permissions.html.tmpl
@@ -18,76 +18,67 @@
   # Contributor(s): Gervase Markham <gerv@gerv.net>
   #%]
 
-[%# INTERFACE:
-  # has_bits: array of hashes. May be empty.
-  #           name => Names of the permissions the user has.
-  #           desc => Descriptions of the permissions the user has.
-  # set_bits: array of hashes. May be empty.
-  #           name => Names of the permissions the user can set for
-  #           other people.
-  #           desc => Descriptions of the permissions the user can set for
-  #           other people.
-  #%]
-
 [% PROCESS global/variables.none.tmpl %]
 
-<table align="center">
-  <tr>
-    <td>
-      [% IF has_bits.size %]
-        You have the following permission bits set on your account:
-        <table align="center">
-          [% FOREACH bit_description = has_bits %]
-            <tr>
-              <td>[% bit_description.name FILTER html %]</td>
-              <td>[% bit_description.desc FILTER html_light %]</td>
-            </tr>
-          [% END %]
-        </table>
+[%
+  # Do not show the can admin column unless we can bless something
+  SET can_bless_any = 0;
+  FOREACH g = groups;
+    IF g.can_bless;
+      can_bless_any = 1;
+    END;
+  END; 
+%]
 
-        [% FOREACH privs = ["editcomponents", "canconfirm", "editbugs"] %]
-          [% SET products = ${"local_$privs"} %]
-          [% IF products && products.size %]
-            <br>
-            <p>
-              You also have local '[% privs FILTER html %]' privileges
-              for the following products:
-            </p>
-            <p>
-              [% FOREACH product = products %]
-                [% product.name FILTER html %]<br>
-              [% END %]
-            </p>
-          [% END %]
+[% IF groups.size %]
+  <p>You have the following permission bits set on your account:</p>
+  <table id="report" class="standard">
+    <tr>
+      <th>Name</th>
+      <th>Description</th>
+      [% IF can_bless_any %]
+      <th>Can Admin</th>
+      [% END %]
+      <th>Inherited From</th>
+    </tr>
+    [% FOREACH g = groups %]
+      <tr>
+        <td>[% g.name FILTER html %]</td>
+        <td>[% g.description FILTER html %]</td>
+        [% IF can_bless_any %]
+        <td>[% IF g.can_bless %]Yes[% ELSE %]No[% END %]
         [% END %]
-
-      [% ELSE %]
-        There are no permission bits set on your account.
-      [% END %]
-
-      [% IF user.in_group('admin') %]
-        <br>
-        You have admin privileges.  You can turn on and off
-        all permissions for all users.
-      [% ELSIF set_bits.size %]
-        <br>
-        And you can turn on or off the following bits for
-        <a href="[% basepath FILTER none %]editusers.cgi">other users</a>:
-          <table align="center">
-          [% FOREACH bit_description = set_bits %]
-            <tr>
-              <td>[% bit_description.name FILTER html %]</td>
-              <td>[% bit_description.desc FILTER html_light %]</td>
-            </tr>
+        <td>
+          [% IF NOT g.inherited.size %]
+            direct
+          [% ELSE %]
+            [% FOREACH inherited_group = g.inherited %]
+              <i>[% inherited_group FILTER html %]</i><br>
+            [% END %]
           [% END %]
-          </table>
-      [% END %]
+        </td>
+      </tr>
+    [% END %]
+  </table>
 
-      [% IF user.in_group('bz_sudoers') %]
-        <br>
-        You are a member of the <b>bz_sudoers</b> group, so you can
-        <a href="[% basepath FILTER none %]relogin.cgi?action=prepare-sudo">impersonate someone else</a>.
-      [% END %]
-    </td>
-  </tr>
-</table>
+  [% FOREACH privs = ["editcomponents", "canconfirm", "editbugs"] %]
+    [% SET products = ${"product_$privs"} %]
+    [% IF products && products.size %]
+      <p>You also have <b>[% privs FILTER html %]</b> privileges for the following products:</p>
+      <p>
+        [% FOREACH product = products %]
+          [% product.name FILTER html %]<br>
+         [% END %]
+      </p>
+    [% END %]
+  [% END %]
+  [% IF user.in_group('admin') %]
+    <p>You have <b>admin</b> privileges. You can turn on and off all permissions for all users.</p>
+  [% END %]
+  [% IF user.in_group('bz_sudoers') %]
+    <p>You are a member of the <b>bz_sudoers</b> group, so you can
+      <a href="relogin.cgi?action=prepare-sudo">impersonate someone else</a>.</p>
+  [% END %]
+ [% ELSE %]
+  There are no permission bits set on your account.
+[% END %]

--- a/template/en/default/account/prefs/permissions.html.tmpl
+++ b/template/en/default/account/prefs/permissions.html.tmpl
@@ -20,8 +20,8 @@
 
 [% PROCESS global/variables.none.tmpl %]
 
+[%# Do not show the can admin column unless we can bless something %]
 [%
-  # Do not show the can admin column unless we can bless something
   SET can_bless_any = 0;
   FOREACH g = groups;
     IF g.can_bless;

--- a/userprefs.cgi
+++ b/userprefs.cgi
@@ -535,38 +535,76 @@ sub SaveEmail {
 sub DoPermissions {
   my $dbh  = Bugzilla->dbh;
   my $user = Bugzilla->user;
-  my (@has_bits, @set_bits);
 
-  my $groups
-    = $dbh->selectall_arrayref('SELECT DISTINCT name, description FROM '
-      . $dbh->quote_identifier('groups')
-      . ' WHERE id IN ('
-      . $user->groups_as_string
-      . ') ORDER BY name');
-  foreach my $group (@$groups) {
-    my ($nam, $desc) = @$group;
-    push(@has_bits, {"desc" => $desc, "name" => $nam});
-  }
-  $groups = $dbh->selectall_arrayref(
-    'SELECT DISTINCT id, name, description
-       FROM ' . $dbh->quote_identifier('groups') . '
-      ORDER BY name'
+  # we need to show which groups are direct and which are inherited
+  my $groups_to_check = $dbh->selectcol_arrayref(
+    q{SELECT DISTINCT group_id
+          FROM user_group_map
+         WHERE user_id = ? AND isbless = 0}, undef, $user->id
   );
-  foreach my $group (@$groups) {
-    my ($group_id, $nam, $desc) = @$group;
-    if ($user->can_bless($group_id)) {
-      push(@set_bits, {"desc" => $desc, "name" => $nam});
+
+  my $rows = $dbh->selectall_arrayref(
+    q{SELECT DISTINCT grantor_id, member_id
+         FROM group_group_map
+        WHERE grant_type = ?}, undef, GROUP_MEMBERSHIP
+  );
+
+  my %group_membership;
+  foreach my $row (@{$rows}) {
+    my ($grantor_id, $member_id) = @{$row};
+    push @{$group_membership{$member_id}}, $grantor_id;
+  }
+
+  my %checked_groups;
+  my %direct_groups;
+  my %indirect_groups;
+  my %groups;
+
+  foreach my $member_id (@{$groups_to_check}) {
+    $direct_groups{$member_id} = 1;
+  }
+
+  while (scalar(@{$groups_to_check}) > 0) {
+    my $member_id = shift @{$groups_to_check};
+    if (!$checked_groups{$member_id}) {
+      $checked_groups{$member_id} = 1;
+      my $members      = $group_membership{$member_id};
+      my @new_to_check = grep { !$checked_groups{$_} } @{$members};
+      push @{$groups_to_check}, @new_to_check;
+      foreach my $id (@new_to_check) {
+        $indirect_groups{$id} = $member_id;
+      }
+      $groups{$member_id} = 1;
     }
   }
+
+  my @groups;
+  my $ra_groups = Bugzilla::Group->new_from_list([keys %groups]);
+  foreach my $group (@{$ra_groups}) {
+    my %inherited;
+    if (!$direct_groups{$group->id}) {
+      foreach my $g (@{$ra_groups}) {
+        if ($g->id == $indirect_groups{$group->id}) {
+          $inherited{$g->name} = 1;
+        }
+      }
+    }
+    push @groups,
+      {
+      name        => $group->name,
+      description => $group->description,
+      can_bless   => $user->can_bless($group->id),
+      inherited   => [keys %inherited],
+      };
+  }
+
+  $vars->{groups} = \@groups;
 
   # If the user has product specific privileges, inform them about that.
   foreach my $privs (PER_PRODUCT_PRIVILEGES) {
     next if $user->in_group($privs);
-    $vars->{"local_$privs"} = $user->get_products_by_permission($privs);
+    $vars->{"product_$privs"} = $user->get_products_by_permission($privs);
   }
-
-  $vars->{'has_bits'} = \@has_bits;
-  $vars->{'set_bits'} = \@set_bits;
 }
 
 # No SavePermissions() because this panel has no changeable fields.


### PR DESCRIPTION
This change revamps the permissions page in user preferences. It uses the css for other reports so it is consistent. Also it now shows which groups someones permission is inherited from.

I also put this change on bugzilla-dev if you want to see it in action:
https://bugzilla-dev.allizom.org/userprefs.cgi?tab=permissions