### PR TITLE
Bug 1936911 - Add back CIRCLECI_SHA1 AND CIRCLE_BUILD_URL back to the build and deploy steps for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,9 @@ jobs:
       - run:
           name: build version.json and push data
           command: |
-            docker-compose -f docker-compose.test.yml run --build --name push_data bmo.test push_data
+            docker-compose -f docker-compose.test.yml run --build \
+              --build-arg CIRCLE_SHA1="$CIRCLE_SHA1" --build-arg CIRCLE_BUILD_URL="$CIRCLE_BUILD_URL" \
+              --name push_data bmo.test push_data
             docker cp push_data:/app/push_data/blog.push.txt build_info/blog.push.txt
             docker cp push_data:/app/push_data/markdown.push.txt build_info/markdown.push.txt
             docker cp push_data:/app/push_data/bug.push.txt build_info/bug.push.txt
@@ -109,7 +111,8 @@ jobs:
       - deploy:
           command: |
             [[ -n "$DOCKERHUB_REPO" && -n "$DOCKER_USER" && -n "$DOCKER_PASS" ]] || exit 0
-            docker build --tag bmo --target base .
+            docker build --build-arg CIRCLE_SHA1="$CIRCLE_SHA1" --build-arg CIRCLE_BUILD_URL="$CIRCLE_BUILD_URL" \
+              --tag bmo --target base .
             if [[ "$CIRCLE_BRANCH" == "master" ]]; then
               TAG="$(cat build_info/tag.txt)"
               if [[ -n "$TAG" && -f build_info/publish.txt ]]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,9 +53,8 @@ jobs:
       - run:
           name: build version.json and push data
           command: |
-            docker-compose -f docker-compose.test.yml run --build \
-              --build-arg CIRCLE_SHA1="$CIRCLE_SHA1" --build-arg CIRCLE_BUILD_URL="$CIRCLE_BUILD_URL" \
-              --name push_data bmo.test push_data
+            docker-compose build --build-arg CIRCLE_SHA1="$CIRCLE_SHA1" --build-arg CIRCLE_BUILD_URL="$CIRCLE_BUILD_URL" bmo.test
+            docker-compose run --name push_data bmo.test push_data
             docker cp push_data:/app/push_data/blog.push.txt build_info/blog.push.txt
             docker cp push_data:/app/push_data/markdown.push.txt build_info/markdown.push.txt
             docker cp push_data:/app/push_data/bug.push.txt build_info/bug.push.txt

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -8,6 +8,8 @@ services:
       context: .
       dockerfile: Dockerfile
       target: test
+      args:
+        - CI=1
     command: dev_httpd
     tmpfs:
       - /tmp

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -8,8 +8,6 @@ services:
       context: .
       dockerfile: Dockerfile
       target: test
-      args:
-        - CI=1
     command: dev_httpd
     tmpfs:
       - /tmp


### PR DESCRIPTION
before these changes, the `/app/version.json` file had empty values for CIRCLE_SHA1 and CIRCLE_BUILD_URI. This fixes the issue.