### PR TITLE
Bug 1909777 - Require new users to set their username during the GitHub account creation flow

### DIFF
--- a/template/en/default/account/auth/verify_account_creation.html.tmpl
+++ b/template/en/default/account/auth/verify_account_creation.html.tmpl
@@ -20,6 +20,9 @@
     to be created.</p>
 
   <form method="POST" action="[% basepath FILTER none %]token.cgi">
+    <p>
+      Real Name <input type="text" name="realname" id="realname" value="[% realname FILTER html %]">
+    </p>
     <input type="hidden" name="t" value="[% token FILTER html %]">
     <input type="hidden" name="a" value="verify_auto_account_creation">
     <input type="submit" name="verify" value="Verify">

--- a/token.cgi
+++ b/token.cgi
@@ -545,10 +545,13 @@ sub verify_auto_account_creation {
   # create user from token data
   my $event = get_token_extra_data($token);
 
+  my $realname = Bugzilla->cgi->param('realname');
+  $realname ||= $event->{realname};
+
   my $user = Bugzilla::User->create({
     login_name    => $event->{login},
     cryptpassword => '*',
-    realname      => $event->{realname}
+    realname      => $realname,
   });
 
   $user->authorizer->auto_verified($user, $event);


### PR DESCRIPTION
This change adds an input field to the github (and other oauth2) login flow that allows a user to set a Real Name when the new account is created.