### PR TITLE
Bug 1919849 - Some features on modal new bug page are not working as expected

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/create.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/create.html.tmpl
@@ -90,7 +90,7 @@
   filtered_product = product.name FILTER uri;
 %]
 
-<form name="changeform" id="create-form" class="enter_bug_form" method="post"
+<form name="changeform" id="changeform" class="enter_bug_form" method="post"
       action="[% basepath FILTER none %]post_bug.cgi" enctype="multipart/form-data"
       data-component-descriptions="[% json_encode(component_descriptions) FILTER html %]"
       data-description-templates="[% json_encode(description_templates) FILTER html %]"

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -1666,7 +1666,7 @@ a.lightbox-icon.markdown {
  * Create form
  */
 
-#create-form:not(.show-advanced-fields) .expert_fields {
+#changeform:not(.show-advanced-fields) .expert_fields {
   display: none;
 }
 
@@ -1721,7 +1721,7 @@ a.lightbox-icon.markdown {
   font-size: var(--font-size-small);
 }
 
-#create-form.show-advanced-fields #component-tip {
+#changeform.show-advanced-fields #component-tip {
   display: none;
 }
 

--- a/extensions/BugModal/web/create.js
+++ b/extensions/BugModal/web/create.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 window.addEventListener('DOMContentLoaded', () => {
-  const $form = document.querySelector('#create-form');
+  const $form = document.querySelector('#changeform');
   const $toggleAdvanced = document.querySelector('#toggle-advanced');
   const $componentDescription = document.querySelector('#component-description');
   const $defaultCcField = document.querySelector('#field-default-cc');


### PR DESCRIPTION
[Bug 1919849 - Some features on modal new bug page are not working as expected](https://bugzilla.mozilla.org/show_bug.cgi?id=1919849)

jQuery in [`bug_modal.js`](https://github.com/mozilla-bteam/bmo/blob/master/extensions/BugModal/web/bug_modal.js) has some `$('#comment', '#changeform')`, meaning the `<form>` has to have `id="changeform"` to match the comment `<textarea>`. 

The modal bug details page has `id="changeform"` for sure, but somehow the modal new bug page  has `id="create-form"`, which breaks the following features. This PR makes the ID consistent so that the shared script will work.

- Add Description button
- Comment draft auto saving in local storage
- Comment `<textarea>` auto resize
- Make comment private checkbox that makes the comment text red