### PR TITLE
Bug 1937614 - Typo "reature" in the warning for Bugzilla vs. bugzilla.mozilla.org

### DIFF
--- a/extensions/BMO/template/en/default/bug/create/bugzilla-admin.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/bugzilla-admin.html.tmpl
@@ -17,7 +17,7 @@
     <p>If you need account changes, permissions, new or updates to products and components, or changes to the values of
       existing fields (versions, milestones, etc) then instead file an Administation request 
       <a href="[% basepath FILTER none %]enter_bug.cgi?product=bugzilla.mozilla.org&component=Administration">here</a>.</p>
-    <p>For reature requests or [% terms.bug %] fixes for this installation then file a [% terms.bug %] report
+    <p>For feature requests or [% terms.bug %] fixes for this installation then file a [% terms.bug %] report
     <a href="[% basepath FILTER none %]enter_bug.cgi?product=bugzilla.mozilla.org&component=General">here</a>.</p>
   </div>
 </div>


### PR DESCRIPTION
Simple text change.