### PR TITLE
Bug 1929501 - Double scroll-bar in search bugs list, preventing easy scrolling

### DIFF
--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -1112,8 +1112,9 @@ input[type="radio"]:checked {
 }
 
 #header-search-dropdown-wrapper {
-  overflow-x: hidden;
-  overflow-y: scroll;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   max-height: 400px;
 }
 
@@ -1130,8 +1131,26 @@ input[type="radio"]:checked {
   text-overflow: ellipsis;
 }
 
+#header-search-dropdown-saved {
+  flex: auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+#header-search-dropdown-saved header {
+  flex: none;
+  border-bottom: 1px solid var(--menu-border-color);
+}
+
+#header-search-dropdown-saved ul {
+  flex: auto;
+  padding: var(--menu-padding);
+  max-height: 400px;
+}
+
 #header-search-dropdown-help {
-  margin-top: var(--menu-padding);
+  flex: none;
 }
 
 #header-search-dropdown-help:only-child {


### PR DESCRIPTION
[Bug 1929501 - Double scroll-bar in search bugs list, preventing easy scrolling](https://bugzilla.mozilla.org/show_bug.cgi?id=1929501)

Optimize the scrollable area in the quick search dropdown. Now the Saved Search header and the Help footer are fixed at the top and bottom of the dropdown, as only the saved search list is scrollable.

<img width="821" alt="image" src="https://github.com/user-attachments/assets/2f299525-1ac2-4c4d-8f42-5a7064a87383">
