### PR TITLE
Bug 1922986 - Create script that exports BMO data as JSON suitable for import into a BigQuery instance in GCP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,7 +286,8 @@ jobs:
           name: run bmo specific tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run bmo.test test_bmo -q -f t/bmo/*.t
+            docker-compose -f docker-compose.test.yml run bmo.test test_bmo \
+              -q -f t/bmo/*.t extensions/*/t/bmo/*.t
       - *store_log
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,8 +286,7 @@ jobs:
           name: run bmo specific tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run bmo.test test_bmo \
-              -q -f t/bmo/*.t extensions/*/t/bmo/*.t
+            docker-compose -f docker-compose.test.yml run bmo.test test_bmo -q -f t/bmo/*.t extensions/*/t/bmo/*.t
       - *store_log
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,32 +17,10 @@ defaults:
         fi
 
   docker_image: &docker_image
-    image: cimg/base:2023.10
+    image: cimg/base:2024.11
     auth:
       username: $DOCKER_USER
       password: $DOCKER_PASS
-
-  build_image: &build_image
-    run:
-      name: Build Docker BMO Image
-      command: |
-        docker build \
-          --build-arg CI="$CI" \
-          --build-arg CIRCLE_SHA1="$CIRCLE_SHA1" \
-          --build-arg CIRCLE_BUILD_URL="$CIRCLE_BUILD_URL" \
-          --target base \
-          -t bmo .
-
-  build_selenium_image: &build_selenium_image
-    run:
-      name: Build Selenium Image
-      command: |
-        docker build \
-          --build-arg CI="$CI" \
-          --build-arg CIRCLE_SHA1="$CIRCLE_SHA1" \
-          --build-arg CIRCLE_BUILD_URL="$CIRCLE_BUILD_URL" \
-          --target test \
-          -t bmo .
 
   store_log: &store_log
     store_artifacts:
@@ -57,7 +35,6 @@ jobs:
       - setup_remote_docker
       - checkout
       - *docker_login
-      - *build_image
       - run: |
           [[ -d build_info ]] || mkdir build_info
       - attach_workspace:
@@ -65,11 +42,11 @@ jobs:
       - run:
           name: build version.json
           command: |
-            docker-compose -f docker-compose.test.yml run bmo.test version | sed '1d' > build_info/version.json
+            docker-compose -f docker-compose.test.yml run --build --no-deps bmo.test version | sed '1d' > build_info/version.json
       - run:
           name: build push data
           command: |
-            docker-compose -f docker-compose.test.yml run --name push_data bmo.test push_data
+            docker-compose -f docker-compose.test.yml run --build --no-deps --name push_data bmo.test push_data
             docker cp push_data:/app/build_info/blog.push.txt build_info/blog.push.txt
             docker cp push_data:/app/build_info/markdown.push.txt build_info/markdown.push.txt
             docker cp push_data:/app/build_info/bug.push.txt build_info/bug.push.txt
@@ -118,11 +95,11 @@ jobs:
       - setup_remote_docker
       - checkout
       - *docker_login
-      - *build_image
       - attach_workspace:
           at: build_info
       - deploy:
           command: |
+            docker build -t bmo .
             [[ -n "$DOCKERHUB_REPO" && -n "$DOCKER_USER" && -n "$DOCKER_PASS" ]] || exit 0
             if [[ "$CIRCLE_BRANCH" == "master" ]]; then
               TAG="$(cat build_info/tag.txt)"
@@ -150,7 +127,6 @@ jobs:
       - setup_remote_docker
       - checkout
       - *docker_login
-      - *build_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -159,7 +135,7 @@ jobs:
           name: run sanity tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run --no-deps bmo.test \
+            docker-compose -f docker-compose.test.yml run --build --no-deps bmo.test \
               test_sanity t/*.t extensions/*/t/*.t
       - store_artifacts:
           path: artifacts
@@ -172,7 +148,6 @@ jobs:
       - setup_remote_docker
       - checkout
       - *docker_login
-      - *build_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -181,7 +156,7 @@ jobs:
           name: run webservice tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run bmo.test test_webservices
+            docker-compose -f docker-compose.test.yml run --build bmo.test test_webservices
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -193,7 +168,6 @@ jobs:
       - setup_remote_docker
       - checkout
       - *docker_login
-      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -202,7 +176,7 @@ jobs:
           name: run selenium tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=1 bmo.test test_selenium
+            docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=1 bmo.test test_selenium
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -214,7 +188,6 @@ jobs:
       - setup_remote_docker
       - checkout
       - *docker_login
-      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -223,7 +196,7 @@ jobs:
           name: run selenium tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=2 bmo.test test_selenium 2
+            docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=2 bmo.test test_selenium 2
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -235,7 +208,6 @@ jobs:
       - setup_remote_docker
       - checkout
       - *docker_login
-      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -244,7 +216,7 @@ jobs:
           name: run selenium tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=3 bmo.test test_selenium 3
+            docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=3 bmo.test test_selenium 3
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -256,7 +228,6 @@ jobs:
       - setup_remote_docker
       - checkout
       - *docker_login
-      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -265,7 +236,7 @@ jobs:
           name: run selenium tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=4 bmo.test test_selenium 4
+            docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=4 bmo.test test_selenium 4
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -277,7 +248,6 @@ jobs:
       - setup_remote_docker
       - checkout
       - *docker_login
-      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -286,7 +256,7 @@ jobs:
           name: run bmo specific tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run bmo.test test_bmo -q -f t/bmo/*.t extensions/*/t/bmo/*.t
+            docker-compose -f docker-compose.test.yml run --build bmo.test test_bmo -q -f t/bmo/*.t extensions/*/t/bmo/*.t
       - *store_log
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ defaults:
         fi
 
   docker_image: &docker_image
-    image: cimg/base:2023.10
+    image: cimg/base:2024.11
     auth:
       username: $DOCKER_USER
       password: $DOCKER_PASS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,42 +22,30 @@ defaults:
       username: $DOCKER_USER
       password: $DOCKER_PASS
 
-  build_image: &build_image
-    run:
-      name: Build Docker BMO Image
-      command: |
-        docker build \
-          --build-arg CI="$CI" \
-          --build-arg CIRCLE_SHA1="$CIRCLE_SHA1" \
-          --build-arg CIRCLE_BUILD_URL="$CIRCLE_BUILD_URL" \
-          --target base \
-          -t bmo .
-
-  build_selenium_image: &build_selenium_image
-    run:
-      name: Build Selenium Image
-      command: |
-        docker build \
-          --build-arg CI="$CI" \
-          --build-arg CIRCLE_SHA1="$CIRCLE_SHA1" \
-          --build-arg CIRCLE_BUILD_URL="$CIRCLE_BUILD_URL" \
-          --target test \
-          -t bmo .
-
   store_log: &store_log
     store_artifacts:
       path: bugzilla.log
       destination: bugzilla.log
 
+commands:
+  # Only used for local jobs docker execution
+  setup_local_docker:
+    steps:
+      - run:
+          name: Use sudo docker in local builds
+          command: |
+            if [[ $CIRCLE_SHELL_ENV == *"localbuild"* ]]; then
+              sudo chmod u+s $(which docker)
+            fi
 jobs:
   build:
     docker:
       - *docker_image
     steps:
       - setup_remote_docker
+      - setup_local_docker
       - checkout
       - *docker_login
-      - *build_image
       - run: |
           [[ -d build_info ]] || mkdir build_info
       - attach_workspace:
@@ -65,11 +53,11 @@ jobs:
       - run:
           name: build version.json
           command: |
-            docker-compose -f docker-compose.test.yml run bmo.test version | sed '1d' > build_info/version.json
+            docker-compose -f docker-compose.test.yml run --build bmo.test version | sed '1d' > build_info/version.json
       - run:
           name: build push data
           command: |
-            docker-compose -f docker-compose.test.yml run --name push_data bmo.test push_data
+            docker-compose -f docker-compose.test.yml run --build --name push_data bmo.test push_data
             docker cp push_data:/app/build_info/blog.push.txt build_info/blog.push.txt
             docker cp push_data:/app/build_info/markdown.push.txt build_info/markdown.push.txt
             docker cp push_data:/app/build_info/bug.push.txt build_info/bug.push.txt
@@ -116,14 +104,15 @@ jobs:
       - *docker_image
     steps:
       - setup_remote_docker
+      - setup_local_docker
       - checkout
       - *docker_login
-      - *build_image
       - attach_workspace:
           at: build_info
       - deploy:
           command: |
             [[ -n "$DOCKERHUB_REPO" && -n "$DOCKER_USER" && -n "$DOCKER_PASS" ]] || exit 0
+            docker build --tag bmo --target base .
             if [[ "$CIRCLE_BRANCH" == "master" ]]; then
               TAG="$(cat build_info/tag.txt)"
               if [[ -n "$TAG" && -f build_info/publish.txt ]]; then
@@ -148,9 +137,9 @@ jobs:
       - *docker_image
     steps:
       - setup_remote_docker
+      - setup_local_docker
       - checkout
       - *docker_login
-      - *build_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -159,8 +148,7 @@ jobs:
           name: run sanity tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run --no-deps bmo.test \
-              test_sanity t/*.t extensions/*/t/*.t
+            docker-compose -f docker-compose.test.yml run --build --no-deps bmo.test test_sanity t/*.t extensions/*/t/*.t
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -170,9 +158,9 @@ jobs:
       - *docker_image
     steps:
       - setup_remote_docker
+      - setup_local_docker
       - checkout
       - *docker_login
-      - *build_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -181,7 +169,7 @@ jobs:
           name: run webservice tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run bmo.test test_webservices
+            docker-compose -f docker-compose.test.yml run --build bmo.test test_webservices
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -191,9 +179,9 @@ jobs:
       - *docker_image
     steps:
       - setup_remote_docker
+      - setup_local_docker
       - checkout
       - *docker_login
-      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -202,7 +190,7 @@ jobs:
           name: run selenium tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=1 bmo.test test_selenium
+            docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=1 bmo.test test_selenium
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -212,9 +200,9 @@ jobs:
       - *docker_image
     steps:
       - setup_remote_docker
+      - setup_local_docker
       - checkout
       - *docker_login
-      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -223,7 +211,7 @@ jobs:
           name: run selenium tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=2 bmo.test test_selenium 2
+            docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=2 bmo.test test_selenium 2
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -233,9 +221,9 @@ jobs:
       - *docker_image
     steps:
       - setup_remote_docker
+      - setup_local_docker
       - checkout
       - *docker_login
-      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -244,7 +232,7 @@ jobs:
           name: run selenium tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=3 bmo.test test_selenium 3
+            docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=3 bmo.test test_selenium 3
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -254,9 +242,9 @@ jobs:
       - *docker_image
     steps:
       - setup_remote_docker
+      - setup_local_docker
       - checkout
       - *docker_login
-      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -265,7 +253,7 @@ jobs:
           name: run selenium tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=4 bmo.test test_selenium 4
+            docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=4 bmo.test test_selenium 4
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -275,9 +263,9 @@ jobs:
       - *docker_image
     steps:
       - setup_remote_docker
+      - setup_local_docker
       - checkout
       - *docker_login
-      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -286,7 +274,7 @@ jobs:
           name: run bmo specific tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run bmo.test test_bmo -q -f t/bmo/*.t extensions/*/t/bmo/*.t
+            docker-compose -f docker-compose.test.yml run --build bmo.test test_bmo -q -f t/bmo/*.t extensions/*/t/bmo/*.t
       - *store_log
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,11 +42,12 @@ jobs:
       - run:
           name: build version.json
           command: |
-            docker-compose -f docker-compose.test.yml run --build --no-deps bmo.test version | sed '1d' > build_info/version.json
+            docker-compose -f docker-compose.test.yml build bmo.test
+            docker-compose -f docker-compose.test.yml run --no-deps bmo.test version | sed '1d' > build_info/version.json
       - run:
           name: build push data
           command: |
-            docker-compose -f docker-compose.test.yml run --build --no-deps --name push_data bmo.test push_data
+            docker-compose -f docker-compose.test.yml run --no-deps --name push_data bmo.test push_data
             docker cp push_data:/app/build_info/blog.push.txt build_info/blog.push.txt
             docker cp push_data:/app/build_info/markdown.push.txt build_info/markdown.push.txt
             docker cp push_data:/app/build_info/bug.push.txt build_info/bug.push.txt
@@ -135,8 +136,8 @@ jobs:
           name: run sanity tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run --build --no-deps bmo.test \
-              test_sanity t/*.t extensions/*/t/*.t
+            docker-compose -f docker-compose.test.yml build bmo.test
+            docker-compose -f docker-compose.test.yml run --no-deps bmo.test test_sanity t/*.t extensions/*/t/*.t
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -156,6 +157,7 @@ jobs:
           name: run webservice tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
+            docker-compose -f docker-compose.test.yml build
             docker-compose -f docker-compose.test.yml run --build bmo.test test_webservices
       - store_artifacts:
           path: artifacts
@@ -176,7 +178,8 @@ jobs:
           name: run selenium tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=1 bmo.test test_selenium
+            docker-compose -f docker-compose.test.yml build
+            docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=1 bmo.test test_selenium
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -196,7 +199,8 @@ jobs:
           name: run selenium tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=2 bmo.test test_selenium 2
+            docker-compose -f docker-compose.test.yml build
+            docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=2 bmo.test test_selenium 2
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -216,7 +220,8 @@ jobs:
           name: run selenium tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=3 bmo.test test_selenium 3
+            docker-compose -f docker-compose.test.yml build
+            docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=3 bmo.test test_selenium 3
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -236,7 +241,8 @@ jobs:
           name: run selenium tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=4 bmo.test test_selenium 4
+            docker-compose -f docker-compose.test.yml build
+            docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=4 bmo.test test_selenium 4
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -256,7 +262,8 @@ jobs:
           name: run bmo specific tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run --build bmo.test test_bmo -q -f t/bmo/*.t extensions/*/t/bmo/*.t
+            docker-compose -f docker-compose.test.yml build
+            docker-compose -f docker-compose.test.yml run bmo.test test_bmo -q -f t/bmo/*.t extensions/*/t/bmo/*.t
       - *store_log
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,10 +17,32 @@ defaults:
         fi
 
   docker_image: &docker_image
-    image: cimg/base:2024.11
+    image: cimg/base:2023.10
     auth:
       username: $DOCKER_USER
       password: $DOCKER_PASS
+
+  build_image: &build_image
+    run:
+      name: Build Docker BMO Image
+      command: |
+        docker build \
+          --build-arg CI="$CI" \
+          --build-arg CIRCLE_SHA1="$CIRCLE_SHA1" \
+          --build-arg CIRCLE_BUILD_URL="$CIRCLE_BUILD_URL" \
+          --target base \
+          -t bmo .
+
+  build_selenium_image: &build_selenium_image
+    run:
+      name: Build Selenium Image
+      command: |
+        docker build \
+          --build-arg CI="$CI" \
+          --build-arg CIRCLE_SHA1="$CIRCLE_SHA1" \
+          --build-arg CIRCLE_BUILD_URL="$CIRCLE_BUILD_URL" \
+          --target test \
+          -t bmo .
 
   store_log: &store_log
     store_artifacts:
@@ -35,6 +57,7 @@ jobs:
       - setup_remote_docker
       - checkout
       - *docker_login
+      - *build_image
       - run: |
           [[ -d build_info ]] || mkdir build_info
       - attach_workspace:
@@ -42,12 +65,11 @@ jobs:
       - run:
           name: build version.json
           command: |
-            docker-compose -f docker-compose.test.yml build bmo.test
-            docker-compose -f docker-compose.test.yml run --no-deps bmo.test version | sed '1d' > build_info/version.json
+            docker-compose -f docker-compose.test.yml run bmo.test version | sed '1d' > build_info/version.json
       - run:
           name: build push data
           command: |
-            docker-compose -f docker-compose.test.yml run --no-deps --name push_data bmo.test push_data
+            docker-compose -f docker-compose.test.yml run --name push_data bmo.test push_data
             docker cp push_data:/app/build_info/blog.push.txt build_info/blog.push.txt
             docker cp push_data:/app/build_info/markdown.push.txt build_info/markdown.push.txt
             docker cp push_data:/app/build_info/bug.push.txt build_info/bug.push.txt
@@ -96,11 +118,11 @@ jobs:
       - setup_remote_docker
       - checkout
       - *docker_login
+      - *build_image
       - attach_workspace:
           at: build_info
       - deploy:
           command: |
-            docker build -t bmo .
             [[ -n "$DOCKERHUB_REPO" && -n "$DOCKER_USER" && -n "$DOCKER_PASS" ]] || exit 0
             if [[ "$CIRCLE_BRANCH" == "master" ]]; then
               TAG="$(cat build_info/tag.txt)"
@@ -128,6 +150,7 @@ jobs:
       - setup_remote_docker
       - checkout
       - *docker_login
+      - *build_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -136,8 +159,8 @@ jobs:
           name: run sanity tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml build bmo.test
-            docker-compose -f docker-compose.test.yml run --no-deps bmo.test test_sanity t/*.t extensions/*/t/*.t
+            docker-compose -f docker-compose.test.yml run --no-deps bmo.test \
+              test_sanity t/*.t extensions/*/t/*.t
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -149,6 +172,7 @@ jobs:
       - setup_remote_docker
       - checkout
       - *docker_login
+      - *build_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -157,8 +181,7 @@ jobs:
           name: run webservice tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml build
-            docker-compose -f docker-compose.test.yml run --build bmo.test test_webservices
+            docker-compose -f docker-compose.test.yml run bmo.test test_webservices
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -170,6 +193,7 @@ jobs:
       - setup_remote_docker
       - checkout
       - *docker_login
+      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -178,7 +202,6 @@ jobs:
           name: run selenium tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml build
             docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=1 bmo.test test_selenium
       - store_artifacts:
           path: artifacts
@@ -191,6 +214,7 @@ jobs:
       - setup_remote_docker
       - checkout
       - *docker_login
+      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -199,7 +223,6 @@ jobs:
           name: run selenium tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml build
             docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=2 bmo.test test_selenium 2
       - store_artifacts:
           path: artifacts
@@ -212,6 +235,7 @@ jobs:
       - setup_remote_docker
       - checkout
       - *docker_login
+      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -220,7 +244,6 @@ jobs:
           name: run selenium tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml build
             docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=3 bmo.test test_selenium 3
       - store_artifacts:
           path: artifacts
@@ -233,6 +256,7 @@ jobs:
       - setup_remote_docker
       - checkout
       - *docker_login
+      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -241,7 +265,6 @@ jobs:
           name: run selenium tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml build
             docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=4 bmo.test test_selenium 4
       - store_artifacts:
           path: artifacts
@@ -254,6 +277,7 @@ jobs:
       - setup_remote_docker
       - checkout
       - *docker_login
+      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -262,7 +286,6 @@ jobs:
           name: run bmo specific tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml build
             docker-compose -f docker-compose.test.yml run bmo.test test_bmo -q -f t/bmo/*.t extensions/*/t/bmo/*.t
       - *store_log
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
       - name: Run bmo specific tests
-        run: docker-compose -f docker-compose.test.yml run -e CI=1 bmo.test test_bmo -q -f t/bmo/*.t
+        run: docker-compose -f docker-compose.test.yml run -e CI=1 bmo.test test_bmo -q -f t/bmo/*.t extensions/*/t/bmo/*.t
 
   test_selenium_1:
     runs-on: ubuntu-latest

--- a/Bugzilla/Config.pm
+++ b/Bugzilla/Config.pm
@@ -109,13 +109,13 @@ sub update {
       {
         if ($old_value ne $new_value) {
           $dbh->do('UPDATE params SET value = ? WHERE name = ?', undef, $new_value, $key);
-          $changes{"$id:$key"} = [$old_value, $new_value];
+          $changes{$key} = [$old_value, $new_value];
         }
       }
       else {
         $dbh->do('INSERT INTO params (name, value) VALUES (?, ?)',
           undef, $key, $new_value);
-        $changes{"$id:$key"} = ['', $new_value];
+        $changes{$key} = ['', $new_value];
       }
     }
 
@@ -132,10 +132,8 @@ sub update {
     # not the case here so we assign the 'id' variable each interation
     # to make audit_log think each is a separate instance of
     # Bugzilla::Config and each change is a separate transaction.
-    foreach my $item (keys %changes) {
-      my ($id, $key) = split /:/, $item;
-      $self->{id} = $id;
-      $self->audit_log({$key => [$changes{$item}->[0], $changes{$item}->[1]]});
+    foreach my $key (keys %changes) {
+      $self->audit_log({$key => [$changes{$key}->[0], $changes{$key}->[1]]});
     }
   }
   catch {
@@ -301,7 +299,7 @@ sub migrate_params {
   }
 
   # Generate unique Duo integration secret key
-  if ($param->{duo_akey} eq '') {
+  if (!exists $param->{duo_akey} || $param->{duo_akey} eq '') {
     require Bugzilla::Util;
     $param->{duo_akey} = Bugzilla::Util::generate_random_password(40);
   }

--- a/Bugzilla/DB/Schema/Mysql.pm
+++ b/Bugzilla/DB/Schema/Mysql.pm
@@ -155,7 +155,7 @@ sub _get_create_index_ddl {
 
   my $sql = "CREATE ";
   $sql .= "$index_type "
-    if ($index_type eq 'UNIQUE' || $index_type eq 'FULLTEXT');
+    if ($index_type && ($index_type eq 'UNIQUE' || $index_type eq 'FULLTEXT'));
   $sql
     .= "INDEX "
     . $dbh->quote_identifier($index_name) . " ON "

--- a/conf/checksetup_answers.txt
+++ b/conf/checksetup_answers.txt
@@ -61,7 +61,7 @@ $answer{'sitemapindex_google_bucket'}          = 'sitemapindex';
 $answer{'sitemapindex_google_service_account'} = 'test';
 
 $answer{'bmo_etl_enabled'}         = 1;
-$answer{'bmo_etl_base_url'}        = 'http://bigquery:9050';
+$answer{'bmo_etl_base_url'}        = 'http://localhost:9050';
 $answer{'bmo_etl_service_account'} = 'test';
 $answer{'bmo_etl_project_id'}      = 'test';
 $answer{'bmo_etl_dataset_id'}      = 'bugzilla';

--- a/conf/checksetup_answers.txt
+++ b/conf/checksetup_answers.txt
@@ -61,7 +61,7 @@ $answer{'sitemapindex_google_bucket'}          = 'sitemapindex';
 $answer{'sitemapindex_google_service_account'} = 'test';
 
 $answer{'bmo_etl_enabled'}         = 1;
-$answer{'bmo_etl_base_url'}        = 'http://127.0.0.1:8002';
+$answer{'bmo_etl_base_url'}        = 'http://bq:9050';
 $answer{'bmo_etl_service_account'} = 'test';
 $answer{'bmo_etl_project_id'}      = 'test';
 $answer{'bmo_etl_dataset_id'}      = 'bugzilla';

--- a/conf/checksetup_answers.txt
+++ b/conf/checksetup_answers.txt
@@ -61,7 +61,7 @@ $answer{'sitemapindex_google_bucket'}          = 'sitemapindex';
 $answer{'sitemapindex_google_service_account'} = 'test';
 
 $answer{'bmo_etl_enabled'}         = 1;
-$answer{'bmo_etl_base_url'}        = 'http://localhost:9050';
+$answer{'bmo_etl_base_url'}        = 'http://bigquery:8002';
 $answer{'bmo_etl_service_account'} = 'test';
 $answer{'bmo_etl_project_id'}      = 'test';
 $answer{'bmo_etl_dataset_id'}      = 'bugzilla';

--- a/conf/checksetup_answers.txt
+++ b/conf/checksetup_answers.txt
@@ -61,7 +61,7 @@ $answer{'sitemapindex_google_bucket'}          = 'sitemapindex';
 $answer{'sitemapindex_google_service_account'} = 'test';
 
 $answer{'bmo_etl_enabled'}         = 1;
-$answer{'bmo_etl_base_url'}        = 'http://bigquery:8002';
+$answer{'bmo_etl_base_url'}        = 'http://127.0.0.1:8002';
 $answer{'bmo_etl_service_account'} = 'test';
 $answer{'bmo_etl_project_id'}      = 'test';
 $answer{'bmo_etl_dataset_id'}      = 'bugzilla';

--- a/conf/checksetup_answers.txt
+++ b/conf/checksetup_answers.txt
@@ -60,6 +60,12 @@ $answer{'sitemapindex_google_host'}            = 'gcs';
 $answer{'sitemapindex_google_bucket'}          = 'sitemapindex';
 $answer{'sitemapindex_google_service_account'} = 'test';
 
+$answer{'bmo_etl_enabled'}         = 1;
+$answer{'bmo_etl_base_url'}        = 'http://bigquery:9050';
+$answer{'bmo_etl_service_account'} = 'test';
+$answer{'bmo_etl_project_id'}      = 'test';
+$answer{'bmo_etl_dataset_id'}      = 'bugzilla';
+
 $answer{'duo_uri'} = 'http://localhost:8001';
 $answer{'duo_client_id'} = '6rZ3KnrL04uyGjLd8foO';
 $answer{'duo_client_secret'} = '3vg6cm0Gj0DpC6ZJACXdZ1NrVRi1AhkwjfXnlFaJ';

--- a/conf/log4perl-test.conf
+++ b/conf/log4perl-test.conf
@@ -1,4 +1,4 @@
-log4perl.rootLogger = FATAL, Cereal, Screen, File
+log4perl.rootLogger = DEBUG, Cereal, Screen, File
 log4perl.appender.Cereal = Log::Log4perl::Appender::Socket
 log4perl.appender.Cereal.PeerAddr=127.0.0.1
 log4perl.appender.Cereal.PeerPort=5880

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,7 +5,6 @@
 services:
   bmo.test:
     platform: linux/x86_64
-    image: bmo
     build: &bmo_build
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,6 +5,7 @@
 services:
   bmo.test:
     platform: linux/x86_64
+    image: bmo
     build: &bmo_build
       context: .
       dockerfile: Dockerfile
@@ -51,7 +52,6 @@ services:
     platform: linux/x86_64
     image: mysql:8
     volumes:
-      - bmo-mysql-data:/var/lib/mysql
       - ./docker/mysql:/etc/mysql/conf.d
     tmpfs:
       - /tmp
@@ -65,23 +65,20 @@ services:
 
   memcached:
     platform: linux/x86_64
-
-    image:  ghcr.io/ghcr-library/memcached:latest
+    image: ghcr.io/ghcr-library/memcached:latest
 
   s3:
     platform: linux/x86_64
     image: scireum/s3-ninja
-    volumes:
-      - "bmo-s3-data:/home/sirius/data"
 
   gcs:
     platform: linux/x86_64
     image: fsouza/fake-gcs-server
     command: "-scheme http"
     volumes:
-      - bmo-gcs-attachments:/data/attachments
-      - bmo-gcs-sitemapindex:/data/sitemapindex
-      - bmo-gcs-mining:/data/mining
+      - ./docker/gcs/attachments:/data/attachments
+      - ./docker/gcs/sitemapindex:/data/sitemapindex
+      - ./docker/gcs/mining:/data/mining
 
   bigquery:
     platform: linux/x86_64
@@ -89,16 +86,7 @@ services:
     ports:
       - 9050:9050
     volumes:
-      - bmo-bigquery-data:/work
       - ./docker/bigquery/data.yaml:/work/data.yaml
     working_dir: /work
     command: |
       --project=test --data-from-yaml=/work/data.yaml --log-level=debug
-
-volumes:
-  bmo-mysql-data:
-  bmo-s3-data:
-  bmo-gcs-attachments:
-  bmo-gcs-sitemapindex:
-  bmo-gcs-mining:
-  bmo-bigquery-data:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,7 +4,7 @@
 
 services:
   bmo.test:
-    image: bmo
+    platform: linux/x86_64
     build: &bmo_build
       context: .
       dockerfile: Dockerfile
@@ -38,15 +38,21 @@ services:
       - memcached
       - s3
       - gcs
+      - bigquery
 
   externalapi.test:
+    platform: linux/x86_64
     build: *bmo_build
     entrypoint: perl /app/external_test_api.pl daemon -l http://*:8001
     ports:
       - 8001:8001
 
   bmo.db:
+    platform: linux/x86_64
     image: mysql:8
+    volumes:
+      - bmo-mysql-data:/var/lib/mysql
+      - ./docker/mysql:/etc/mysql/conf.d
     tmpfs:
       - /tmp
     logging:
@@ -58,15 +64,41 @@ services:
       - MYSQL_ALLOW_EMPTY_PASSWORD=1
 
   memcached:
+    platform: linux/x86_64
+
     image:  ghcr.io/ghcr-library/memcached:latest
 
   s3:
+    platform: linux/x86_64
     image: scireum/s3-ninja
+    volumes:
+      - "bmo-s3-data:/home/sirius/data"
 
   gcs:
+    platform: linux/x86_64
     image: fsouza/fake-gcs-server
     command: "-scheme http"
     volumes:
-      - ./docker/gcs/attachments:/data/attachments
-      - ./docker/gcs/sitemapindex:/data/sitemapindex
-      - ./docker/gcs/mining:/data/mining
+      - bmo-gcs-attachments:/data/attachments
+      - bmo-gcs-sitemapindex:/data/sitemapindex
+      - bmo-gcs-mining:/data/mining
+
+  bigquery:
+    platform: linux/x86_64
+    image: ghcr.io/goccy/bigquery-emulator:latest
+    ports:
+      - 9050:9050
+    volumes:
+      - bmo-bigquery-data:/work
+      - ./docker/bigquery/data.yaml:/work/data.yaml
+    working_dir: /work
+    command: |
+      --project=test --data-from-yaml=/work/data.yaml --log-level=debug
+
+volumes:
+  bmo-mysql-data:
+  bmo-s3-data:
+  bmo-gcs-attachments:
+  bmo-gcs-sitemapindex:
+  bmo-gcs-mining:
+  bmo-bigquery-data:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,6 +5,7 @@
 services:
   bmo.test:
     platform: linux/x86_64
+    image: bmo
     build: &bmo_build
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -84,7 +84,7 @@ services:
     platform: linux/x86_64
     image: ghcr.io/goccy/bigquery-emulator:latest
     ports:
-      - 9050:9050
+      - 8002:9050
     volumes:
       - ./docker/bigquery/data.yaml:/work/data.yaml
     working_dir: /work

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,9 +4,7 @@
 
 services:
   bmo.test:
-    platform: linux/x86_64
-    image: bmo
-    build: &bmo_build
+    build: &build_bmo
       context: .
       dockerfile: Dockerfile
       target: test
@@ -39,17 +37,15 @@ services:
       - memcached
       - s3
       - gcs
-      - bigquery
+      - bq
 
   externalapi.test:
-    platform: linux/x86_64
-    build: *bmo_build
+    build: *build_bmo
     entrypoint: perl /app/external_test_api.pl daemon -l http://*:8001
     ports:
       - 8001:8001
 
   bmo.db:
-    platform: linux/x86_64
     image: mysql:8
     volumes:
       - ./docker/mysql:/etc/mysql/conf.d
@@ -64,15 +60,12 @@ services:
       - MYSQL_ALLOW_EMPTY_PASSWORD=1
 
   memcached:
-    platform: linux/x86_64
     image: ghcr.io/ghcr-library/memcached:latest
 
   s3:
-    platform: linux/x86_64
     image: scireum/s3-ninja
 
   gcs:
-    platform: linux/x86_64
     image: fsouza/fake-gcs-server
     command: "-scheme http"
     volumes:
@@ -80,13 +73,12 @@ services:
       - ./docker/gcs/sitemapindex:/data/sitemapindex
       - ./docker/gcs/mining:/data/mining
 
-  bigquery:
-    platform: linux/x86_64
-    image: ghcr.io/goccy/bigquery-emulator:latest
+  bq:
+    build:
+      context: ./docker/bigquery
+      dockerfile: Dockerfile
     ports:
-      - 8002:9050
-    volumes:
-      - ./docker/bigquery/data.yaml:/work/data.yaml
+      - 9050:9050
     working_dir: /work
     command: |
-      --project=test --data-from-yaml=/work/data.yaml --log-level=debug
+      --project=test --data-from-yaml=/data.yaml

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -82,7 +82,6 @@ services:
 
   bigquery:
     platform: linux/x86_64
-    container_name: bigquery
     image: ghcr.io/goccy/bigquery-emulator:latest
     ports:
       - 9050:9050

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -82,6 +82,7 @@ services:
 
   bigquery:
     platform: linux/x86_64
+    container_name: bigquery
     image: ghcr.io/goccy/bigquery-emulator:latest
     ports:
       - 9050:9050

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       - memcached
       - s3
       - gcs
+      - bigquery
       - externalapi.test
     ports:
       - 8000:8000
@@ -107,6 +108,7 @@ services:
     volumes:
       - bmo-mysql-db:/var/lib/mysql
       - ./docker/mysql:/etc/mysql/conf.d
+      #- /var/home/dkl/Downloads/bugs-05-08-24.sql:/docker-entrypoint-initdb.d/bugs.sql
     tmpfs:
       - /tmp
     logging:
@@ -136,6 +138,18 @@ services:
       - bmo-gcs-sitemapindex:/data/sitemapindex
       - bmo-gcs-mining:/data/mining
 
+  bigquery:
+    platform: linux/x86_64
+    image: ghcr.io/goccy/bigquery-emulator:latest
+    ports:
+      - 9050:9050
+    volumes:
+      - bmo-bigquery-data:/work
+      - ./docker/bigquery/data.yaml:/work/data.yaml
+    working_dir: /work
+    command: |
+      --project=test --data-from-yaml=/work/data.yaml --log-level=debug
+
   externalapi.test:
     platform: linux/x86_64
     build: *bmo_build
@@ -150,3 +164,4 @@ volumes:
   bmo-gcs-attachments:
   bmo-gcs-sitemapindex:
   bmo-gcs-mining:
+  bmo-bigquery-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,7 +108,6 @@ services:
     volumes:
       - bmo-mysql-db:/var/lib/mysql
       - ./docker/mysql:/etc/mysql/conf.d
-      #- /var/home/dkl/Downloads/bugs-05-08-24.sql:/docker-entrypoint-initdb.d/bugs.sql
     tmpfs:
       - /tmp
     logging:

--- a/docker/bigquery/Dockerfile
+++ b/docker/bigquery/Dockerfile
@@ -1,0 +1,3 @@
+FROM ghcr.io/goccy/bigquery-emulator:0.6.5
+
+COPY data.yaml /data.yaml

--- a/docker/bigquery/data.yaml
+++ b/docker/bigquery/data.yaml
@@ -1,0 +1,186 @@
+projects:
+- id: test
+  datasets:
+    - id: bugzilla
+      tables:
+        - id: bugs
+          columns:
+            - name: id
+              type: INTEGER 
+            - name: assignee_id
+              type: INTEGER 
+            - name: url 
+              type: STRING 
+            - name: severity
+              type: STRING 
+            - name: status
+              type: STRING 
+            - name: type
+              type: STRING 
+            - name: crash_signature
+              type: STRING 
+            - name: component
+              type: STRING 
+            - name: creation_ts
+              type: TIMESTAMP 
+            - name: updated_ts
+              type: TIMESTAMP 
+            - name: op_sys
+              type: STRING 
+            - name: priority
+              type: STRING 
+            - name: product
+              type: STRING 
+            - name: platform
+              type: STRING 
+            - name: reporter_id
+              type: INTEGER 
+            - name: resolution
+              type: STRING 
+            - name:  summary
+              type: STRING 
+            - name: whiteboard
+              type: STRING 
+            - name: milestone
+              type: STRING 
+            - name: version
+              type: STRING 
+            - name: team_name
+              type: STRING 
+            - name: group
+              type: STRING 
+            - name: classification
+              type: STRING 
+            - name: is_public
+              type: BOOLEAN 
+            - name: comment_count
+              type: INTEGER 
+            - name: cc_count
+              type: INTEGER 
+            - name: vote_count
+              type: INTEGER 
+            - name: snapshot_date
+              type: TIMESTAMP
+        - id: attachments
+          columns:
+          - name: id
+            type: INT64
+          - name: bug_id
+            type: INT64
+          - name: creation_ts
+            type: TIMESTAMP
+          - name: description
+            type: STRING
+          - name: filename
+            type: STRING
+          - name: is_obsolete
+            type: BOOL
+          - name: content_type
+            type: STRING
+          - name: updated_ts
+            type: TIMESTAMP
+          - name: submitter_id
+            type: INT64
+          - name: snapshot_date
+            type: TIMESTAMP
+        - id: flags
+          columns:
+          - name: attachment_id
+            type: INT64
+          - name: bug_id
+            type: INT64
+          - name: creation_ts
+            type: TIMESTAMP
+          - name: updated_ts
+            type: TIMESTAMP
+          - name: requestee_id
+            type: INT64
+          - name: setter_id
+            type: INT64
+          - name: name
+            type: STRING
+          - name: value
+            type: STRING
+          - name: snapshot
+            type: TIMESTAMP
+        - id: tracking_flags
+          columns:
+          - name: bug_id
+            type: INT64
+          - name: name
+            type: STRING
+          - name: value
+            type: STRING
+          - name: snapshot
+            type: TIMESTAMP
+        - id: keywords
+          columns:
+          - name: bug_id
+            type: INT64
+          - name: keyword
+            type: STRING
+          - name: snapshot
+            type: TIMESTAMP
+        - id: see_also
+          columns:
+          - name: bug_id
+            type: INT64
+          - name: url
+            type: STRING
+          - name: snapshot
+            type: TIMESTAMP
+        - id: bug_mentors
+          columns:
+          - name: bug_id
+            type: INT64
+          - name: user_id
+            type: INT64
+          - name: snapshot
+            type: TIMESTAMP
+        - id: bug_dependencies
+          columns:
+          - name: bug_id
+            type: INT64
+          - name: depends_on_id
+            type: INT64
+          - name: snapshot
+            type: TIMESTAMP
+        - id: bug_regressions
+          columns:
+          - name: bug_id
+            type: INT64
+          - name: regresses_id
+            type: INT64
+          - name: snapshot
+            type: TIMESTAMP
+        - id: bug_duplicates
+          columns:
+          - name: bug_id
+            type: INT64
+          - name: duplicate_of_id
+            type: INT64
+          - name: snapshot
+            type: TIMESTAMP
+        - id: users
+          columns:
+          - name: id
+            type: INT64
+          - name: last_seen
+            type: TIMESTAMP
+          - name: email
+            type: STRING
+          - name: nick
+            type: STRING
+          - name: name
+            type: STRING
+          - name: is_staff
+            type: BOOL
+          - name: is_trusted
+            type: BOOL
+          - name: ldap_email
+            type: STRING
+          - name: is_new
+            type: BOOL
+          - name: snapshot
+            type: TIMESTAMP
+  ])

--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -1384,6 +1384,16 @@ sub db_schema_abstract_schema {
     ],
     INDEXES => [job_last_run_name_idx => {FIELDS => ['name'], TYPE => 'UNIQUE',},],
   };
+    $args->{schema}->{bmo_etl_cache} = {
+    FIELDS => [
+      id            => {TYPE => 'INT3',         NOTNULL => 1,},
+      snapshot_date => {TYPE => 'DATETIME',     NOTNULL => 1,},
+      table_name    => {TYPE => 'VARCHAR(100)', NOTNULL => 1,},
+      data          => {TYPE => 'LONGBLOB',     NOTNULL => 1,},
+    ],
+    INDEXES =>
+      [bmo_etl_cache_idx => {FIELDS => ['id', 'snapshot_date', 'table_name']}],
+  };
 }
 
 sub install_update_db {
@@ -2588,6 +2598,33 @@ sub config_modify_panels {
     name    => 'enable_triaged_keyword',
     type    => 'b',
     };
+  push @{$args->{panels}->{reports}->{params}},
+    {
+    name => 'bmo_etl_enabled',
+    type => 'b',
+    default => 0,
+    };
+  push @{$args->{panels}->{reports}->{params}},
+    {
+    name => 'bmo_etl_base_url',
+    type => 't',
+    };
+  push @{$args->{panels}->{reports}->{params}},
+    {
+    name => 'bmo_etl_service_account',
+    type => 't',
+    };
+  push @{$args->{panels}->{reports}->{params}},
+    {
+    name => 'bmo_etl_project_id',
+    type => 't',
+    };
+  push @{$args->{panels}->{reports}->{params}},
+    {
+    name => 'bmo_etl_dataset_id',
+    type => 't',
+    };
+
 }
 
 sub comment_after_add_tag {

--- a/extensions/BMO/bin/export_bmo_etl.pl
+++ b/extensions/BMO/bin/export_bmo_etl.pl
@@ -567,7 +567,7 @@ sub store_cache {
   gzip \$data => \$gzipped_data or die "gzip failed: $GzipError\n";
 
   # We need to use the main DB for write operations
-  my $main_dbh = Bugzilla->dbh;
+  my $main_dbh = Bugzilla->dbh_main;
 
   # Clean out outdated JSON
   $main_dbh->do('DELETE FROM bmo_etl_cache WHERE id = ? AND table_name = ?',
@@ -605,12 +605,7 @@ sub send_data {
   }
 
   my $big_query = {
-    resource   => 'tabledata',
-    method     => 'insertAll',
-    project_id => $project_id,
-    dataset_id => $dataset_id,
-    table_id   => $table,
-    content    => {rows => \@json_rows}
+    rows => \@json_rows
   };
 
   if ($test) {
@@ -635,7 +630,7 @@ sub send_data {
   my $http_headers = HTTP::Headers->new;
 
   # Do not attempt to get access token if running in test environment
-  if ($base_url !~ /bigquery/) {
+  if ($base_url !~ /^http:\/\/bigquery:/) {
     my $access_token = _get_access_token();
     $http_headers->header(Authorization => 'Bearer ' . $access_token);
   }

--- a/extensions/BMO/bin/export_bmo_etl.pl
+++ b/extensions/BMO/bin/export_bmo_etl.pl
@@ -1,0 +1,659 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+use 5.10.1;
+use strict;
+use warnings;
+use lib qw(. lib local/lib/perl5);
+
+use Bugzilla;
+use Bugzilla::Attachment;
+use Bugzilla::Bug;
+use Bugzilla::Constants;
+use Bugzilla::Flag;
+use Bugzilla::User;
+use Bugzilla::Util qw(mojo_user_agent);
+
+use HTTP::Headers;
+use HTTP::Request;
+use IO::Compress::Gzip     qw(gzip $GzipError);
+use IO::Uncompress::Gunzip qw(gunzip $GunzipError);
+use Mojo::File             qw(path);
+use Mojo::JSON             qw(decode_json encode_json false true);
+use Mojo::Util             qw(getopt);
+
+# BigQuery API cannot handle payloads larger than 10MB so
+# we will send data in blocks.
+use constant API_BLOCK_COUNT => 1000;
+
+Bugzilla->usage_mode(USAGE_MODE_CMDLINE);
+getopt 't|test' => \my $test, 'v|verbose' => \my $verbose;
+
+if (!Bugzilla->params->{bmo_etl_enabled}) {
+  die "BMO ETL not enabled.\n";
+}
+
+if (!$test && !Bugzilla->params->{bmo_etl_base_url}) {
+  die "BMO ETL base url not defined.\n";
+}
+
+# Use replica if available
+my $dbh = Bugzilla->switch_to_shadow_db();
+
+my $ua = mojo_user_agent();
+
+# This date will be added to each object as it is being sent
+my $snapshot_date = $dbh->selectrow_array('SELECT LOCALTIMESTAMP(0)');
+my $file_snapshot = $snapshot_date;
+$file_snapshot =~ s/[\s:-]+/_/g;
+
+### Bugs
+
+my $table_name = 'bugs';
+my $rows       = $dbh->selectall_arrayref(
+  'SELECT bug_id AS id, delta_ts AS modification_time FROM bugs ORDER BY bug_id',
+  {Slice => {}}
+);
+
+my $total = scalar @{$rows};
+my $count = 0;
+
+print "Processing $total bugs.\n" if $verbose;
+
+my @results = ();
+foreach my $row (@{$rows}) {
+
+  # First check to see if we have a cached version with the same modification date
+  my $data = get_cache($row->{id}, $table_name, $row->{modification_time});
+  if (!$data) {
+    print "$table_name id " . $row->{id} . " not found in cache.\n" if $verbose;
+
+    my $obj = Bugzilla::Bug->new($row->{id});
+
+    $data = {
+      id              => $obj->id,
+      assignee_id     => $obj->assigned_to->id,
+      url             => $obj->bug_file_loc,
+      severity        => $obj->bug_severity,
+      status          => $obj->bug_status,
+      type            => $obj->bug_type,
+      crash_signature => $obj->cf_crash_signature,
+      component       => $obj->component,
+      creation_ts     => $obj->creation_ts,
+      updated_ts      => $obj->delta_ts,
+      op_sys          => $obj->op_sys,
+      priority        => $obj->priority,
+      product         => $obj->product,
+      platform        => $obj->rep_platform,
+      reporter_id     => $obj->reporter->id,
+      resolution      => $obj->resolution,
+      summary         => $obj->short_desc,
+      whiteboard      => $obj->status_whiteboard,
+      milestone       => $obj->target_milestone,
+      version         => $obj->version,
+      team_name       => $obj->component_obj->team_name,
+      classification  => $obj->classification,
+      comment_count   => $obj->comment_count,
+      vote_count      => $obj->votes,
+      group           => (join ',', map { $_->name } @{$obj->groups}),
+      is_public       => (scalar @{$obj->groups_in} ? true : false),
+      cc_count        => scalar @{$obj->cc || []},
+    };
+
+    # Store a copy of the data for use in later executions
+    store_cache($obj->id, $table_name, $obj->delta_ts, $data);
+  }
+
+  push @results, $data;
+
+  # Send the row to the server if we have the right number of rows
+  if (scalar @results == API_BLOCK_COUNT) {
+    send_data($table_name, \@results, $count);
+    @results = ();
+  }
+
+  $count++;
+}
+
+### Attachments
+
+$table_name = 'attachments';
+$rows       = $dbh->selectall_arrayref(
+  'SELECT attach_id AS id, modification_time FROM attachments ORDER BY attach_id',
+  {Slice => {}}
+);
+
+$total = scalar @{$rows};
+$count = 0;
+
+print "Processing $total attachments.\n" if $verbose;
+
+@results = ();
+foreach my $row (@{$rows}) {
+
+  # First check to see if we have a cached version with the same modification date
+  my $data = get_cache($row->{id}, $table_name, $row->{modification_time});
+  if (!$data) {
+    print "$table_name id "
+      . $row->{id}
+      . ' with time '
+      . $row->{modification_time}
+      . " not found in cache.\n"
+      if $verbose;
+
+    my $obj = Bugzilla::Attachment->new($row->{id});
+
+    $data = {
+      id           => $obj->id,
+      bug_id       => $obj->bug_id,
+      creation_ts  => $obj->attached,
+      description  => $obj->description,
+      filename     => $obj->filename,
+      content_type => $obj->contenttype,
+      updated_ts   => $obj->modification_time,
+      submitter_id => $obj->attacher->id,
+      is_obsolete  => ($obj->isobsolete ? true : false),
+    };
+
+    # Store a new copy of the data for use later
+    store_cache($obj->id, $table_name, $obj->modification_time, $data);
+  }
+
+  push @results, $data;
+
+  # Send the row to the server if we have the right number of rows
+  if (scalar @results == API_BLOCK_COUNT) {
+    send_data($table_name, \@results, $count);
+    @results = ();
+  }
+
+  $count++;
+}
+
+### Flags
+
+$table_name = 'flags';
+$rows
+  = $dbh->selectall_arrayref(
+  'SELECT id, modification_date FROM flags ORDER BY id',
+  {Slice => {}});
+
+$total = scalar @{$rows};
+$count = 0;
+
+print "Processing $total flags.\n" if $verbose;
+
+@results = ();
+foreach my $row (@{$rows}) {
+
+  # First check to see if we have a cached version with the same modification date
+  my $data = get_cache($row->{id}, $table_name, $row->{modification_date});
+  if (!$data) {
+    print "$table_name id " . $row->{id} . " not found in cache.\n" if $verbose;
+
+    my $obj = Bugzilla::Flag->new($row->{id});
+
+    $data = {
+      attachment_id => $obj->attach_id,
+      bug_id        => $obj->bug_id,
+      creation_ts   => $obj->creation_date,
+      updated_ts    => $obj->modification_date,
+      requestee_id  => $obj->requestee_id,
+      setter_id     => $obj->setter_id,
+      name          => $obj->type->name,
+      value         => $obj->status,
+    };
+
+    # Store a new copy of the data for use later
+    store_cache($obj->id, $table_name, $obj->modification_date, $data);
+  }
+
+  push @results, $data;
+
+  # Send the row to the server if we have the right number of rows
+  if (scalar @results == API_BLOCK_COUNT) {
+    send_data($table_name, \@results, $count);
+    @results = ();
+  }
+
+  $count++;
+}
+
+### Tracking Flags
+
+$table_name = 'tracking_flags';
+$rows       = $dbh->selectall_arrayref(
+  'SELECT tracking_flags.name AS name, tracking_flags_bugs.bug_id AS bug_id, tracking_flags_bugs.value AS value
+     FROM tracking_flags_bugs
+          JOIN tracking_flags
+          ON tracking_flags_bugs.tracking_flag_id = tracking_flags.id
+    ORDER BY tracking_flags_bugs.bug_id', {Slice => {}}
+);
+
+$total = scalar @{$rows};
+$count = 0;
+
+print "Processing $total tracking flags.\n" if $verbose;
+
+@results = ();
+foreach my $row (@{$rows}) {
+  my $data
+    = {bug_id => $row->{bug_id}, name => $row->{name}, value => $row->{value},};
+
+  push @results, $data;
+
+  # Send the row to the server if we have the right number of rows
+  if (scalar @results == API_BLOCK_COUNT) {
+    send_data($table_name, \@results, $count);
+    @results = ();
+  }
+
+  $count++;
+}
+
+### Keywords
+
+$table_name = 'keywords';
+$rows       = $dbh->selectall_arrayref(
+  'SELECT bug_id, keyworddefs.name AS name
+       FROM keywords
+            JOIN keyworddefs
+            ON keywords.keywordid = keyworddefs.id
+      ORDER BY bug_id', {Slice => {}}
+);
+
+$total = scalar @{$rows};
+$count = 0;
+
+print "Processing $total keywords.\n" if $verbose;
+
+@results = ();
+foreach my $row (@{$rows}) {
+  my $data = {bug_id => $row->{bug_id}, keyword => $row->{name},};
+
+  push @results, $data;
+
+  # Send the row to the server if we have the right number of rows
+  if (scalar @results == API_BLOCK_COUNT) {
+    send_data($table_name, \@results, $count);
+    @results = ();
+  }
+
+  $count++;
+}
+
+### See Also
+
+$table_name = 'see_also';
+$rows
+  = $dbh->selectall_arrayref(
+  'SELECT bug_id, value, class FROM bug_see_also ORDER BY bug_id',
+  {Slice => {}});
+
+$total = scalar @{$rows};
+$count = 0;
+
+print "Processing $total see also values.\n" if $verbose;
+
+@results = ();
+foreach my $row (@{$rows}) {
+  my $data = {bug_id => $row->{bug_id},};
+  if ($row->{class} =~ /::Local/) {
+    $data->{url}
+      = Bugzilla->localconfig->urlbase . 'show_bug.cgi?id=' . $row->{value};
+  }
+  else {
+    $data->{url} = $row->{value};
+  }
+
+  push @results, $data;
+
+  # Send the row to the server if we have the right number of rows
+  if (scalar @results == API_BLOCK_COUNT) {
+    send_data($table_name, \@results, $count);
+    @results = ();
+  }
+
+  $count++;
+}
+
+### Mentors
+
+$table_name = 'mentors';
+$rows
+  = $dbh->selectall_arrayref(
+  'SELECT bug_id, user_id FROM bug_mentors ORDER BY bug_id',
+  {Slice => {}});
+
+$total = scalar @{$rows};
+$count = 0;
+
+print "Processing $total mentors.\n" if $verbose;
+
+@results = ();
+foreach my $row (@{$rows}) {
+  my $data = {bug_id => $row->{bug_id}, user_id => $row->{user_id}};
+
+  push @results, $data;
+
+  # Send the row to the server if we have the right number of rows
+  if (scalar @results == API_BLOCK_COUNT) {
+    send_data($table_name, \@results, $count);
+    @results = ();
+  }
+
+  $count++;
+}
+
+### Dependencies
+
+$table_name = 'bug_dependencies';
+$rows
+  = $dbh->selectall_arrayref(
+  'SELECT blocked, dependson FROM dependencies ORDER BY blocked',
+  {Slice => {}});
+
+$total = scalar @{$rows};
+$count = 0;
+
+print "Processing $total bug dependency values.\n" if $verbose;
+
+@results = ();
+foreach my $row (@{$rows}) {
+  my $data = {bug_id => $row->{blocked}, depends_on_id => $row->{dependson}};
+
+  push @results, $data;
+
+  # Send the row to the server if we have the right number of rows
+  if (scalar @results == API_BLOCK_COUNT) {
+    send_data($table_name, \@results, $count);
+    @results = ();
+  }
+
+  $count++;
+}
+
+### Regressions
+
+$table_name = 'bug_regressions';
+$rows
+  = $dbh->selectall_arrayref('SELECT regresses, regressed_by FROM regressions',
+  {Slice => {}});
+
+$total = scalar @{$rows};
+$count = 0;
+
+print "Processing $total bug regression values.\n" if $verbose;
+
+@results = ();
+foreach my $row (@{$rows}) {
+  my $data = {bug_id => $row->{regresses}, regresses_id => $row->{regressed_by},};
+
+  push @results, $data;
+
+  # Send the row to the server if we have the right number of rows
+  if (scalar @results == API_BLOCK_COUNT) {
+    send_data($table_name, \@results, $count);
+    @results = ();
+  }
+
+  $count++;
+}
+
+### Duplicates
+
+$table_name = 'bug_duplicates';
+$rows       = $dbh->selectall_arrayref('SELECT dupe, dupe_of FROM duplicates',
+  {Slice => {}});
+
+$total = scalar @{$rows};
+$count = 0;
+
+print "Processing $total bug duplicate values.\n" if $verbose;
+
+@results = ();
+foreach my $row (@{$rows}) {
+  my $data = {bug_id => $row->{dupe}, duplicate_of_id => $row->{dupe_of},};
+
+  push @results, $data;
+
+  # Send the row to the server if we have the right number of rows
+  if (scalar @results == API_BLOCK_COUNT) {
+    send_data($table_name, \@results, $count);
+    @results = ();
+  }
+
+  $count++;
+}
+
+### Users
+
+$table_name = 'users';
+$rows
+  = $dbh->selectall_arrayref(
+  'SELECT userid AS id FROM profiles ORDER BY userid',
+  {Slice => {}});
+
+$total = scalar @{$rows};
+$count = 0;
+
+print "Processing $total users.\n" if $verbose;
+
+@results = ();
+foreach my $row (@{$rows}) {
+
+  # Determine last update timestamp for this user
+  # The profiles table does not have its own modification_time field
+  # so we have find it from the profiles_activity table and/or audit_log.
+  my ($profiles_activity_ts, $profiles_activity_epoch) = $dbh->selectrow_array(
+    'SELECT profiles_when, UNIX_TIMESTAMP(profiles_when) FROM profiles_activity WHERE userid = ? ORDER BY profiles_when DESC LIMIT 1',
+    undef, $row->{id}
+  );
+  my ($audit_log_ts, $audit_log_epoch) = $dbh->selectrow_array(
+    'SELECT at_time, UNIX_TIMESTAMP(at_time) FROM audit_log WHERE class = \'Bugzilla::User\' AND object_id = ? ORDER BY at_time DESC LIMIT 1',
+    undef, $row->{id}
+  );
+
+  $profiles_activity_epoch ||= 0;
+  $audit_log_epoch         ||= 0;
+
+  my $modification_time;
+  if ($audit_log_epoch > $profiles_activity_epoch) {
+    $modification_time = $audit_log_ts;
+  }
+  elsif ($profiles_activity_epoch > $audit_log_epoch) {
+    $modification_time = $profiles_activity_ts;
+  }
+
+  if ($verbose) {
+    print 'Modification time is '
+      . ($modification_time ? $modification_time : 'undefined') . "\n";
+  }
+
+  # First check to see if we have a cached version with the same modification date
+  my $data;
+  if ($modification_time) {
+    $data = get_cache($row->{id}, $table_name, $modification_time);
+  }
+
+  if (!$data) {
+    print "$table_name id " . $row->{id} . " not found in cache.\n" if $verbose;
+
+    my $obj = Bugzilla::User->new($row->{id});
+
+    $data = {
+      id         => $obj->id,
+      last_seen  => $obj->last_seen_date,
+      email      => $obj->email,
+      nick       => $obj->nick,
+      name       => $obj->name,
+      ldap_email => $obj->ldap_email,
+      is_new     => $obj->is_new,
+      is_staff   => ($obj->in_group('mozilla-employee-confidential') ? true : false),
+      is_trusted => ($obj->in_group('editbugs')                      ? true : false),
+    };
+
+    # Store a new copy of the data for use later
+    if ($modification_time) {
+      store_cache($obj->id, $table_name, $modification_time, $data);
+    }
+  }
+
+  push @results, $data;
+
+  # Send the row to the server if we have the right number of rows
+  if (scalar @results == API_BLOCK_COUNT) {
+    send_data($table_name, \@results, $count);
+    @results = ();
+  }
+
+  $count++;
+}
+
+# Functions
+
+sub get_cache {
+  my ($id, $table, $timestamp) = @_;
+
+  print "Retreiving data from $table for $id with time $timestamp.\n" if $verbose;
+
+  # Retrieve compressed JSON from cache table if it exists
+  my $gzipped_data = $dbh->selectrow_array(
+    'SELECT data FROM bmo_etl_cache WHERE id = ? AND table_name = ? AND snapshot_date = ?',
+    undef, $id, $table, $timestamp
+  );
+  return undef if !$gzipped_data;
+
+  # First uncompress the JSON and then decode it back to Perl data
+  my $data;
+  gunzip \$gzipped_data => \$data or die "gunzip failed: $GunzipError\n";
+  return decode_json($data);
+}
+
+sub store_cache {
+  my ($id, $table, $timestamp, $data) = @_;
+
+  print "Storing data into $table for $id with time $timestamp.\n" if $verbose;
+
+  # Encode the perl data into JSON
+  $data = encode_json($data);
+
+  # Compress the JSON to save space in the DB
+  my $gzipped_data;
+  gzip \$data => \$gzipped_data or die "gzip failed: $GzipError\n";
+
+  # Clean out outdated JSON
+  $dbh->do('DELETE FROM bmo_etl_cache WHERE id = ? AND table_name = ?',
+    undef, $id, $table);
+
+  # Enter new cached JSON
+  $dbh->do(
+    'INSERT INTO bmo_etl_cache (id, table_name, snapshot_date, data) VALUES (?, ?, ?, ?)',
+    undef, $id, $table, $timestamp, $gzipped_data
+  );
+}
+
+sub send_data {
+  my ($table, $rows, $current_count) = @_;
+
+  print 'Sending '
+    . scalar @{$rows}
+    . " rows to table $table using BigQuery API\n"
+    if $verbose;
+
+  # Add the same snapshot date to every row sent
+  foreach my $row (@{$rows}) {
+    $row->{snapshot_date} = $snapshot_date;
+  }
+
+  my $project_id = Bugzilla->params->{bmo_etl_project_id};
+  $project_id || die "Invalid BigQuery product ID.\n";
+
+  my $dataset_id = Bugzilla->params->{bmo_etl_dataset_id};
+  $dataset_id || die "Invalid BigQuery dataset ID.\n";
+
+  my @json_rows = ();
+  foreach my $row (@{$rows}) {
+    push @json_rows, {json => $row};
+  }
+
+  my $big_query = {
+    resource   => 'tabledata',
+    method     => 'insertAll',
+    project_id => $project_id,
+    dataset_id => $dataset_id,
+    table_id   => $table,
+    content    => {rows => \@json_rows}
+  };
+
+  if ($test) {
+    my $filename
+      = bz_locations()->{'datadir'} . '/'
+      . $file_snapshot . '_'
+      . $table . '_'
+      . $current_count . '.json';
+
+    print "Writing data to $filename\n" if $verbose;
+
+    my $fh = path($filename)->open('>>');
+    print $fh encode_json($big_query) . "\n";
+    close $fh || die "Could not close $filename: $!\n";
+
+    return;
+  }
+
+  my $access_token = _get_access_token($ua);
+
+  my $http_headers
+    = HTTP::Headers->new->header(Authorization => 'Bearer ' . $access_token);
+
+  my $full_path = sprintf 'projects/%s/datasets/%s/tables/%s/insertAll',
+    $project_id, $dataset_id, $table;
+  my $full_url = Bugzilla->params->{bmo_etl_base_url} . "/$full_path";
+
+  my $request = HTTP::Request->new('POST', $full_url, $http_headers);
+  $request->header('Content-Type' => 'application/json');
+  $request->content(encode_json($big_query));
+
+  my $res = $ua->request($request);
+  if (!$res->is_success) {
+    die 'Google Big Query insert failure: ' . $res->content;
+  }
+}
+
+sub _get_access_token {
+  state $access_token;    # We should only need to get this once
+
+  return $access_token if defined $access_token;
+
+# Google Kubernetes allows for the use of Workload Identity. This allows
+# us to link two serice accounts together and give special access for applications
+# running under Kubernetes. We use the special access to get an OAuth2 access_token
+# that can then be used for accessing the the Google API such as BigQuery.
+  my $url
+    = sprintf
+    'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/%s/token',
+    Bugzilla->params->{bmo_etl_service_account};
+
+  my $http_headers = HTTP::Headers->new;
+  $http_headers->header('Metadata-Flavor' => 'Google');
+
+  my $request = HTTP::Request->new('GET', $url, $http_headers);
+
+  my $res = $ua->request($request);
+
+  if (!$res->is_success) {
+    die 'Google access token failure: ' . $res->content;
+  }
+
+  my $result = decode_json($res->decoded_content);
+  $access_token = $result->{access_token};
+
+  return $access_token;
+}
+
+1;

--- a/extensions/BMO/bin/export_bmo_etl.pl
+++ b/extensions/BMO/bin/export_bmo_etl.pl
@@ -566,12 +566,15 @@ sub store_cache {
   my $gzipped_data;
   gzip \$data => \$gzipped_data or die "gzip failed: $GzipError\n";
 
+  # We need to use the main DB for write operations
+  my $main_dbh = Bugzilla->dbh;
+
   # Clean out outdated JSON
-  $dbh->do('DELETE FROM bmo_etl_cache WHERE id = ? AND table_name = ?',
+  $main_dbh->do('DELETE FROM bmo_etl_cache WHERE id = ? AND table_name = ?',
     undef, $id, $table);
 
   # Enter new cached JSON
-  $dbh->do(
+  $main_dbh->do(
     'INSERT INTO bmo_etl_cache (id, table_name, snapshot_date, data) VALUES (?, ?, ?, ?)',
     undef, $id, $table, $timestamp, $gzipped_data
   );

--- a/extensions/BMO/bin/export_bmo_etl.pl
+++ b/extensions/BMO/bin/export_bmo_etl.pl
@@ -630,7 +630,7 @@ sub send_data {
   my $http_headers = HTTP::Headers->new;
 
   # Do not attempt to get access token if running in test environment
-  if ($base_url !~ /^http:\/\/bigquery:/) {
+  if ($base_url !~ /^http:\/\/(localhost|bigquery):/) {
     my $access_token = _get_access_token();
     $http_headers->header(Authorization => 'Bearer ' . $access_token);
   }

--- a/extensions/BMO/bin/export_bmo_etl.pl
+++ b/extensions/BMO/bin/export_bmo_etl.pl
@@ -630,7 +630,7 @@ sub send_data {
   my $http_headers = HTTP::Headers->new;
 
   # Do not attempt to get access token if running in test environment
-  if ($base_url !~ /^http:\/\/(localhost|bigquery):/) {
+  if ($base_url !~ /^http:\/\/bigquery:/) {
     my $access_token = _get_access_token();
     $http_headers->header(Authorization => 'Bearer ' . $access_token);
   }

--- a/extensions/BMO/t/bmo/bmo_etl.t
+++ b/extensions/BMO/t/bmo/bmo_etl.t
@@ -1,0 +1,136 @@
+#!/usr/bin/env perl
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+use 5.10.1;
+use strict;
+use warnings;
+use lib qw(. lib local/lib/perl5 qa/t/lib);
+
+use Bugzilla;
+use Bugzilla::Constants;
+
+BEGIN {
+  Bugzilla->extensions;
+}
+
+use Capture::Tiny qw(capture);
+use QA::Util      qw(get_config);
+use MIME::Base64  qw(encode_base64 decode_base64);
+use Test::Mojo;
+use Test::More;
+
+my $config        = get_config();
+my $admin_login   = $config->{admin_user_login};
+my $admin_api_key = $config->{admin_user_api_key};
+my $url           = Bugzilla->localconfig->urlbase;
+
+my $t = Test::Mojo->new();
+
+# Allow 1 redirect max
+$t->ua->max_redirects(1);
+
+### Section 1: Create new bug
+
+my $new_bug_1 = {
+  product     => 'Firefox',
+  component   => 'General',
+  summary     => 'This is a new test bug',
+  type        => 'defect',
+  version     => 'unspecified',
+  severity    => 'blocker',
+  description => 'This is a new test bug',
+};
+
+$t->post_ok($url
+    . 'rest/bug' => {'X-Bugzilla-API-Key' => $admin_api_key} => json =>
+    $new_bug_1)->status_is(200)->json_has('/id');
+
+my $bug_id_1 = $t->tx->res->json->{id};
+
+### Section 2: Create a new dependent bug
+
+my $new_bug_2 = {
+  product     => 'Firefox',
+  component   => 'General',
+  summary     => 'This is a new dependent bug',
+  type        => 'defect',
+  version     => 'unspecified',
+  severity    => 'blocker',
+  description => 'This is a new dependent bug',
+  depends_on  => [$bug_id_1],
+};
+
+$t->post_ok($url
+    . 'rest/bug' => {'X-Bugzilla-API-Key' => $admin_api_key} => json =>
+    $new_bug_2)->status_is(200)->json_has('/id');
+
+my $bug_id_2 = $t->tx->res->json->{id};
+
+### Section 3: Create an attachment
+
+my $attach_data = 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+
+my $new_attach_1 = {
+  is_patch     => 1,
+  comment      => 'This is a new attachment',
+  summary      => 'Test Attachment',
+  content_type => 'text/plain',
+  data         => encode_base64($attach_data),
+  file_name    => 'test_attachment.patch',
+  obsoletes    => [],
+  is_private   => 0,
+};
+
+$t->post_ok($url
+    . "rest/bug/$bug_id_1/attachment"        =>
+    {'X-Bugzilla-API-Key' => $admin_api_key} => json => $new_attach_1)->status_is(201)
+  ->json_has('/attachments');
+
+my ($attach_id) = keys %{$t->tx->res->json->{attachments}};
+
+### Section 4: Export data to test files
+
+my @cmd
+  = ('perl', 'extensions/BMO/bin/export_bmo_etl.pl', '--verbose', '--test');
+
+my ($output, $error, $rv) = capture { system @cmd; };
+ok(!$rv, 'Data exported to test files');
+if ($rv != 0) {
+  say "$output\n$error";
+  exit $rv;
+}
+
+### Section 5: Export data to BigQuery test instance
+
+@cmd = ('perl', 'extensions/BMO/bin/export_bmo_etl.pl', '--verbose');
+
+($output, $error, $rv) = capture { system @cmd; };
+ok(!$rv, 'Data exported to BigQuery test instance');
+if ($rv != 0) {
+  say "$output\n$error";
+  exit $rv;
+}
+
+### Section 6: Retrieve data from BigQuery instance and verify
+
+my $query = {query => 'SELECT summary FROM test.bugzilla.bugs WHERE id = ' . $bug_id_1};
+$t->post_ok(
+  'http://bigquery:9050/bigquery/v2/projects/test/queries' => json =>
+    $query)->status_is(200)->json_is('/rows/0/f/0/v' => $new_bug_1->{summary});
+
+$query = {query => 'SELECT description FROM test.bugzilla.attachments WHERE id = ' . $attach_id};
+$t->post_ok(
+  'http://bigquery:9050/bigquery/v2/projects/test/queries' => json =>
+    $query)->status_is(200)->json_is('/rows/0/f/0/v' => $new_attach_1->{summary});
+
+$query = {query => 'SELECT depends_on_id FROM test.bugzilla.bug_dependencies WHERE bug_id = ' . $bug_id_2};
+$t->post_ok(
+  'http://bigquery:9050/bigquery/v2/projects/test/queries' => json =>
+    $query)->status_is(200)->json_is('/rows/0/f/0/v' => $bug_id_1);
+
+done_testing;

--- a/extensions/BMO/t/bmo/bmo_etl.t
+++ b/extensions/BMO/t/bmo/bmo_etl.t
@@ -100,10 +100,10 @@ my @cmd
 
 my ($output, $error, $rv) = capture { system @cmd; };
 ok(!$rv, 'Data exported to test files');
-if ($rv != 0) {
+#if ($rv != 0) {
   say "$output\n$error";
-  exit $rv;
-}
+  #  exit $rv;
+#}
 
 ### Section 5: Export data to BigQuery test instance
 
@@ -111,10 +111,10 @@ if ($rv != 0) {
 
 ($output, $error, $rv) = capture { system @cmd; };
 ok(!$rv, 'Data exported to BigQuery test instance');
-if ($rv != 0) {
+#if ($rv != 0) {
   say "$output\n$error";
-  exit $rv;
-}
+  #  exit $rv;
+#}
 
 ### Section 6: Retrieve data from BigQuery instance and verify
 

--- a/extensions/BMO/t/bmo/bmo_etl.t
+++ b/extensions/BMO/t/bmo/bmo_etl.t
@@ -120,17 +120,17 @@ ok(!$rv, 'Data exported to BigQuery test instance');
 
 my $query = {query => 'SELECT summary FROM test.bugzilla.bugs WHERE id = ' . $bug_id_1};
 $t->post_ok(
-  'http://bigquery:9050/bigquery/v2/projects/test/queries' => json =>
+  'http://localhost:9050/bigquery/v2/projects/test/queries' => json =>
     $query)->status_is(200)->json_is('/rows/0/f/0/v' => $new_bug_1->{summary});
 
 $query = {query => 'SELECT description FROM test.bugzilla.attachments WHERE id = ' . $attach_id};
 $t->post_ok(
-  'http://bigquery:9050/bigquery/v2/projects/test/queries' => json =>
+  'http://localhost:9050/bigquery/v2/projects/test/queries' => json =>
     $query)->status_is(200)->json_is('/rows/0/f/0/v' => $new_attach_1->{summary});
 
 $query = {query => 'SELECT depends_on_id FROM test.bugzilla.bug_dependencies WHERE bug_id = ' . $bug_id_2};
 $t->post_ok(
-  'http://bigquery:9050/bigquery/v2/projects/test/queries' => json =>
+  'http://localhost:9050/bigquery/v2/projects/test/queries' => json =>
     $query)->status_is(200)->json_is('/rows/0/f/0/v' => $bug_id_1);
 
 done_testing;

--- a/extensions/BMO/t/bmo/bmo_etl.t
+++ b/extensions/BMO/t/bmo/bmo_etl.t
@@ -120,17 +120,28 @@ ok(!$rv, 'Data exported to BigQuery test instance');
 
 my $query = {query => 'SELECT summary FROM test.bugzilla.bugs WHERE id = ' . $bug_id_1};
 $t->post_ok(
-  'http://127.0.0.1:8002/bigquery/v2/projects/test/queries' => json =>
+  'http://bigquery:9050/bigquery/v2/projects/test/queries' => json =>
     $query)->status_is(200)->json_is('/rows/0/f/0/v' => $new_bug_1->{summary});
+
+my $result = $t->tx->res->json;
+use Bugzilla::Logging;
+use Mojo::Util qw(dumper);
+DEBUG(dumper $result);
 
 $query = {query => 'SELECT description FROM test.bugzilla.attachments WHERE id = ' . $attach_id};
 $t->post_ok(
-  'http://127.0.0.1:8002/bigquery/v2/projects/test/queries' => json =>
+  'http://bigquery:9050/bigquery/v2/projects/test/queries' => json =>
     $query)->status_is(200)->json_is('/rows/0/f/0/v' => $new_attach_1->{summary});
+
+$result = $t->tx->res->json;
+DEBUG(dumper $result);
 
 $query = {query => 'SELECT depends_on_id FROM test.bugzilla.bug_dependencies WHERE bug_id = ' . $bug_id_2};
 $t->post_ok(
-  'http://127.0.0.1:8002/bigquery/v2/projects/test/queries' => json =>
+  'http://bigquery:9050/bigquery/v2/projects/test/queries' => json =>
     $query)->status_is(200)->json_is('/rows/0/f/0/v' => $bug_id_1);
+
+$result = $t->tx->res->json;
+DEBUG(dumper $result);
 
 done_testing;

--- a/extensions/BMO/t/bmo/bmo_etl.t
+++ b/extensions/BMO/t/bmo/bmo_etl.t
@@ -120,17 +120,17 @@ ok(!$rv, 'Data exported to BigQuery test instance');
 
 my $query = {query => 'SELECT summary FROM test.bugzilla.bugs WHERE id = ' . $bug_id_1};
 $t->post_ok(
-  'http://bigquery:8002/bigquery/v2/projects/test/queries' => json =>
+  'http://127.0.0.1:8002/bigquery/v2/projects/test/queries' => json =>
     $query)->status_is(200)->json_is('/rows/0/f/0/v' => $new_bug_1->{summary});
 
 $query = {query => 'SELECT description FROM test.bugzilla.attachments WHERE id = ' . $attach_id};
 $t->post_ok(
-  'http://bigquery:8002/bigquery/v2/projects/test/queries' => json =>
+  'http://127.0.0.1:8002/bigquery/v2/projects/test/queries' => json =>
     $query)->status_is(200)->json_is('/rows/0/f/0/v' => $new_attach_1->{summary});
 
 $query = {query => 'SELECT depends_on_id FROM test.bugzilla.bug_dependencies WHERE bug_id = ' . $bug_id_2};
 $t->post_ok(
-  'http://bigquery:8002/bigquery/v2/projects/test/queries' => json =>
+  'http://127.0.0.1:8002/bigquery/v2/projects/test/queries' => json =>
     $query)->status_is(200)->json_is('/rows/0/f/0/v' => $bug_id_1);
 
 done_testing;

--- a/extensions/BMO/t/bmo/bmo_etl.t
+++ b/extensions/BMO/t/bmo/bmo_etl.t
@@ -120,17 +120,17 @@ ok(!$rv, 'Data exported to BigQuery test instance');
 
 my $query = {query => 'SELECT summary FROM test.bugzilla.bugs WHERE id = ' . $bug_id_1};
 $t->post_ok(
-  'http://localhost:9050/bigquery/v2/projects/test/queries' => json =>
+  'http://bigquery:8002/bigquery/v2/projects/test/queries' => json =>
     $query)->status_is(200)->json_is('/rows/0/f/0/v' => $new_bug_1->{summary});
 
 $query = {query => 'SELECT description FROM test.bugzilla.attachments WHERE id = ' . $attach_id};
 $t->post_ok(
-  'http://localhost:9050/bigquery/v2/projects/test/queries' => json =>
+  'http://bigquery:8002/bigquery/v2/projects/test/queries' => json =>
     $query)->status_is(200)->json_is('/rows/0/f/0/v' => $new_attach_1->{summary});
 
 $query = {query => 'SELECT depends_on_id FROM test.bugzilla.bug_dependencies WHERE bug_id = ' . $bug_id_2};
 $t->post_ok(
-  'http://localhost:9050/bigquery/v2/projects/test/queries' => json =>
+  'http://bigquery:8002/bigquery/v2/projects/test/queries' => json =>
     $query)->status_is(200)->json_is('/rows/0/f/0/v' => $bug_id_1);
 
 done_testing;

--- a/extensions/BMO/template/en/default/hook/admin/params/editparams-current_panel.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/admin/params/editparams-current_panel.html.tmpl
@@ -18,5 +18,12 @@ ELSIF panel.name == "bugfields";
 ELSIF panel.name == "bugchange";
   panel.param_descs.enable_triaged_keyword = 'Enforce usage of the "triaged" keyword on selected products.';
 
+ELSIF panel.name == "reports";
+  panel.param_descs.bmo_etl_enabled = 'Enable export to BMO ETL.';
+  panel.param_descs.bmo_etl_base_url = 'The base URL for sending BMO ETL data.';
+  panel.param_descs.bmo_etl_service_account = 'THe Google service account for accessing the BMO ETL API.';
+  panel.param_descs.bmo_etl_project_id = 'The project ID for the BMO ETL data.';
+  panel.param_descs.bmo_etl_dataset_id = 'The dataset ID for the BMO ETL data.';
+
 END;
 %]

--- a/scripts/entrypoint.pl
+++ b/scripts/entrypoint.pl
@@ -104,7 +104,7 @@ sub cmd_selenium_dev {
   cmd_load_test_data();
   check_data_dir();
   copy_qa_extension();
-  mkdir('/app/artifacts');
+  mkdir '/app/artifacts' if !-d '/app/artifacts';
 
   assert_database->get();
   my $httpd_exit_f = run_cereal_and_httpd('-DACCESS_LOGS');
@@ -179,7 +179,7 @@ sub cmd_test_qa {
 
   cmd_load_test_data();
   check_data_dir();
-  mkdir('/app/artifacts');
+  mkdir '/app/artifacts' if !-d '/app/artifacts';
 
   assert_database()->get;
   my $httpd_exit_f = run_cereal_and_httpd('-DHTTPD_IN_SUBDIR', '-DACCESS_LOGS');

--- a/scripts/entrypoint.pl
+++ b/scripts/entrypoint.pl
@@ -185,7 +185,7 @@ sub cmd_test_qa {
   my $httpd_exit_f = run_cereal_and_httpd('-DHTTPD_IN_SUBDIR', '-DACCESS_LOGS');
   my $prove_exit_f = run_prove(
     prove_cmd => [
-      'prove', '-qf', '-I/app', '-I/app/local/lib/perl5',
+      'prove', '-vf', '-I/app', '-I/app/local/lib/perl5',
       sub { glob $test_files },
     ],
     prove_dir => '/app/qa/t',


### PR DESCRIPTION
This pull request adds a new script and test suite changes to support exporting bug data from the DB to BigQuery. When this is merged, I will file a new PR to have a cron container run once daily to call export_bmo_etl.pl and import a snapshot of the bug data for that day. Each row of each table will have the same timestamp. The test suite does some basic tests against a bigquery emulator that does not require credentials. We have a bigquery instances already setup for production and dev and I am running a full import from bugzilla-dev currently to see how long it will take.