### PR TITLE
Bug 1932257 - CircleCI configuration cleanups and removal of un-used code in entrypoint.pl

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,28 +22,6 @@ defaults:
       username: $DOCKER_USER
       password: $DOCKER_PASS
 
-  build_image: &build_image
-    run:
-      name: Build Docker BMO Image
-      command: |
-        docker build \
-          --build-arg CI="$CI" \
-          --build-arg CIRCLE_SHA1="$CIRCLE_SHA1" \
-          --build-arg CIRCLE_BUILD_URL="$CIRCLE_BUILD_URL" \
-          --target base \
-          -t bmo .
-
-  build_selenium_image: &build_selenium_image
-    run:
-      name: Build Selenium Image
-      command: |
-        docker build \
-          --build-arg CI="$CI" \
-          --build-arg CIRCLE_SHA1="$CIRCLE_SHA1" \
-          --build-arg CIRCLE_BUILD_URL="$CIRCLE_BUILD_URL" \
-          --target test \
-          -t bmo .
-
   store_log: &store_log
     store_artifacts:
       path: bugzilla.log
@@ -68,25 +46,21 @@ jobs:
       - setup_local_docker
       - checkout
       - *docker_login
-      - *build_image
       - run: |
           [[ -d build_info ]] || mkdir build_info
       - attach_workspace:
           at: build_info
       - run:
-          name: build version.json
+          name: build version.json and push data
           command: |
-            docker-compose -f docker-compose.test.yml run bmo.test version | sed '1d' > build_info/version.json
-      - run:
-          name: build push data
-          command: |
-            docker-compose -f docker-compose.test.yml run --name push_data bmo.test push_data
-            docker cp push_data:/app/build_info/blog.push.txt build_info/blog.push.txt
-            docker cp push_data:/app/build_info/markdown.push.txt build_info/markdown.push.txt
-            docker cp push_data:/app/build_info/bug.push.txt build_info/bug.push.txt
-            docker cp push_data:/app/build_info/email.push.txt build_info/email.push.txt
-            docker cp push_data:/app/build_info/tag.txt build_info/tag.txt
-            docker cp push_data:/app/build_info/wiki.push.txt build_info/wiki.push.txt
+            docker-compose -f docker-compose.test.yml run --build --name push_data bmo.test push_data
+            docker cp push_data:/app/push_data/blog.push.txt build_info/blog.push.txt
+            docker cp push_data:/app/push_data/markdown.push.txt build_info/markdown.push.txt
+            docker cp push_data:/app/push_data/bug.push.txt build_info/bug.push.txt
+            docker cp push_data:/app/push_data/email.push.txt build_info/email.push.txt
+            docker cp push_data:/app/push_data/tag.txt build_info/tag.txt
+            docker cp push_data:/app/push_data/wiki.push.txt build_info/wiki.push.txt
+            docker cp push_data:/app/version.json build_info/version.json
             docker rm push_data
       - run:
           name: only publish if tag exists
@@ -117,7 +91,7 @@ jobs:
             echo yes > build_info/only_version_changed.txt
       - persist_to_workspace:
           root: build_info
-          paths: ["*.txt"]
+          paths: ["*.txt", "*.json"]
       - store_artifacts:
           path: build_info
       - *store_log
@@ -130,12 +104,12 @@ jobs:
       - setup_local_docker
       - checkout
       - *docker_login
-      - *build_image
       - attach_workspace:
           at: build_info
       - deploy:
           command: |
             [[ -n "$DOCKERHUB_REPO" && -n "$DOCKER_USER" && -n "$DOCKER_PASS" ]] || exit 0
+            docker build --tag bmo --target base .
             if [[ "$CIRCLE_BRANCH" == "master" ]]; then
               TAG="$(cat build_info/tag.txt)"
               if [[ -n "$TAG" && -f build_info/publish.txt ]]; then
@@ -163,7 +137,6 @@ jobs:
       - setup_local_docker
       - checkout
       - *docker_login
-      - *build_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -172,8 +145,7 @@ jobs:
           name: run sanity tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run --no-deps bmo.test \
