### PR TITLE
Bug 1929582 - Tooltips don't scroll with the page

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -296,11 +296,20 @@ $(function() {
             $(this).hide();
         });
 
+    const $tooltipParent = document.querySelector('#bugzilla-body');
+
     // use non-native tooltips for relative/absolute times and bug summaries
     const tooltip_sources = $('.rel-time, .rel-time-title, .abs-time-title, .bz_bug_link, .tt').tooltip({
         position: { my: "left top+8", at: "left bottom", collision: "flipfit" },
         show: { effect: 'none' },
-        hide: { effect: 'none' }
+        hide: { effect: 'none' },
+        open: (event, ui) => {
+          const $tooltip = /** @type {HTMLElement} */ (ui.tooltip[0]);
+          const currentTop = Number.parseInt($tooltip.style.top, 10);
+
+          $tooltip.style.top = `${currentTop - $tooltipParent.offsetTop + $tooltipParent.scrollTop}px`;
+          $tooltipParent.appendChild($tooltip);
+        }
     });
 
     // Don't show the tooltip when the window gets focus

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -303,6 +303,8 @@ $(function() {
         position: { my: "left top+8", at: "left bottom", collision: "flipfit" },
         show: { effect: 'none' },
         hide: { effect: 'none' },
+        // Change the parent element from `<body>` to the main scrolling area and recalculate the
+        // position when a tooltip is displayed, so that it won’t be affected by the fixed header
         open: (event, ui) => {
           const $tooltip = /** @type {HTMLElement} */ (ui.tooltip[0]);
           const currentTop = Number.parseInt($tooltip.style.top, 10);


### PR DESCRIPTION
[Bug 1929582 - Tooltips don't scroll with the page](https://bugzilla.mozilla.org/show_bug.cgi?id=1929582)

Looks like the [jQuery tooltip widget](https://api.jqueryui.com/tooltip/) always appends a tooltip to `<body>` and there is no way to change the parent element, so use the `open` event to adjust the parent and position manually.