### PR TITLE
Bug 1941468 - Sitemap robots.txt template is looking at the wrong variable to determine if running on production bugzilla.mozilla.org

### DIFF
--- a/template/en/default/robots.txt.tmpl
+++ b/template/en/default/robots.txt.tmpl
@@ -1,9 +1,8 @@
 User-agent: *
 Disallow: [% basepath FILTER none %]
 Crawl-delay: 30
-[% IF Bugzilla.localconfig.urlbase == "https://bugzilla.mozilla.org/" %]
+[% IF urlbase == "https://bugzilla.mozilla.org/" %]
 
-[% USE Bugzilla %]
 Allow: [% basepath FILTER none %]$
 Allow: [% basepath FILTER none %]index.cgi
 


### PR DESCRIPTION
Unfortunately in my earlier changes for the robots.txt I was looking at the incorrect variable name for determining if running on production. `urlbase` is the proper variable to look at when comparing.