### PR TITLE
Bug 1934616 - Add comment to SQL that is generated by buglist.cgi to add userid, query string, and user agent

### DIFF
--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -870,9 +870,19 @@ sub data {
     '_no_security_check' => 1
   );
 
+  # Add some user information to the SQL so we can pinpoint where some
+  # slow running queries originate and help to refine the searches.
+  my $sql_user_info
+    = ' /* userid: '
+    . Bugzilla->user->id
+    . ' useragent: '
+    . Bugzilla->cgi->user_agent
+    . ' query: '
+    . Bugzilla->cgi->canonicalize_query() . ' */ ';
+
   $start_time = [gettimeofday()];
   $sql        = $search->_sql;
-  my $unsorted_data = $dbh->selectall_arrayref($sql);
+  my $unsorted_data = $dbh->selectall_arrayref($sql . $sql_user_info);    # Add extra info for logging purposes
   push(@extra_data, {sql => $sql, time => tv_interval($start_time)});
 
   # Let's sort the data. We didn't do it in the query itself because


### PR DESCRIPTION
To help pin-pointing where some long running MySQL queries are coming from, we can add comment strings to the SQL statements that will show up in the long running query logs. The extra information will be helpful in finding out where/who they are coming from and we can work with them to find more efficient ways of getting the data they need like bespoke API calls using the Search API support we have.