### PR TITLE
Bug 1923415 - Update Dockerfile and docker-compose*.yml to optimize build times and remove warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM mozillabteam/bmo-perl-slim:20240822.1 AS base
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 ARG CI
 ARG CIRCLE_SHA1
@@ -10,17 +10,15 @@ ENV CI=${CI}
 ENV CIRCLE_BUILD_URL=${CIRCLE_BUILD_URL}
 ENV CIRCLE_SHA1=${CIRCLE_SHA1}
 
+# we run a loopback logging server on this TCP port.
 ENV LOG4PERL_CONFIG_FILE=log4perl-json.conf
+ENV LOGGING_PORT=5880
+ENV LOCALCONFIG_ENV=1
 
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y rsync curl \
     && rm -rf /var/lib/apt/lists/*
-
-# we run a loopback logging server on this TCP port.
-ENV LOGGING_PORT=5880
-
-ENV LOCALCONFIG_ENV=1
 
 WORKDIR /app
 
@@ -43,7 +41,7 @@ HEALTHCHECK CMD curl -sfk http://localhost -o/dev/null
 ENTRYPOINT ["/app/scripts/entrypoint.pl"]
 CMD ["httpd"]
 
-FROM base AS TEST
+FROM base AS test
 
 HEALTHCHECK NONE
 

--- a/README.rst
+++ b/README.rst
@@ -55,13 +55,7 @@ following command instead:
 
 .. code-block:: bash
 
-    docker-compose up --build bmo.test
-
-Then, you must configure your browser to use localhost and port 1080 as an HTTP proxy.
-For setting a proxy in Firefox, see `Firefox Connection Settings`_.
-The procedure should be similar for other browsers.
-
-.. _`Firefox Connection Settings`: https://support.mozilla.org/en-US/kb/connection-settings-firefox
+    docker compose up --build bmo.test
 
 After that, you should be able to visit http://localhost:8000/ from your browser.
 You can login as admin@mozilla.bugs with the password "password012!" (without
@@ -321,14 +315,6 @@ environmental variable.
 Logging configuration also controls which errors are sent to Sentry.
 
 
-Persistent Data Volume
-----------------------
-
-This container expects /app/data to be a persistent, shared, writable directory
-owned by uid 10001. This must be a shared (NFS/EFS/etc) volume between all
-nodes.
-
-
 Development Tips
 ================
 
@@ -342,19 +328,19 @@ Basic sanity tests
 
 .. code-block:: bash
 
-  docker compose -f docker-compose.test.yml down && docker build -t bmo . && docker compose -f docker-compose.test.yml run -e CI=1 --no-deps bmo.test test_sanity
+  docker compose -f docker-compose.test.yml down && docker compose -f docker-compose.test.yml run -e CI=1 --no-deps bmo.test test_sanity
 
 Webservices API tests
 
 .. code-block:: bash
 
-  docker compose -f docker-compose.test.yml down && docker build -t bmo . && docker compose -f docker-compose.test.yml run bmo.test test_webservices
+  docker compose -f docker-compose.test.yml down && docker compose -f docker-compose.test.yml run bmo.test test_webservices
 
 Selenium Web UI tests
 
 .. code-block:: bash
 
-  docker compose -f docker-compose.test.yml down && docker build -t bmo . && docker compose -f docker-compose.test.yml run bmo.test test_selenium
+  docker compose -f docker-compose.test.yml down && docker compose -f docker-compose.test.yml run bmo.test test_selenium
 
 Testing Emails
 --------------

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,11 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-version: "3"
-
 services:
   bmo.test:
     image: bmo
+    build: &bmo_build
+      context: .
+      dockerfile: Dockerfile
+      target: test
     command: dev_httpd
     tmpfs:
       - /tmp
@@ -38,7 +40,7 @@ services:
       - gcs
 
   externalapi.test:
-    image: bmo
+    build: *bmo_build
     entrypoint: perl /app/external_test_api.pl daemon -l http://*:8001
     ports:
       - 8001:8001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-version: "3.4"
-
 services:
   bmo.test:
     platform: linux/x86_64
     build: &bmo_build
       context: .
       dockerfile: Dockerfile
+      target: base
     command: dev_httpd
     volumes:
       - bmo-data-dir:/app/data
@@ -27,6 +26,7 @@ services:
       - BMO_memcached_servers=memcached:11211
       - BMO_ses_username=ses@mozilla.bugs
       - BMO_ses_password=password123456789!
+      - BMO_size_limit=2000000
       - BMO_urlbase=http://localhost:8000/
       - BUGZILLA_ALLOW_INSECURE_HTTP=1
       - BZ_ANSWERS_FILE=/app/conf/checksetup_answers.txt


### PR DESCRIPTION
- Add size_limit setting with higher than default to allow proper functionality on OSX and Docker
- Updated dockerfile to remove warnings 
- Update targets in docker-compose*.yml to only install Firefox and lsof when tests are being ran