### PR TITLE
Bug 1907893 - Malformed URL in SES complaint emails sent to bugzilla maintainers

### DIFF
--- a/template/en/default/email/ses-complaint.txt.tmpl
+++ b/template/en/default/email/ses-complaint.txt.tmpl
@@ -23,7 +23,7 @@ X-Bugzilla-Type: admin
 SES Complaint received for [% email %]: [% reason %]
 
 [% IF user %]
-[% urlbase %]/editusers.cgi?action=edit&userid=[% user.id %]
+[% urlbase %]editusers.cgi?action=edit&userid=[% user.id %]
 [% ELSE %]
 Failed to find corresponding user in Bugzilla.
 [% END %]


### PR DESCRIPTION
In the templates [% urlbase %] always contains a / at the end (ex: https://bugzilla.mozilla.org/) so adding another / is not needed and causes //. This patch  removes the extra / from the link in the complain email sent to admins.