### PR TITLE
Bug 1931622 - When using API to attach a file when too small for cloud storage, it will still try to get the new attachment from cloud storage generating an error

### DIFF
--- a/Bugzilla/Attachment.pm
+++ b/Bugzilla/Attachment.pm
@@ -745,6 +745,8 @@ sub create {
     $data = $tmp;
   }
 
+  $attachment->{data} = $data;
+
   $attachment->current_storage->set_data($data)->set_class();
 
   # Return the new attachment object


### PR DESCRIPTION
This change sets the $attachment->{data} value to the currently submitted attachment data. Later this will prevent having to hit the database or net storage for the data if the same object is being used elsewhere. If the object is gone and another one is instantiated, then the data will be loaded from the correct location. This also solves the error in the bug report because the same object is being used later to return results to the client. 