### PR TITLE
Bug 1908265 - cannot log in unless HTTP Referer request header is enabled

### DIFF
--- a/Bugzilla/Auth/Login/CGI.pm
+++ b/Bugzilla/Auth/Login/CGI.pm
@@ -45,24 +45,13 @@ sub get_login_info {
     $valid = 1 if $expected_token eq $login_token;
     $cgi->remove_cookie('Bugzilla_login_request_cookie');
   }
-
   # WebServices and other local scripts can bypass this check.
   # This is safe because we won't store a login cookie in this case.
   elsif (Bugzilla->usage_mode != USAGE_MODE_BROWSER) {
     $valid = 1;
   }
-
-  # Else falls back to the Referer header and accept local URLs.
-  # Attachments are served from a separate host (ideally), and so
-  # an evil attachment cannot abuse this check with a redirect.
-  elsif (my $referer = $cgi->referer) {
-    my $urlbase = Bugzilla->localconfig->urlbase;
-    $valid = 1 if $referer =~ /^\Q$urlbase\E/;
-  }
-
-  # If the web browser doesn't accept cookies and the Referer header
-  # is missing, we have no way to make sure that the authentication
-  # request comes from the user.
+  # If the web browser doesn't accept cookies, we have no way to 
+  # make sure that the authentication request comes from the user.
   elsif ($login && $password) {
     Bugzilla->iprepd_report('bmo.token_mismatch');
     ThrowUserError('auth_untrusted_request', {login => $login});

--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -667,13 +667,13 @@ sub set_dated_content_disp {
 }
 
 # If a cookie is requested that has been set but not yet stored in the browser,
-# then we can return it here
+# then we can return it here. 'X' means the cookie is being removed
 sub cookie {
   my ($self, @params) = @_;
   if (scalar @params == 1 && scalar @{$self->{Bugzilla_cookie_list}}) {
     foreach my $cookie (@{$self->{Bugzilla_cookie_list}}) {
-      return $cookie->value if $cookie->name eq $params[0];
-    };
+      return $cookie->value if $cookie->name eq $params[0] && $cookie->value ne 'X';
+    }
   }
   return $self->SUPER::cookie(@params);
 }

--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -666,6 +666,18 @@ sub set_dated_content_disp {
   $self->{'_content_disp'} = $disposition;
 }
 
+# If a cookie is requested that has been set but not yet stored in the browser,
+# then we can return it here
+sub cookie {
+  my ($self, @params) = @_;
+  if (scalar @params == 1 && scalar @{$self->{Bugzilla_cookie_list}}) {
+    foreach my $cookie (@{$self->{Bugzilla_cookie_list}}) {
+      return $cookie->value if $cookie->name eq $params[0];
+    };
+  }
+  return $self->SUPER::cookie(@params);
+}
+
 ##########################
 # Vars TIEHASH Interface #
 ##########################

--- a/token.cgi
+++ b/token.cgi
@@ -452,8 +452,11 @@ sub confirm_create_account {
   $vars->{'otheruser'} = $otheruser;
 
   # Log in the new user using credentials they just gave.
-  $cgi->param('Bugzilla_login',    $otheruser->login);
-  $cgi->param('Bugzilla_password', $password);
+  my $cookie = Bugzilla->cgi->cookie('Bugzilla_login_request_cookie');
+  $cgi->param('Bugzilla_login_token',
+    issue_hash_token(['login_request', $cookie]));
+  $cgi->param('Bugzilla_login',        $otheruser->login);
+  $cgi->param('Bugzilla_password',     $password);
   $cgi->param('token_account_created', 1);
   Bugzilla->login(LOGIN_OPTIONAL);
 


### PR DESCRIPTION
Quite a few automated tests and a few places in the code were relying on the referer header change that was put in place long ago. I have fixed up the tests and places where it will instead (properly) rely on cookies instead of referer to validate a request is legitimate. 