### PR TITLE
Bug 1946805 - Count is not being incremented properly when excluding bugs from the full list and therefore the export script is hanging

### DIFF
--- a/extensions/BMO/bin/export_bmo_etl.pl
+++ b/extensions/BMO/bin/export_bmo_etl.pl
@@ -157,6 +157,7 @@ sub process_bugs {
 
         if (any { $obj->product eq $_ } EXCLUDE_PRODUCTS) {
           $excluded_bugs{$obj->id} = 1;
+          $count++;
           next;
         }
 
@@ -262,7 +263,10 @@ sub process_attachments {
 
         my $obj = Bugzilla::Attachment->new($id);
 
-        next if $excluded_bugs{$obj->bug_id};
+        if ($excluded_bugs{$obj->bug_id}) {
+          $count++;
+          next;
+        }
 
         # Standard non-sensitive fields
         $data = {
@@ -323,7 +327,10 @@ sub process_flags {
 
         my $obj = Bugzilla::Flag->new($id);
 
-        next if $excluded_bugs{$obj->bug_id};
+        if ($excluded_bugs{$obj->bug_id}) {
+          $count++;
+          next;
+        }
 
         $data = {
           attachment_id => $obj->attach_id || undef,
@@ -389,7 +396,10 @@ sub process_flag_state_activity {
 
         my $obj = Bugzilla::Extension::Review::FlagStateActivity->new($id);
 
-        next if $excluded_bugs{$obj->bug_id};
+        if ($excluded_bugs{$obj->bug_id}) {
+          $count++;
+          next;
+        }
 
         $data = {
           attachment_id => $obj->attachment_id || undef,
@@ -446,7 +456,10 @@ sub process_tracking_flags {
     $sth->execute(API_BLOCK_COUNT, $last_offset);
 
     while (my ($name, $bug_id, $value) = $sth->fetchrow_array()) {
-      next if $excluded_bugs{$bug_id};
+      if ($excluded_bugs{$bug_id}) {
+        $count++;
+        next;
+      }
 
       # Standard fields
       my $data = {bug_id => $bug_id};
@@ -495,7 +508,10 @@ sub process_keywords {
     $sth->execute(API_BLOCK_COUNT, $last_offset);
 
     while (my ($bug_id, $keyword) = $sth->fetchrow_array()) {
-      next if $excluded_bugs{$bug_id};
+      if ($excluded_bugs{$bug_id}) {
+        $count++;
+        next;
+      }
 
       # Standard fields
       my $data = {bug_id => $bug_id};
@@ -534,7 +550,10 @@ sub process_see_also {
     $sth->execute(API_BLOCK_COUNT, $last_offset);
 
     while (my ($bug_id, $value, $class) = $sth->fetchrow_array()) {
-      next if $excluded_bugs{$bug_id};
+      if ($excluded_bugs{$bug_id}) {
+        $count++;
+        next;
+      }
 
       # Standard fields
       my $data = {bug_id => $bug_id,};
@@ -643,7 +662,10 @@ sub process_two_columns {
     $sth->execute(API_BLOCK_COUNT, $last_offset);
 
     while (my ($value1, $value2) = $sth->fetchrow_array()) {
-      next if $excluded_bugs{$value1};
+      if ($excluded_bugs{$value1}) {
+        $count++;
+        next;
+      }
 
       print "Processing values $value1, $value2 for $table_name.\n" if $verbose;
 


### PR DESCRIPTION
The new BMO ETL export script has a bug in that it does not properly increment the $count variable when encountering bugs that are to be skipped in the export. These include Legal bugs, etc. Then the while() loop runs forever as $count is always less than $total.

Bad code:
```perl
        if (any { $obj->product eq $_ } EXCLUDE_PRODUCTS) {
          $excluded_bugs{$obj->id} = 1;
          next;
        }
```

This should be instead:

```perl
        if (any { $obj->product eq $_ } EXCLUDE_PRODUCTS) {
          $excluded_bugs{$obj->id} = 1;
          $count++;
          next;
        }
```

I didn't not catch this unfortunately til we tried it in production as bugzilla-dev does not have any bugs to be excluded so the count was always correct. 

Any other functions where we skip excluded bugs will also need to be update to increment $count so I will fix those as well.