### PR TITLE
Bug 1905292 - Hide spam content to discourage spammers

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -53,6 +53,10 @@
 
   FOREACH change_set IN bug.activity_stream;
     NEXT IF change_set.cc_only;
+
+    # Hide the comment if marked as spam from users without editbugs
+    NEXT IF change_set.comment && change_set.comment.tags.contains('spam') && !user.in_group('editbugs');
+
     extra_class = change_set.comment.collapsed ? " ca-" _ change_set.comment.author.id : "";
     '<div class="change-set' _ extra_class _ '" id="' _ change_set.id _ '">';
 


### PR DESCRIPTION
This patch skip the rendering of comments that have spam tag to users without editbugs permissions.