### PR TITLE
Bug 1949556 - Add new index for object_id to audit_log table to speed up modification_ts migration in bug 1926081

### DIFF
--- a/Bugzilla/DB/Schema.pm
+++ b/Bugzilla/DB/Schema.pm
@@ -652,7 +652,10 @@ use constant ABSTRACT_SCHEMA => {
       added     => {TYPE => 'MEDIUMTEXT'},
       at_time   => {TYPE => 'DATETIME', NOTNULL => 1},
     ],
-    INDEXES => [audit_log_class_idx => ['class', 'at_time'],],
+    INDEXES => [
+      audit_log_class_idx     => ['class', 'at_time'],
+      audit_log_object_id_idx => ['object_id'],
+    ],
   },
 
   # Keywords

--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -841,6 +841,9 @@ sub update_table_definitions {
   # Bug 1926081 - dkl@mozilla.com
   _migrate_profiles_modification_ts();
 
+  # Bug 1949556 - dkl@mozilla.com
+  $dbh->bz_add_index('audit_log', 'audit_log_object_id_idx', ['object_id']);
+
   ################################################################
   # New --TABLE-- changes should go *** A B O V E *** this point #
   ################################################################

--- a/scripts/bug1926081.pl
+++ b/scripts/bug1926081.pl
@@ -28,8 +28,8 @@ my $sth = $dbh->prepare(
 my $now_when
   = $dbh->selectrow_array('SELECT UNIX_TIMESTAMP(LOCALTIMESTAMP(0))');
 
-my $user_ids
-  = $dbh->selectcol_arrayref('SELECT userid FROM profiles ORDER BY userid');
+my $user_ids = $dbh->selectcol_arrayref(
+  'SELECT userid FROM profiles WHERE modification_ts IS NULL ORDER BY userid');
 
 my $count = 1;
 my $total = scalar @{$user_ids};


### PR DESCRIPTION
Adding a new index to the audit_log table for the object_id column significantly speeds up the migration process I am trying complete for [bug 1926081](https://bugzilla.mozilla.org/show_bug.cgi?id=1926081). I have tested this change on bugzilla-dev where I saw the increase. Also updated the migration script to skip profiles where modification_ts is already set which lowers the amount of rows to process.