### PR TITLE
Bug 1930782 - show_bug.cgi is using subframe scrolling again

### DIFF
--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -917,7 +917,9 @@ td.flag-requestee {
 }
 
 .new-changes-link {
-  flex: none;
+  position: sticky;
+  top: calc(var(--global-header-height) + var(--private-bug-banner-height, 0px) + 8px);
+  z-index: calc(var(--global-header-z-index) - 1);
   overflow: hidden;
   box-sizing: border-box;
   margin: 8px auto 0;

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -115,7 +115,7 @@
 
     /** Global */
     --global-header-height: 48px;
-    --bug-banner-height: 24px;
+    --global-header-z-index: 100;
 
     /** Region */
     --primary-region-border-radius: 4px;
@@ -933,15 +933,17 @@ input[type="radio"]:checked {
  */
 
 #bugzilla-body {
-  flex: auto;
   display: flow-root;
   position: relative;
   overflow: auto;
   outline: none;
-  scroll-padding-top: 8px;
 }
 
 @media screen {
+  :root {
+    scroll-padding-top: calc(var(--global-header-height) + var(--private-bug-banner-height, 0px) + 8px);
+  }
+
   body {
     color: var(--application-foreground-color);
     background-color: var(--application-background-color);
@@ -949,13 +951,13 @@ input[type="radio"]:checked {
   }
 
   #wrapper {
+    padding-top: calc(var(--global-header-height) + var(--private-bug-banner-height, 0px));
+  }
+
+  #header {
     position: fixed;
-    inset: 0;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-    width: 100%;
-    height: 100%;
+    inset: 0 0 auto;
+    z-index: var(--global-header-z-index);
   }
 
   #main-inner {
@@ -969,7 +971,6 @@ input[type="radio"]:checked {
  */
 
 #header {
-  flex: none;
   height: var(--global-header-height);
   color: var(--application-header-foreground-color);
   background-color: var(--application-header-background-color);
@@ -1065,6 +1066,10 @@ input[type="radio"]:checked {
   color: inherit;
   background: transparent;
   box-shadow: none;
+}
+
+#header .dropdown-content {
+  z-index: calc(var(--global-header-z-index) + 1);
 }
 
 /**
@@ -1547,12 +1552,18 @@ input[type="radio"]:checked {
  * Private group banner for confidential and security bugs
  */
 
+:root:has(#private-bug-banner) {
+  --private-bug-banner-height: 24px;
+}
+
 #private-bug-banner {
-  flex: none;
+  position: fixed;
+  inset: var(--global-header-height) 0 auto;
+  z-index: calc(var(--global-header-z-index) - 1);
   background-color: var(--confidential-bug-background-color);
   color: #111;
   box-sizing: border-box;
-  height: var(--bug-banner-height);
+  height: var(--private-bug-banner-height);
   padding: 4px;
   text-align: center;
   -webkit-user-select: none;


### PR DESCRIPTION
[Bug 1930782 - show_bug.cgi is using subframe scrolling again](https://bugzilla.mozilla.org/show_bug.cgi?id=1930782)

Rework the fixed header implemented in #2334 not to use subframes. The challenges are the private bug banner pushing down the main content and some `z-index` issues, but I have used CSS variables and `:has()` to solve the problems.