### PR TITLE
Bug 1921383 - Bugzilla rich text editor shortcuts don't respect user layout

### DIFF
--- a/js/util.js
+++ b/js/util.js
@@ -721,7 +721,7 @@ Bugzilla.Event = class Event {
    * the key is a key combination and the value is a handler function and event options. In most
    * cases, `Ctrl` (Windows/Linux) and `Meta` (macOS) should be replaced with the `Accel` virtual
    * modifier that corresponds to both keys.
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values
    * @see https://w3c.github.io/aria/#aria-keyshortcuts
    * @example { 'Accel+Shift+R': () => this.reload(), 'Accel+Space': event => this.open_bug(event) }
    */

--- a/js/util.js
+++ b/js/util.js
@@ -764,8 +764,7 @@ Bugzilla.Event = class Event {
       for (const shortcut of shortcuts) {
         if (
           modifiers.every((key) => event[key] === shortcut[key]) &&
-          event.code.replace(/^(?:Digit|Key)(.)$/, '$1').toLowerCase() ===
-            shortcut.code.toLowerCase()
+          event.key === shortcut.code.toLowerCase()
         ) {
           if (shortcut.preventDefault) {
             event.preventDefault();


### PR DESCRIPTION
[Bug 1921383 - Bugzilla rich text editor shortcuts don't respect user layout](https://bugzilla.mozilla.org/show_bug.cgi?id=1921383)

Fix the keyboard event handler to support different keyboard layouts. Tested with [Dvorak](https://en.wikipedia.org/wiki/Dvorak_keyboard_layout), [Colemak](https://en.wikipedia.org/wiki/Colemak) and QWERTY.

Actually this code originated from my Sveltia UI library. I made the change in https://github.com/sveltia/sveltia-ui/commit/9dc5d25d0f7e7a8cb95306642b1839ad9c34ee76 but don’t remember why...