### PR TITLE
Bug 1919237 - Extra empty space in each bugzilla comment when there are no emoji reactions to it and logged in on old bugs that disallow reactions

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/comment_reactions.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/comment_reactions.html.tmpl
@@ -15,7 +15,7 @@
 [% reaction_disabled = !user.id || bug.is_closed_for({months => 3})
     || (bug.restrict_comments && !user.in_group(Param('restrict_comments_group'))) %]
 
-[% IF user.id || total_count %]
+[% IF !reaction_disabled || total_count %]
   <div id="cre-[% comment.count FILTER none %]" class="comment-reactions"
        [% IF comment.collapsed +%] style="display:none"[% END %]>
     [% IF !reaction_disabled %]


### PR DESCRIPTION
[Bug 1919237 - Extra empty space in each bugzilla comment when there are no emoji reactions to it and logged in on old bugs that disallow reactions](https://bugzilla.mozilla.org/show_bug.cgi?id=1919237)

Fix the `IF` condition for showing the emoji wrapper element.