### PR TITLE
Bug 1941032 - "Always Enable Edit Mode" is broken

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -139,7 +139,7 @@ $(function() {
     // restore edit mode after navigating back
     function restoreEditMode() {
         if (!$('#editing').val()) {
-            if (Bugzilla.Storage.get('modal-perm-edit-mode') === 'true') {
+            if (Bugzilla.Storage.get('modal-perm-edit-mode') === true) {
                 $('#mode-btn').click();
                 $('#action-enable-perm-edit').attr('aria-checked', 'true');
             }


### PR DESCRIPTION
With the changes to suppose cookie banner, the old code was looking for the string 'true' instead of a proper true/false boolean.