### PR TITLE
Bug 1954571 - Add development branch to CI build triggers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,8 @@ name: BMO Deployment
 
 on:
   push:
+    branches:
+      - development
     tags:
       - release-**
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - release-**
-  workflow_dispatch: {}
 
 env:
   IMAGE_NAME: mozilla-bteam/bmo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - release-**
+  workflow_dispatch: {}
 
 env:
   IMAGE_NAME: mozilla-bteam/bmo


### PR DESCRIPTION
This will ensure Docker images are build and pushed to GAR when the `development` branch is updated.