### PR TITLE
Bug 1920995 - wrong calculation of relative date (rel-time) caused by repeatedly rounding in time_ago

### DIFF
--- a/Bugzilla/Util.pm
+++ b/Bugzilla/Util.pm
@@ -650,10 +650,12 @@ sub time_ago {
   # DateTime object or seconds
   my $ss = ref($param) ? time() - $param->epoch : $param;
   my $mm = round($ss / 60);
-  my $hh = round($mm / 60);
-  my $dd = round($hh / 24);
-  my $mo = round($dd / 30);
-  my $yy = round($mo / 12);
+  my $hh = round($ss / (60 * 60));
+  my $dd = round($ss / (60 * 60 * 24));
+  # They are not the best definition of month and year,
+  # but they should be good enough to be used here.
+  my $mo = round($ss / (60 * 60 * 24 * 30));
+  my $yy = round($ss / (60 * 60 * 24 * 365.2422));
 
   return 'Just now'           if $ss < 10;
   return $ss . ' seconds ago' if $ss < 45;

--- a/js/util.js
+++ b/js/util.js
@@ -348,10 +348,12 @@ function bz_toggleClass(anElement, aClass) {
 function timeAgo(param) {
     var ss = param.constructor === Date ? Math.round((new Date() - param) / 1000) : param;
     var mm = Math.round(ss / 60),
-        hh = Math.round(mm / 60),
-        dd = Math.round(hh / 24),
-        mo = Math.round(dd / 30),
-        yy = Math.round(mo / 12);
+        hh = Math.round(ss / (60 * 60)),
+        dd = Math.round(ss / (60 * 60 * 24)),
+        // They are not the best definition of month and year,
+        // but they should be good enough to be used here.
+        mo = Math.round(ss / (60 * 60 * 24 * 30)),
+        yy = Math.round(ss / (60 * 60 * 24 * 365.2422));
     if (ss < 10) return 'Just now';
     if (ss < 45) return ss + ' seconds ago';
     if (ss < 90) return '1 minute ago';


### PR DESCRIPTION
Avoid huge errors of rounding the seconds again and again.
Instead, every unit of time should be directly calculated from seconds and rounded just once.