### PR TITLE
Bug 1930197 - Add an option (or config) to not set the qe-verify+ flag when a GitHub push closes a bug in a given product

### DIFF
--- a/Bugzilla/API/V1/Github.pm
+++ b/Bugzilla/API/V1/Github.pm
@@ -318,8 +318,8 @@ sub push_comment {
       $set_all->{resolution} = 'FIXED';
 
       # Update the qe-verify flag if not set and the bug was closed.
-      # Do not perform this change if Fenix or Focus product.
-      if ($bug->product ne 'Fenix' && $bug->product ne 'Focus') {
+      # Do not set the flag if the no-qe-verify parameter is true.
+      if (!$self->param('no-qe-verify')) {
         my $found_flag;
         foreach my $flag (@{$bug->flags}) {
 

--- a/qa/t/rest_github_push_comment.t
+++ b/qa/t/rest_github_push_comment.t
@@ -295,9 +295,10 @@ $payload = {
 };
 
 # Post the valid GitHub event to the rest/github/push_comment API endpoint
+# Also pass in the no-qe-verify option so that the qe-verify flag is not set
 $t->post_ok(
   $url
-    . 'rest/github/push_comment' => {
+    . 'rest/github/push_comment?no-qe-verify=1' => {
     'X-Hub-Signature-256' => generate_payload_signature($secret, $payload),
     'X-GitHub-Event'      => 'push'
     } => json => $payload
@@ -329,8 +330,7 @@ $t->get_ok($url
   ->json_is('/bugs/0/resolution',           'FIXED')
   ->json_is('/bugs/0/cf_status_firefox111', 'fixed')
   ->json_is('/bugs/0/target_milestone',     '111 Branch')
-  ->json_is('/bugs/0/flags/0/name',         'qe-verify')
-  ->json_is('/bugs/0/flags/0/status',       '+');
+  ->json_hasnt('/bugs/0/flags/0/name',      'qe-verify');
 
 # Change to make sure the flag change entry is recorded properly in the bug history
 $t->get_ok(


### PR DESCRIPTION
Before deployment, I will get with the Fenix and Focus people to add the ?no-qe-verify=1 to their webhooks.