### PR TITLE
Bug 1923840 - Searching for bugs containing a mentor times out (504 Gateway timeout)

### DIFF
--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -384,7 +384,7 @@ sub SPECIAL_PARSING {
     bug_interest_ts => \&_last_visit_datetime,
 
     # BMO - Add ability to use pronoun for bug mentors field
-    bug_mentor => \&_commenter_pronoun,
+    bug_mentor => \&_contact_pronoun,
 
     # BMO - add ability to use pronoun for triage owners
     triage_owner => \&_triage_owner_pronoun,


### PR DESCRIPTION
When selecting a search include Mentors, it is using a non-existent function _commenter_pronoun and needs to instead use _contact_pronoun. This was missed in an earlier commit back porting pronoun support to more places.