### PR TITLE
Bug 1910693 - Update sanitizeme script to remove more sensitive user data from dump file

### DIFF
--- a/extensions/AntiSpam/Extension.pm
+++ b/extensions/AntiSpam/Extension.pm
@@ -291,6 +291,14 @@ sub config_add_panels {
   $modules->{AntiSpam} = "Bugzilla::Extension::AntiSpam::Config";
 }
 
+sub db_sanitize {
+  my $dbh = Bugzilla->dbh;
+  print "Deleting antispam settings...\n";
+  $dbh->do('TRUNCATE TABLE antispam_domain_blocklist');
+  $dbh->do('TRUNCATE TABLE antispam_comment_blocklist');
+  $dbh->do('TRUNCATE TABLE antispam_ip_blocklist');
+}
+
 #
 # installation
 #

--- a/extensions/ComponentWatching/Extension.pm
+++ b/extensions/ComponentWatching/Extension.pm
@@ -702,6 +702,12 @@ sub sanitycheck_repair {
   }
 }
 
+sub db_sanitize {
+  my $dbh = Bugzilla->dbh;
+  print "Deleting component watchers...\n";
+  $dbh->do('TRUNCATE TABLE component_watch');
+}
+
 #
 # webservice
 #

--- a/extensions/SecureMail/Extension.pm
+++ b/extensions/SecureMail/Extension.pm
@@ -705,4 +705,10 @@ sub _filter_bug_links {
   });
 }
 
+sub db_sanitize {
+  my $dbh = Bugzilla->dbh;
+  print "Clearing public keys from profiles...\n";
+  $dbh->do("UPDATE profiles SET public_key = ''");
+}
+
 __PACKAGE__->NAME;

--- a/scripts/sanitizeme.pl
+++ b/scripts/sanitizeme.pl
@@ -253,6 +253,34 @@ sub delete_sensitive_user_data {
   $dbh->do("DELETE FROM ts_funcmap");
   $dbh->do("DELETE FROM ts_job");
   $dbh->do("DELETE FROM ts_note");
+
+  # Reminders
+  $dbh->do('TRUNCATE TABLE reminders');
+
+  # Whine events
+  $dbh->do('DELETE FROM whine_events');
+
+  # Watched users by other users
+  $dbh->do('TRUNCATE TABLE watch');
+
+  # Series data (charts)
+  $dbh->do('DELETE FROM series_categories');
+
+  # Email rate limiting
+  $dbh->do('TRUNCATE TABLE email_rates');
+
+  # Clear MFA for all users
+  $dbh->do("UPDATE profiles SET mfa = ''");
+
+  # Ignored bugs
+  $dbh->do('TRUNCATE TABLE email_bug_ignore');
+
+  # secbugs_* tables no longer used by any code
+  # but may contain sensitive info on older bugs
+  $dbh->do('TRUNCATE TABLE secbugs_Bugs');
+  $dbh->do('TRUNCATE TABLE secbugs_BugHistory');
+  $dbh->do('TRUNCATE TABLE secbugs_Details');
+  $dbh->do('TRUNCATE TABLE secbugs_Stats');
 }
 
 sub delete_attachment_data {


### PR DESCRIPTION
This pull request removes additional user specific data from the DB when doing a sanitized dump.

Tables cleared:
component_watch
anstispam_*
reminders
whine_*
watch
series_*
email_rates
email_bug_ignore
secbugs_*

Also the following:
Clears MFA values from the profiles table
Clears user public gpg keys from the profiles table