### PR TITLE
Bug 1706715 - disable font ligatures to avoid mangling URLs

### DIFF
--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -514,6 +514,15 @@ input[type="number"] {
   margin: -2px 0 8px;
 }
 
+/* disable ligatures in locations where URLs are used */
+.bug-url,
+#bug_file_loc,
+#field-see_also .link a,
+#see_also,
+.activity .change a {
+  font-variant-ligatures: none;
+}
+
 /**
  * actions
  */

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -2713,6 +2713,10 @@ div.bz_comment_text pre {
   margin-bottom: 0 !important;
 }
 
+.markdown-body a {
+  font-variant-ligatures: none;
+}
+
 .markdown-body a:not([href]) {
   color: inherit;
   text-decoration: none;

--- a/skins/standard/text-editor.css
+++ b/skins/standard/text-editor.css
@@ -75,6 +75,7 @@
 .text-editor textarea {
   display: block;
   border-radius: 0 0 var(--control-border-radius) var(--control-border-radius);
+  font-variant-ligatures: none;
   padding: 12px;
   width: 100%;
   min-height: 10em;


### PR DESCRIPTION
Disable font ligatures where URLs are provided or displayed.