-              test_sanity t/*.t extensions/*/t/*.t
+            docker-compose -f docker-compose.test.yml run --build --no-deps bmo.test test_sanity t/*.t extensions/*/t/*.t
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -186,7 +158,6 @@ jobs:
       - setup_local_docker
       - checkout
       - *docker_login
-      - *build_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -195,7 +166,7 @@ jobs:
           name: run webservice tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run bmo.test test_webservices
+            docker-compose -f docker-compose.test.yml run --build bmo.test test_webservices
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -208,7 +179,6 @@ jobs:
       - setup_local_docker
       - checkout
       - *docker_login
-      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -217,7 +187,7 @@ jobs:
           name: run selenium tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=1 bmo.test test_selenium
+            docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=1 bmo.test test_selenium
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -230,7 +200,6 @@ jobs:
       - setup_local_docker
       - checkout
       - *docker_login
-      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -239,7 +208,7 @@ jobs:
           name: run selenium tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=2 bmo.test test_selenium 2
+            docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=2 bmo.test test_selenium 2
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -252,7 +221,6 @@ jobs:
       - setup_local_docker
       - checkout
       - *docker_login
-      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -261,7 +229,7 @@ jobs:
           name: run selenium tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=3 bmo.test test_selenium 3
+            docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=3 bmo.test test_selenium 3
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -274,7 +242,6 @@ jobs:
       - setup_local_docker
       - checkout
       - *docker_login
-      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -283,7 +250,7 @@ jobs:
           name: run selenium tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=4 bmo.test test_selenium 4
+            docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=4 bmo.test test_selenium 4
       - store_artifacts:
           path: artifacts
       - *store_log
@@ -296,7 +263,6 @@ jobs:
       - setup_local_docker
       - checkout
       - *docker_login
-      - *build_selenium_image
       - run: |
           [[ -d artifacts ]] || mkdir artifacts
       - attach_workspace:
@@ -305,7 +271,7 @@ jobs:
           name: run bmo specific tests
           command: |
             [[ -f build_info/only_version_changed.txt ]] && exit 0
-            docker-compose -f docker-compose.test.yml run bmo.test test_bmo -q -f t/bmo/*.t
+            docker-compose -f docker-compose.test.yml run --build bmo.test test_bmo -q -f t/bmo/*.t
       - *store_log
 
 workflows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,75 +8,61 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the Docker image
-        run: docker build -t bmo --target base .
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
       - name: Run sanity tests
-        run: docker-compose -f docker-compose.test.yml run --no-deps bmo.test test_sanity t/*.t extensions/*/t/*.t
+        run: docker-compose -f docker-compose.test.yml run --build --no-deps bmo.test test_sanity t/*.t extensions/*/t/*.t
 
   test_webservices:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the Docker image
-        run: docker build -t bmo --target base .
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
       - name: Run webservice tests
-        run: docker-compose -f docker-compose.test.yml run bmo.test test_webservices
+        run: docker-compose -f docker-compose.test.yml run --build bmo.test test_webservices
 
   test_bmo:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the Docker image
-        run: docker build -t bmo --target test .
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
       - name: Run bmo specific tests
-        run: docker-compose -f docker-compose.test.yml run -e CI=1 bmo.test test_bmo -q -f t/bmo/*.t
+        run: docker-compose -f docker-compose.test.yml run --build -e CI=1 bmo.test test_bmo -q -f t/bmo/*.t
 
   test_selenium_1:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the Docker image
-        run: docker build -t bmo --target test .
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
       - name: Run Selenium tests (1)
-        run: docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=1 bmo.test test_selenium
+        run: docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=1 bmo.test test_selenium
 
   test_selenium_2:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the Docker image
-        run: docker build -t bmo --target test .
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
       - name: Run Selenium tests (2)
-        run: docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=2 bmo.test test_selenium
+        run: docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=2 bmo.test test_selenium
 
   test_selenium_3:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the Docker image
-        run: docker build -t bmo --target test .
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
       - name: Run Selenium tests (3)
-        run: docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=3 bmo.test test_selenium
+        run: docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=3 bmo.test test_selenium
 
   test_selenium_4:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the Docker image
-        run: docker build -t bmo --target test .
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
       - name: Run Selenium tests (4)
-        run: docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=4 bmo.test test_selenium
+        run: docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=4 bmo.test test_selenium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
+      - name: Build Docker test images
+        run: docker-compose -f docker-compose.test.yml build bmo.test
       - name: Run sanity tests
-        run: docker-compose -f docker-compose.test.yml run --build --no-deps bmo.test test_sanity t/*.t extensions/*/t/*.t
+        run: docker-compose -f docker-compose.test.yml run --no-deps bmo.test test_sanity t/*.t extensions/*/t/*.t
 
   test_webservices:
     runs-on: ubuntu-latest
@@ -19,8 +21,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
+      - name: Build Docker test images
+        run: docker-compose -f docker-compose.test.yml build
       - name: Run webservice tests
-        run: docker-compose -f docker-compose.test.yml run --build bmo.test test_webservices
+        run: docker-compose -f docker-compose.test.yml run bmo.test test_webservices
 
   test_bmo:
     runs-on: ubuntu-latest
@@ -28,8 +32,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
+      - name: Build Docker test images
+        run: docker-compose -f docker-compose.test.yml build
       - name: Run bmo specific tests
-        run: docker-compose -f docker-compose.test.yml run --build -e CI=1 bmo.test test_bmo -q -f t/bmo/*.t
+        run: docker-compose -f docker-compose.test.yml run -e CI=1 bmo.test test_bmo -q -f t/bmo/*.t
 
   test_selenium_1:
     runs-on: ubuntu-latest
@@ -37,8 +43,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
+      - name: Build Docker test images
+        run: docker-compose -f docker-compose.test.yml build
       - name: Run Selenium tests (1)
-        run: docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=1 bmo.test test_selenium
+        run: docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=1 bmo.test test_selenium
 
   test_selenium_2:
     runs-on: ubuntu-latest
@@ -46,8 +54,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
+      - name: Build Docker test images
+        run: docker-compose -f docker-compose.test.yml build
       - name: Run Selenium tests (2)
-        run: docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=2 bmo.test test_selenium
+        run: docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=2 bmo.test test_selenium
 
   test_selenium_3:
     runs-on: ubuntu-latest
@@ -55,8 +65,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
+      - name: Build Docker test images
+        run: docker-compose -f docker-compose.test.yml build
       - name: Run Selenium tests (3)
-        run: docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=3 bmo.test test_selenium
+        run: docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=3 bmo.test test_selenium
 
   test_selenium_4:
     runs-on: ubuntu-latest
@@ -64,5 +76,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
+      - name: Build Docker test images
+        run: docker-compose -f docker-compose.test.yml build
       - name: Run Selenium tests (4)
-        run: docker-compose -f docker-compose.test.yml run --build -e SELENIUM_GROUP=4 bmo.test test_selenium
+        run: docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=4 bmo.test test_selenium

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,9 +20,11 @@ jobs:
         run: mkdir build_info
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
+      - name: Build Docker image
+        run: docker-compose -f docker-compose.test.yml build bmo.test
       - name: Copy version.json and build push data
         run: |
-          docker-compose -f docker-compose.test.yml run --build --no-deps --name push_data bmo.test push_data
+          docker-compose -f docker-compose.test.yml run --no-deps --name push_data bmo.test push_data
           docker cp push_data:/app/build_info/blog.push.txt build_info/blog.push.txt
           docker cp push_data:/app/build_info/markdown.push.txt build_info/markdown.push.txt
           docker cp push_data:/app/build_info/bug.push.txt build_info/bug.push.txt

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,26 +16,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the Docker image
-        run: docker build -t bmo --target base .
       - name: Create directory for artifacts
         run: mkdir build_info
       - name: Install docker-compose
         run: sudo apt update && sudo apt install -y docker-compose
-      - name: Build version.json
+      - name: Copy version.json and build push data
         run: |
-          docker-compose -f docker-compose.test.yml run --no-deps --name version_json --entrypoint true bmo.test
-          docker cp version_json:/app/version.json build_info/version.json
-          docker rm version_json
-      - name: Build push data
-        run: |
-          docker-compose -f docker-compose.test.yml run --no-deps --name push_data bmo.test push_data
+          docker-compose -f docker-compose.test.yml run --build --no-deps --name push_data bmo.test push_data
           docker cp push_data:/app/build_info/blog.push.txt build_info/blog.push.txt
           docker cp push_data:/app/build_info/markdown.push.txt build_info/markdown.push.txt
           docker cp push_data:/app/build_info/bug.push.txt build_info/bug.push.txt
           docker cp push_data:/app/build_info/email.push.txt build_info/email.push.txt
           docker cp push_data:/app/build_info/tag.txt build_info/tag.txt
           docker cp push_data:/app/build_info/wiki.push.txt build_info/wiki.push.txt
+          docker cp push_data:/app/version.json build_info/version.json
           docker rm push_data
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -776,7 +776,7 @@ sub check_rate_limit {
     my $rules = decode_json($params->{rate_limit_rules});
     my $limit = $rules->{$name};
     unless ($limit) {
-      warn "no rules for $name!";
+      WARN("no rules for $name!");
       return 0;
     }
     if (Bugzilla->memcached->should_rate_limit("$name:$identifier", @$limit)) {

--- a/Bugzilla/Config.pm
+++ b/Bugzilla/Config.pm
@@ -109,13 +109,13 @@ sub update {
       {
         if ($old_value ne $new_value) {
           $dbh->do('UPDATE params SET value = ? WHERE name = ?', undef, $new_value, $key);
-          $changes{"$id:$key"} = [$old_value, $new_value];
+          $changes{$key} = [$old_value, $new_value];
         }
       }
       else {
         $dbh->do('INSERT INTO params (name, value) VALUES (?, ?)',
           undef, $key, $new_value);
-        $changes{"$id:$key"} = ['', $new_value];
+        $changes{$key} = ['', $new_value];
       }
     }
 
@@ -132,10 +132,8 @@ sub update {
     # not the case here so we assign the 'id' variable each interation
     # to make audit_log think each is a separate instance of
     # Bugzilla::Config and each change is a separate transaction.
-    foreach my $item (keys %changes) {
-      my ($id, $key) = split /:/, $item;
-      $self->{id} = $id;
-      $self->audit_log({$key => [$changes{$item}->[0], $changes{$item}->[1]]});
+    foreach my $key (keys %changes) {
+      $self->audit_log({$key => [$changes{$key}->[0], $changes{$key}->[1]]});
     }
   }
   catch {
@@ -301,7 +299,7 @@ sub migrate_params {
   }
 
   # Generate unique Duo integration secret key
-  if ($param->{duo_akey} eq '') {
+  if (!exists $param->{duo_akey} || $param->{duo_akey} eq '') {
     require Bugzilla::Util;
     $param->{duo_akey} = Bugzilla::Util::generate_random_password(40);
   }

--- a/Bugzilla/DB/Schema/Mysql.pm
+++ b/Bugzilla/DB/Schema/Mysql.pm
@@ -155,7 +155,7 @@ sub _get_create_index_ddl {
 
   my $sql = "CREATE ";
   $sql .= "$index_type "
-    if ($index_type eq 'UNIQUE' || $index_type eq 'FULLTEXT');
+    if ($index_type && ($index_type eq 'UNIQUE' || $index_type eq 'FULLTEXT'));
   $sql
     .= "INDEX "
     . $dbh->quote_identifier($index_name) . " ON "

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,8 +4,7 @@
 
 services:
   bmo.test:
-    image: bmo
-    build: &bmo_build
+    build: &build_bmo
       context: .
       dockerfile: Dockerfile
       target: test
@@ -40,7 +39,7 @@ services:
       - gcs
 
   externalapi.test:
-    build: *bmo_build
+    build: *build_bmo
     entrypoint: perl /app/external_test_api.pl daemon -l http://*:8001
     ports:
       - 8001:8001
@@ -58,7 +57,7 @@ services:
       - MYSQL_ALLOW_EMPTY_PASSWORD=1
 
   memcached:
-    image:  ghcr.io/ghcr-library/memcached:latest
+    image: ghcr.io/ghcr-library/memcached:latest
 
   s3:
     image: scireum/s3-ninja

--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -410,7 +410,7 @@ sub parse_bounty_attachment_description {
     fixed_date     => $+{fixed_date} // '',
     awarded_date   => $+{awarded_date} // '',
     publish        => $map{$+{publish} // 'false'},
-    credit         => [grep {$_} split(/\s*,\s*/, $+{credits})]
+    credit         => [grep {$_} split(/\s*,\s*/, $+{credits} || '')]
   };
 }
 

