### PR TITLE
Bug 1917348 - Update robots.txt hook for SiteMapIndex to add 'Allow: /sitemap/' to fix blocked sitemap issue

### DIFF
--- a/extensions/SiteMapIndex/template/en/default/hook/robots-end.txt.tmpl
+++ b/extensions/SiteMapIndex/template/en/default/hook/robots-end.txt.tmpl
@@ -1,7 +1,7 @@
 [% IF Param('sitemapindex_enabled') %]
 [%# comment lines are required to produce line breaks %]
 #
-Allow: /sitemap
+Allow: /sitemap/
 Sitemap: [% SITEMAP_URL %]
 #
 [% END %]

--- a/extensions/SiteMapIndex/template/en/default/hook/robots-end.txt.tmpl
+++ b/extensions/SiteMapIndex/template/en/default/hook/robots-end.txt.tmpl
@@ -1,6 +1,7 @@
 [% IF Param('sitemapindex_enabled') %]
 [%# comment lines are required to produce line breaks %]
 #
+Allow: /sitemap
 Sitemap: [% SITEMAP_URL %]
 #
 [% END %]


### PR DESCRIPTION
After waiting a while for Google to finally get around to indexing bugzilla-dev.allizom.org to test this fix, it seems like this is now working. Please review.