### PR TITLE
Bug 1929001 - Saved data for comment 0 overrides "comment" parameter

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -203,7 +203,8 @@ $(function() {
         let value = JSON.parse(localStorage.getItem(bugCommentCacheKey));
         if (value){
             let commentBox = document.querySelector("textarea#comment");
-            commentBox.value = value['text'];
+            if (commentBox.value === '')
+              commentBox.value = value['text'];
             // Resize the textarea and enable the Preview button
             commentBox.dispatchEvent(new InputEvent('input'));
         }


### PR DESCRIPTION
This simple fix just checks to make sure that the comment textarea is empty before pre-filling the stored comment text in localStorage.