### PR TITLE
Bug 1947216 - BMO ETL: Update export script to add arbitrary timestamp for profiles modification_ts if one is not yet set for the actual profile

### DIFF
--- a/extensions/BMO/bin/export_bmo_etl.pl
+++ b/extensions/BMO/bin/export_bmo_etl.pl
@@ -583,6 +583,10 @@ sub process_users {
     while (my ($id, $mod_time) = $sth->fetchrow_array()) {
       print "Processing id $id with mod_time of $mod_time.\n" if $verbose;
 
+      # Set the mod time to an arbitrary value for caching purposes if its
+      # real mod time is not yet been set to a real value.
+      $mod_time = '1970-01-01 12:00:00' if !$mod_time;
+
       # First check to see if we have a cached version with the same modification date
       my $data = get_cache($id, $table_name, $mod_time);
       if (!$data) {


### PR DESCRIPTION
Currently the export script looks for a modification_ts value to exist in the profiles table when caching the profile in the bmo_etl_cache table. But due to the migration script, implemented by [bug 1926081](https://bugzilla.mozilla.org/show_bug.cgi?id=1926081), failing to complete for various reasons, some values are still NULL in the profiles table.

I am working on getting the migration to complete now and it is very slow going. In the meantime I want to update the export script to use an arbitrary timestamp, say 1970-01-01 12:00:00 for example, in place of the NULL timestamp which will allow the script to work fully and also to cache the profile in a useful way until the real timestamp is filled in by the migration script.