### PR TITLE
Bug 1916787 - Extra empty space in each bugzilla comment when there are no emoji reactions to it

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/comment_reactions.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/comment_reactions.html.tmpl
@@ -6,24 +6,32 @@
   # defined by the Mozilla Public License, v. 2.0.
   #%]
 
-<div id="cre-[% comment.count FILTER none %]" class="comment-reactions"
-     [% IF comment.collapsed +%] style="display:none"[% END %]>
-  [% IF user.id %]
-    <button type="button" class="anchor">
-      <span class="icon" aria-label="Toggle Reaction Picker"></span>
-    </button>
-    <div class="picker" role="dialog" aria-label="Reaction Picker" inert>
+[% total_count = 0 %]
+
+[% FOREACH key IN comment.supported_reactions.keys %]
+  [% total_count = total_count + (comment.reactions.$key || 0) %]
+[% END %]
+
+[% IF user.id || total_count %]
+  <div id="cre-[% comment.count FILTER none %]" class="comment-reactions"
+       [% IF comment.collapsed +%] style="display:none"[% END %]>
+    [% IF user.id %]
+      <button type="button" class="anchor">
+        <span class="icon" aria-label="Toggle Reaction Picker"></span>
+      </button>
+      <div class="picker" role="dialog" aria-label="Reaction Picker" inert>
+        [% FOREACH key IN comment.supported_reactions.keys %]
+          [% PROCESS emoji_button key = key sum = 0 %]
+        [% END %]
+      </div>
+    [% END %]
+    <div class="sums">
       [% FOREACH key IN comment.supported_reactions.keys %]
-        [% PROCESS emoji_button key = key sum = 0 %]
+        [% PROCESS emoji_button key = key sum = 1 %]
       [% END %]
     </div>
-  [% END %]
-  <div class="sums">
-    [% FOREACH key IN comment.supported_reactions.keys %]
-      [% PROCESS emoji_button key = key sum = 1 %]
-    [% END %]
   </div>
-</div>
+[% END %]
 
 [% BLOCK emoji_button %]
   [% count = comment.reactions.$key || 0 %]

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -1275,6 +1275,10 @@ a.comment-tag-url {
   anchor-name: --comment-reactions;
 }
 
+.comment-text.bz_private + .comment-reactions {
+  padding: 12px;
+}
+
 .comment-reactions .emoji {
   font-size: 14px;
   font-family: Emoji;

--- a/extensions/EditComments/web/styles/inline-editor.css
+++ b/extensions/EditComments/web/styles/inline-editor.css
@@ -53,3 +53,7 @@
 .comment-editor .bottom-toolbar label {
   margin: 0 8px;
 }
+
+.comment-editor  + .comment-reactions {
+  display: none;
+}


### PR DESCRIPTION
[Bug 1916787 - Extra empty space in each bugzilla comment when there are no emoji reactions to it](https://bugzilla.mozilla.org/show_bug.cgi?id=1916787)

Hide the reactions wrapper element if the user is signed out and there are no reactions logged on the comment, so there would be no CSS padding on it.

Sidealongs (I’ve actually added those changes to #2307 but it’s better to have them here instead):

- Add an extra space after a private comment with a red border
- Hide the reactions when the inline comment editor is open