### PR TITLE
Bug 1933585 - Fix TOTP form layout on Account Verification page

### DIFF
--- a/skins/standard/login.css
+++ b/skins/standard/login.css
@@ -74,8 +74,14 @@ button[type="submit"] {
   font-size: var(--font-size-h3);
 }
 
-#verify-totp-form div {
-  margin-bottom: 15px;
+#verify-totp-form {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+#verify-totp-form input[type="submit"] {
+  width: auto;
 }
 
 #verify-totp-error {

--- a/skins/standard/login.css
+++ b/skins/standard/login.css
@@ -74,20 +74,19 @@ button[type="submit"] {
   font-size: var(--font-size-h3);
 }
 
-#verify-totp-form {
+#verify-totp-input {
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
-#verify-totp-form input[type="submit"] {
+#verify-totp-input input[type="submit"] {
   width: auto;
 }
 
 #verify-totp-error {
-  padding: 5px;
+  margin-top: 8px;
   color: var(--error-message-foreground-color);
-  background-color: var(--error-message-background-color);
 }
 
 @media screen and (768px <= width) {

--- a/template/en/default/mfa/totp/verify.html.tmpl
+++ b/template/en/default/mfa/totp/verify.html.tmpl
@@ -22,18 +22,16 @@
 </p>
 <div class="verify-totp">
   <form id="verify-totp-form" method="POST" action="[% postback.action FILTER none %]">
-    <div>
-      <span id="verify-totp-input">
-        [% FOREACH field IN postback.fields.keys %]
-          <input type="hidden" name="[% field FILTER html %]" value="[% postback.fields.item(field) FILTER html %]">
-        [% END %]
-        <input type="text" name="code" id="code" data-token="[% token FILTER html %]"
-               placeholder="123456" maxlength="9" pattern="\d{6,9}" size="10"
-               autocomplete="off" inputmode="numeric" required autofocus>
-      </span>
-      <span id="verify-totp-error" class="bz_default_hidden"></span>
+    <div id="verify-totp-input">
+      [% FOREACH field IN postback.fields.keys %]
+        <input type="hidden" name="[% field FILTER html %]" value="[% postback.fields.item(field) FILTER html %]">
+      [% END %]
+      <input type="text" name="code" id="code" data-token="[% token FILTER html %]"
+             placeholder="123456" maxlength="9" pattern="\d{6,9}" size="10"
+             autocomplete="off" inputmode="numeric" required autofocus>
+      <input type="submit" value="Submit">
     </div>
-    <input type="submit" value="Submit">
+    <div id="verify-totp-error" class="bz_default_hidden"></div>
   </form>
 </div>
 


### PR DESCRIPTION
I haven’t filed a bug, but I believe this is a fallout from #2334. When you sign in, you’ll probably enter a 6-digit verification code on the Account Verification page. Currently, the Submit button is displayed in full width, which is not an intended layout. This PR fixes it.

(The UI could be [better than this](https://www.google.com/search?q=otp+input&udm=2), but it’s out of scope 😉)

### Before

![image](https://github.com/user-attachments/assets/36d9c64e-f94c-4af5-aa2a-3cbb096004c2)

### After

![image](https://github.com/user-attachments/assets/fa8719fd-4747-419c-8e03-4bd3b63d9cca)
