### PR TITLE
Bug 1928077 - Bugzilla comment/description font bigger on desktop

### DIFF
--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -97,9 +97,9 @@
     --font-size-h2: 26px;
     --font-size-h3: 20px;
     --font-size-h4: 16px;
-    --font-size-x-large: 16px;
-    --font-size-large: 15px;
-    --font-size-medium: 14px;
+    --font-size-x-large: 15px;
+    --font-size-large: 14px;
+    --font-size-medium: 13px;
     --font-size-small: 12px;
     --font-size-x-small: 11px;
     --line-height-default: 1.25;


### PR DESCRIPTION
[Bug 1928077 - Bugzilla comment/description font bigger on desktop](https://bugzilla.mozilla.org/show_bug.cgi?id=1928077)

Changing the base font sizes affects many places... Restore the variables to the original.