### PR TITLE
Bug 1917008 - Emoji Reaction Button Off-Centered

### DIFF
--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -1291,7 +1291,6 @@ a.comment-tag-url {
   min-width: 24px;
   height: 24px;
   font-size: 12px;
-  line-height: 0;
 }
 
 .comment-reactions button:disabled {


### PR DESCRIPTION
[Bug 1917008 - Emoji Reaction Button Off-Centered](https://bugzilla.mozilla.org/show_bug.cgi?id=1917008)

Remove unnecessary line from CSS to fix the vertical alignment of the emoji.