### PR TITLE
Bug 1921383 - Bugzilla rich text editor shortcuts don't respect user layout (revised)

### DIFF
--- a/js/text-editor.js
+++ b/js/text-editor.js
@@ -93,7 +93,7 @@ Bugzilla.TextEditor = class TextEditor {
         'Accel+I': { handler: () => this.execCommand('italic') },
         'Accel+E': { handler: () => this.execCommand('code') },
         'Accel+K': { handler: () => this.execCommand('link') },
-        'Accel+Shift+Period': { handler: () => this.execCommand('quote') },
+        'Accel+Shift+.': { handler: () => this.execCommand('quote') },
         'Accel+Shift+7': { handler: () => this.execCommand('numbered-list') },
         'Accel+Shift+8': { handler: () => this.execCommand('bulleted-list') },
       });

--- a/js/text-editor.js
+++ b/js/text-editor.js
@@ -106,9 +106,10 @@ Bugzilla.TextEditor = class TextEditor {
    */
   createContainer() {
     const $placeholder = document.createElement('div');
-    const accelPrefix = Bugzilla.UserAgent.isMac ? '\u2318' : 'Ctrl+';
     /** @param {string} key */
     const _ = (key) => this.str[key].htmlEncode();
+    /** @param {string} shortcut */
+    const ks = (shortcut) => Bugzilla.Event.formatKeyShortcut(shortcut);
     /** @type {{ text: string, href: string }[]} */
     const footerLinks = [];
 
@@ -144,19 +145,19 @@ Bugzilla.TextEditor = class TextEditor {
                 <div role="toolbar" class="markdown-toolbar" aria-label="${_('toolbar_label')}">
                   <div role="group">
                     <button type="button" tabindex="0" class="ghost iconic"
-                        title="${_('command_bold')} (${accelPrefix}B)" data-command="bold">
+                        title="${_('command_bold')} (${ks('Accel+B')})" data-command="bold">
                       <span class="icon" aria-hidden="true"></span>
                     </button>
                     <button type="button" tabindex="0" class="ghost iconic"
-                        title="${_('command_italic')} (${accelPrefix}I)" data-command="italic">
+                        title="${_('command_italic')} (${ks('Accel+I')})" data-command="italic">
                       <span class="icon" aria-hidden="true"></span>
                     </button>
                     <button type="button" tabindex="0" class="ghost iconic"
-                        title="${_('command_code')} (${accelPrefix}E)" data-command="code">
+                        title="${_('command_code')} (${ks('Accel+E')})" data-command="code">
                       <span class="icon" aria-hidden="true"></span>
                     </button>
                     <button type="button" tabindex="0" class="ghost iconic"
-                        title="${_('command_link')} (${accelPrefix}K)" data-command="link">
+                        title="${_('command_link')} (${ks('Accel+K')})" data-command="link">
                       <span class="icon" aria-hidden="true"></span>
                     </button>
                   </div>
@@ -166,17 +167,19 @@ Bugzilla.TextEditor = class TextEditor {
                       <span class="icon" aria-hidden="true"></span>
                     </button>
                     <button type="button" tabindex="0" class="ghost iconic"
-                        title="${_('command_quote')}" data-command="quote">
+                        title="${_('command_quote')} (${ks('Accel+Shift+.')})" data-command="quote">
                       <span class="icon" aria-hidden="true"></span>
                     </button>
                   </div>
                   <div role="group">
                     <button type="button" tabindex="0" class="ghost iconic"
-                        title="${_('command_numbered_list')}" data-command="numbered-list">
+                        title="${_('command_numbered_list')} (${ks('Accel+Shift+7')})"
+                        data-command="numbered-list">
                       <span class="icon" aria-hidden="true"></span>
                     </button>
                     <button type="button" tabindex="0" class="ghost iconic"
-                        title="${_('command_bulleted_list')}" data-command="bulleted-list">
+                        title="${_('command_bulleted_list')} (${ks('Accel+Shift+8')})"
+                        data-command="bulleted-list">
                       <span class="icon" aria-hidden="true"></span>
                     </button>
                   </div>

--- a/js/text-editor.js
+++ b/js/text-editor.js
@@ -98,10 +98,6 @@ Bugzilla.TextEditor = class TextEditor {
         'Accel+Shift+8': { handler: () => this.execCommand('bulleted-list') },
       });
     }
-
-    Bugzilla.Event.activateKeyShortcuts(window, {
-      'Control+Shift+P': { handler: (event) => this.switchTabs(event) },
-    });
   }
 
   /**

--- a/js/text-editor.js
+++ b/js/text-editor.js
@@ -100,7 +100,7 @@ Bugzilla.TextEditor = class TextEditor {
     }
 
     Bugzilla.Event.activateKeyShortcuts(window, {
-      'Ctrl+Shift+P': { handler: (event) => this.switchTabs(event) },
+      'Control+Shift+P': { handler: (event) => this.switchTabs(event) },
     });
   }
 

--- a/js/util.js
+++ b/js/util.js
@@ -765,10 +765,7 @@ Bugzilla.Event = class Event {
       } = options;
 
       if ($target instanceof HTMLElement && setAriaAttr) {
-        $target.setAttribute(
-          'aria-keyshortcuts',
-          combination.replace(/\bAccel\b/, isMac ? 'Meta' : 'Control'),
-        );
+        $target.setAttribute('aria-keyshortcuts', this.formatKeyShortcut(combination, true));
       }
 
       return {
@@ -798,6 +795,50 @@ Bugzilla.Event = class Event {
         }
       });
     });
+  }
+
+  /**
+   * Format the given keyboard shortcut according to the user’s operating system.
+   * @param {string} combination Shortcut, e.g. `Accel+Shift+R`.
+   * @param {boolean} [forAria] Whether the formatted shortcut is used for the `aria-keyshortcuts`
+   * attribute.
+   * @returns {string} Formatted shortcut.
+   */
+  static formatKeyShortcut = (combination, forAria = false) => {
+    const { isMac } = Bugzilla.UserAgent;
+
+    if (forAria) {
+      return combination.replace(/\bAccel\b/, isMac ? 'Meta' : 'Control');
+    }
+
+    if (!isMac) {
+      return combination.replace(/\bAccel\b/, 'Ctrl');
+    }
+
+    const keys = new Set(combination.split('+'));
+    const keyArray = [];
+
+    if (keys.delete('Control')) {
+      keyArray.push('⌃');
+    }
+
+    if (keys.delete('Shift')) {
+      keyArray.push('⇧');
+    }
+
+    if (keys.delete('Alt')) {
+      keyArray.push('⌥');
+    }
+
+    if (keys.delete('Meta') || keys.delete('Accel')) {
+      keyArray.push('⌘');
+    }
+
+    if (keys.size) {
+      keyArray.push([...keys][0]);
+    }
+
+    return keyArray.join('');
   }
 };
 

