### PR TITLE
Bug 1916929 - Prevent emoji reactions on old, closed bugs

### DIFF
--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -1425,6 +1425,10 @@ sub update_comment_reactions {
     ThrowUserError('comment_is_private', {id => $comment_id});
   }
 
+  if ($comment->bug->is_closed_for({months => 3})) {
+    ThrowUserError('comment_reaction_closed');
+  }
+
   my $dbh = Bugzilla->dbh;
   $dbh->bz_start_transaction();
   foreach my $reaction (@{$params->{add} || []}) {

--- a/Bugzilla/WebService/Constants.pm
+++ b/Bugzilla/WebService/Constants.pm
@@ -117,6 +117,7 @@ use constant WS_ERROR_CODE => {
   # Comment reactions
   comment_reaction_disabled => 136,
   comment_reaction_invalid  => 137,
+  comment_reaction_closed   => 138,
 
   # Comment tagging
   comment_tag_disabled  => 125,

--- a/extensions/BugModal/template/en/default/bug_modal/comment_reactions.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/comment_reactions.html.tmpl
@@ -8,7 +8,7 @@
 
 <div id="cre-[% comment.count FILTER none %]" class="comment-reactions"
      [% IF comment.collapsed +%] style="display:none"[% END %]>
-  [% IF user.id %]
+  [% IF user.id && !bug.is_closed_for({months => 3}) %]
     <button type="button" class="anchor">
       <span class="icon" aria-label="Toggle Reaction Picker"></span>
     </button>

--- a/extensions/BugModal/web/comments.js
+++ b/extensions/BugModal/web/comments.js
@@ -550,6 +550,11 @@ Bugzilla.BugModal.CommentReactions = class CommentReactions {
     /** @type {Number} */
     this.commentId = Number(/** @type {HTMLElement} */ ($wrapper.parentElement.querySelector('.comment')).dataset.id);
 
+    // Users cannot react on old bugs
+    if (!this.$anchor) {
+      return;
+    }
+
     if (this.canUsePopover) {
       this.$anchor.popoverTargetElement = this.$picker;
       this.$anchor.popoverTargetAction = 'toggle';

--- a/template/en/default/global/user-error.html.tmpl
+++ b/template/en/default/global/user-error.html.tmpl
@@ -380,6 +380,10 @@
     [% title = "Invalid Comment Reaction" %]
     The comment reaction "[% reaction FILTER html %]" is not supported.
 
+  [% ELSIF error == "comment_reaction_closed" %]
+    [% title = "Comment Reactions Closed" %]
+    This [% terms.bug %] no longer accepts comment reactions.
+
   [% ELSIF error == "comment_tag_disabled" %]
     [% title = "Comment Tagging Disabled" %]
     The comment tagging is not enabled.


### PR DESCRIPTION
[Bug 1916929 - Prevent emoji reactions on old, closed bugs](https://bugzilla.mozilla.org/show_bug.cgi?id=1916929)

Compare `cf_last_resolved` and the current timestamp to see if comment reactions are accepted. If not, hide the emoji picker button and raise an error in case the API is used.

Not sure if we could test this time lapse thing but you can test it by changing `months => 3` to `minutes => 1` 😅 