### PR TITLE
Bug 1891378 - meta-clicking on attachment name should open the attachment, not the details page

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -294,7 +294,7 @@
         [% END %]
         <span id="att-[% att.id FILTER none %]-description" itemprop="description">[% att.description FILTER html %]</span></a>
         [% " (obsolete)" IF att.isobsolete; " (deleted)" IF !att.datasize %]
-        — <a href="[% link FILTER html %]&amp;action=edit" itemprop="url">Details</a>
+        — <a href="[% link FILTER html %]&amp;action=edit" itemprop="url" data-details="1">Details</a>
         [% IF att.ispatch && Param('splinter_base') %]
           — <a href="[% Bugzilla.splinter_review_url(bug.bug_id, att.id) FILTER none %]">Splinter Review</a>
         [% END %]

--- a/extensions/BugModal/template/en/default/bug_modal/attachments.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/attachments.html.tmpl
@@ -86,7 +86,7 @@
         [% END ~%]
       </td>
       <td class="attach-actions">
-        <a href="[% basepath FILTER none %]attachment.cgi?id=[% attachment.id FILTER none %]&amp;action=edit">Details</a>
+        <a href="[% basepath FILTER none %]attachment.cgi?id=[% attachment.id FILTER none %]&amp;action=edit" data-details="1">Details</a>
         [% IF attachment.ispatch %]
           | <a href="[% basepath FILTER none %]attachment.cgi?id=[% attachment.id FILTER none %]&amp;action=diff">Diff</a>
         [% END %]

--- a/extensions/BugModal/web/attachments_overlay.js
+++ b/extensions/BugModal/web/attachments_overlay.js
@@ -202,9 +202,15 @@ window.addEventListener('DOMContentLoaded', () => {
           event.preventDefault();
 
           if (event.ctrlKey || event.metaKey) {
-            // Open the bug page, not the legacy attachment page, in a new tab with Ctrl/Cmd+click.
-            // The `attachment_id` URL param works as an overlay trigger. (See below)
-            window.open(`${basepath}show_bug.cgi?id=${bugId}&attachment_id=${id}`);
+            if ($link.dataset.details) {
+              // Details link
+              // Open the bug page, not the legacy attachment page, in a new tab with Ctrl/Cmd+click.
+              // The `attachment_id` URL param works as an overlay trigger. (See below)
+              window.open(`${basepath}show_bug.cgi?id=${bugId}&attachment_id=${id}`);
+            } else {
+              // Open the attachment directly
+              window.open($link.href);
+            }
           } else {
             showOverlay();
             loadAttachment(id, mode);


### PR DESCRIPTION
- aligns behaviour with opening via the context menu
- the details link can be meta-clicked for the current behaviour