### PR TITLE
Bug 1956136 - GITHUB: Add new bmo slim work flow to Github actions to allow manually building and pushing of new bmo-perl-slim images to GAR (fix docker run)

### DIFF
--- a/.github/workflows/perl-slim.yml
+++ b/.github/workflows/perl-slim.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Generate new cpanfile and cpanfile.snapshot
       run: docker build -t bmo-cpanfile -f Dockerfile.cpanfile .
     - name: Copy the new cpanfile and cpanfile.snapshot from image
-      run: docker run -it -v $(pwd)/build_info:/app/result bmo-cpanfile cp cpanfile cpanfile.snapshot /app/result
+      run: docker run -v $(pwd)/build_info:/app/result bmo-cpanfile cp cpanfile cpanfile.snapshot /app/result
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/perl-slim.yml
+++ b/.github/workflows/perl-slim.yml
@@ -24,7 +24,9 @@ jobs:
     - name: Generate new cpanfile and cpanfile.snapshot
       run: docker build -t bmo-cpanfile -f Dockerfile.cpanfile .
     - name: Copy the new cpanfile and cpanfile.snapshot from image
-      run: docker run -v $(pwd)/build_info:/app/result bmo-cpanfile cp cpanfile cpanfile.snapshot /app/result
+      run: |
+        docker run -v $(pwd):/app/result bmo-cpanfile cp cpanfile cpanfile.snapshot /app/result
+        cp cpanfile cpanfile.snapshot build_info
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
- Removed -it a it caused a TTY error in Github Actions
- Copied cpanfile* into build_info after it was copied in current working directory.