### PR TITLE
Bug 1928083 - Bugzilla’s emojis are displayed on the bottom of the page when activated creating a new scroll bar

### DIFF
--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -1249,7 +1249,6 @@ a.comment-tag-url {
   position: relative;
   padding: 0 12px 12px;
   background: var(--primary-text-background-color);
-  anchor-name: --comment-reactions;
 }
 
 .comment-text.bz_private + .comment-reactions {
@@ -1322,7 +1321,6 @@ a.comment-tag-url {
   transform-origin: bottom left;
   transition: all 100ms;
   pointer-events: none;
-  position-anchor: --comment-reactions;
 }
 
 .comment-reactions .picker:popover-open {

--- a/extensions/BugModal/web/comments.js
+++ b/extensions/BugModal/web/comments.js
@@ -536,7 +536,7 @@ Bugzilla.BugModal.CommentReactions = class CommentReactions {
     /** @type {Number} */
     this.commentId = Number(/** @type {HTMLElement} */ ($wrapper.parentElement.querySelector('.comment')).dataset.id);
     /** @type {string} */
-    this.anchorName = `--comment-reactions-${this.commentId}`;
+    this.anchorName = `--comment-${this.commentId}-reactions`;
 
     // Users cannot react on old bugs
     if (!this.$anchor) {

--- a/extensions/BugModal/web/comments.js
+++ b/extensions/BugModal/web/comments.js
@@ -511,8 +511,12 @@ Bugzilla.BugModal.Comments = class Comments {
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Popover_API
  */
 Bugzilla.BugModal.CommentReactions = class CommentReactions {
-  /** @type {Boolean} */
-  canUsePopover = 'popover' in HTMLElement.prototype;
+  /**
+   * Check the availability of the Popover API. This also detects the CSS Anchor Positioning API, as positioning doesn’t
+   * work well without it, depending on how the page layout (fixed global header) is structured.
+   * @type {Boolean}
+   */
+  canUsePopover = 'popover' in HTMLElement.prototype && CSS.supports('anchor-name', '--comment-reactions');
   /** @type {Record<string, object[]> | null} */
   reactionCache = null;
   /** @type {Intl.ListFormat} */
@@ -531,6 +535,8 @@ Bugzilla.BugModal.CommentReactions = class CommentReactions {
     this.$picker = $wrapper.querySelector('.picker');
     /** @type {Number} */
     this.commentId = Number(/** @type {HTMLElement} */ ($wrapper.parentElement.querySelector('.comment')).dataset.id);
+    /** @type {string} */
+    this.anchorName = `--comment-reactions-${this.commentId}`;
 
     // Users cannot react on old bugs
     if (!this.$anchor) {
@@ -538,6 +544,10 @@ Bugzilla.BugModal.CommentReactions = class CommentReactions {
     }
 
     if (this.canUsePopover) {
+      // Set the anchor name dynamically
+      this.$wrapper.style.setProperty('anchor-name', this.anchorName);
+      this.$picker.style.setProperty('position-anchor', this.anchorName);
+
       this.$anchor.popoverTargetElement = this.$picker;
       this.$anchor.popoverTargetAction = 'toggle';
       this.$picker.popover = 'auto';


### PR DESCRIPTION
[Bug 1928083 - Bugzilla’s emojis are displayed on the bottom of the page when activated creating a new scroll bar](https://bugzilla.mozilla.org/show_bug.cgi?id=1928083)

The cause is due to a change in page layout (fixed global header) in #2334, but reverting the change would rather introduce other problems (I don’t remember exactly, but I saw several problems while working on mobile optimization).

The solution to detect the CSS Anchor Positioning API, which is not yet implemented in Firefox and Safari, and fall back to the legacy implementation if the API is not available.

This also fixes the anchor positioning itself. My initial implementation hardcoded `anchor-name` in CSS, but it doesn’t work well because there are usually multiple comments in a bug, and `anchor-name` needs to be unique for each. Not sure why it wasn’t caught earlier.

I’ve tested this fix with Firefox, Chrome and Safari.