### PR TITLE
Bug 1956154 - When impersonating another user (sudo) from admin, it fails when using MFA due to not honoring the mfa_verification_token cookie

### DIFF
--- a/relogin.cgi
+++ b/relogin.cgi
@@ -88,20 +88,22 @@ elsif ($action eq 'begin-sudo') {
   my $reason           = $cgi->param('reason') || '';
   my $token            = $cgi->param('token');
   my $current_password = $cgi->param('current_password');
-  my $mfa_token        = $cgi->param('mfa_token');
 
-  # must provide a password
-  $current_password
-    || ThrowUserError('sudo_password_required',
-    {target_login => $target_login, reason => $reason});
+  my $mfa_token = $cgi->cookie('mfa_verification_token');
+  $cgi->remove_cookie('mfa_verification_token');
 
-  # validate entered password
-  my $crypt_password = $user->cryptpassword;
-  unless (($user->mfa && $mfa_token)
-    || bz_crypt($current_password, $crypt_password) eq $crypt_password)
-  {
-    ThrowUserError('sudo_password_required',
+  unless ($user->mfa && $mfa_token) {
+    # must provide a password
+    $current_password
+      || ThrowUserError('sudo_password_required',
       {target_login => $target_login, reason => $reason});
+
+    # validate entered password
+    my $crypt_password = $user->cryptpassword;
+    unless (bz_crypt($current_password, $crypt_password) eq $crypt_password) {
+      ThrowUserError('sudo_password_required',
+        {target_login => $target_login, reason => $reason});
+    }
   }
 
   # Check for MFA


### PR DESCRIPTION
You get an error every time that a password was not provided after performing the MFA check. This fixes the sudo code in relogin.cgi to honor the mfa_verification_token cookie and not check for password twice allowing sudo to work correctly.