--- a/js/util.js
+++ b/js/util.js
@@ -717,7 +717,7 @@ Bugzilla.Event = class Event {
    * Normalize the given keyboard shortcut key to the format of `event.key`.
    * @param {string} key Alphanumeric or any other key value supported by `event.key`. `Space` is a
    * special case; see the comment of {@link activateKeyShortcuts} below.
-   * @param {boolean} shiftKey Whether the Shift key is pressed.
+   * @param {boolean} shiftKey Whether the Shift key is included in the keyboard shortcut.
    * @returns {string} Normalized key.
    * @see https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values
    */
@@ -742,7 +742,8 @@ Bugzilla.Event = class Event {
    * the key is a key combination and the value is a handler function and event options. In most
    * cases, `Control` (Windows/Linux) and `Meta` (macOS) should be replaced with the `Accel` virtual
    * modifier that corresponds to both keys. Also, the Space key should be written as `Space`,
-   * whereas `event.key` returns ` ` for that key; it will be converted in {@link normalizeKey}.
+   * whereas `event.key` returns a single space character for that key; it will be converted in
+   * {@link normalizeKey}.
    * @see https://w3c.github.io/aria/#aria-keyshortcuts
    * @example { 'Accel+Shift+R': () => this.reload(), 'Accel+Space': event => this.open_bug(event) }
    */

--- a/js/util.js
+++ b/js/util.js
@@ -740,7 +740,7 @@ Bugzilla.Event = class Event {
    * @param {Record<string, { handler: (event: KeyboardEvent) => void, preventDefault?: boolean,
    * stopPropagation?: boolean, setAriaAttr?: boolean }>} mapping Key binding mapping object where
    * the key is a key combination and the value is a handler function and event options. In most
-   * cases, `Ctrl` (Windows/Linux) and `Meta` (macOS) should be replaced with the `Accel` virtual
+   * cases, `Control` (Windows/Linux) and `Meta` (macOS) should be replaced with the `Accel` virtual
    * modifier that corresponds to both keys. Also, the Space key should be written as `Space`,
    * whereas `event.key` returns ` ` for that key; it will be converted in {@link normalizeKey}.
    * @see https://w3c.github.io/aria/#aria-keyshortcuts
@@ -754,7 +754,7 @@ Bugzilla.Event = class Event {
       const accelKey = keys.delete('Accel');
 
       const modifiers = {
-        ctrlKey: keys.delete('Ctrl') || (!isMac && accelKey),
+        ctrlKey: keys.delete('Control') || (!isMac && accelKey),
         metaKey: keys.delete('Meta') || (isMac && accelKey),
         altKey: keys.delete('Alt'),
         shiftKey: keys.delete('Shift'),
@@ -770,7 +770,7 @@ Bugzilla.Event = class Event {
       if ($target instanceof HTMLElement && setAriaAttr) {
         $target.setAttribute(
           'aria-keyshortcuts',
-          combination.replace(/\bAccel\b/, isMac ? 'Meta' : 'Ctrl'),
+          combination.replace(/\bAccel\b/, isMac ? 'Meta' : 'Control'),
         );
       }
 


### PR DESCRIPTION
[Bug 1921383 - Bugzilla rich text editor shortcuts don't respect user layout](https://bugzilla.mozilla.org/show_bug.cgi?id=1921383)

Sorry, #2331 was incomplete and broke shortcuts with non-alphanumeric keys like Space and Enter. Now I remember why I said “keyboard shortcuts not working sometimes” in my Sveltia UI change 😓 This does the right thing.