### PR TITLE
Bug 1923931 - Editing a comment breaks when two different people have previously edited the same comment

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/user.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/user.html.tmpl
@@ -41,6 +41,9 @@ END;
         <img src="[% u.gravatar(gravatar_size * 2) FILTER none %]" class="gravatar"
           width="[% gravatar_size FILTER none %]" height="[% gravatar_size FILTER none %]">
       [% END %]
+      [% IF gravatar_only && user.id %]
+        <span class="email" data-user-id="[% u.id FILTER html %]"></span>
+      [% END %]
       [% UNLESS gravatar_only %]
         <a class="email [%= "disabled" UNLESS u.is_enabled %] [% " show_usermenu" IF user.id %]"
           [% IF user.id %]

--- a/extensions/EditComments/web/js/inline-comment-editor.js
+++ b/extensions/EditComments/web/js/inline-comment-editor.js
@@ -35,7 +35,7 @@ Bugzilla.InlineCommentEditor = class InlineCommentEditor extends Bugzilla.Commen
     this.commentId = Number($commentBody.dataset.commentId);
     /** @type {number} */
     this.commenterId = Number(
-      /** @type {HTMLElement} */ ($changeSet.querySelector('.email')).dataset.userId,
+      /** @type {HTMLElement} */ ($changeSet.querySelectorAll('.email')[0]).dataset.userId,
     );
     /** @type {boolean} */
     this.isEmpty = $commentBody.matches('.empty');


### PR DESCRIPTION
If multiple people edit the first comment (description) then editing it again will fail due to JS error. This fixes the issue for that use case.