### PR TITLE
Bug 1916765 - add preference to not display emoji

### DIFF
--- a/extensions/BugModal/Extension.pm
+++ b/extensions/BugModal/Extension.pm
@@ -334,6 +334,12 @@ sub install_before_final_checks {
     default  => 'on',
     category => 'User Interface',
   });
+  add_setting({
+    name     => 'ui_show_comment_reactions',
+    options  => ['on', 'off'],
+    default  => 'on',
+    category => 'User Interface',
+  });
 }
 
 sub editable_tables {

--- a/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/activity_stream.html.tmpl
@@ -320,7 +320,7 @@
       <em>No description provided.</em>
     [%~ END ~%]
   </[% comment_tag FILTER none %]>
-  [% IF Param('use_comment_reactions') %]
+  [% IF Param('use_comment_reactions') AND user.setting('ui_show_comment_reactions') == 'on' %]
     [% INCLUDE bug_modal/comment_reactions.html.tmpl %]
   [% END %]
 [% END %]

--- a/extensions/BugModal/template/en/default/hook/global/setting-descs-settings.none.tmpl
+++ b/extensions/BugModal/template/en/default/hook/global/setting-descs-settings.none.tmpl
@@ -10,4 +10,5 @@
   setting_descs.ui_remember_collapsed = "Remember visibility of header sections when viewing a bug"
   setting_descs.ui_use_absolute_time = "Use absolute format instead of relative time when viewing a bug"
   setting_descs.ui_attach_long_paste = "When pasting long text in bug comments, convert it into an attachment text file"
+  setting_descs.ui_show_comment_reactions = "Show emoji comment reactions when viewing a bug"
 %]


### PR DESCRIPTION
[Bug 1916765 - add preference to not display emoji](https://bugzilla.mozilla.org/show_bug.cgi?id=1916765)

Add a new user preference to the User Interface section that allows users to hide emoji comment reactions if they want.