### PR TITLE
Bug 1916637 - Fix order of names for emoji comment reactions

### DIFF
--- a/Bugzilla/Comment.pm
+++ b/Bugzilla/Comment.pm
@@ -282,7 +282,8 @@ sub reactions_with_users {
   {
     my $rows = Bugzilla->dbh->selectall_arrayref(
       "SELECT reaction, user_id FROM longdescs_reactions
-              WHERE comment_id = ?", undef, $self->id);
+              WHERE comment_id = ?
+              ORDER BY id", undef, $self->id);
 
     my %reactions_with_users;
 


### PR DESCRIPTION
[Bug 1916637 - Fix order of names for emoji comment reactions](https://bugzilla.mozilla.org/show_bug.cgi?id=1916637)

The `longdescs_reactions` table doesn’t store the date/time for each reaction, but since the `id` column is auto-incrementing, it can be used to sort the reactions by date instead of user id.

This change may make the API response slightly slower because the `id` column is not included in the index, but it shouldn’t be critical since user names are fetched only when an emoji is hovered.