### PR TITLE
Bug 1921966 - List ending by double enter wipes rest of comment

### DIFF
--- a/js/text-editor.js
+++ b/js/text-editor.js
@@ -572,8 +572,8 @@ Bugzilla.TextEditor = class TextEditor {
         start: start + 1 + newMarker.length + 1,
       });
     } else {
-      this.updateText(`${beforeLines.join('\n')}`, {
-        start: start + 1,
+      this.updateText(`${beforeLines.join('\n')}${afterText}`, {
+        start: start - [...beforeText.split(/\n/).pop()].length,
       });
     }
   }


### PR DESCRIPTION
[Bug 1921966 - List ending by double enter wipes rest of comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1921966)

#2336 has to be merged first because the Enter key handler is broken 😶 