### PR TITLE
Bug 1926574 - When changing product of a bug and the destination product only has one component, pre-select the one component

### DIFF
--- a/extensions/BugModal/lib/WebService.pm
+++ b/extensions/BugModal/lib/WebService.pm
@@ -311,6 +311,10 @@ sub new_product {
     # identical component in both products
     $component->{selected} = $true;
   }
+  elsif (scalar @{$components} == 1) {
+    # New product has one component so preselect it
+    $components->[0]->{selected} = $true;
+  }
   else {
     # default to a blank value
     unshift @$components, {name => '', selected => $true,};


### PR DESCRIPTION
This change updates the webservice API that BugModal (show_bug.cgi) page uses to fetch a list of components when a user changes the product. If the new product selected only contains one component (i.e. Invalid Bugs) then it pre-selects the single component. If it has more than one, then it does the old behavior of adding a block component value and requires the user to select the proper component before submitting.