### PR TITLE
Bug 1951989 - Update cookie banner wording to be more explicit that non-essential cookies are NOT used for tracking and/or analytics in Bugzilla

### DIFF
--- a/template/en/default/global/footer.html.tmpl
+++ b/template/en/default/global/footer.html.tmpl
@@ -33,8 +33,9 @@
     <h2  class="moz-consent-banner-heading">Help us improve your [% terms.BugzillaTitle %] experience</h2>
     <div class="moz-consent-banner-copy">
       <p>
-        In addition to cookies necessary for this site to function, we’d like your permission to set some additional
-        that will improve your experience. Rest assured - we value your privacy. You will be able to change your
+        In addition to cookies necessary for this site to function, we’d like your permission to store some additional information
+        that will improve your experience. [% terms.Bugzilla %] does not use this information for tracking or any kind of analytics.
+        Rest assured - we value your privacy. You will be able to change your
         <a href="[% basepath FILTER none %]page.cgi?id=cookies.html">Cookie Settings</a> later.
       </p>
       <div class="moz-consent-banner-controls">


### PR DESCRIPTION
New wording has been approved for now by nneka https://bugzilla.mozilla.org/show_bug.cgi?id=1951989#c8