### PR TITLE
Bug 1919789 - `comment` parameter to prefill bug from URLs is ignored

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/new_comment.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/new_comment.html.tmpl
@@ -38,7 +38,7 @@
   <textarea id="comment" name="comment" rows="5" cols="80"
       aria-label="[% mode == 'create' ? 'Description' : 'Add Comment' %]"
       [%~ IF user.setting('ui_attach_long_paste') == 'on' +%] class="attach-long-paste"[% END %]
-  ></textarea>
+  >[% comment FILTER html %]</textarea>
 
   <div id="after-comment-commit-button">
     [% IF user.is_insider && add_extras %]


### PR DESCRIPTION
[Bug 1919789 - `comment` parameter to prefill bug from URLs is ignored](https://bugzilla.mozilla.org/show_bug.cgi?id=1919789)

Restore the default `comment` removed by mistake in #2307. 😓 