--- a/extensions/Voting/Extension.pm
+++ b/extensions/Voting/Extension.pm
@@ -667,6 +667,9 @@ sub _update_votes {
 
   $dbh->bz_commit_transaction();
 
+  use Bugzilla::Logging;
+  use Mojo::Util qw(dumper);
+
   print $cgi->header() if scalar @updated_bugs;
   $vars->{'type'}      = "votes";
   $vars->{'title_tag'} = 'change_votes';
@@ -674,6 +677,7 @@ sub _update_votes {
     $vars->{'id'} = $bug_id;
     $vars->{'sent_bugmail'}
       = Bugzilla::BugMail::Send($bug_id, {'changer' => $user});
+    $vars->{'recipient_count'} = scalar @{$vars->{'sent_bugmail'}->{'sent'}};
 
     $template->process("bug/process/results.html.tmpl", $vars)
       || ThrowTemplateError($template->error());

--- a/extensions/Voting/template/en/default/hook/admin/products/updated-changes.html.tmpl
+++ b/extensions/Voting/template/en/default/hook/admin/products/updated-changes.html.tmpl
@@ -88,6 +88,7 @@
       [%# This is INCLUDED instead of PROCESSED to avoid variables getting
           overwritten, which happens otherwise %]
       [% INCLUDE bug/process/results.html.tmpl
+        recipient_count = changes._confirmed_bugs_sent_bugmail.$id.size
         type = 'votes'
         header_done = 1
         sent_bugmail = changes._confirmed_bugs_sent_bugmail.$id

--- a/scripts/build-bmo-push-data.pl
+++ b/scripts/build-bmo-push-data.pl
@@ -32,8 +32,8 @@ my $tag          = 'release-' . Bugzilla->VERSION;
 my $prod_tag     = "release-$version_info->{version}";
 my $tag_url      = "$github_repo/tree/$tag";
 
-runx('git', 'clone', '--single-branch', $github_repo, 'build_info');
-chdir '/app/build_info';
+runx('git', 'clone', '--single-branch', $github_repo, 'push_data');
+chdir '/app/push_data';
 my @log = capture(qw(git log --oneline), "$prod_tag..HEAD");
 chomp @log;
 

--- a/scripts/entrypoint.pl
+++ b/scripts/entrypoint.pl
@@ -84,34 +84,6 @@ sub cmd_demo {
   cmd_httpd();
 }
 
-sub cmd_httpd {
-  check_data_dir();
-  wait_for_db();
-
-  my $httpd_exit_f = run_cereal_and_httpd();
-  assert_httpd()->get();
-  exit $httpd_exit_f->get();
-}
-
-sub cmd_jobqueue {
-  my (@args) = @_;
-  check_data_dir();
-  wait_for_db();
-  exit run_cereal_and_jobqueue(@args)->get;
-}
-
-sub cmd_selenium_dev {
-  cmd_load_test_data();
-  check_data_dir();
-  copy_qa_extension();
-  mkdir('/app/artifacts');
-
-  assert_database->get();
-  my $httpd_exit_f = run_cereal_and_httpd('-DACCESS_LOGS');
-  assert_httpd()->get;
-  exit $httpd_exit_f->get;
-}
-
 sub cmd_dev_httpd {
   assert_database->get();
 
@@ -125,12 +97,6 @@ sub cmd_dev_httpd {
   my $httpd_exit_f = run_cereal_and_httpd('-DACCESS_LOGS');
   assert_httpd()->get;
   exit $httpd_exit_f->get;
-}
-
-sub cmd_checksetup {
-  check_data_dir();
-  wait_for_db();
-  run_quiet('perl', 'checksetup.pl', '--no-template', '--no-permissions');
 }
 
 sub cmd_load_test_data {
@@ -179,7 +145,7 @@ sub cmd_test_qa {
 
   cmd_load_test_data();
   check_data_dir();
-  mkdir('/app/artifacts');
+  mkdir '/app/artifacts' if !-d '/app/artifacts';
 
   assert_database()->get;
   my $httpd_exit_f = run_cereal_and_httpd('-DHTTPD_IN_SUBDIR', '-DACCESS_LOGS');
@@ -192,15 +158,6 @@ sub cmd_test_qa {
   );
   exit Future->wait_any($prove_exit_f, $httpd_exit_f)->get;
 }
-
-sub cmd_shell { run('bash', '-l'); }
-
-sub cmd_prove {
-  my (@args) = @_;
-  run('prove', '-I/app', '-I/app/local/lib/perl5', @args);
-}
-
-sub cmd_version { run('cat', '/app/version.json'); }
 
 sub cmd_test_bmo {
   my (@prove_args) = @_;
@@ -257,11 +214,6 @@ sub run_prove {
       return $prove_exit_f;
       });
   });
-}
-
-sub copy_qa_extension {
-  say 'copying the QA extension...';
-  dircopy('/app/qa/extensions/QA', '/app/extensions/QA');
 }
 
 sub wait_for_db {

--- a/t/hash-sig.t
+++ b/t/hash-sig.t
@@ -12,7 +12,7 @@ use Bugzilla::Util qw(generate_random_password);
 use Bugzilla::Token qw(issue_hash_sig check_hash_sig);
 use Bugzilla::Localconfig;
 use Test2::V0;
-use Test2::Mock qw(mock);
+use Test2::Tools::Mock qw(mock);
 
 my $site_wide_secret = generate_random_password(256);
 my $Localconfig = mock 'Bugzilla::Localconfig' => (

--- a/t/mojo-example.t
+++ b/t/mojo-example.t
@@ -43,7 +43,7 @@ my $api_key = issue_api_key('api@mozilla.org')->api_key;
 my $t = Test::Mojo->new('Bugzilla::App');
 
 # we ensure this file exists so the /__lbhearbeat__ test passes.
-$t->app->home->child('__lbheartbeat__')->spurt('httpd OK');
+$t->app->home->child('__lbheartbeat__')->spew('httpd OK');
 
 # Method chaining is used extensively.
 $t->get_ok('/__lbheartbeat__')->status_is(200)->content_is('httpd OK');

--- a/template/en/default/bug/process/bugmail.html.tmpl
+++ b/template/en/default/bug/process/bugmail.html.tmpl
@@ -27,6 +27,8 @@
 [% USE Bugzilla %]
 [% PROCESS global/variables.none.tmpl %]
 
+[% recipient_count = 0 IF !recipient_count.defined %]
+
 [% IF recipient_count > 1 %]
   Email sent to [% recipient_count FILTER none %] recipients.
 [% ELSIF recipient_count == 1 %]

--- a/template/en/default/bug/process/bugmail.html.tmpl
+++ b/template/en/default/bug/process/bugmail.html.tmpl
@@ -27,8 +27,6 @@
 [% USE Bugzilla %]
 [% PROCESS global/variables.none.tmpl %]
 
-[% recipient_count = 0 IF !recipient_count.defined %]
-
 [% IF recipient_count > 1 %]
   Email sent to [% recipient_count FILTER none %] recipients.
 [% ELSIF recipient_count == 1 %]


### PR DESCRIPTION
Rather than junk up the other pull request for the ETL work with these minor fixes, I am making them here instead. These are changes to the way images are built in CircleCI for running the automated tests as well as some code cleanup to remove unused code and get rid of some warnings in the test output that looks bad.

In order to build the bigquery-emulator container for testing in the ETL pull request, we need to build the images from the docker-compose.test.yml file instead of doing docker builds outside of docker-compose. Instead of `docker build -t bmo . ; docker-compose run bmo.test test_webservices`, I do `docker run --build bmo.test test_webservices`.

For github, I still need to do the `docker-compose build` before the test run since for some reason their implementation did not like using `docker-compose run --build ...`.

I removed some extra functions in entrypoint.pl that are never used by BMO or mozilla-conduit/suite.

The rest of the changes are small fixes to remove warnings and other extra stuff sent to STDOUT that was cluttering up the test logs.
