### PR TITLE
Bug 1956957 - Update docker base image to bmo-perl-slim:20250328

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mozillabteam/bmo-perl-slim:20240822.1 AS base
+FROM us-docker.pkg.dev/moz-fx-bugzilla-prod/bugzilla-prod/bmo-perl-slim:20250328 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -96,6 +96,7 @@ my %requires = (
   'Scope::Guard'                        => '0.21',
   'Sereal'                              => '4.004',
   'Set::Object'                         => 0,
+  'Sub::Identify'                       => 0,
   'Sub::Quote'                          => '2.005000',
   'Template'                            => '2.24',
   'Text::CSV_XS'                        => '1.26',

--- a/cpanfile
+++ b/cpanfile
@@ -104,6 +104,7 @@ requires 'SQL::Tokenizer';
 requires 'Scope::Guard', '0.21';
 requires 'Sereal', '4.004';
 requires 'Set::Object';
+requires 'Sub::Identify';
 requires 'Sub::Quote', '2.005000';
 requires 'Sys::Syslog';
 requires 'Template', '2.24';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -22,88 +22,88 @@ DISTRIBUTIONS
       Algorithm::Diff::_impl 1.201
     requirements:
       ExtUtils::MakeMaker 0
-  Alien-Build-2.83
-    pathname: P/PL/PLICEASE/Alien-Build-2.83.tar.gz
+  Alien-Build-2.84
+    pathname: P/PL/PLICEASE/Alien-Build-2.84.tar.gz
     provides:
-      Alien::Base 2.83
-      Alien::Base::PkgConfig 2.83
-      Alien::Base::Wrapper 2.83
-      Alien::Build 2.83
-      Alien::Build::CommandSequence 2.83
-      Alien::Build::Helper 2.83
-      Alien::Build::Interpolate 2.83
-      Alien::Build::Interpolate::Default 2.83
-      Alien::Build::Interpolate::Helper 2.83
-      Alien::Build::Log 2.83
-      Alien::Build::Log::Abbreviate 2.83
-      Alien::Build::Log::Default 2.83
-      Alien::Build::MM 2.83
-      Alien::Build::Meta 2.83
-      Alien::Build::Plugin 2.83
-      Alien::Build::Plugin::Build::Autoconf 2.83
-      Alien::Build::Plugin::Build::CMake 2.83
-      Alien::Build::Plugin::Build::Copy 2.83
-      Alien::Build::Plugin::Build::MSYS 2.83
-      Alien::Build::Plugin::Build::Make 2.83
-      Alien::Build::Plugin::Build::SearchDep 2.83
-      Alien::Build::Plugin::Core::CleanInstall 2.83
-      Alien::Build::Plugin::Core::Download 2.83
-      Alien::Build::Plugin::Core::FFI 2.83
-      Alien::Build::Plugin::Core::Gather 2.83
-      Alien::Build::Plugin::Core::Legacy 2.83
-      Alien::Build::Plugin::Core::Override 2.83
-      Alien::Build::Plugin::Core::Setup 2.83
-      Alien::Build::Plugin::Core::Tail 2.83
-      Alien::Build::Plugin::Decode::DirListing 2.83
-      Alien::Build::Plugin::Decode::DirListingFtpcopy 2.83
-      Alien::Build::Plugin::Decode::HTML 2.83
-      Alien::Build::Plugin::Decode::Mojo 2.83
-      Alien::Build::Plugin::Digest::Negotiate 2.83
-      Alien::Build::Plugin::Digest::SHA 2.83
-      Alien::Build::Plugin::Digest::SHAPP 2.83
-      Alien::Build::Plugin::Download::Negotiate 2.83
-      Alien::Build::Plugin::Extract::ArchiveTar 2.83
-      Alien::Build::Plugin::Extract::ArchiveZip 2.83
-      Alien::Build::Plugin::Extract::CommandLine 2.83
-      Alien::Build::Plugin::Extract::Directory 2.83
-      Alien::Build::Plugin::Extract::File 2.83
-      Alien::Build::Plugin::Extract::Negotiate 2.83
-      Alien::Build::Plugin::Fetch::CurlCommand 2.83
-      Alien::Build::Plugin::Fetch::HTTPTiny 2.83
-      Alien::Build::Plugin::Fetch::LWP 2.83
-      Alien::Build::Plugin::Fetch::Local 2.83
-      Alien::Build::Plugin::Fetch::LocalDir 2.83
-      Alien::Build::Plugin::Fetch::NetFTP 2.83
-      Alien::Build::Plugin::Fetch::Wget 2.83
-      Alien::Build::Plugin::Gather::IsolateDynamic 2.83
-      Alien::Build::Plugin::PkgConfig::CommandLine 2.83
-      Alien::Build::Plugin::PkgConfig::LibPkgConf 2.83
-      Alien::Build::Plugin::PkgConfig::MakeStatic 2.83
-      Alien::Build::Plugin::PkgConfig::Negotiate 2.83
-      Alien::Build::Plugin::PkgConfig::PP 2.83
-      Alien::Build::Plugin::Prefer::BadVersion 2.83
-      Alien::Build::Plugin::Prefer::GoodVersion 2.83
-      Alien::Build::Plugin::Prefer::SortVersions 2.83
-      Alien::Build::Plugin::Probe::CBuilder 2.83
-      Alien::Build::Plugin::Probe::CommandLine 2.83
-      Alien::Build::Plugin::Probe::Vcpkg 2.83
-      Alien::Build::Plugin::Test::Mock 2.83
-      Alien::Build::PluginMeta 2.83
-      Alien::Build::Temp 2.83
-      Alien::Build::TempDir 2.83
-      Alien::Build::Util 2.83
-      Alien::Build::Version::Basic 2.83
-      Alien::Build::rc 2.83
-      Alien::Role 2.83
-      Alien::Util 2.83
-      Test::Alien 2.83
-      Test::Alien::Build 2.83
-      Test::Alien::CanCompile 2.83
-      Test::Alien::CanPlatypus 2.83
-      Test::Alien::Diag 2.83
-      Test::Alien::Run 2.83
-      Test::Alien::Synthetic 2.83
-      alienfile 2.83
+      Alien::Base 2.84
+      Alien::Base::PkgConfig 2.84
+      Alien::Base::Wrapper 2.84
+      Alien::Build 2.84
+      Alien::Build::CommandSequence 2.84
+      Alien::Build::Helper 2.84
+      Alien::Build::Interpolate 2.84
+      Alien::Build::Interpolate::Default 2.84
+      Alien::Build::Interpolate::Helper 2.84
+      Alien::Build::Log 2.84
+      Alien::Build::Log::Abbreviate 2.84
+      Alien::Build::Log::Default 2.84
+      Alien::Build::MM 2.84
+      Alien::Build::Meta 2.84
+      Alien::Build::Plugin 2.84
+      Alien::Build::Plugin::Build::Autoconf 2.84
+      Alien::Build::Plugin::Build::CMake 2.84
+      Alien::Build::Plugin::Build::Copy 2.84
+      Alien::Build::Plugin::Build::MSYS 2.84
+      Alien::Build::Plugin::Build::Make 2.84
+      Alien::Build::Plugin::Build::SearchDep 2.84
+      Alien::Build::Plugin::Core::CleanInstall 2.84
+      Alien::Build::Plugin::Core::Download 2.84
+      Alien::Build::Plugin::Core::FFI 2.84
+      Alien::Build::Plugin::Core::Gather 2.84
+      Alien::Build::Plugin::Core::Legacy 2.84
+      Alien::Build::Plugin::Core::Override 2.84
+      Alien::Build::Plugin::Core::Setup 2.84
+      Alien::Build::Plugin::Core::Tail 2.84
+      Alien::Build::Plugin::Decode::DirListing 2.84
+      Alien::Build::Plugin::Decode::DirListingFtpcopy 2.84
+      Alien::Build::Plugin::Decode::HTML 2.84
+      Alien::Build::Plugin::Decode::Mojo 2.84
+      Alien::Build::Plugin::Digest::Negotiate 2.84
+      Alien::Build::Plugin::Digest::SHA 2.84
+      Alien::Build::Plugin::Digest::SHAPP 2.84
+      Alien::Build::Plugin::Download::Negotiate 2.84
+      Alien::Build::Plugin::Extract::ArchiveTar 2.84
+      Alien::Build::Plugin::Extract::ArchiveZip 2.84
+      Alien::Build::Plugin::Extract::CommandLine 2.84
+      Alien::Build::Plugin::Extract::Directory 2.84
+      Alien::Build::Plugin::Extract::File 2.84
+      Alien::Build::Plugin::Extract::Negotiate 2.84
+      Alien::Build::Plugin::Fetch::CurlCommand 2.84
+      Alien::Build::Plugin::Fetch::HTTPTiny 2.84
+      Alien::Build::Plugin::Fetch::LWP 2.84
+      Alien::Build::Plugin::Fetch::Local 2.84
+      Alien::Build::Plugin::Fetch::LocalDir 2.84
+      Alien::Build::Plugin::Fetch::NetFTP 2.84
+      Alien::Build::Plugin::Fetch::Wget 2.84
+      Alien::Build::Plugin::Gather::IsolateDynamic 2.84
+      Alien::Build::Plugin::PkgConfig::CommandLine 2.84
+      Alien::Build::Plugin::PkgConfig::LibPkgConf 2.84
+      Alien::Build::Plugin::PkgConfig::MakeStatic 2.84
+      Alien::Build::Plugin::PkgConfig::Negotiate 2.84
+      Alien::Build::Plugin::PkgConfig::PP 2.84
+      Alien::Build::Plugin::Prefer::BadVersion 2.84
+      Alien::Build::Plugin::Prefer::GoodVersion 2.84
+      Alien::Build::Plugin::Prefer::SortVersions 2.84
+      Alien::Build::Plugin::Probe::CBuilder 2.84
+      Alien::Build::Plugin::Probe::CommandLine 2.84
+      Alien::Build::Plugin::Probe::Vcpkg 2.84
+      Alien::Build::Plugin::Test::Mock 2.84
+      Alien::Build::PluginMeta 2.84
+      Alien::Build::Temp 2.84
+      Alien::Build::TempDir 2.84
+      Alien::Build::Util 2.84
+      Alien::Build::Version::Basic 2.84
+      Alien::Build::rc 2.84
+      Alien::Role 2.84
+      Alien::Util 2.84
+      Test::Alien 2.84
+      Test::Alien::Build 2.84
+      Test::Alien::CanCompile 2.84
+      Test::Alien::CanPlatypus 2.84
+      Test::Alien::Diag 2.84
+      Test::Alien::Run 2.84
+      Test::Alien::Synthetic 2.84
+      alienfile 2.84
     requirements:
       Capture::Tiny 0.17
       Digest::SHA 0
@@ -302,10 +302,10 @@ DISTRIBUTIONS
       IO::Seekable 0
       Time::Local 0
       perl 5.006
-  Auth-GoogleAuth-1.05
-    pathname: G/GR/GRYPHON/Auth-GoogleAuth-1.05.tar.gz
+  Auth-GoogleAuth-1.07
+    pathname: G/GR/GRYPHON/Auth-GoogleAuth-1.07.tar.gz
     provides:
-      Auth::GoogleAuth 1.05
+      Auth::GoogleAuth 1.07
     requirements:
       Carp 0
       Class::Accessor 0
@@ -315,7 +315,7 @@ DISTRIBUTIONS
       Math::Random::MT 0
       URI::Escape 0
       base 0
-      perl 5.008
+      perl 5.010
       strict 0
       warnings 0
   Authen-SASL-2.1700
@@ -394,19 +394,19 @@ DISTRIBUTIONS
       Scalar::Util 1.21
       Test::More 0.98
       perl 5.006000
-  CGI-4.66
-    pathname: L/LE/LEEJO/CGI-4.66.tar.gz
+  CGI-4.67
+    pathname: L/LE/LEEJO/CGI-4.67.tar.gz
     provides:
-      CGI 4.66
-      CGI::Carp 4.66
+      CGI 4.67
+      CGI::Carp 4.67
       CGI::Cookie 4.59
-      CGI::File::Temp 4.66
+      CGI::File::Temp 4.67
       CGI::HTML::Functions undef
-      CGI::MultipartBuffer 4.66
-      CGI::Pretty 4.66
-      CGI::Push 4.66
-      CGI::Util 4.66
-      Fh 4.66
+      CGI::MultipartBuffer 4.67
+      CGI::Pretty 4.67
+      CGI::Push 4.67
+      CGI::Util 4.67
+      Fh 4.67
     requirements:
       Carp 0
       Config 0
@@ -424,10 +424,10 @@ DISTRIBUTIONS
       strict 0
       utf8 0
       warnings 0
-  CGI-Compile-0.26
-    pathname: R/RK/RKITOVER/CGI-Compile-0.26.tar.gz
+  CGI-Compile-0.27
+    pathname: R/RK/RKITOVER/CGI-Compile-0.27.tar.gz
     provides:
-      CGI::Compile 0.26
+      CGI::Compile 0.27
     requirements:
       File::pushd 0
       Module::Build::Tiny 0.034
@@ -484,10 +484,10 @@ DISTRIBUTIONS
       Canary::Stability 2013
     requirements:
       ExtUtils::MakeMaker 0
-  Capture-Tiny-0.48
-    pathname: D/DA/DAGOLDEN/Capture-Tiny-0.48.tar.gz
+  Capture-Tiny-0.50
+    pathname: D/DA/DAGOLDEN/Capture-Tiny-0.50.tar.gz
     provides:
-      Capture::Tiny 0.48
+      Capture::Tiny 0.50
     requirements:
       Carp 0
       Exporter 0
@@ -676,12 +676,19 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       MRO::Compat 0.09
       perl 5.006002
-  Class-Data-Inheritable-0.09
-    pathname: R/RS/RSHERER/Class-Data-Inheritable-0.09.tar.gz
+  Class-Data-Inheritable-0.10
+    pathname: R/RS/RSHERER/Class-Data-Inheritable-0.10.tar.gz
     provides:
-      Class::Data::Inheritable 0.09
+      Class::Data::Inheritable 0.10
     requirements:
       ExtUtils::MakeMaker 0
+  Class-ErrorHandler-0.04
+    pathname: T/TO/TOKUHIROM/Class-ErrorHandler-0.04.tar.gz
+    provides:
+      Class::ErrorHandler 0.04
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.008_001
   Class-Inspector-1.36
     pathname: P/PL/PLICEASE/Class-Inspector-1.36.tar.gz
     provides:
@@ -890,6 +897,12 @@ DISTRIBUTIONS
       Digest::MD5 0
       ExtUtils::MakeMaker 0
       MIME::Base64 0
+  Convert-ASN1-0.34
+    pathname: T/TI/TIMLEGGE/Convert-ASN1-0.34.tar.gz
+    provides:
+      Convert::ASN1 0.34
+    requirements:
+      ExtUtils::MakeMaker 0
   Convert-Base32-0.06
     pathname: I/IK/IKEGAMI/Convert-Base32-0.06.tar.gz
     provides:
@@ -898,6 +911,19 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Test::Exception 0
       Test::More 0
+  Convert-PEM-0.13
+    pathname: T/TI/TIMLEGGE/Convert-PEM-0.13.tar.gz
+    provides:
+      Convert::PEM 0.13
+      Convert::PEM::CBC 0.13
+    requirements:
+      Class::ErrorHandler 0
+      Convert::ASN1 0.34
+      Crypt::DES_EDE3 0
+      Crypt::PRNG 0
+      Digest::MD5 0
+      ExtUtils::MakeMaker 0
+      MIME::Base64 0
   Cookie-Baker-0.12
     pathname: K/KA/KAZEBURO/Cookie-Baker-0.12.tar.gz
     provides:
@@ -907,10 +933,10 @@ DISTRIBUTIONS
       Module::Build::Tiny 0.035
       URI::Escape 0
       perl 5.008001
-  Cpanel-JSON-XS-4.38
-    pathname: R/RU/RURBAN/Cpanel-JSON-XS-4.38.tar.gz
+  Cpanel-JSON-XS-4.39
+    pathname: R/RU/RURBAN/Cpanel-JSON-XS-4.39.tar.gz
     provides:
-      Cpanel::JSON::XS 4.38
+      Cpanel::JSON::XS 4.39
       Cpanel::JSON::XS::Type undef
     requirements:
       Carp 0
@@ -970,34 +996,36 @@ DISTRIBUTIONS
       Crypt::DES 2.07
     requirements:
       ExtUtils::MakeMaker 0
-  Crypt-DES_EDE3-0.01
-    pathname: B/BT/BTROTT/Crypt-DES_EDE3-0.01.tar.gz
+  Crypt-DES_EDE3-0.03
+    pathname: T/TI/TIMLEGGE/Crypt-DES_EDE3-0.03.tar.gz
     provides:
-      Crypt::DES_EDE3 0.01
+      Crypt::DES_EDE3 0.03
     requirements:
       Crypt::DES 0
       ExtUtils::MakeMaker 0
-  Crypt-DSA-1.17
-    pathname: A/AD/ADAMK/Crypt-DSA-1.17.tar.gz
+  Crypt-DSA-1.19
+    pathname: T/TI/TIMLEGGE/Crypt-DSA-1.19.tar.gz
     provides:
-      BufferWithInt 1.17
-      Crypt::DSA 1.17
-      Crypt::DSA::Key 1.17
-      Crypt::DSA::Key::PEM 1.17
-      Crypt::DSA::Key::SSH2 1.17
-      Crypt::DSA::KeyChain 1.17
-      Crypt::DSA::Signature 1.17
-      Crypt::DSA::Util 1.17
+      BufferWithInt 1.19
+      Crypt::DSA 1.19
+      Crypt::DSA::Key 1.19
+      Crypt::DSA::Key::PEM 1.19
+      Crypt::DSA::Key::SSH2 1.19
+      Crypt::DSA::KeyChain 1.19
+      Crypt::DSA::Signature 1.19
+      Crypt::DSA::Util 1.19
     requirements:
+      Convert::ASN1 0
+      Convert::PEM 0.13
+      Crypt::URandom 0
       Data::Buffer 0.01
-      Digest::SHA1 0
+      Digest::SHA 0
       ExtUtils::MakeMaker 6.42
       File::Spec 0
       File::Which 0.05
       IPC::Open3 0
       MIME::Base64 0
       Math::BigInt 1.78
-      Test::More 0.42
       perl 5.006
   Crypt-IDEA-1.10
     pathname: D/DP/DPARIS/Crypt-IDEA-1.10.tar.gz
@@ -1006,11 +1034,11 @@ DISTRIBUTIONS
       IDEA 1.10
     requirements:
       ExtUtils::MakeMaker 0
-  Crypt-JWT-0.035
-    pathname: M/MI/MIK/Crypt-JWT-0.035.tar.gz
+  Crypt-JWT-0.036
+    pathname: M/MI/MIK/Crypt-JWT-0.036.tar.gz
     provides:
-      Crypt::JWT 0.035
-      Crypt::KeyWrap 0.035
+      Crypt::JWT 0.036
+      Crypt::KeyWrap 0.036
     requirements:
       Compress::Raw::Zlib 0
       CryptX 0.067
@@ -1020,80 +1048,82 @@ DISTRIBUTIONS
       Scalar::Util 0
       Test::More 0.88
       perl 5.006
-  Crypt-OpenPGP-1.12
-    pathname: S/SR/SROMANOV/Crypt-OpenPGP-1.12.tar.gz
+  Crypt-OpenPGP-1.19
+    pathname: T/TI/TIMLEGGE/Crypt-OpenPGP-1.19.tar.gz
     provides:
-      Crypt::OpenPGP 1.12
-      Crypt::OpenPGP::Armour undef
-      Crypt::OpenPGP::Buffer undef
-      Crypt::OpenPGP::CFB undef
-      Crypt::OpenPGP::Certificate undef
-      Crypt::OpenPGP::Cipher undef
-      Crypt::OpenPGP::Cipher::Blowfish undef
-      Crypt::OpenPGP::Cipher::CAST5 undef
-      Crypt::OpenPGP::Cipher::DES3 undef
-      Crypt::OpenPGP::Cipher::IDEA undef
-      Crypt::OpenPGP::Cipher::Rijndael undef
-      Crypt::OpenPGP::Cipher::Rijndael192 undef
-      Crypt::OpenPGP::Cipher::Rijndael256 undef
-      Crypt::OpenPGP::Cipher::Twofish undef
-      Crypt::OpenPGP::Ciphertext undef
-      Crypt::OpenPGP::Compressed undef
-      Crypt::OpenPGP::Config undef
-      Crypt::OpenPGP::Config::GnuPG undef
-      Crypt::OpenPGP::Config::PGP2 undef
-      Crypt::OpenPGP::Config::PGP5 undef
-      Crypt::OpenPGP::Constants undef
-      Crypt::OpenPGP::Digest undef
-      Crypt::OpenPGP::Digest::MD5 undef
-      Crypt::OpenPGP::Digest::RIPEMD160 undef
-      Crypt::OpenPGP::Digest::SHA1 undef
-      Crypt::OpenPGP::Digest::SHA224 undef
-      Crypt::OpenPGP::Digest::SHA256 undef
-      Crypt::OpenPGP::Digest::SHA384 undef
-      Crypt::OpenPGP::Digest::SHA512 undef
-      Crypt::OpenPGP::ElGamal::Private undef
-      Crypt::OpenPGP::ElGamal::Public undef
-      Crypt::OpenPGP::ErrorHandler undef
-      Crypt::OpenPGP::Key undef
-      Crypt::OpenPGP::Key::Public undef
-      Crypt::OpenPGP::Key::Public::DSA undef
-      Crypt::OpenPGP::Key::Public::ElGamal undef
-      Crypt::OpenPGP::Key::Public::RSA undef
-      Crypt::OpenPGP::Key::Secret undef
-      Crypt::OpenPGP::Key::Secret::DSA undef
-      Crypt::OpenPGP::Key::Secret::ElGamal undef
-      Crypt::OpenPGP::Key::Secret::RSA undef
-      Crypt::OpenPGP::KeyBlock undef
-      Crypt::OpenPGP::KeyRing undef
-      Crypt::OpenPGP::KeyServer undef
-      Crypt::OpenPGP::MDC undef
-      Crypt::OpenPGP::Marker undef
-      Crypt::OpenPGP::Message undef
-      Crypt::OpenPGP::OnePassSig undef
-      Crypt::OpenPGP::PacketFactory undef
-      Crypt::OpenPGP::Plaintext undef
-      Crypt::OpenPGP::S2k undef
-      Crypt::OpenPGP::S2k::Salt_Iter undef
-      Crypt::OpenPGP::S2k::Salted undef
-      Crypt::OpenPGP::S2k::Simple undef
-      Crypt::OpenPGP::SKSessionKey undef
-      Crypt::OpenPGP::SessionKey undef
-      Crypt::OpenPGP::Signature undef
-      Crypt::OpenPGP::Signature::SubPacket undef
-      Crypt::OpenPGP::Trust undef
-      Crypt::OpenPGP::UserID undef
-      Crypt::OpenPGP::Util undef
-      Crypt::OpenPGP::Words undef
+      Crypt::OpenPGP 1.19
+      Crypt::OpenPGP::Armour 1.19
+      Crypt::OpenPGP::Buffer 1.19
+      Crypt::OpenPGP::CFB 1.19
+      Crypt::OpenPGP::Certificate 1.19
+      Crypt::OpenPGP::Cipher 1.19
+      Crypt::OpenPGP::Cipher::Blowfish 1.19
+      Crypt::OpenPGP::Cipher::CAST5 1.19
+      Crypt::OpenPGP::Cipher::DES3 1.19
+      Crypt::OpenPGP::Cipher::IDEA 1.19
+      Crypt::OpenPGP::Cipher::Rijndael 1.19
+      Crypt::OpenPGP::Cipher::Rijndael192 1.19
+      Crypt::OpenPGP::Cipher::Rijndael256 1.19
+      Crypt::OpenPGP::Cipher::Twofish 1.19
+      Crypt::OpenPGP::Ciphertext 1.19
+      Crypt::OpenPGP::Compressed 1.19
+      Crypt::OpenPGP::Config 1.19
+      Crypt::OpenPGP::Config::GnuPG 1.19
+      Crypt::OpenPGP::Config::PGP2 1.19
+      Crypt::OpenPGP::Config::PGP5 1.19
+      Crypt::OpenPGP::Constants 1.19
+      Crypt::OpenPGP::Digest 1.19
+      Crypt::OpenPGP::Digest::MD5 1.19
+      Crypt::OpenPGP::Digest::RIPEMD160 1.19
+      Crypt::OpenPGP::Digest::SHA1 1.19
+      Crypt::OpenPGP::Digest::SHA224 1.19
+      Crypt::OpenPGP::Digest::SHA256 1.19
+      Crypt::OpenPGP::Digest::SHA384 1.19
+      Crypt::OpenPGP::Digest::SHA512 1.19
+      Crypt::OpenPGP::ElGamal::Private 1.19
+      Crypt::OpenPGP::ElGamal::Public 1.19
+      Crypt::OpenPGP::ErrorHandler 1.19
+      Crypt::OpenPGP::Key 1.19
+      Crypt::OpenPGP::Key::Public 1.19
+      Crypt::OpenPGP::Key::Public::DSA 1.19
+      Crypt::OpenPGP::Key::Public::ElGamal 1.19
+      Crypt::OpenPGP::Key::Public::RSA 1.19
+      Crypt::OpenPGP::Key::Secret 1.19
+      Crypt::OpenPGP::Key::Secret::DSA 1.19
+      Crypt::OpenPGP::Key::Secret::ElGamal 1.19
+      Crypt::OpenPGP::Key::Secret::RSA 1.19
+      Crypt::OpenPGP::KeyBlock 1.19
+      Crypt::OpenPGP::KeyRing 1.19
+      Crypt::OpenPGP::KeyServer 1.19
+      Crypt::OpenPGP::MDC 1.19
+      Crypt::OpenPGP::Marker 1.19
+      Crypt::OpenPGP::Message 1.19
+      Crypt::OpenPGP::OnePassSig 1.19
+      Crypt::OpenPGP::PacketFactory 1.19
+      Crypt::OpenPGP::Plaintext 1.19
+      Crypt::OpenPGP::S2k 1.19
+      Crypt::OpenPGP::S2k::Salt_Iter 1.19
+      Crypt::OpenPGP::S2k::Salted 1.19
+      Crypt::OpenPGP::S2k::Simple 1.19
+      Crypt::OpenPGP::SKSessionKey 1.19
+      Crypt::OpenPGP::SessionKey 1.19
+      Crypt::OpenPGP::Signature 1.19
+      Crypt::OpenPGP::Signature::SubPacket 1.19
+      Crypt::OpenPGP::Trust 1.19
+      Crypt::OpenPGP::UserAttribute 1.19
+      Crypt::OpenPGP::UserID 1.19
+      Crypt::OpenPGP::Util 1.19
+      Crypt::OpenPGP::Words 1.19
     requirements:
       Alt::Crypt::RSA::BigInt 0
+      Bytes::Random::Secure 0
       Compress::Zlib 0
       Crypt::Blowfish 0
       Crypt::CAST5_PP 0
       Crypt::DES_EDE3 0
-      Crypt::DSA 0
+      Crypt::DSA 1.17
       Crypt::IDEA 0
-      Crypt::RIPEMD160 0
+      Crypt::RIPEMD160 0.05
       Crypt::Rijndael 0
       Crypt::Twofish 0
       Data::Buffer 0.04
@@ -1209,10 +1239,10 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       perl 5.006
-  Crypt-SMIME-0.30
-    pathname: M/MI/MIKAGE/Crypt-SMIME-0.30.tar.gz
+  Crypt-SMIME-0.31
+    pathname: M/MI/MIKAGE/Crypt-SMIME-0.31.tar.gz
     provides:
-      Crypt::SMIME 0.30
+      Crypt::SMIME 0.31
     requirements:
       ExtUtils::CChecker 0
       ExtUtils::Constant 0.23
@@ -1228,130 +1258,142 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       strict 0
-  CryptX-0.080
-    pathname: M/MI/MIK/CryptX-0.080.tar.gz
+  Crypt-URandom-0.54
+    pathname: D/DD/DDICK/Crypt-URandom-0.54.tar.gz
     provides:
-      Crypt::AuthEnc 0.080
-      Crypt::AuthEnc::CCM 0.080
-      Crypt::AuthEnc::ChaCha20Poly1305 0.080
-      Crypt::AuthEnc::EAX 0.080
-      Crypt::AuthEnc::GCM 0.080
-      Crypt::AuthEnc::OCB 0.080
-      Crypt::Checksum 0.080
-      Crypt::Checksum::Adler32 0.080
-      Crypt::Checksum::CRC32 0.080
-      Crypt::Cipher 0.080
-      Crypt::Cipher::AES 0.080
-      Crypt::Cipher::Anubis 0.080
-      Crypt::Cipher::Blowfish 0.080
-      Crypt::Cipher::CAST5 0.080
-      Crypt::Cipher::Camellia 0.080
-      Crypt::Cipher::DES 0.080
-      Crypt::Cipher::DES_EDE 0.080
-      Crypt::Cipher::IDEA 0.080
-      Crypt::Cipher::KASUMI 0.080
-      Crypt::Cipher::Khazad 0.080
-      Crypt::Cipher::MULTI2 0.080
-      Crypt::Cipher::Noekeon 0.080
-      Crypt::Cipher::RC2 0.080
-      Crypt::Cipher::RC5 0.080
-      Crypt::Cipher::RC6 0.080
-      Crypt::Cipher::SAFERP 0.080
-      Crypt::Cipher::SAFER_K128 0.080
-      Crypt::Cipher::SAFER_K64 0.080
-      Crypt::Cipher::SAFER_SK128 0.080
-      Crypt::Cipher::SAFER_SK64 0.080
-      Crypt::Cipher::SEED 0.080
-      Crypt::Cipher::Serpent 0.080
-      Crypt::Cipher::Skipjack 0.080
-      Crypt::Cipher::Twofish 0.080
-      Crypt::Cipher::XTEA 0.080
-      Crypt::Digest 0.080
-      Crypt::Digest::BLAKE2b_160 0.080
-      Crypt::Digest::BLAKE2b_256 0.080
-      Crypt::Digest::BLAKE2b_384 0.080
-      Crypt::Digest::BLAKE2b_512 0.080
-      Crypt::Digest::BLAKE2s_128 0.080
-      Crypt::Digest::BLAKE2s_160 0.080
-      Crypt::Digest::BLAKE2s_224 0.080
-      Crypt::Digest::BLAKE2s_256 0.080
-      Crypt::Digest::CHAES 0.080
-      Crypt::Digest::Keccak224 0.080
-      Crypt::Digest::Keccak256 0.080
-      Crypt::Digest::Keccak384 0.080
-      Crypt::Digest::Keccak512 0.080
-      Crypt::Digest::MD2 0.080
-      Crypt::Digest::MD4 0.080
-      Crypt::Digest::MD5 0.080
-      Crypt::Digest::RIPEMD128 0.080
-      Crypt::Digest::RIPEMD160 0.080
-      Crypt::Digest::RIPEMD256 0.080
-      Crypt::Digest::RIPEMD320 0.080
-      Crypt::Digest::SHA1 0.080
-      Crypt::Digest::SHA224 0.080
-      Crypt::Digest::SHA256 0.080
-      Crypt::Digest::SHA384 0.080
-      Crypt::Digest::SHA3_224 0.080
-      Crypt::Digest::SHA3_256 0.080
-      Crypt::Digest::SHA3_384 0.080
-      Crypt::Digest::SHA3_512 0.080
-      Crypt::Digest::SHA512 0.080
-      Crypt::Digest::SHA512_224 0.080
-      Crypt::Digest::SHA512_256 0.080
-      Crypt::Digest::SHAKE 0.080
-      Crypt::Digest::Tiger192 0.080
-      Crypt::Digest::Whirlpool 0.080
-      Crypt::KeyDerivation 0.080
-      Crypt::Mac 0.080
-      Crypt::Mac::BLAKE2b 0.080
-      Crypt::Mac::BLAKE2s 0.080
-      Crypt::Mac::F9 0.080
-      Crypt::Mac::HMAC 0.080
-      Crypt::Mac::OMAC 0.080
-      Crypt::Mac::PMAC 0.080
-      Crypt::Mac::Pelican 0.080
-      Crypt::Mac::Poly1305 0.080
-      Crypt::Mac::XCBC 0.080
-      Crypt::Misc 0.080
-      Crypt::Mode 0.080
-      Crypt::Mode::CBC 0.080
-      Crypt::Mode::CFB 0.080
-      Crypt::Mode::CTR 0.080
-      Crypt::Mode::ECB 0.080
-      Crypt::Mode::OFB 0.080
-      Crypt::PK 0.080
-      Crypt::PK::DH 0.080
-      Crypt::PK::DSA 0.080
-      Crypt::PK::ECC 0.080
-      Crypt::PK::Ed25519 0.080
-      Crypt::PK::RSA 0.080
-      Crypt::PK::X25519 0.080
-      Crypt::PRNG 0.080
-      Crypt::PRNG::ChaCha20 0.080
-      Crypt::PRNG::Fortuna 0.080
-      Crypt::PRNG::RC4 0.080
-      Crypt::PRNG::Sober128 0.080
-      Crypt::PRNG::Yarrow 0.080
-      Crypt::Stream::ChaCha 0.080
-      Crypt::Stream::RC4 0.080
-      Crypt::Stream::Rabbit 0.080
-      Crypt::Stream::Salsa20 0.080
-      Crypt::Stream::Sober128 0.080
-      Crypt::Stream::Sosemanuk 0.080
-      CryptX 0.080
-      Math::BigInt::LTM 0.080
+      Crypt::URandom 0.54
+    requirements:
+      Carp 1.26
+      English 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      FileHandle 0
+      constant 0
+      perl 5.006
+  CryptX-0.085
+    pathname: M/MI/MIK/CryptX-0.085.tar.gz
+    provides:
+      Crypt::AuthEnc 0.085
+      Crypt::AuthEnc::CCM 0.085
+      Crypt::AuthEnc::ChaCha20Poly1305 0.085
+      Crypt::AuthEnc::EAX 0.085
+      Crypt::AuthEnc::GCM 0.085
+      Crypt::AuthEnc::OCB 0.085
+      Crypt::Checksum 0.085
+      Crypt::Checksum::Adler32 0.085
+      Crypt::Checksum::CRC32 0.085
+      Crypt::Cipher 0.085
+      Crypt::Cipher::AES 0.085
+      Crypt::Cipher::Anubis 0.085
+      Crypt::Cipher::Blowfish 0.085
+      Crypt::Cipher::CAST5 0.085
+      Crypt::Cipher::Camellia 0.085
+      Crypt::Cipher::DES 0.085
+      Crypt::Cipher::DES_EDE 0.085
+      Crypt::Cipher::IDEA 0.085
+      Crypt::Cipher::KASUMI 0.085
+      Crypt::Cipher::Khazad 0.085
+      Crypt::Cipher::MULTI2 0.085
+      Crypt::Cipher::Noekeon 0.085
+      Crypt::Cipher::RC2 0.085
+      Crypt::Cipher::RC5 0.085
+      Crypt::Cipher::RC6 0.085
+      Crypt::Cipher::SAFERP 0.085
+      Crypt::Cipher::SAFER_K128 0.085
+      Crypt::Cipher::SAFER_K64 0.085
+      Crypt::Cipher::SAFER_SK128 0.085
+      Crypt::Cipher::SAFER_SK64 0.085
+      Crypt::Cipher::SEED 0.085
+      Crypt::Cipher::Serpent 0.085
+      Crypt::Cipher::Skipjack 0.085
+      Crypt::Cipher::Twofish 0.085
+      Crypt::Cipher::XTEA 0.085
+      Crypt::Digest 0.085
+      Crypt::Digest::BLAKE2b_160 0.085
+      Crypt::Digest::BLAKE2b_256 0.085
+      Crypt::Digest::BLAKE2b_384 0.085
+      Crypt::Digest::BLAKE2b_512 0.085
+      Crypt::Digest::BLAKE2s_128 0.085
+      Crypt::Digest::BLAKE2s_160 0.085
+      Crypt::Digest::BLAKE2s_224 0.085
+      Crypt::Digest::BLAKE2s_256 0.085
+      Crypt::Digest::CHAES 0.085
+      Crypt::Digest::Keccak224 0.085
+      Crypt::Digest::Keccak256 0.085
+      Crypt::Digest::Keccak384 0.085
+      Crypt::Digest::Keccak512 0.085
+      Crypt::Digest::MD2 0.085
+      Crypt::Digest::MD4 0.085
+      Crypt::Digest::MD5 0.085
+      Crypt::Digest::RIPEMD128 0.085
+      Crypt::Digest::RIPEMD160 0.085
+      Crypt::Digest::RIPEMD256 0.085
+      Crypt::Digest::RIPEMD320 0.085
+      Crypt::Digest::SHA1 0.085
+      Crypt::Digest::SHA224 0.085
+      Crypt::Digest::SHA256 0.085
+      Crypt::Digest::SHA384 0.085
+      Crypt::Digest::SHA3_224 0.085
+      Crypt::Digest::SHA3_256 0.085
+      Crypt::Digest::SHA3_384 0.085
+      Crypt::Digest::SHA3_512 0.085
+      Crypt::Digest::SHA512 0.085
+      Crypt::Digest::SHA512_224 0.085
+      Crypt::Digest::SHA512_256 0.085
+      Crypt::Digest::SHAKE 0.085
+      Crypt::Digest::Tiger192 0.085
+      Crypt::Digest::Whirlpool 0.085
+      Crypt::KeyDerivation 0.085
+      Crypt::Mac 0.085
+      Crypt::Mac::BLAKE2b 0.085
+      Crypt::Mac::BLAKE2s 0.085
+      Crypt::Mac::F9 0.085
+      Crypt::Mac::HMAC 0.085
+      Crypt::Mac::OMAC 0.085
+      Crypt::Mac::PMAC 0.085
+      Crypt::Mac::Pelican 0.085
+      Crypt::Mac::Poly1305 0.085
+      Crypt::Mac::XCBC 0.085
+      Crypt::Misc 0.085
+      Crypt::Mode 0.085
+      Crypt::Mode::CBC 0.085
+      Crypt::Mode::CFB 0.085
+      Crypt::Mode::CTR 0.085
+      Crypt::Mode::ECB 0.085
+      Crypt::Mode::OFB 0.085
+      Crypt::PK 0.085
+      Crypt::PK::DH 0.085
+      Crypt::PK::DSA 0.085
+      Crypt::PK::ECC 0.085
+      Crypt::PK::Ed25519 0.085
+      Crypt::PK::RSA 0.085
+      Crypt::PK::X25519 0.085
+      Crypt::PRNG 0.085
+      Crypt::PRNG::ChaCha20 0.085
+      Crypt::PRNG::Fortuna 0.085
+      Crypt::PRNG::RC4 0.085
+      Crypt::PRNG::Sober128 0.085
+      Crypt::PRNG::Yarrow 0.085
+      Crypt::Stream::ChaCha 0.085
+      Crypt::Stream::RC4 0.085
+      Crypt::Stream::Rabbit 0.085
+      Crypt::Stream::Salsa20 0.085
+      Crypt::Stream::Sober128 0.085
+      Crypt::Stream::Sosemanuk 0.085
+      CryptX 0.085
+      Math::BigInt::LTM 0.085
     requirements:
       ExtUtils::MakeMaker 0
       Math::BigInt 0
       perl 5.006
-  DBD-SQLite-1.74
-    pathname: I/IS/ISHIGAKI/DBD-SQLite-1.74.tar.gz
+  DBD-SQLite-1.76
+    pathname: I/IS/ISHIGAKI/DBD-SQLite-1.76.tar.gz
     provides:
-      DBD::SQLite 1.74
+      DBD::SQLite 1.76
       DBD::SQLite::Constants undef
       DBD::SQLite::GetInfo undef
-      DBD::SQLite::VirtualTable 1.74
-      DBD::SQLite::VirtualTable::Cursor 1.74
+      DBD::SQLite::VirtualTable 1.76
+      DBD::SQLite::VirtualTable::Cursor 1.76
       DBD::SQLite::VirtualTable::FileContent undef
       DBD::SQLite::VirtualTable::FileContent::Cursor undef
       DBD::SQLite::VirtualTable::PerlData undef
@@ -1378,8 +1420,8 @@ DISTRIBUTIONS
       Devel::CheckLib 1.09
       ExtUtils::MakeMaker 0
       perl 5.008001
-  DBI-1.643
-    pathname: T/TI/TIMB/DBI-1.643.tar.gz
+  DBI-1.647
+    pathname: H/HM/HMBRAND/DBI-1.647.tgz
     provides:
       Bundle::DBI 12.008696
       DBD::DBM 0.08
@@ -1435,7 +1477,7 @@ DISTRIBUTIONS
       DBD::Sponge::dr 12.010003
       DBD::Sponge::st 12.010003
       DBDI 12.015129
-      DBI 1.643
+      DBI 1.647
       DBI::Const::GetInfo::ANSI 2.008697
       DBI::Const::GetInfo::ODBC 2.011374
       DBI::Const::GetInfoReturn 2.008697
@@ -1475,15 +1517,15 @@ DISTRIBUTIONS
       DBI::SQL::Nano::Table_ 1.015544
       DBI::Util::CacheMemory 0.010315
       DBI::Util::_accessor 0.009479
-      DBI::common 1.643
+      DBI::common 1.647
     requirements:
       ExtUtils::MakeMaker 6.48
       Test::Simple 0.90
       perl 5.008001
-  DBIx-Class-0.082843
-    pathname: R/RI/RIBASUSHI/DBIx-Class-0.082843.tar.gz
+  DBIx-Class-0.082844
+    pathname: R/RI/RIBASUSHI/DBIx-Class-0.082844.tar.gz
     provides:
-      DBIx::Class 0.082843
+      DBIx::Class 0.082844
       DBIx::Class::AccessorGroup undef
       DBIx::Class::Admin undef
       DBIx::Class::CDBICompat undef
@@ -1602,12 +1644,12 @@ DISTRIBUTIONS
       Try::Tiny 0.07
       namespace::clean 0.24
       perl 5.008001
-  DBIx-Class-Candy-0.005003
-    pathname: F/FR/FREW/DBIx-Class-Candy-0.005003.tar.gz
+  DBIx-Class-Candy-0.005004
+    pathname: W/WE/WESM/DBIx-Class-Candy-0.005004.tar.gz
     provides:
-      DBIx::Class::Candy 0.005003
-      DBIx::Class::Candy::Exports 0.005003
-      DBIx::Class::Candy::ResultSet 0.005003
+      DBIx::Class::Candy 0.005004
+      DBIx::Class::Candy::Exports 0.005004
+      DBIx::Class::Candy::ResultSet 0.005004
     requirements:
       DBIx::Class 0.08123
       ExtUtils::MakeMaker 0
@@ -1704,20 +1746,21 @@ DISTRIBUTIONS
       Try::Tiny 0
       namespace::clean 0.23
       parent 0
-  DBIx-Connector-0.59
-    pathname: A/AR/ARISTOTLE/DBIx-Connector-0.59.tar.gz
+  DBIx-Connector-0.60
+    pathname: A/AR/ARISTOTLE/DBIx-Connector-0.60.tar.gz
     provides:
-      DBIx::Connector 0.59
-      DBIx::Connector::Driver 0.59
-      DBIx::Connector::Driver::Firebird 0.59
-      DBIx::Connector::Driver::MSSQL 0.59
-      DBIx::Connector::Driver::Oracle 0.59
-      DBIx::Connector::Driver::Pg 0.59
-      DBIx::Connector::Driver::SQLite 0.59
-      DBIx::Connector::Driver::mysql 0.59
-      DBIx::Connector::RollbackError 0.59
-      DBIx::Connector::SvpRollbackError 0.59
-      DBIx::Connector::TxnRollbackError 0.59
+      DBIx::Connector 0.60
+      DBIx::Connector::Driver 0.60
+      DBIx::Connector::Driver::Firebird 0.60
+      DBIx::Connector::Driver::MSSQL 0.60
+      DBIx::Connector::Driver::MariaDB 0.60
+      DBIx::Connector::Driver::Oracle 0.60
+      DBIx::Connector::Driver::Pg 0.60
+      DBIx::Connector::Driver::SQLite 0.60
+      DBIx::Connector::Driver::mysql 0.60
+      DBIx::Connector::RollbackError 0.60
+      DBIx::Connector::SvpRollbackError 0.60
+      DBIx::Connector::TxnRollbackError 0.60
     requirements:
       DBI 1.605
       perl 5.008001
@@ -1748,10 +1791,10 @@ DISTRIBUTIONS
       Getopt::Long 0
       Text::Wrap 0
       Time::HiRes 0
-  Data-Buffer-0.04
-    pathname: B/BT/BTROTT/Data-Buffer-0.04.tar.gz
+  Data-Buffer-0.06
+    pathname: T/TI/TIMLEGGE/Data-Buffer-0.06.tar.gz
     provides:
-      Data::Buffer 0.04
+      Data::Buffer 0.06
     requirements:
       ExtUtils::MakeMaker 0
   Data-Dump-1.25
@@ -1779,10 +1822,10 @@ DISTRIBUTIONS
       Exporter 0
       ExtUtils::MakeMaker 0
       perl 5.006
-  Data-ObjectDriver-0.22
-    pathname: S/SI/SIXAPART/Data-ObjectDriver-0.22.tar.gz
+  Data-ObjectDriver-0.23
+    pathname: S/SI/SIXAPART/Data-ObjectDriver-0.23.tar.gz
     provides:
-      Data::ObjectDriver 0.22
+      Data::ObjectDriver 0.23
       Data::ObjectDriver::BaseObject undef
       Data::ObjectDriver::BaseView undef
       Data::ObjectDriver::Driver::BaseCache undef
@@ -1873,19 +1916,19 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
-  DateTime-1.65
-    pathname: D/DR/DROLSKY/DateTime-1.65.tar.gz
+  DateTime-1.66
+    pathname: D/DR/DROLSKY/DateTime-1.66.tar.gz
     provides:
-      DateTime 1.65
-      DateTime::Duration 1.65
-      DateTime::Helpers 1.65
-      DateTime::Infinite 1.65
-      DateTime::Infinite::Future 1.65
-      DateTime::Infinite::Past 1.65
-      DateTime::LeapSecond 1.65
-      DateTime::PP 1.65
-      DateTime::PPExtra 1.65
-      DateTime::Types 1.65
+      DateTime 1.66
+      DateTime::Duration 1.66
+      DateTime::Helpers 1.66
+      DateTime::Infinite 1.66
+      DateTime::Infinite::Future 1.66
+      DateTime::Infinite::Past 1.66
+      DateTime::LeapSecond 1.66
+      DateTime::PP 1.66
+      DateTime::PPExtra 1.66
+      DateTime::Types 1.66
     requirements:
       Carp 0
       DateTime::Locale 1.06
@@ -1895,7 +1938,7 @@ DISTRIBUTIONS
       POSIX 0
       Params::ValidationCompiler 0.26
       Scalar::Util 0
-      Specio 0.18
+      Specio 0.50
       Specio::Declare 0
       Specio::Exporter 0
       Specio::Library::Builtins 0
@@ -1974,15 +2017,15 @@ DISTRIBUTIONS
       parent 0
       strict 0
       warnings 0
-  DateTime-Locale-1.43
-    pathname: D/DR/DROLSKY/DateTime-Locale-1.43.tar.gz
+  DateTime-Locale-1.44
+    pathname: D/DR/DROLSKY/DateTime-Locale-1.44.tar.gz
     provides:
-      DateTime::Locale 1.43
-      DateTime::Locale::Base 1.43
-      DateTime::Locale::Catalog 1.43
-      DateTime::Locale::Data 1.43
-      DateTime::Locale::FromData 1.43
-      DateTime::Locale::Util 1.43
+      DateTime::Locale 1.44
+      DateTime::Locale::Base 1.44
+      DateTime::Locale::Catalog 1.44
+      DateTime::Locale::Data 1.44
+      DateTime::Locale::FromData 1.44
+      DateTime::Locale::Util 1.44
     requirements:
       Carp 0
       Dist::CheckConflicts 0.02
@@ -2012,346 +2055,335 @@ DISTRIBUTIONS
       Params::Validate 0
       Set::Infinite 0.59
       Test::More 0
-  DateTime-TimeZone-2.62
-    pathname: D/DR/DROLSKY/DateTime-TimeZone-2.62.tar.gz
+  DateTime-TimeZone-2.65
+    pathname: D/DR/DROLSKY/DateTime-TimeZone-2.65.tar.gz
     provides:
-      DateTime::TimeZone 2.62
-      DateTime::TimeZone::Africa::Abidjan 2.62
-      DateTime::TimeZone::Africa::Algiers 2.62
-      DateTime::TimeZone::Africa::Bissau 2.62
-      DateTime::TimeZone::Africa::Cairo 2.62
-      DateTime::TimeZone::Africa::Casablanca 2.62
-      DateTime::TimeZone::Africa::Ceuta 2.62
-      DateTime::TimeZone::Africa::El_Aaiun 2.62
-      DateTime::TimeZone::Africa::Johannesburg 2.62
-      DateTime::TimeZone::Africa::Juba 2.62
-      DateTime::TimeZone::Africa::Khartoum 2.62
-      DateTime::TimeZone::Africa::Lagos 2.62
-      DateTime::TimeZone::Africa::Maputo 2.62
-      DateTime::TimeZone::Africa::Monrovia 2.62
-      DateTime::TimeZone::Africa::Nairobi 2.62
-      DateTime::TimeZone::Africa::Ndjamena 2.62
-      DateTime::TimeZone::Africa::Sao_Tome 2.62
-      DateTime::TimeZone::Africa::Tripoli 2.62
-      DateTime::TimeZone::Africa::Tunis 2.62
-      DateTime::TimeZone::Africa::Windhoek 2.62
-      DateTime::TimeZone::America::Adak 2.62
-      DateTime::TimeZone::America::Anchorage 2.62
-      DateTime::TimeZone::America::Araguaina 2.62
-      DateTime::TimeZone::America::Argentina::Buenos_Aires 2.62
-      DateTime::TimeZone::America::Argentina::Catamarca 2.62
-      DateTime::TimeZone::America::Argentina::Cordoba 2.62
-      DateTime::TimeZone::America::Argentina::Jujuy 2.62
-      DateTime::TimeZone::America::Argentina::La_Rioja 2.62
-      DateTime::TimeZone::America::Argentina::Mendoza 2.62
-      DateTime::TimeZone::America::Argentina::Rio_Gallegos 2.62
-      DateTime::TimeZone::America::Argentina::Salta 2.62
-      DateTime::TimeZone::America::Argentina::San_Juan 2.62
-      DateTime::TimeZone::America::Argentina::San_Luis 2.62
-      DateTime::TimeZone::America::Argentina::Tucuman 2.62
-      DateTime::TimeZone::America::Argentina::Ushuaia 2.62
-      DateTime::TimeZone::America::Asuncion 2.62
-      DateTime::TimeZone::America::Bahia 2.62
-      DateTime::TimeZone::America::Bahia_Banderas 2.62
-      DateTime::TimeZone::America::Barbados 2.62
-      DateTime::TimeZone::America::Belem 2.62
-      DateTime::TimeZone::America::Belize 2.62
-      DateTime::TimeZone::America::Boa_Vista 2.62
-      DateTime::TimeZone::America::Bogota 2.62
-      DateTime::TimeZone::America::Boise 2.62
-      DateTime::TimeZone::America::Cambridge_Bay 2.62
-      DateTime::TimeZone::America::Campo_Grande 2.62
-      DateTime::TimeZone::America::Cancun 2.62
-      DateTime::TimeZone::America::Caracas 2.62
-      DateTime::TimeZone::America::Cayenne 2.62
-      DateTime::TimeZone::America::Chicago 2.62
-      DateTime::TimeZone::America::Chihuahua 2.62
-      DateTime::TimeZone::America::Ciudad_Juarez 2.62
-      DateTime::TimeZone::America::Costa_Rica 2.62
-      DateTime::TimeZone::America::Cuiaba 2.62
-      DateTime::TimeZone::America::Danmarkshavn 2.62
-      DateTime::TimeZone::America::Dawson 2.62
-      DateTime::TimeZone::America::Dawson_Creek 2.62
-      DateTime::TimeZone::America::Denver 2.62
-      DateTime::TimeZone::America::Detroit 2.62
-      DateTime::TimeZone::America::Edmonton 2.62
-      DateTime::TimeZone::America::Eirunepe 2.62
-      DateTime::TimeZone::America::El_Salvador 2.62
-      DateTime::TimeZone::America::Fort_Nelson 2.62
-      DateTime::TimeZone::America::Fortaleza 2.62
-      DateTime::TimeZone::America::Glace_Bay 2.62
-      DateTime::TimeZone::America::Goose_Bay 2.62
-      DateTime::TimeZone::America::Grand_Turk 2.62
-      DateTime::TimeZone::America::Guatemala 2.62
-      DateTime::TimeZone::America::Guayaquil 2.62
-      DateTime::TimeZone::America::Guyana 2.62
-      DateTime::TimeZone::America::Halifax 2.62
-      DateTime::TimeZone::America::Havana 2.62
-      DateTime::TimeZone::America::Hermosillo 2.62
-      DateTime::TimeZone::America::Indiana::Indianapolis 2.62
-      DateTime::TimeZone::America::Indiana::Knox 2.62
-      DateTime::TimeZone::America::Indiana::Marengo 2.62
-      DateTime::TimeZone::America::Indiana::Petersburg 2.62
-      DateTime::TimeZone::America::Indiana::Tell_City 2.62
-      DateTime::TimeZone::America::Indiana::Vevay 2.62
-      DateTime::TimeZone::America::Indiana::Vincennes 2.62
-      DateTime::TimeZone::America::Indiana::Winamac 2.62
-      DateTime::TimeZone::America::Inuvik 2.62
-      DateTime::TimeZone::America::Iqaluit 2.62
-      DateTime::TimeZone::America::Jamaica 2.62
-      DateTime::TimeZone::America::Juneau 2.62
-      DateTime::TimeZone::America::Kentucky::Louisville 2.62
-      DateTime::TimeZone::America::Kentucky::Monticello 2.62
-      DateTime::TimeZone::America::La_Paz 2.62
-      DateTime::TimeZone::America::Lima 2.62
-      DateTime::TimeZone::America::Los_Angeles 2.62
-      DateTime::TimeZone::America::Maceio 2.62
-      DateTime::TimeZone::America::Managua 2.62
-      DateTime::TimeZone::America::Manaus 2.62
-      DateTime::TimeZone::America::Martinique 2.62
-      DateTime::TimeZone::America::Matamoros 2.62
-      DateTime::TimeZone::America::Mazatlan 2.62
-      DateTime::TimeZone::America::Menominee 2.62
-      DateTime::TimeZone::America::Merida 2.62
-      DateTime::TimeZone::America::Metlakatla 2.62
-      DateTime::TimeZone::America::Mexico_City 2.62
-      DateTime::TimeZone::America::Miquelon 2.62
-      DateTime::TimeZone::America::Moncton 2.62
-      DateTime::TimeZone::America::Monterrey 2.62
-      DateTime::TimeZone::America::Montevideo 2.62
-      DateTime::TimeZone::America::New_York 2.62
-      DateTime::TimeZone::America::Nome 2.62
-      DateTime::TimeZone::America::Noronha 2.62
-      DateTime::TimeZone::America::North_Dakota::Beulah 2.62
-      DateTime::TimeZone::America::North_Dakota::Center 2.62
-      DateTime::TimeZone::America::North_Dakota::New_Salem 2.62
-      DateTime::TimeZone::America::Nuuk 2.62
-      DateTime::TimeZone::America::Ojinaga 2.62
-      DateTime::TimeZone::America::Panama 2.62
-      DateTime::TimeZone::America::Paramaribo 2.62
-      DateTime::TimeZone::America::Phoenix 2.62
-      DateTime::TimeZone::America::Port_au_Prince 2.62
-      DateTime::TimeZone::America::Porto_Velho 2.62
-      DateTime::TimeZone::America::Puerto_Rico 2.62
-      DateTime::TimeZone::America::Punta_Arenas 2.62
-      DateTime::TimeZone::America::Rankin_Inlet 2.62
-      DateTime::TimeZone::America::Recife 2.62
-      DateTime::TimeZone::America::Regina 2.62
-      DateTime::TimeZone::America::Resolute 2.62
-      DateTime::TimeZone::America::Rio_Branco 2.62
-      DateTime::TimeZone::America::Santarem 2.62
-      DateTime::TimeZone::America::Santiago 2.62
-      DateTime::TimeZone::America::Santo_Domingo 2.62
-      DateTime::TimeZone::America::Sao_Paulo 2.62
-      DateTime::TimeZone::America::Scoresbysund 2.62
-      DateTime::TimeZone::America::Sitka 2.62
-      DateTime::TimeZone::America::St_Johns 2.62
-      DateTime::TimeZone::America::Swift_Current 2.62
-      DateTime::TimeZone::America::Tegucigalpa 2.62
-      DateTime::TimeZone::America::Thule 2.62
-      DateTime::TimeZone::America::Tijuana 2.62
-      DateTime::TimeZone::America::Toronto 2.62
-      DateTime::TimeZone::America::Vancouver 2.62
-      DateTime::TimeZone::America::Whitehorse 2.62
-      DateTime::TimeZone::America::Winnipeg 2.62
-      DateTime::TimeZone::America::Yakutat 2.62
-      DateTime::TimeZone::Antarctica::Casey 2.62
-      DateTime::TimeZone::Antarctica::Davis 2.62
-      DateTime::TimeZone::Antarctica::Macquarie 2.62
-      DateTime::TimeZone::Antarctica::Mawson 2.62
-      DateTime::TimeZone::Antarctica::Palmer 2.62
-      DateTime::TimeZone::Antarctica::Rothera 2.62
-      DateTime::TimeZone::Antarctica::Troll 2.62
-      DateTime::TimeZone::Antarctica::Vostok 2.62
-      DateTime::TimeZone::Asia::Almaty 2.62
-      DateTime::TimeZone::Asia::Amman 2.62
-      DateTime::TimeZone::Asia::Anadyr 2.62
-      DateTime::TimeZone::Asia::Aqtau 2.62
-      DateTime::TimeZone::Asia::Aqtobe 2.62
-      DateTime::TimeZone::Asia::Ashgabat 2.62
-      DateTime::TimeZone::Asia::Atyrau 2.62
-      DateTime::TimeZone::Asia::Baghdad 2.62
-      DateTime::TimeZone::Asia::Baku 2.62
-      DateTime::TimeZone::Asia::Bangkok 2.62
-      DateTime::TimeZone::Asia::Barnaul 2.62
-      DateTime::TimeZone::Asia::Beirut 2.62
-      DateTime::TimeZone::Asia::Bishkek 2.62
-      DateTime::TimeZone::Asia::Chita 2.62
-      DateTime::TimeZone::Asia::Choibalsan 2.62
-      DateTime::TimeZone::Asia::Colombo 2.62
-      DateTime::TimeZone::Asia::Damascus 2.62
-      DateTime::TimeZone::Asia::Dhaka 2.62
-      DateTime::TimeZone::Asia::Dili 2.62
-      DateTime::TimeZone::Asia::Dubai 2.62
-      DateTime::TimeZone::Asia::Dushanbe 2.62
-      DateTime::TimeZone::Asia::Famagusta 2.62
-      DateTime::TimeZone::Asia::Gaza 2.62
-      DateTime::TimeZone::Asia::Hebron 2.62
-      DateTime::TimeZone::Asia::Ho_Chi_Minh 2.62
-      DateTime::TimeZone::Asia::Hong_Kong 2.62
-      DateTime::TimeZone::Asia::Hovd 2.62
-      DateTime::TimeZone::Asia::Irkutsk 2.62
-      DateTime::TimeZone::Asia::Jakarta 2.62
-      DateTime::TimeZone::Asia::Jayapura 2.62
-      DateTime::TimeZone::Asia::Jerusalem 2.62
-      DateTime::TimeZone::Asia::Kabul 2.62
-      DateTime::TimeZone::Asia::Kamchatka 2.62
-      DateTime::TimeZone::Asia::Karachi 2.62
-      DateTime::TimeZone::Asia::Kathmandu 2.62
-      DateTime::TimeZone::Asia::Khandyga 2.62
-      DateTime::TimeZone::Asia::Kolkata 2.62
-      DateTime::TimeZone::Asia::Krasnoyarsk 2.62
-      DateTime::TimeZone::Asia::Kuching 2.62
-      DateTime::TimeZone::Asia::Macau 2.62
-      DateTime::TimeZone::Asia::Magadan 2.62
-      DateTime::TimeZone::Asia::Makassar 2.62
-      DateTime::TimeZone::Asia::Manila 2.62
-      DateTime::TimeZone::Asia::Nicosia 2.62
-      DateTime::TimeZone::Asia::Novokuznetsk 2.62
-      DateTime::TimeZone::Asia::Novosibirsk 2.62
-      DateTime::TimeZone::Asia::Omsk 2.62
-      DateTime::TimeZone::Asia::Oral 2.62
-      DateTime::TimeZone::Asia::Pontianak 2.62
-      DateTime::TimeZone::Asia::Pyongyang 2.62
-      DateTime::TimeZone::Asia::Qatar 2.62
-      DateTime::TimeZone::Asia::Qostanay 2.62
-      DateTime::TimeZone::Asia::Qyzylorda 2.62
-      DateTime::TimeZone::Asia::Riyadh 2.62
-      DateTime::TimeZone::Asia::Sakhalin 2.62
-      DateTime::TimeZone::Asia::Samarkand 2.62
-      DateTime::TimeZone::Asia::Seoul 2.62
-      DateTime::TimeZone::Asia::Shanghai 2.62
-      DateTime::TimeZone::Asia::Singapore 2.62
-      DateTime::TimeZone::Asia::Srednekolymsk 2.62
-      DateTime::TimeZone::Asia::Taipei 2.62
-      DateTime::TimeZone::Asia::Tashkent 2.62
-      DateTime::TimeZone::Asia::Tbilisi 2.62
-      DateTime::TimeZone::Asia::Tehran 2.62
-      DateTime::TimeZone::Asia::Thimphu 2.62
-      DateTime::TimeZone::Asia::Tokyo 2.62
-      DateTime::TimeZone::Asia::Tomsk 2.62
-      DateTime::TimeZone::Asia::Ulaanbaatar 2.62
-      DateTime::TimeZone::Asia::Urumqi 2.62
-      DateTime::TimeZone::Asia::Ust_Nera 2.62
-      DateTime::TimeZone::Asia::Vladivostok 2.62
-      DateTime::TimeZone::Asia::Yakutsk 2.62
-      DateTime::TimeZone::Asia::Yangon 2.62
-      DateTime::TimeZone::Asia::Yekaterinburg 2.62
-      DateTime::TimeZone::Asia::Yerevan 2.62
-      DateTime::TimeZone::Atlantic::Azores 2.62
-      DateTime::TimeZone::Atlantic::Bermuda 2.62
-      DateTime::TimeZone::Atlantic::Canary 2.62
-      DateTime::TimeZone::Atlantic::Cape_Verde 2.62
-      DateTime::TimeZone::Atlantic::Faroe 2.62
-      DateTime::TimeZone::Atlantic::Madeira 2.62
-      DateTime::TimeZone::Atlantic::South_Georgia 2.62
-      DateTime::TimeZone::Atlantic::Stanley 2.62
-      DateTime::TimeZone::Australia::Adelaide 2.62
-      DateTime::TimeZone::Australia::Brisbane 2.62
-      DateTime::TimeZone::Australia::Broken_Hill 2.62
-      DateTime::TimeZone::Australia::Darwin 2.62
-      DateTime::TimeZone::Australia::Eucla 2.62
-      DateTime::TimeZone::Australia::Hobart 2.62
-      DateTime::TimeZone::Australia::Lindeman 2.62
-      DateTime::TimeZone::Australia::Lord_Howe 2.62
-      DateTime::TimeZone::Australia::Melbourne 2.62
-      DateTime::TimeZone::Australia::Perth 2.62
-      DateTime::TimeZone::Australia::Sydney 2.62
-      DateTime::TimeZone::CET 2.62
-      DateTime::TimeZone::CST6CDT 2.62
-      DateTime::TimeZone::Catalog 2.62
-      DateTime::TimeZone::EET 2.62
-      DateTime::TimeZone::EST 2.62
-      DateTime::TimeZone::EST5EDT 2.62
-      DateTime::TimeZone::Europe::Andorra 2.62
-      DateTime::TimeZone::Europe::Astrakhan 2.62
-      DateTime::TimeZone::Europe::Athens 2.62
-      DateTime::TimeZone::Europe::Belgrade 2.62
-      DateTime::TimeZone::Europe::Berlin 2.62
-      DateTime::TimeZone::Europe::Brussels 2.62
-      DateTime::TimeZone::Europe::Bucharest 2.62
-      DateTime::TimeZone::Europe::Budapest 2.62
-      DateTime::TimeZone::Europe::Chisinau 2.62
-      DateTime::TimeZone::Europe::Dublin 2.62
-      DateTime::TimeZone::Europe::Gibraltar 2.62
-      DateTime::TimeZone::Europe::Helsinki 2.62
-      DateTime::TimeZone::Europe::Istanbul 2.62
-      DateTime::TimeZone::Europe::Kaliningrad 2.62
-      DateTime::TimeZone::Europe::Kirov 2.62
-      DateTime::TimeZone::Europe::Kyiv 2.62
-      DateTime::TimeZone::Europe::Lisbon 2.62
-      DateTime::TimeZone::Europe::London 2.62
-      DateTime::TimeZone::Europe::Madrid 2.62
-      DateTime::TimeZone::Europe::Malta 2.62
-      DateTime::TimeZone::Europe::Minsk 2.62
-      DateTime::TimeZone::Europe::Moscow 2.62
-      DateTime::TimeZone::Europe::Paris 2.62
-      DateTime::TimeZone::Europe::Prague 2.62
-      DateTime::TimeZone::Europe::Riga 2.62
-      DateTime::TimeZone::Europe::Rome 2.62
-      DateTime::TimeZone::Europe::Samara 2.62
-      DateTime::TimeZone::Europe::Saratov 2.62
-      DateTime::TimeZone::Europe::Simferopol 2.62
-      DateTime::TimeZone::Europe::Sofia 2.62
-      DateTime::TimeZone::Europe::Tallinn 2.62
-      DateTime::TimeZone::Europe::Tirane 2.62
-      DateTime::TimeZone::Europe::Ulyanovsk 2.62
-      DateTime::TimeZone::Europe::Vienna 2.62
-      DateTime::TimeZone::Europe::Vilnius 2.62
-      DateTime::TimeZone::Europe::Volgograd 2.62
-      DateTime::TimeZone::Europe::Warsaw 2.62
-      DateTime::TimeZone::Europe::Zurich 2.62
-      DateTime::TimeZone::Floating 2.62
-      DateTime::TimeZone::HST 2.62
-      DateTime::TimeZone::Indian::Chagos 2.62
-      DateTime::TimeZone::Indian::Maldives 2.62
-      DateTime::TimeZone::Indian::Mauritius 2.62
-      DateTime::TimeZone::Local 2.62
-      DateTime::TimeZone::Local::Android 2.62
-      DateTime::TimeZone::Local::Unix 2.62
-      DateTime::TimeZone::Local::VMS 2.62
-      DateTime::TimeZone::MET 2.62
-      DateTime::TimeZone::MST 2.62
-      DateTime::TimeZone::MST7MDT 2.62
-      DateTime::TimeZone::OffsetOnly 2.62
-      DateTime::TimeZone::OlsonDB 2.62
-      DateTime::TimeZone::OlsonDB::Change 2.62
-      DateTime::TimeZone::OlsonDB::Observance 2.62
-      DateTime::TimeZone::OlsonDB::Rule 2.62
-      DateTime::TimeZone::OlsonDB::Zone 2.62
-      DateTime::TimeZone::PST8PDT 2.62
-      DateTime::TimeZone::Pacific::Apia 2.62
-      DateTime::TimeZone::Pacific::Auckland 2.62
-      DateTime::TimeZone::Pacific::Bougainville 2.62
-      DateTime::TimeZone::Pacific::Chatham 2.62
-      DateTime::TimeZone::Pacific::Easter 2.62
-      DateTime::TimeZone::Pacific::Efate 2.62
-      DateTime::TimeZone::Pacific::Fakaofo 2.62
-      DateTime::TimeZone::Pacific::Fiji 2.62
-      DateTime::TimeZone::Pacific::Galapagos 2.62
-      DateTime::TimeZone::Pacific::Gambier 2.62
-      DateTime::TimeZone::Pacific::Guadalcanal 2.62
-      DateTime::TimeZone::Pacific::Guam 2.62
-      DateTime::TimeZone::Pacific::Honolulu 2.62
-      DateTime::TimeZone::Pacific::Kanton 2.62
-      DateTime::TimeZone::Pacific::Kiritimati 2.62
-      DateTime::TimeZone::Pacific::Kosrae 2.62
-      DateTime::TimeZone::Pacific::Kwajalein 2.62
-      DateTime::TimeZone::Pacific::Marquesas 2.62
-      DateTime::TimeZone::Pacific::Nauru 2.62
-      DateTime::TimeZone::Pacific::Niue 2.62
-      DateTime::TimeZone::Pacific::Norfolk 2.62
-      DateTime::TimeZone::Pacific::Noumea 2.62
-      DateTime::TimeZone::Pacific::Pago_Pago 2.62
-      DateTime::TimeZone::Pacific::Palau 2.62
-      DateTime::TimeZone::Pacific::Pitcairn 2.62
-      DateTime::TimeZone::Pacific::Port_Moresby 2.62
-      DateTime::TimeZone::Pacific::Rarotonga 2.62
-      DateTime::TimeZone::Pacific::Tahiti 2.62
-      DateTime::TimeZone::Pacific::Tarawa 2.62
-      DateTime::TimeZone::Pacific::Tongatapu 2.62
-      DateTime::TimeZone::UTC 2.62
-      DateTime::TimeZone::WET 2.62
+      DateTime::TimeZone 2.65
+      DateTime::TimeZone::Africa::Abidjan 2.65
+      DateTime::TimeZone::Africa::Algiers 2.65
+      DateTime::TimeZone::Africa::Bissau 2.65
+      DateTime::TimeZone::Africa::Cairo 2.65
+      DateTime::TimeZone::Africa::Casablanca 2.65
+      DateTime::TimeZone::Africa::Ceuta 2.65
+      DateTime::TimeZone::Africa::El_Aaiun 2.65
+      DateTime::TimeZone::Africa::Johannesburg 2.65
+      DateTime::TimeZone::Africa::Juba 2.65
+      DateTime::TimeZone::Africa::Khartoum 2.65
+      DateTime::TimeZone::Africa::Lagos 2.65
+      DateTime::TimeZone::Africa::Maputo 2.65
+      DateTime::TimeZone::Africa::Monrovia 2.65
+      DateTime::TimeZone::Africa::Nairobi 2.65
+      DateTime::TimeZone::Africa::Ndjamena 2.65
+      DateTime::TimeZone::Africa::Sao_Tome 2.65
+      DateTime::TimeZone::Africa::Tripoli 2.65
+      DateTime::TimeZone::Africa::Tunis 2.65
+      DateTime::TimeZone::Africa::Windhoek 2.65
+      DateTime::TimeZone::America::Adak 2.65
+      DateTime::TimeZone::America::Anchorage 2.65
+      DateTime::TimeZone::America::Araguaina 2.65
+      DateTime::TimeZone::America::Argentina::Buenos_Aires 2.65
+      DateTime::TimeZone::America::Argentina::Catamarca 2.65
+      DateTime::TimeZone::America::Argentina::Cordoba 2.65
+      DateTime::TimeZone::America::Argentina::Jujuy 2.65
+      DateTime::TimeZone::America::Argentina::La_Rioja 2.65
+      DateTime::TimeZone::America::Argentina::Mendoza 2.65
+      DateTime::TimeZone::America::Argentina::Rio_Gallegos 2.65
+      DateTime::TimeZone::America::Argentina::Salta 2.65
+      DateTime::TimeZone::America::Argentina::San_Juan 2.65
+      DateTime::TimeZone::America::Argentina::San_Luis 2.65
+      DateTime::TimeZone::America::Argentina::Tucuman 2.65
+      DateTime::TimeZone::America::Argentina::Ushuaia 2.65
+      DateTime::TimeZone::America::Asuncion 2.65
+      DateTime::TimeZone::America::Bahia 2.65
+      DateTime::TimeZone::America::Bahia_Banderas 2.65
+      DateTime::TimeZone::America::Barbados 2.65
+      DateTime::TimeZone::America::Belem 2.65
+      DateTime::TimeZone::America::Belize 2.65
+      DateTime::TimeZone::America::Boa_Vista 2.65
+      DateTime::TimeZone::America::Bogota 2.65
+      DateTime::TimeZone::America::Boise 2.65
+      DateTime::TimeZone::America::Cambridge_Bay 2.65
+      DateTime::TimeZone::America::Campo_Grande 2.65
+      DateTime::TimeZone::America::Cancun 2.65
+      DateTime::TimeZone::America::Caracas 2.65
+      DateTime::TimeZone::America::Cayenne 2.65
+      DateTime::TimeZone::America::Chicago 2.65
+      DateTime::TimeZone::America::Chihuahua 2.65
+      DateTime::TimeZone::America::Ciudad_Juarez 2.65
+      DateTime::TimeZone::America::Costa_Rica 2.65
+      DateTime::TimeZone::America::Coyhaique 2.65
+      DateTime::TimeZone::America::Cuiaba 2.65
+      DateTime::TimeZone::America::Danmarkshavn 2.65
+      DateTime::TimeZone::America::Dawson 2.65
+      DateTime::TimeZone::America::Dawson_Creek 2.65
+      DateTime::TimeZone::America::Denver 2.65
+      DateTime::TimeZone::America::Detroit 2.65
+      DateTime::TimeZone::America::Edmonton 2.65
+      DateTime::TimeZone::America::Eirunepe 2.65
+      DateTime::TimeZone::America::El_Salvador 2.65
+      DateTime::TimeZone::America::Fort_Nelson 2.65
+      DateTime::TimeZone::America::Fortaleza 2.65
+      DateTime::TimeZone::America::Glace_Bay 2.65
+      DateTime::TimeZone::America::Goose_Bay 2.65
+      DateTime::TimeZone::America::Grand_Turk 2.65
+      DateTime::TimeZone::America::Guatemala 2.65
+      DateTime::TimeZone::America::Guayaquil 2.65
+      DateTime::TimeZone::America::Guyana 2.65
+      DateTime::TimeZone::America::Halifax 2.65
+      DateTime::TimeZone::America::Havana 2.65
+      DateTime::TimeZone::America::Hermosillo 2.65
+      DateTime::TimeZone::America::Indiana::Indianapolis 2.65
+      DateTime::TimeZone::America::Indiana::Knox 2.65
+      DateTime::TimeZone::America::Indiana::Marengo 2.65
+      DateTime::TimeZone::America::Indiana::Petersburg 2.65
+      DateTime::TimeZone::America::Indiana::Tell_City 2.65
+      DateTime::TimeZone::America::Indiana::Vevay 2.65
+      DateTime::TimeZone::America::Indiana::Vincennes 2.65
+      DateTime::TimeZone::America::Indiana::Winamac 2.65
+      DateTime::TimeZone::America::Inuvik 2.65
+      DateTime::TimeZone::America::Iqaluit 2.65
+      DateTime::TimeZone::America::Jamaica 2.65
+      DateTime::TimeZone::America::Juneau 2.65
+      DateTime::TimeZone::America::Kentucky::Louisville 2.65
+      DateTime::TimeZone::America::Kentucky::Monticello 2.65
+      DateTime::TimeZone::America::La_Paz 2.65
+      DateTime::TimeZone::America::Lima 2.65
+      DateTime::TimeZone::America::Los_Angeles 2.65
+      DateTime::TimeZone::America::Maceio 2.65
+      DateTime::TimeZone::America::Managua 2.65
+      DateTime::TimeZone::America::Manaus 2.65
+      DateTime::TimeZone::America::Martinique 2.65
+      DateTime::TimeZone::America::Matamoros 2.65
+      DateTime::TimeZone::America::Mazatlan 2.65
+      DateTime::TimeZone::America::Menominee 2.65
+      DateTime::TimeZone::America::Merida 2.65
+      DateTime::TimeZone::America::Metlakatla 2.65
+      DateTime::TimeZone::America::Mexico_City 2.65
+      DateTime::TimeZone::America::Miquelon 2.65
+      DateTime::TimeZone::America::Moncton 2.65
+      DateTime::TimeZone::America::Monterrey 2.65
+      DateTime::TimeZone::America::Montevideo 2.65
+      DateTime::TimeZone::America::New_York 2.65
+      DateTime::TimeZone::America::Nome 2.65
+      DateTime::TimeZone::America::Noronha 2.65
+      DateTime::TimeZone::America::North_Dakota::Beulah 2.65
+      DateTime::TimeZone::America::North_Dakota::Center 2.65
+      DateTime::TimeZone::America::North_Dakota::New_Salem 2.65
+      DateTime::TimeZone::America::Nuuk 2.65
+      DateTime::TimeZone::America::Ojinaga 2.65
+      DateTime::TimeZone::America::Panama 2.65
+      DateTime::TimeZone::America::Paramaribo 2.65
+      DateTime::TimeZone::America::Phoenix 2.65
+      DateTime::TimeZone::America::Port_au_Prince 2.65
+      DateTime::TimeZone::America::Porto_Velho 2.65
+      DateTime::TimeZone::America::Puerto_Rico 2.65
+      DateTime::TimeZone::America::Punta_Arenas 2.65
+      DateTime::TimeZone::America::Rankin_Inlet 2.65
+      DateTime::TimeZone::America::Recife 2.65
+      DateTime::TimeZone::America::Regina 2.65
+      DateTime::TimeZone::America::Resolute 2.65
+      DateTime::TimeZone::America::Rio_Branco 2.65
+      DateTime::TimeZone::America::Santarem 2.65
+      DateTime::TimeZone::America::Santiago 2.65
+      DateTime::TimeZone::America::Santo_Domingo 2.65
+      DateTime::TimeZone::America::Sao_Paulo 2.65
+      DateTime::TimeZone::America::Scoresbysund 2.65
+      DateTime::TimeZone::America::Sitka 2.65
+      DateTime::TimeZone::America::St_Johns 2.65
+      DateTime::TimeZone::America::Swift_Current 2.65
+      DateTime::TimeZone::America::Tegucigalpa 2.65
+      DateTime::TimeZone::America::Thule 2.65
+      DateTime::TimeZone::America::Tijuana 2.65
+      DateTime::TimeZone::America::Toronto 2.65
+      DateTime::TimeZone::America::Vancouver 2.65
+      DateTime::TimeZone::America::Whitehorse 2.65
+      DateTime::TimeZone::America::Winnipeg 2.65
+      DateTime::TimeZone::America::Yakutat 2.65
+      DateTime::TimeZone::Antarctica::Casey 2.65
+      DateTime::TimeZone::Antarctica::Davis 2.65
+      DateTime::TimeZone::Antarctica::Macquarie 2.65
+      DateTime::TimeZone::Antarctica::Mawson 2.65
+      DateTime::TimeZone::Antarctica::Palmer 2.65
+      DateTime::TimeZone::Antarctica::Rothera 2.65
+      DateTime::TimeZone::Antarctica::Troll 2.65
+      DateTime::TimeZone::Antarctica::Vostok 2.65
+      DateTime::TimeZone::Asia::Almaty 2.65
+      DateTime::TimeZone::Asia::Amman 2.65
+      DateTime::TimeZone::Asia::Anadyr 2.65
+      DateTime::TimeZone::Asia::Aqtau 2.65
+      DateTime::TimeZone::Asia::Aqtobe 2.65
+      DateTime::TimeZone::Asia::Ashgabat 2.65
+      DateTime::TimeZone::Asia::Atyrau 2.65
+      DateTime::TimeZone::Asia::Baghdad 2.65
+      DateTime::TimeZone::Asia::Baku 2.65
+      DateTime::TimeZone::Asia::Bangkok 2.65
+      DateTime::TimeZone::Asia::Barnaul 2.65
+      DateTime::TimeZone::Asia::Beirut 2.65
+      DateTime::TimeZone::Asia::Bishkek 2.65
+      DateTime::TimeZone::Asia::Chita 2.65
+      DateTime::TimeZone::Asia::Colombo 2.65
+      DateTime::TimeZone::Asia::Damascus 2.65
+      DateTime::TimeZone::Asia::Dhaka 2.65
+      DateTime::TimeZone::Asia::Dili 2.65
+      DateTime::TimeZone::Asia::Dubai 2.65
+      DateTime::TimeZone::Asia::Dushanbe 2.65
+      DateTime::TimeZone::Asia::Famagusta 2.65
+      DateTime::TimeZone::Asia::Gaza 2.65
+      DateTime::TimeZone::Asia::Hebron 2.65
+      DateTime::TimeZone::Asia::Ho_Chi_Minh 2.65
+      DateTime::TimeZone::Asia::Hong_Kong 2.65
+      DateTime::TimeZone::Asia::Hovd 2.65
+      DateTime::TimeZone::Asia::Irkutsk 2.65
+      DateTime::TimeZone::Asia::Jakarta 2.65
+      DateTime::TimeZone::Asia::Jayapura 2.65
+      DateTime::TimeZone::Asia::Jerusalem 2.65
+      DateTime::TimeZone::Asia::Kabul 2.65
+      DateTime::TimeZone::Asia::Kamchatka 2.65
+      DateTime::TimeZone::Asia::Karachi 2.65
+      DateTime::TimeZone::Asia::Kathmandu 2.65
+      DateTime::TimeZone::Asia::Khandyga 2.65
+      DateTime::TimeZone::Asia::Kolkata 2.65
+      DateTime::TimeZone::Asia::Krasnoyarsk 2.65
+      DateTime::TimeZone::Asia::Kuching 2.65
+      DateTime::TimeZone::Asia::Macau 2.65
+      DateTime::TimeZone::Asia::Magadan 2.65
+      DateTime::TimeZone::Asia::Makassar 2.65
+      DateTime::TimeZone::Asia::Manila 2.65
+      DateTime::TimeZone::Asia::Nicosia 2.65
+      DateTime::TimeZone::Asia::Novokuznetsk 2.65
+      DateTime::TimeZone::Asia::Novosibirsk 2.65
+      DateTime::TimeZone::Asia::Omsk 2.65
+      DateTime::TimeZone::Asia::Oral 2.65
+      DateTime::TimeZone::Asia::Pontianak 2.65
+      DateTime::TimeZone::Asia::Pyongyang 2.65
+      DateTime::TimeZone::Asia::Qatar 2.65
+      DateTime::TimeZone::Asia::Qostanay 2.65
+      DateTime::TimeZone::Asia::Qyzylorda 2.65
+      DateTime::TimeZone::Asia::Riyadh 2.65
+      DateTime::TimeZone::Asia::Sakhalin 2.65
+      DateTime::TimeZone::Asia::Samarkand 2.65
+      DateTime::TimeZone::Asia::Seoul 2.65
+      DateTime::TimeZone::Asia::Shanghai 2.65
+      DateTime::TimeZone::Asia::Singapore 2.65
+      DateTime::TimeZone::Asia::Srednekolymsk 2.65
+      DateTime::TimeZone::Asia::Taipei 2.65
+      DateTime::TimeZone::Asia::Tashkent 2.65
+      DateTime::TimeZone::Asia::Tbilisi 2.65
+      DateTime::TimeZone::Asia::Tehran 2.65
+      DateTime::TimeZone::Asia::Thimphu 2.65
+      DateTime::TimeZone::Asia::Tokyo 2.65
+      DateTime::TimeZone::Asia::Tomsk 2.65
+      DateTime::TimeZone::Asia::Ulaanbaatar 2.65
+      DateTime::TimeZone::Asia::Urumqi 2.65
+      DateTime::TimeZone::Asia::Ust_Nera 2.65
+      DateTime::TimeZone::Asia::Vladivostok 2.65
+      DateTime::TimeZone::Asia::Yakutsk 2.65
+      DateTime::TimeZone::Asia::Yangon 2.65
+      DateTime::TimeZone::Asia::Yekaterinburg 2.65
+      DateTime::TimeZone::Asia::Yerevan 2.65
+      DateTime::TimeZone::Atlantic::Azores 2.65
+      DateTime::TimeZone::Atlantic::Bermuda 2.65
+      DateTime::TimeZone::Atlantic::Canary 2.65
+      DateTime::TimeZone::Atlantic::Cape_Verde 2.65
+      DateTime::TimeZone::Atlantic::Faroe 2.65
+      DateTime::TimeZone::Atlantic::Madeira 2.65
+      DateTime::TimeZone::Atlantic::South_Georgia 2.65
+      DateTime::TimeZone::Atlantic::Stanley 2.65
+      DateTime::TimeZone::Australia::Adelaide 2.65
+      DateTime::TimeZone::Australia::Brisbane 2.65
+      DateTime::TimeZone::Australia::Broken_Hill 2.65
+      DateTime::TimeZone::Australia::Darwin 2.65
+      DateTime::TimeZone::Australia::Eucla 2.65
+      DateTime::TimeZone::Australia::Hobart 2.65
+      DateTime::TimeZone::Australia::Lindeman 2.65
+      DateTime::TimeZone::Australia::Lord_Howe 2.65
+      DateTime::TimeZone::Australia::Melbourne 2.65
+      DateTime::TimeZone::Australia::Perth 2.65
+      DateTime::TimeZone::Australia::Sydney 2.65
+      DateTime::TimeZone::Catalog 2.65
+      DateTime::TimeZone::Europe::Andorra 2.65
+      DateTime::TimeZone::Europe::Astrakhan 2.65
+      DateTime::TimeZone::Europe::Athens 2.65
+      DateTime::TimeZone::Europe::Belgrade 2.65
+      DateTime::TimeZone::Europe::Berlin 2.65
+      DateTime::TimeZone::Europe::Brussels 2.65
+      DateTime::TimeZone::Europe::Bucharest 2.65
+      DateTime::TimeZone::Europe::Budapest 2.65
+      DateTime::TimeZone::Europe::Chisinau 2.65
+      DateTime::TimeZone::Europe::Dublin 2.65
+      DateTime::TimeZone::Europe::Gibraltar 2.65
+      DateTime::TimeZone::Europe::Helsinki 2.65
+      DateTime::TimeZone::Europe::Istanbul 2.65
+      DateTime::TimeZone::Europe::Kaliningrad 2.65
+      DateTime::TimeZone::Europe::Kirov 2.65
+      DateTime::TimeZone::Europe::Kyiv 2.65
+      DateTime::TimeZone::Europe::Lisbon 2.65
+      DateTime::TimeZone::Europe::London 2.65
+      DateTime::TimeZone::Europe::Madrid 2.65
+      DateTime::TimeZone::Europe::Malta 2.65
+      DateTime::TimeZone::Europe::Minsk 2.65
+      DateTime::TimeZone::Europe::Moscow 2.65
+      DateTime::TimeZone::Europe::Paris 2.65
+      DateTime::TimeZone::Europe::Prague 2.65
+      DateTime::TimeZone::Europe::Riga 2.65
+      DateTime::TimeZone::Europe::Rome 2.65
+      DateTime::TimeZone::Europe::Samara 2.65
+      DateTime::TimeZone::Europe::Saratov 2.65
+      DateTime::TimeZone::Europe::Simferopol 2.65
+      DateTime::TimeZone::Europe::Sofia 2.65
+      DateTime::TimeZone::Europe::Tallinn 2.65
+      DateTime::TimeZone::Europe::Tirane 2.65
+      DateTime::TimeZone::Europe::Ulyanovsk 2.65
+      DateTime::TimeZone::Europe::Vienna 2.65
+      DateTime::TimeZone::Europe::Vilnius 2.65
+      DateTime::TimeZone::Europe::Volgograd 2.65
+      DateTime::TimeZone::Europe::Warsaw 2.65
+      DateTime::TimeZone::Europe::Zurich 2.65
+      DateTime::TimeZone::Floating 2.65
+      DateTime::TimeZone::Indian::Chagos 2.65
+      DateTime::TimeZone::Indian::Maldives 2.65
+      DateTime::TimeZone::Indian::Mauritius 2.65
+      DateTime::TimeZone::Local 2.65
+      DateTime::TimeZone::Local::Android 2.65
+      DateTime::TimeZone::Local::Unix 2.65
+      DateTime::TimeZone::Local::VMS 2.65
+      DateTime::TimeZone::OffsetOnly 2.65
+      DateTime::TimeZone::OlsonDB 2.65
+      DateTime::TimeZone::OlsonDB::Change 2.65
+      DateTime::TimeZone::OlsonDB::Observance 2.65
+      DateTime::TimeZone::OlsonDB::Rule 2.65
+      DateTime::TimeZone::OlsonDB::Zone 2.65
+      DateTime::TimeZone::Pacific::Apia 2.65
+      DateTime::TimeZone::Pacific::Auckland 2.65
+      DateTime::TimeZone::Pacific::Bougainville 2.65
+      DateTime::TimeZone::Pacific::Chatham 2.65
+      DateTime::TimeZone::Pacific::Easter 2.65
+      DateTime::TimeZone::Pacific::Efate 2.65
+      DateTime::TimeZone::Pacific::Fakaofo 2.65
+      DateTime::TimeZone::Pacific::Fiji 2.65
+      DateTime::TimeZone::Pacific::Galapagos 2.65
+      DateTime::TimeZone::Pacific::Gambier 2.65
+      DateTime::TimeZone::Pacific::Guadalcanal 2.65
+      DateTime::TimeZone::Pacific::Guam 2.65
+      DateTime::TimeZone::Pacific::Honolulu 2.65
+      DateTime::TimeZone::Pacific::Kanton 2.65
+      DateTime::TimeZone::Pacific::Kiritimati 2.65
+      DateTime::TimeZone::Pacific::Kosrae 2.65
+      DateTime::TimeZone::Pacific::Kwajalein 2.65
+      DateTime::TimeZone::Pacific::Marquesas 2.65
+      DateTime::TimeZone::Pacific::Nauru 2.65
+      DateTime::TimeZone::Pacific::Niue 2.65
+      DateTime::TimeZone::Pacific::Norfolk 2.65
+      DateTime::TimeZone::Pacific::Noumea 2.65
+      DateTime::TimeZone::Pacific::Pago_Pago 2.65
+      DateTime::TimeZone::Pacific::Palau 2.65
+      DateTime::TimeZone::Pacific::Pitcairn 2.65
+      DateTime::TimeZone::Pacific::Port_Moresby 2.65
+      DateTime::TimeZone::Pacific::Rarotonga 2.65
+      DateTime::TimeZone::Pacific::Tahiti 2.65
+      DateTime::TimeZone::Pacific::Tarawa 2.65
+      DateTime::TimeZone::Pacific::Tongatapu 2.65
+      DateTime::TimeZone::UTC 2.65
     requirements:
       Class::Singleton 1.03
       Cwd 3
@@ -2460,31 +2492,23 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Test::More 0
       perl 5.004
-  Digest-HMAC-1.04
-    pathname: A/AR/ARODLAND/Digest-HMAC-1.04.tar.gz
+  Digest-HMAC-1.05
+    pathname: A/AR/ARODLAND/Digest-HMAC-1.05.tar.gz
     provides:
-      Digest::HMAC 1.04
-      Digest::HMAC_MD5 1.04
-      Digest::HMAC_SHA1 1.04
+      Digest::HMAC 1.05
+      Digest::HMAC_MD5 1.05
+      Digest::HMAC_SHA1 1.05
     requirements:
       Digest::MD5 2
       Digest::SHA 1
       ExtUtils::MakeMaker 0
-      perl 5.004
+      perl 5.008001
   Digest-MD2-2.04
     pathname: G/GA/GAAS/Digest-MD2-2.04.tar.gz
     provides:
       Digest::MD2 2.04
     requirements:
       ExtUtils::MakeMaker 0
-  Digest-SHA1-2.13
-    pathname: G/GA/GAAS/Digest-SHA1-2.13.tar.gz
-    provides:
-      Digest::SHA1 2.13
-    requirements:
-      Digest::base 1.00
-      ExtUtils::MakeMaker 0
-      perl 5.004
   Digest-SHA3-1.05
     pathname: M/MS/MSHELOR/Digest-SHA3-1.05.tar.gz
     provides:
@@ -2492,36 +2516,44 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       perl 5.003
-  Dist-Build-0.011
-    pathname: L/LE/LEONT/Dist-Build-0.011.tar.gz
+  Dist-Build-0.018
+    pathname: L/LE/LEONT/Dist-Build-0.018.tar.gz
     provides:
-      Dist::Build 0.011
-      Dist::Build::Core 0.011
-      Dist::Build::Serializer 0.011
-      Dist::Build::ShareDir 0.011
-      Dist::Build::XS 0.011
-      Dist::Build::XS::Conf 0.011
+      Dist::Build 0.018
+      Dist::Build::Core 0.018
+      Dist::Build::DynamicPrereqs 0.018
+      Dist::Build::Serializer 0.018
+      Dist::Build::ShareDir 0.018
+      Dist::Build::XS 0.018
+      Dist::Build::XS::Alien 0.018
+      Dist::Build::XS::Conf 0.018
+      Dist::Build::XS::Export 0.018
+      Dist::Build::XS::Import 0.018
+      Dist::Build::XS::WriteConstants 0.018
     requirements:
       CPAN::Meta 0
+      CPAN::Meta::Merge 0
       CPAN::Requirements::Dynamic 0
       Carp 0
       Exporter 5.57
       ExtUtils::Builder::Action::Function 0
-      ExtUtils::Builder::AutoDetect::C 0.016
-      ExtUtils::Builder::Conf 0.016
+      ExtUtils::Builder::Compiler 0.025
       ExtUtils::Builder::Node 0
       ExtUtils::Builder::ParseXS 0
-      ExtUtils::Builder::Planner 0.008
+      ExtUtils::Builder::Planner 0.015
       ExtUtils::Builder::Planner::Extension 0
       ExtUtils::Builder::Serializer 0
+      ExtUtils::Builder::Util 0
       ExtUtils::Config 0
-      ExtUtils::Helpers 0.007
+      ExtUtils::Helpers 0.028
       ExtUtils::Install 0
       ExtUtils::InstallPaths 0
+      ExtUtils::Manifest 0
       File::Basename 0
       File::Copy 0
       File::Find 0
       File::Path 0
+      File::ShareDir::Tiny 0
       File::Spec::Functions 0
       Getopt::Long 2.36
       List::Util 1.33
@@ -2852,24 +2884,28 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 6.17
       perl 5.006001
-  ExtUtils-Builder-0.011
-    pathname: L/LE/LEONT/ExtUtils-Builder-0.011.tar.gz
+  ExtUtils-Builder-0.015
+    pathname: L/LE/LEONT/ExtUtils-Builder-0.015.tar.gz
     provides:
-      ExtUtils::Builder 0.011
-      ExtUtils::Builder::Action 0.011
-      ExtUtils::Builder::Action::Code 0.011
-      ExtUtils::Builder::Action::Command 0.011
-      ExtUtils::Builder::Action::Composite 0.011
-      ExtUtils::Builder::Action::Function 0.011
-      ExtUtils::Builder::Action::Perl 0.011
-      ExtUtils::Builder::Action::Primitive 0.011
-      ExtUtils::Builder::MakeMaker 0.011
-      ExtUtils::Builder::Node 0.011
-      ExtUtils::Builder::Plan 0.011
-      ExtUtils::Builder::Planner 0.011
-      ExtUtils::Builder::Planner::Extension 0.011
-      ExtUtils::Builder::Serializer 0.011
-      ExtUtils::Builder::Util 0.011
+      ExtUtils::Builder 0.015
+      ExtUtils::Builder::Action 0.015
+      ExtUtils::Builder::Action::Code 0.015
+      ExtUtils::Builder::Action::Command 0.015
+      ExtUtils::Builder::Action::Composite 0.015
+      ExtUtils::Builder::Action::Function 0.015
+      ExtUtils::Builder::Action::Perl 0.015
+      ExtUtils::Builder::Action::Primitive 0.015
+      ExtUtils::Builder::FileSet 0.015
+      ExtUtils::Builder::FileSet::Filter 0.015
+      ExtUtils::Builder::FileSet::Free 0.015
+      ExtUtils::Builder::FileSet::Subst 0.015
+      ExtUtils::Builder::MakeMaker 0.015
+      ExtUtils::Builder::Node 0.015
+      ExtUtils::Builder::Plan 0.015
+      ExtUtils::Builder::Planner 0.015
+      ExtUtils::Builder::Planner::Extension 0.015
+      ExtUtils::Builder::Serializer 0.015
+      ExtUtils::Builder::Util 0.015
     requirements:
       Carp 0
       Data::Dumper 0
@@ -2877,47 +2913,51 @@ DISTRIBUTIONS
       ExtUtils::Config 0
       ExtUtils::Config::MakeMaker 0
       ExtUtils::MakeMaker 6.68
+      ExtUtils::Manifest 0
+      File::Basename 0
       File::Spec 0
-      File::Spec::Functions 0
+      File::Spec::Unix 0
       List::Util 1.45
       Scalar::Util 0
+      base 0
       parent 0
-      perl 5.006
+      perl 5.010
       strict 0
       warnings 0
-  ExtUtils-Builder-Compiler-0.020
-    pathname: L/LE/LEONT/ExtUtils-Builder-Compiler-0.020.tar.gz
+  ExtUtils-Builder-Compiler-0.025
+    pathname: L/LE/LEONT/ExtUtils-Builder-Compiler-0.025.tar.gz
     provides:
-      ExtUtils::Builder::ArgumentCollector 0.020
-      ExtUtils::Builder::AutoDetect::C 0.020
-      ExtUtils::Builder::AutoDetect::Cpp 0.020
-      ExtUtils::Builder::Binary 0.020
-      ExtUtils::Builder::Compiler 0.020
-      ExtUtils::Builder::Compiler::MSVC 0.020
-      ExtUtils::Builder::Compiler::Unixy 0.020
-      ExtUtils::Builder::Compiler::VMS 0.020
-      ExtUtils::Builder::Conf 0.020
-      ExtUtils::Builder::Linker 0.020
-      ExtUtils::Builder::Linker::Ar 0.020
-      ExtUtils::Builder::Linker::COFF 0.020
-      ExtUtils::Builder::Linker::ELF::Any 0.020
-      ExtUtils::Builder::Linker::ELF::GCC 0.020
-      ExtUtils::Builder::Linker::Mach::GCC 0.020
-      ExtUtils::Builder::Linker::PE::GCC 0.020
-      ExtUtils::Builder::Linker::PE::MSVC 0.020
-      ExtUtils::Builder::Linker::Unixy 0.020
-      ExtUtils::Builder::Linker::XCOFF 0.020
-      ExtUtils::Builder::MultiLingual 0.020
-      ExtUtils::Builder::ParseXS 0.020
-      ExtUtils::Builder::Profile::Perl 0.020
+      ExtUtils::Builder::ArgumentCollector 0.025
+      ExtUtils::Builder::AutoDetect::C 0.025
+      ExtUtils::Builder::AutoDetect::Cpp 0.025
+      ExtUtils::Builder::Binary 0.025
+      ExtUtils::Builder::Compiler 0.025
+      ExtUtils::Builder::Compiler::MSVC 0.025
+      ExtUtils::Builder::Compiler::Unixy 0.025
+      ExtUtils::Builder::Compiler::VMS 0.025
+      ExtUtils::Builder::Conf 0.025
+      ExtUtils::Builder::Linker 0.025
+      ExtUtils::Builder::Linker::Ar 0.025
+      ExtUtils::Builder::Linker::COFF 0.025
+      ExtUtils::Builder::Linker::ELF::Any 0.025
+      ExtUtils::Builder::Linker::ELF::GCC 0.025
+      ExtUtils::Builder::Linker::Mach::GCC 0.025
+      ExtUtils::Builder::Linker::PE::GCC 0.025
+      ExtUtils::Builder::Linker::PE::MSVC 0.025
+      ExtUtils::Builder::Linker::Unixy 0.025
+      ExtUtils::Builder::Linker::XCOFF 0.025
+      ExtUtils::Builder::MultiLingual 0.025
+      ExtUtils::Builder::ParseXS 0.025
+      ExtUtils::Builder::Profile::Perl 0.025
     requirements:
       Carp 0
       DynaLoader 0
+      ExtUtils::Builder 0.013
       ExtUtils::Builder::Action::Command 0
-      ExtUtils::Builder::Action::Function 0
       ExtUtils::Builder::Node 0
-      ExtUtils::Builder::Planner 0.009
+      ExtUtils::Builder::Planner 0.007
       ExtUtils::Builder::Planner::Extension 0
+      ExtUtils::Builder::Util 0
       ExtUtils::Config 0.007
       ExtUtils::Helpers 0.027
       ExtUtils::MakeMaker 0
@@ -2926,7 +2966,7 @@ DISTRIBUTIONS
       File::Temp 0
       Perl::OSType 0
       parent 0
-      perl 5.006
+      perl 5.010
       sort 0
       strict 0
       warnings 0
@@ -2950,10 +2990,10 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
-  ExtUtils-Depends-0.8001
-    pathname: X/XA/XAOC/ExtUtils-Depends-0.8001.tar.gz
+  ExtUtils-Depends-0.8002
+    pathname: E/ET/ETJ/ExtUtils-Depends-0.8002.tar.gz
     provides:
-      ExtUtils::Depends 0.8001
+      ExtUtils::Depends 0.8002
     requirements:
       Data::Dumper 0
       ExtUtils::MakeMaker 7.44
@@ -2977,13 +3017,13 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
-  ExtUtils-Helpers-0.027
-    pathname: L/LE/LEONT/ExtUtils-Helpers-0.027.tar.gz
+  ExtUtils-Helpers-0.028
+    pathname: L/LE/LEONT/ExtUtils-Helpers-0.028.tar.gz
     provides:
-      ExtUtils::Helpers 0.027
-      ExtUtils::Helpers::Unix 0.027
-      ExtUtils::Helpers::VMS 0.027
-      ExtUtils::Helpers::Windows 0.027
+      ExtUtils::Helpers 0.028
+      ExtUtils::Helpers::Unix 0.028
+      ExtUtils::Helpers::VMS 0.028
+      ExtUtils::Helpers::Windows 0.028
     requirements:
       Carp 0
       Exporter 5.57
@@ -2994,16 +3034,16 @@ DISTRIBUTIONS
       Text::ParseWords 3.24
       strict 0
       warnings 0
-  ExtUtils-InstallPaths-0.013
-    pathname: L/LE/LEONT/ExtUtils-InstallPaths-0.013.tar.gz
+  ExtUtils-InstallPaths-0.014
+    pathname: L/LE/LEONT/ExtUtils-InstallPaths-0.014.tar.gz
     provides:
-      ExtUtils::InstallPaths 0.013
+      ExtUtils::InstallPaths 0.014
     requirements:
       Carp 0
-      ExtUtils::Config 0.002
+      ExtUtils::Config 0.009
       ExtUtils::MakeMaker 0
       File::Spec 0
-      perl 5.006
+      perl 5.008
       strict 0
       warnings 0
   ExtUtils-PkgConfig-1.16
@@ -3021,58 +3061,58 @@ DISTRIBUTIONS
       File::Which 0
       List::Util 1.33
       perl 5.006
-  FFI-Platypus-2.09
-    pathname: P/PL/PLICEASE/FFI-Platypus-2.09.tar.gz
+  FFI-Platypus-2.10
+    pathname: P/PL/PLICEASE/FFI-Platypus-2.10.tar.gz
     provides:
-      FFI::Build 2.09
-      FFI::Build::File::Base 2.09
-      FFI::Build::File::C 2.09
-      FFI::Build::File::CXX 2.09
-      FFI::Build::File::Library 2.09
-      FFI::Build::File::Object 2.09
-      FFI::Build::MM 2.09
-      FFI::Build::MM::FBX 2.09
-      FFI::Build::Platform 2.09
-      FFI::Build::Plugin 2.09
+      FFI::Build 2.10
+      FFI::Build::File::Base 2.10
+      FFI::Build::File::C 2.10
+      FFI::Build::File::CXX 2.10
+      FFI::Build::File::Library 2.10
+      FFI::Build::File::Object 2.10
+      FFI::Build::MM 2.10
+      FFI::Build::MM::FBX 2.10
+      FFI::Build::Platform 2.10
+      FFI::Build::Plugin 2.10
       FFI::Build::Plugin::Foo1 undef
       FFI::Build::Plugin::Foo2 undef
-      FFI::Build::PluginData 2.09
-      FFI::Platypus 2.09
-      FFI::Platypus::API 2.09
-      FFI::Platypus::Buffer 2.09
-      FFI::Platypus::Bundle 2.09
-      FFI::Platypus::Closure 2.09
-      FFI::Platypus::ClosureData 2.09
-      FFI::Platypus::Constant 2.09
-      FFI::Platypus::DL 2.09
-      FFI::Platypus::Function 2.09
-      FFI::Platypus::Function::Function 2.09
-      FFI::Platypus::Function::Wrapper 2.09
-      FFI::Platypus::Internal 2.09
-      FFI::Platypus::Lang 2.09
-      FFI::Platypus::Lang::ASM 2.09
-      FFI::Platypus::Lang::C 2.09
-      FFI::Platypus::Lang::Win32 2.09
-      FFI::Platypus::Legacy 2.09
-      FFI::Platypus::Memory 2.09
-      FFI::Platypus::Record 2.09
-      FFI::Platypus::Record::Meta 2.09
-      FFI::Platypus::Record::TieArray 2.09
-      FFI::Platypus::ShareConfig 2.09
-      FFI::Platypus::Type 2.09
-      FFI::Platypus::Type::PointerSizeBuffer 2.09
-      FFI::Platypus::Type::StringArray 2.09
-      FFI::Platypus::Type::StringPointer 2.09
-      FFI::Platypus::Type::WideString 2.09
-      FFI::Platypus::TypeParser 2.09
-      FFI::Platypus::TypeParser::Version0 2.09
-      FFI::Platypus::TypeParser::Version1 2.09
-      FFI::Platypus::TypeParser::Version2 2.09
-      FFI::Probe 2.09
-      FFI::Probe::Runner 2.09
-      FFI::Probe::Runner::Builder 2.09
-      FFI::Probe::Runner::Result 2.09
-      FFI::Temp 2.09
+      FFI::Build::PluginData 2.10
+      FFI::Platypus 2.10
+      FFI::Platypus::API 2.10
+      FFI::Platypus::Buffer 2.10
+      FFI::Platypus::Bundle 2.10
+      FFI::Platypus::Closure 2.10
+      FFI::Platypus::ClosureData 2.10
+      FFI::Platypus::Constant 2.10
+      FFI::Platypus::DL 2.10
+      FFI::Platypus::Function 2.10
+      FFI::Platypus::Function::Function 2.10
+      FFI::Platypus::Function::Wrapper 2.10
+      FFI::Platypus::Internal 2.10
+      FFI::Platypus::Lang 2.10
+      FFI::Platypus::Lang::ASM 2.10
+      FFI::Platypus::Lang::C 2.10
+      FFI::Platypus::Lang::Win32 2.10
+      FFI::Platypus::Legacy 2.10
+      FFI::Platypus::Memory 2.10
+      FFI::Platypus::Record 2.10
+      FFI::Platypus::Record::Meta 2.10
+      FFI::Platypus::Record::TieArray 2.10
+      FFI::Platypus::ShareConfig 2.10
+      FFI::Platypus::Type 2.10
+      FFI::Platypus::Type::PointerSizeBuffer 2.10
+      FFI::Platypus::Type::StringArray 2.10
+      FFI::Platypus::Type::StringPointer 2.10
+      FFI::Platypus::Type::WideString 2.10
+      FFI::Platypus::TypeParser 2.10
+      FFI::Platypus::TypeParser::Version0 2.10
+      FFI::Platypus::TypeParser::Version1 2.10
+      FFI::Platypus::TypeParser::Version2 2.10
+      FFI::Probe 2.10
+      FFI::Probe::Runner 2.10
+      FFI::Probe::Runner::Builder 2.10
+      FFI::Probe::Runner::Result 2.10
+      FFI::Temp 2.10
     requirements:
       Capture::Tiny 0
       ExtUtils::CBuilder 0
@@ -3216,6 +3256,18 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
+  File-ShareDir-Tiny-0.001
+    pathname: L/LE/LEONT/File-ShareDir-Tiny-0.001.tar.gz
+    provides:
+      File::ShareDir::Tiny 0.001
+    requirements:
+      Carp 0
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      File::Spec::Functions 0
+      perl 5.006
+      strict 0
+      warnings 0
   File-Slurp-9999.32
     pathname: C/CA/CAPOEIRAB/File-Slurp-9999.32.tar.gz
     provides:
@@ -3313,22 +3365,23 @@ DISTRIBUTIONS
       Scalar::Util 1.17
       Test::Exception 0
       Test::More 0
-  Future-0.50
-    pathname: P/PE/PEVANS/Future-0.50.tar.gz
+  Future-0.51
+    pathname: P/PE/PEVANS/Future-0.51.tar.gz
     provides:
-      Future 0.50
-      Future::Exception 0.50
-      Future::Mutex 0.50
-      Future::PP 0.50
-      Future::Utils 0.50
-      Test::Future 0.50
-      Test::Future::Deferred 0.50
+      Future 0.51
+      Future::Exception 0.51
+      Future::Mutex 0.51
+      Future::PP 0.51
+      Future::Utils 0.51
+      Test::Future 0.51
+      Test::Future::Deferred 0.51
     requirements:
       Carp 1.25
+      List::Util 1.29
       Module::Build 0.4004
       Test::Builder::Module 0
       Time::HiRes 0
-      perl 5.010
+      perl 5.014
   GD-2.83
     pathname: R/RU/RURBAN/GD-2.83.tar.gz
     provides:
@@ -3416,10 +3469,10 @@ DISTRIBUTIONS
       MooseX::Clone 0.04
       MooseX::Storage 0.23
       Test::More 0
-  Graph-0.9730
-    pathname: E/ET/ETJ/Graph-0.9730.tar.gz
+  Graph-0.9735
+    pathname: E/ET/ETJ/Graph-0.9735.tar.gz
     provides:
-      Graph 0.9730
+      Graph 0.9735
       Graph::AdjacencyMap undef
       Graph::AdjacencyMap::Light undef
       Graph::AdjacencyMatrix undef
@@ -3685,19 +3738,19 @@ DISTRIBUTIONS
       HTTP::Date 0
       Module::Build::Tiny 0.035
       perl 5.008001
-  HTTP-Message-6.46
-    pathname: O/OA/OALDERS/HTTP-Message-6.46.tar.gz
+  HTTP-Message-7.00
+    pathname: O/OA/OALDERS/HTTP-Message-7.00.tar.gz
     provides:
-      HTTP::Config 6.46
-      HTTP::Headers 6.46
-      HTTP::Headers::Auth 6.46
-      HTTP::Headers::ETag 6.46
-      HTTP::Headers::Util 6.46
-      HTTP::Message 6.46
-      HTTP::Request 6.46
-      HTTP::Request::Common 6.46
-      HTTP::Response 6.46
-      HTTP::Status 6.46
+      HTTP::Config 7.00
+      HTTP::Headers 7.00
+      HTTP::Headers::Auth 7.00
+      HTTP::Headers::ETag 7.00
+      HTTP::Headers::Util 7.00
+      HTTP::Message 7.00
+      HTTP::Request 7.00
+      HTTP::Request::Common 7.00
+      HTTP::Response 7.00
+      HTTP::Status 7.00
     requirements:
       Carp 0
       Clone 0.46
@@ -3878,18 +3931,18 @@ DISTRIBUTIONS
       IO::SessionSet undef
     requirements:
       ExtUtils::MakeMaker 0
-  IO-Socket-SSL-2.088
-    pathname: S/SU/SULLR/IO-Socket-SSL-2.088.tar.gz
+  IO-Socket-SSL-2.089
+    pathname: S/SU/SULLR/IO-Socket-SSL-2.089.tar.gz
     provides:
-      IO::Socket::SSL 2.088
+      IO::Socket::SSL 2.089
       IO::Socket::SSL::Intercept 2.056
-      IO::Socket::SSL::OCSP_Cache 2.088
-      IO::Socket::SSL::OCSP_Resolver 2.088
+      IO::Socket::SSL::OCSP_Cache 2.089
+      IO::Socket::SSL::OCSP_Resolver 2.089
       IO::Socket::SSL::PublicSuffix undef
-      IO::Socket::SSL::SSL_Context 2.088
-      IO::Socket::SSL::SSL_HANDLE 2.088
-      IO::Socket::SSL::Session_Cache 2.088
-      IO::Socket::SSL::Trace 2.088
+      IO::Socket::SSL::SSL_Context 2.089
+      IO::Socket::SSL::SSL_HANDLE 2.089
+      IO::Socket::SSL::Session_Cache 2.089
+      IO::Socket::SSL::Trace 2.089
       IO::Socket::SSL::Utils 2.015
     requirements:
       ExtUtils::MakeMaker 0
@@ -4005,10 +4058,10 @@ DISTRIBUTIONS
       Router::Simple 0
       Test::More 0
       parent 0
-  JSON-Validator-5.14
-    pathname: J/JH/JHTHORSEN/JSON-Validator-5.14.tar.gz
+  JSON-Validator-5.15
+    pathname: J/JH/JHTHORSEN/JSON-Validator-5.15.tar.gz
     provides:
-      JSON::Validator 5.14
+      JSON::Validator 5.15
       JSON::Validator::Error undef
       JSON::Validator::Formats undef
       JSON::Validator::Joi undef
@@ -4287,6 +4340,15 @@ DISTRIBUTIONS
       Scope::Guard 0.21
       Sentry::Raven 0.05
       Text::Template 1.46
+  MIME-Base32-1.303
+    pathname: R/RE/REHSACK/MIME-Base32-1.303.tar.gz
+    provides:
+      MIME::Base32 1.303
+    requirements:
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      perl 5.008001
+      utf8 0
   MIME-Charset-1.013.1
     pathname: N/NE/NEZUMI/MIME-Charset-1.013.1.tar.gz
     provides:
@@ -4297,12 +4359,12 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 6.42
       Test::More 0
       perl 5.005
-  MIME-Types-2.26
-    pathname: M/MA/MARKOV/MIME-Types-2.26.tar.gz
+  MIME-Types-2.27
+    pathname: M/MA/MARKOV/MIME-Types-2.27.tar.gz
     provides:
-      MIME::Type 2.26
-      MIME::Types 2.26
-      MojoX::MIME::Types 2.26
+      MIME::Type 2.27
+      MIME::Types 2.27
+      MojoX::MIME::Types 2.27
     requirements:
       ExtUtils::MakeMaker 0
       File::Basename 0
@@ -4363,38 +4425,38 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       perl 5.006
-  MailTools-2.21
-    pathname: M/MA/MARKOV/MailTools-2.21.tar.gz
+  MailTools-2.22
+    pathname: M/MA/MARKOV/MailTools-2.22.tar.gz
     provides:
-      Mail::Address 2.21
-      Mail::Cap 2.21
-      Mail::Field 2.21
-      Mail::Field::AddrList 2.21
-      Mail::Field::Date 2.21
-      Mail::Field::Generic 2.21
-      Mail::Filter 2.21
-      Mail::Header 2.21
-      Mail::Internet 2.21
-      Mail::Mailer 2.21
-      Mail::Mailer::qmail 2.21
-      Mail::Mailer::rfc822 2.21
-      Mail::Mailer::sendmail 2.21
-      Mail::Mailer::smtp 2.21
-      Mail::Mailer::smtp::pipe 2.21
-      Mail::Mailer::smtps 2.21
-      Mail::Mailer::smtps::pipe 2.21
-      Mail::Mailer::testfile 2.21
-      Mail::Mailer::testfile::pipe 2.21
-      Mail::Send 2.21
-      Mail::Util 2.21
-      MailTools 2.21
+      Mail::Address 2.22
+      Mail::Cap 2.22
+      Mail::Field 2.22
+      Mail::Field::AddrList 2.22
+      Mail::Field::Date 2.22
+      Mail::Field::Generic 2.22
+      Mail::Filter 2.22
+      Mail::Header 2.22
+      Mail::Internet 2.22
+      Mail::Mailer 2.22
+      Mail::Mailer::qmail 2.22
+      Mail::Mailer::rfc822 2.22
+      Mail::Mailer::sendmail 2.22
+      Mail::Mailer::smtp 2.22
+      Mail::Mailer::smtp::pipe 2.22
+      Mail::Mailer::smtps 2.22
+      Mail::Mailer::smtps::pipe 2.22
+      Mail::Mailer::testfile 2.22
+      Mail::Mailer::testfile::pipe 2.22
+      Mail::Send 2.22
+      Mail::Util 2.22
+      MailTools 2.22
     requirements:
       Date::Format 0
       Date::Parse 0
       ExtUtils::MakeMaker 0
       IO::Handle 0
       Net::Domain 1.05
-      Net::SMTP 1.03
+      Net::SMTP 1.28
       Test::More 0
   Math-Prime-Util-0.73
     pathname: D/DA/DANAJ/Math-Prime-Util-0.73.tar.gz
@@ -4532,13 +4594,12 @@ DISTRIBUTIONS
       Test::Requires 0
       parent 0
       perl 5.008001
-  Module-Build-Tiny-0.048
-    pathname: L/LE/LEONT/Module-Build-Tiny-0.048.tar.gz
+  Module-Build-Tiny-0.051
+    pathname: L/LE/LEONT/Module-Build-Tiny-0.051.tar.gz
     provides:
-      Module::Build::Tiny 0.048
+      Module::Build::Tiny 0.051
     requirements:
       CPAN::Meta 0
-      CPAN::Requirements::Dynamic 0
       DynaLoader 0
       Exporter 5.57
       ExtUtils::CBuilder 0
@@ -4558,10 +4619,10 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
-  Module-Find-0.16
-    pathname: C/CR/CRENZ/Module-Find-0.16.tar.gz
+  Module-Find-0.17
+    pathname: C/CR/CRENZ/Module-Find-0.17.tar.gz
     provides:
-      Module::Find 0.16
+      Module::Find 0.17
     requirements:
       ExtUtils::MakeMaker 0
       File::Find 0
@@ -4579,11 +4640,11 @@ DISTRIBUTIONS
       Try::Tiny 0
       strict 0
       warnings 0
-  Module-Pluggable-5.2
-    pathname: S/SI/SIMONW/Module-Pluggable-5.2.tar.gz
+  Module-Pluggable-6.3
+    pathname: S/SI/SIMONW/Module-Pluggable-6.3.tar.gz
     provides:
       Devel::InnerPackage 0.4
-      Module::Pluggable 5.2
+      Module::Pluggable 6.3
       Module::Pluggable::Object 5.2
     requirements:
       Exporter 5.57
@@ -4592,8 +4653,9 @@ DISTRIBUTIONS
       File::Find 0
       File::Spec 3.00
       File::Spec::Functions 0
+      Scalar::Util 0
       if 0
-      perl 5.005030
+      perl 5.006
       strict 0
   Module-Runtime-0.016
     pathname: Z/ZE/ZEFRAM/Module-Runtime-0.016.tar.gz
@@ -4616,13 +4678,12 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
-  Mojo-JWT-0.09
-    pathname: J/JB/JBERGER/Mojo-JWT-0.09.tar.gz
+  Mojo-JWT-1.01
+    pathname: J/JB/JBERGER/Mojo-JWT-1.01.tar.gz
     provides:
-      Mojo::JWT 0.09
+      Mojo::JWT 1.01
     requirements:
-      Digest::SHA 0
-      MIME::Base64 3.11
+      CryptX 0.029
       Module::Build::Tiny 0
       Mojolicious 5.00
       perl 5.010
@@ -4636,8 +4697,8 @@ DISTRIBUTIONS
       Mojolicious 2
       Test::More 0.94
       perl 5.010001
-  Mojolicious-9.38
-    pathname: S/SR/SRI/Mojolicious-9.38.tar.gz
+  Mojolicious-9.39
+    pathname: S/SR/SRI/Mojolicious-9.39.tar.gz
     provides:
       Mojo undef
       Mojo::Asset undef
@@ -4706,7 +4767,7 @@ DISTRIBUTIONS
       Mojo::UserAgent::Transactor undef
       Mojo::Util undef
       Mojo::WebSocket undef
-      Mojolicious 9.38
+      Mojolicious 9.39
       Mojolicious::Command undef
       Mojolicious::Command::Author::cpanify undef
       Mojolicious::Command::Author::generate undef
@@ -4816,21 +4877,19 @@ DISTRIBUTIONS
       Sub::Defer 2.006006
       Sub::Quote 2.006006
       perl 5.006
-  MooX-StrictConstructor-0.011
-    pathname: H/HA/HARTZELL/MooX-StrictConstructor-0.011.tar.gz
+  MooX-StrictConstructor-0.013
+    pathname: H/HA/HAARG/MooX-StrictConstructor-0.013.tar.gz
     provides:
-      Method::Generate::Constructor::Role::StrictConstructor 0.011
-      MooX::StrictConstructor 0.011
+      MooX::StrictConstructor 0.013
+      MooX::StrictConstructor::Role::BuildAll 0.013
+      MooX::StrictConstructor::Role::Constructor 0.013
+      MooX::StrictConstructor::Role::Constructor::Base 0.013
+      MooX::StrictConstructor::Role::Constructor::Late 0.013
     requirements:
-      B 0
-      Class::Method::Modifiers 0
-      ExtUtils::MakeMaker 6.17
-      Moo 1.001000
+      ExtUtils::MakeMaker 0
+      Moo 2.004000
       Moo::Role 0
-      constant 0
-      perl 5.006
-      strict 0
-      strictures 1
+      perl 5.008
   MooX-Types-MooseLike-0.29
     pathname: M/MA/MATEU/MooX-Types-MooseLike-0.29.tar.gz
     provides:
@@ -5412,120 +5471,123 @@ DISTRIBUTIONS
       perl 5.008
       strict 0
       warnings 0
-  Mozilla-CA-20240730
-    pathname: L/LW/LWP/Mozilla-CA-20240730.tar.gz
+  Mozilla-CA-20250202
+    pathname: L/LW/LWP/Mozilla-CA-20250202.tar.gz
     provides:
-      Mozilla::CA 20240730
+      Mozilla::CA 20250202
     requirements:
       ExtUtils::MakeMaker 0
-  Net-DNS-1.46
-    pathname: N/NL/NLNETLABS/Net-DNS-1.46.tar.gz
+  Net-DNS-1.50
+    pathname: N/NL/NLNETLABS/Net-DNS-1.50.tar.gz
     provides:
-      Net::DNS 1.46
-      Net::DNS::Domain 1913
-      Net::DNS::DomainName 1898
-      Net::DNS::DomainName1035 1898
-      Net::DNS::DomainName2535 1898
-      Net::DNS::Header 1982
-      Net::DNS::Mailbox 1910
-      Net::DNS::Mailbox1035 1910
-      Net::DNS::Mailbox2535 1910
-      Net::DNS::Nameserver 1963
-      Net::DNS::Packet 1982
-      Net::DNS::Parameters 1987
-      Net::DNS::Question 1895
-      Net::DNS::RR 1965
-      Net::DNS::RR::A 1972
-      Net::DNS::RR::AAAA 1896
-      Net::DNS::RR::AFSDB 1972
-      Net::DNS::RR::AMTRELAY 1896
-      Net::DNS::RR::APL 1896
-      Net::DNS::RR::APL::Item 1896
-      Net::DNS::RR::CAA 1910
-      Net::DNS::RR::CDNSKEY 1909
-      Net::DNS::RR::CDS 1909
-      Net::DNS::RR::CERT 1972
-      Net::DNS::RR::CNAME 1972
-      Net::DNS::RR::CSYNC 1910
-      Net::DNS::RR::DELEG 1965
-      Net::DNS::RR::DHCID 1896
-      Net::DNS::RR::DNAME 1896
-      Net::DNS::RR::DNSKEY 1972
-      Net::DNS::RR::DS 1972
-      Net::DNS::RR::EUI48 1896
-      Net::DNS::RR::EUI64 1896
-      Net::DNS::RR::GPOS 1910
-      Net::DNS::RR::HINFO 1896
-      Net::DNS::RR::HIP 1896
-      Net::DNS::RR::HTTPS 1972
-      Net::DNS::RR::IPSECKEY 1957
-      Net::DNS::RR::ISDN 1972
-      Net::DNS::RR::KEY 1972
-      Net::DNS::RR::KX 1945
-      Net::DNS::RR::L32 1896
-      Net::DNS::RR::L64 1896
-      Net::DNS::RR::LOC 1896
-      Net::DNS::RR::LP 1896
-      Net::DNS::RR::MB 1972
-      Net::DNS::RR::MG 1972
-      Net::DNS::RR::MINFO 1972
-      Net::DNS::RR::MR 1972
-      Net::DNS::RR::MX 1972
-      Net::DNS::RR::NAPTR 1898
-      Net::DNS::RR::NID 1896
-      Net::DNS::RR::NS 1972
-      Net::DNS::RR::NSEC 1972
-      Net::DNS::RR::NSEC3 1972
-      Net::DNS::RR::NSEC3PARAM 1972
-      Net::DNS::RR::NULL 1972
-      Net::DNS::RR::OPENPGPKEY 1896
-      Net::DNS::RR::OPT 1980
-      Net::DNS::RR::OPT::CHAIN 1980
-      Net::DNS::RR::OPT::CLIENT_SUBNET 1980
-      Net::DNS::RR::OPT::COOKIE 1980
-      Net::DNS::RR::OPT::DAU 1980
-      Net::DNS::RR::OPT::DHU 1980
-      Net::DNS::RR::OPT::EXPIRE 1980
-      Net::DNS::RR::OPT::EXTENDED_ERROR 1980
-      Net::DNS::RR::OPT::KEY_TAG 1980
-      Net::DNS::RR::OPT::N3U 1980
-      Net::DNS::RR::OPT::NSID 1980
-      Net::DNS::RR::OPT::PADDING 1980
-      Net::DNS::RR::OPT::REPORT_CHANNEL 1980
-      Net::DNS::RR::OPT::TCP_KEEPALIVE 1980
-      Net::DNS::RR::PTR 1972
-      Net::DNS::RR::PX 1945
-      Net::DNS::RR::RP 1972
-      Net::DNS::RR::RRSIG 1987
-      Net::DNS::RR::RT 1972
-      Net::DNS::RR::SIG 1972
-      Net::DNS::RR::SMIMEA 1896
-      Net::DNS::RR::SOA 1972
-      Net::DNS::RR::SPF 1896
-      Net::DNS::RR::SRV 1945
-      Net::DNS::RR::SSHFP 1896
-      Net::DNS::RR::SVCB 1970
-      Net::DNS::RR::TKEY 1908
-      Net::DNS::RR::TLSA 1896
-      Net::DNS::RR::TSIG 1980
-      Net::DNS::RR::TXT 1972
-      Net::DNS::RR::URI 1896
-      Net::DNS::RR::X25 1972
-      Net::DNS::RR::ZONEMD 1896
-      Net::DNS::Resolver 1981
-      Net::DNS::Resolver::Base 1982
-      Net::DNS::Resolver::MSWin32 1981
-      Net::DNS::Resolver::Recurse 1981
-      Net::DNS::Resolver::UNIX 1981
-      Net::DNS::Resolver::android 1981
-      Net::DNS::Resolver::cygwin 1981
-      Net::DNS::Resolver::os2 1981
-      Net::DNS::Resolver::os390 1981
-      Net::DNS::Text 1894
-      Net::DNS::Update 1895
-      Net::DNS::ZoneFile 1957
-      Net::DNS::ZoneFile::Generator 1957
-      Net::DNS::ZoneFile::Text 1957
+      Net::DNS 1.50
+      Net::DNS::Domain 2002
+      Net::DNS::DomainName 2005
+      Net::DNS::DomainName1035 2005
+      Net::DNS::DomainName2535 2005
+      Net::DNS::Header 2002
+      Net::DNS::Mailbox 2002
+      Net::DNS::Mailbox1035 2002
+      Net::DNS::Mailbox2535 2002
+      Net::DNS::Nameserver 2002
+      Net::DNS::Packet 2003
+      Net::DNS::Parameters 2002
+      Net::DNS::Question 2002
+      Net::DNS::RR 2003
+      Net::DNS::RR::A 2003
+      Net::DNS::RR::AAAA 2003
+      Net::DNS::RR::AFSDB 2002
+      Net::DNS::RR::AMTRELAY 2003
+      Net::DNS::RR::APL 2003
+      Net::DNS::RR::APL::Item 2003
+      Net::DNS::RR::CAA 2003
+      Net::DNS::RR::CDNSKEY 2003
+      Net::DNS::RR::CDS 2003
+      Net::DNS::RR::CERT 2002
+      Net::DNS::RR::CNAME 2003
+      Net::DNS::RR::CSYNC 2003
+      Net::DNS::RR::DELEG 2003
+      Net::DNS::RR::DHCID 2003
+      Net::DNS::RR::DNAME 2003
+      Net::DNS::RR::DNSKEY 2003
+      Net::DNS::RR::DS 2003
+      Net::DNS::RR::DSYNC 2003
+      Net::DNS::RR::EUI48 2003
+      Net::DNS::RR::EUI64 2003
+      Net::DNS::RR::GPOS 2003
+      Net::DNS::RR::HINFO 2003
+      Net::DNS::RR::HIP 2003
+      Net::DNS::RR::HTTPS 2002
+      Net::DNS::RR::IPSECKEY 2003
+      Net::DNS::RR::ISDN 2002
+      Net::DNS::RR::KEY 2002
+      Net::DNS::RR::KX 2003
+      Net::DNS::RR::L32 2003
+      Net::DNS::RR::L64 2003
+      Net::DNS::RR::LOC 2003
+      Net::DNS::RR::LP 2003
+      Net::DNS::RR::MB 2002
+      Net::DNS::RR::MG 2002
+      Net::DNS::RR::MINFO 2002
+      Net::DNS::RR::MR 2002
+      Net::DNS::RR::MX 2002
+      Net::DNS::RR::NAPTR 2003
+      Net::DNS::RR::NID 2003
+      Net::DNS::RR::NS 2003
+      Net::DNS::RR::NSEC 2002
+      Net::DNS::RR::NSEC3 2003
+      Net::DNS::RR::NSEC3PARAM 2003
+      Net::DNS::RR::NULL 2002
+      Net::DNS::RR::OPENPGPKEY 2003
+      Net::DNS::RR::OPT 2005
+      Net::DNS::RR::OPT::CHAIN 2005
+      Net::DNS::RR::OPT::CLIENT_SUBNET 2005
+      Net::DNS::RR::OPT::COOKIE 2005
+      Net::DNS::RR::OPT::DAU 2005
+      Net::DNS::RR::OPT::DHU 2005
+      Net::DNS::RR::OPT::EXPIRE 2005
+      Net::DNS::RR::OPT::EXTENDED_ERROR 2005
+      Net::DNS::RR::OPT::KEY_TAG 2005
+      Net::DNS::RR::OPT::N3U 2005
+      Net::DNS::RR::OPT::NSID 2005
+      Net::DNS::RR::OPT::PADDING 2005
+      Net::DNS::RR::OPT::REPORT_CHANNEL 2005
+      Net::DNS::RR::OPT::TCP_KEEPALIVE 2005
+      Net::DNS::RR::OPT::ZONEVERSION 2005
+      Net::DNS::RR::PTR 2002
+      Net::DNS::RR::PX 2003
+      Net::DNS::RR::RESINFO 2003
+      Net::DNS::RR::RP 2002
+      Net::DNS::RR::RRSIG 2003
+      Net::DNS::RR::RT 2003
+      Net::DNS::RR::SIG 2003
+      Net::DNS::RR::SMIMEA 2003
+      Net::DNS::RR::SOA 2002
+      Net::DNS::RR::SPF 2003
+      Net::DNS::RR::SRV 2003
+      Net::DNS::RR::SSHFP 2003
+      Net::DNS::RR::SVCB 2003
+      Net::DNS::RR::TKEY 2003
+      Net::DNS::RR::TLSA 2003
+      Net::DNS::RR::TSIG 2003
+      Net::DNS::RR::TXT 2003
+      Net::DNS::RR::URI 2003
+      Net::DNS::RR::X25 2002
+      Net::DNS::RR::ZONEMD 2003
+      Net::DNS::Resolver 2009
+      Net::DNS::Resolver::Base 2011
+      Net::DNS::Resolver::MSWin32 2002
+      Net::DNS::Resolver::Recurse 2002
+      Net::DNS::Resolver::UNIX 2007
+      Net::DNS::Resolver::android 2007
+      Net::DNS::Resolver::cygwin 2002
+      Net::DNS::Resolver::os2 2007
+      Net::DNS::Resolver::os390 2007
+      Net::DNS::Text 2002
+      Net::DNS::Update 2003
+      Net::DNS::ZoneFile 2002
+      Net::DNS::ZoneFile::Generator 2002
+      Net::DNS::ZoneFile::Text 2002
     requirements:
       Carp 1.1
       Config 0
@@ -5630,100 +5692,101 @@ DISTRIBUTIONS
       POSIX 0
       Time::Local 0
       perl 5.008001
-  PPI-1.278
-    pathname: O/OA/OALDERS/PPI-1.278.tar.gz
+  PPI-1.281
+    pathname: M/MI/MITHALDU/PPI-1.281.tar.gz
     provides:
-      PPI 1.278
-      PPI::Cache 1.278
-      PPI::Document 1.278
-      PPI::Document::File 1.278
-      PPI::Document::Fragment 1.278
-      PPI::Document::Normalized 1.278
-      PPI::Dumper 1.278
-      PPI::Element 1.278
-      PPI::Exception 1.278
-      PPI::Exception::ParserRejection 1.278
-      PPI::Find 1.278
-      PPI::Lexer 1.278
-      PPI::Node 1.278
-      PPI::Normal 1.278
-      PPI::Normal::Standard 1.278
-      PPI::Singletons 1.278
-      PPI::Statement 1.278
-      PPI::Statement::Break 1.278
-      PPI::Statement::Compound 1.278
-      PPI::Statement::Data 1.278
-      PPI::Statement::End 1.278
-      PPI::Statement::Expression 1.278
-      PPI::Statement::Given 1.278
-      PPI::Statement::Include 1.278
-      PPI::Statement::Include::Perl6 1.278
-      PPI::Statement::Null 1.278
-      PPI::Statement::Package 1.278
-      PPI::Statement::Scheduled 1.278
-      PPI::Statement::Sub 1.278
-      PPI::Statement::Unknown 1.278
-      PPI::Statement::UnmatchedBrace 1.278
-      PPI::Statement::Variable 1.278
-      PPI::Statement::When 1.278
-      PPI::Structure 1.278
-      PPI::Structure::Block 1.278
-      PPI::Structure::Condition 1.278
-      PPI::Structure::Constructor 1.278
-      PPI::Structure::For 1.278
-      PPI::Structure::Given 1.278
-      PPI::Structure::List 1.278
-      PPI::Structure::Subscript 1.278
-      PPI::Structure::Unknown 1.278
-      PPI::Structure::When 1.278
-      PPI::Token 1.278
-      PPI::Token::ArrayIndex 1.278
-      PPI::Token::Attribute 1.278
-      PPI::Token::BOM 1.278
-      PPI::Token::Cast 1.278
-      PPI::Token::Comment 1.278
-      PPI::Token::DashedWord 1.278
-      PPI::Token::Data 1.278
-      PPI::Token::End 1.278
-      PPI::Token::HereDoc 1.278
-      PPI::Token::Label 1.278
-      PPI::Token::Magic 1.278
-      PPI::Token::Number 1.278
-      PPI::Token::Number::Binary 1.278
-      PPI::Token::Number::Exp 1.278
-      PPI::Token::Number::Float 1.278
-      PPI::Token::Number::Hex 1.278
-      PPI::Token::Number::Octal 1.278
-      PPI::Token::Number::Version 1.278
-      PPI::Token::Operator 1.278
-      PPI::Token::Pod 1.278
-      PPI::Token::Prototype 1.278
-      PPI::Token::Quote 1.278
-      PPI::Token::Quote::Double 1.278
-      PPI::Token::Quote::Interpolate 1.278
-      PPI::Token::Quote::Literal 1.278
-      PPI::Token::Quote::Single 1.278
-      PPI::Token::QuoteLike 1.278
-      PPI::Token::QuoteLike::Backtick 1.278
-      PPI::Token::QuoteLike::Command 1.278
-      PPI::Token::QuoteLike::Readline 1.278
-      PPI::Token::QuoteLike::Regexp 1.278
-      PPI::Token::QuoteLike::Words 1.278
-      PPI::Token::Regexp 1.278
-      PPI::Token::Regexp::Match 1.278
-      PPI::Token::Regexp::Substitute 1.278
-      PPI::Token::Regexp::Transliterate 1.278
-      PPI::Token::Separator 1.278
-      PPI::Token::Structure 1.278
-      PPI::Token::Symbol 1.278
-      PPI::Token::Unknown 1.278
-      PPI::Token::Whitespace 1.278
-      PPI::Token::Word 1.278
-      PPI::Tokenizer 1.278
-      PPI::Transform 1.278
-      PPI::Transform::UpdateCopyright 1.278
-      PPI::Util 1.278
-      PPI::XSAccessor 1.278
+      PPI 1.281
+      PPI::Cache 1.281
+      PPI::Document 1.281
+      PPI::Document::File 1.281
+      PPI::Document::Fragment 1.281
+      PPI::Document::Normalized 1.281
+      PPI::Dumper 1.281
+      PPI::Element 1.281
+      PPI::Exception 1.281
+      PPI::Exception::ParserRejection 1.281
+      PPI::Find 1.281
+      PPI::Lexer 1.281
+      PPI::Node 1.281
+      PPI::Normal 1.281
+      PPI::Normal::Standard 1.281
+      PPI::Singletons 1.281
+      PPI::Statement 1.281
+      PPI::Statement::Break 1.281
+      PPI::Statement::Compound 1.281
+      PPI::Statement::Data 1.281
+      PPI::Statement::End 1.281
+      PPI::Statement::Expression 1.281
+      PPI::Statement::Given 1.281
+      PPI::Statement::Include 1.281
+      PPI::Statement::Include::Perl6 1.281
+      PPI::Statement::Null 1.281
+      PPI::Statement::Package 1.281
+      PPI::Statement::Scheduled 1.281
+      PPI::Statement::Sub 1.281
+      PPI::Statement::Unknown 1.281
+      PPI::Statement::UnmatchedBrace 1.281
+      PPI::Statement::Variable 1.281
+      PPI::Statement::When 1.281
+      PPI::Structure 1.281
+      PPI::Structure::Block 1.281
+      PPI::Structure::Condition 1.281
+      PPI::Structure::Constructor 1.281
+      PPI::Structure::For 1.281
+      PPI::Structure::Given 1.281
+      PPI::Structure::List 1.281
+      PPI::Structure::Signature 1.281
+      PPI::Structure::Subscript 1.281
+      PPI::Structure::Unknown 1.281
+      PPI::Structure::When 1.281
+      PPI::Token 1.281
+      PPI::Token::ArrayIndex 1.281
+      PPI::Token::Attribute 1.281
+      PPI::Token::BOM 1.281
+      PPI::Token::Cast 1.281
+      PPI::Token::Comment 1.281
+      PPI::Token::DashedWord 1.281
+      PPI::Token::Data 1.281
+      PPI::Token::End 1.281
+      PPI::Token::HereDoc 1.281
+      PPI::Token::Label 1.281
+      PPI::Token::Magic 1.281
+      PPI::Token::Number 1.281
+      PPI::Token::Number::Binary 1.281
+      PPI::Token::Number::Exp 1.281
+      PPI::Token::Number::Float 1.281
+      PPI::Token::Number::Hex 1.281
+      PPI::Token::Number::Octal 1.281
+      PPI::Token::Number::Version 1.281
+      PPI::Token::Operator 1.281
+      PPI::Token::Pod 1.281
+      PPI::Token::Prototype 1.281
+      PPI::Token::Quote 1.281
+      PPI::Token::Quote::Double 1.281
+      PPI::Token::Quote::Interpolate 1.281
+      PPI::Token::Quote::Literal 1.281
+      PPI::Token::Quote::Single 1.281
+      PPI::Token::QuoteLike 1.281
+      PPI::Token::QuoteLike::Backtick 1.281
+      PPI::Token::QuoteLike::Command 1.281
+      PPI::Token::QuoteLike::Readline 1.281
+      PPI::Token::QuoteLike::Regexp 1.281
+      PPI::Token::QuoteLike::Words 1.281
+      PPI::Token::Regexp 1.281
+      PPI::Token::Regexp::Match 1.281
+      PPI::Token::Regexp::Substitute 1.281
+      PPI::Token::Regexp::Transliterate 1.281
+      PPI::Token::Separator 1.281
+      PPI::Token::Structure 1.281
+      PPI::Token::Symbol 1.281
+      PPI::Token::Unknown 1.281
+      PPI::Token::Whitespace 1.281
+      PPI::Token::Word 1.281
+      PPI::Tokenizer 1.281
+      PPI::Transform 1.281
+      PPI::Transform::UpdateCopyright 1.281
+      PPI::Util 1.281
+      PPI::XSAccessor 1.281
     requirements:
       Carp 0
       Clone 0.30
@@ -5734,14 +5797,17 @@ DISTRIBUTIONS
       File::Spec 0.84
       List::Util 1.33
       Params::Util 1.00
+      Safe::Isa 0
       Scalar::Util 0
       Storable 2.17
       Task::Weaken 0
+      YAML::PP 0
       constant 0
       if 0
       overload 0
       perl 5.006
       strict 0
+      version 0.77
   PPIx-QuoteLike-0.023
     pathname: W/WY/WYANT/PPIx-QuoteLike-0.023.tar.gz
     provides:
@@ -6039,11 +6105,11 @@ DISTRIBUTIONS
       overload 0
       parent 0
       strict 0
-  Path-Tiny-0.146
-    pathname: D/DA/DAGOLDEN/Path-Tiny-0.146.tar.gz
+  Path-Tiny-0.148
+    pathname: D/DA/DAGOLDEN/Path-Tiny-0.148.tar.gz
     provides:
-      Path::Tiny 0.146
-      Path::Tiny::Error 0.146
+      Path::Tiny 0.148
+      Path::Tiny::Error 0.148
     requirements:
       Carp 0
       Cwd 0
@@ -6066,203 +6132,203 @@ DISTRIBUTIONS
       strict 0
       warnings 0
       warnings::register 0
-  Perl-Critic-1.152
-    pathname: P/PE/PETDANCE/Perl-Critic-1.152.tar.gz
+  Perl-Critic-1.156
+    pathname: P/PE/PETDANCE/Perl-Critic-1.156.tar.gz
     provides:
-      Perl::Critic 1.152
-      Perl::Critic::Annotation 1.152
-      Perl::Critic::Command 1.152
-      Perl::Critic::Config 1.152
-      Perl::Critic::Document 1.152
-      Perl::Critic::Exception 1.152
-      Perl::Critic::Exception::AggregateConfiguration 1.152
-      Perl::Critic::Exception::Configuration 1.152
-      Perl::Critic::Exception::Configuration::Generic 1.152
-      Perl::Critic::Exception::Configuration::NonExistentPolicy 1.152
-      Perl::Critic::Exception::Configuration::Option 1.152
-      Perl::Critic::Exception::Configuration::Option::Global 1.152
-      Perl::Critic::Exception::Configuration::Option::Global::ExtraParameter 1.152
-      Perl::Critic::Exception::Configuration::Option::Global::ParameterValue 1.152
-      Perl::Critic::Exception::Configuration::Option::Policy 1.152
-      Perl::Critic::Exception::Configuration::Option::Policy::ExtraParameter 1.152
-      Perl::Critic::Exception::Configuration::Option::Policy::ParameterValue 1.152
-      Perl::Critic::Exception::Fatal 1.152
-      Perl::Critic::Exception::Fatal::Generic 1.152
-      Perl::Critic::Exception::Fatal::Internal 1.152
-      Perl::Critic::Exception::Fatal::PolicyDefinition 1.152
-      Perl::Critic::Exception::IO 1.152
-      Perl::Critic::Exception::Parse 1.152
-      Perl::Critic::OptionsProcessor 1.152
-      Perl::Critic::Policy 1.152
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitBooleanGrep 1.152
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitComplexMappings 1.152
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitLvalueSubstr 1.152
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitReverseSortBlock 1.152
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitShiftRef 1.152
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitSleepViaSelect 1.152
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitStringyEval 1.152
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitStringySplit 1.152
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitUniversalCan 1.152
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitUniversalIsa 1.152
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitUselessTopic 1.152
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitVoidGrep 1.152
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitVoidMap 1.152
-      Perl::Critic::Policy::BuiltinFunctions::RequireBlockGrep 1.152
-      Perl::Critic::Policy::BuiltinFunctions::RequireBlockMap 1.152
-      Perl::Critic::Policy::BuiltinFunctions::RequireGlobFunction 1.152
-      Perl::Critic::Policy::BuiltinFunctions::RequireSimpleSortBlock 1.152
-      Perl::Critic::Policy::ClassHierarchies::ProhibitAutoloading 1.152
-      Perl::Critic::Policy::ClassHierarchies::ProhibitExplicitISA 1.152
-      Perl::Critic::Policy::ClassHierarchies::ProhibitOneArgBless 1.152
-      Perl::Critic::Policy::CodeLayout::ProhibitHardTabs 1.152
-      Perl::Critic::Policy::CodeLayout::ProhibitParensWithBuiltins 1.152
-      Perl::Critic::Policy::CodeLayout::ProhibitQuotedWordLists 1.152
-      Perl::Critic::Policy::CodeLayout::ProhibitTrailingWhitespace 1.152
-      Perl::Critic::Policy::CodeLayout::RequireConsistentNewlines 1.152
-      Perl::Critic::Policy::CodeLayout::RequireTidyCode 1.152
-      Perl::Critic::Policy::CodeLayout::RequireTrailingCommas 1.152
-      Perl::Critic::Policy::ControlStructures::ProhibitCStyleForLoops 1.152
-      Perl::Critic::Policy::ControlStructures::ProhibitCascadingIfElse 1.152
-      Perl::Critic::Policy::ControlStructures::ProhibitDeepNests 1.152
-      Perl::Critic::Policy::ControlStructures::ProhibitLabelsWithSpecialBlockNames 1.152
-      Perl::Critic::Policy::ControlStructures::ProhibitMutatingListFunctions 1.152
-      Perl::Critic::Policy::ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions 1.152
-      Perl::Critic::Policy::ControlStructures::ProhibitPostfixControls 1.152
-      Perl::Critic::Policy::ControlStructures::ProhibitUnlessBlocks 1.152
-      Perl::Critic::Policy::ControlStructures::ProhibitUnreachableCode 1.152
-      Perl::Critic::Policy::ControlStructures::ProhibitUntilBlocks 1.152
-      Perl::Critic::Policy::ControlStructures::ProhibitYadaOperator 1.152
-      Perl::Critic::Policy::Documentation::PodSpelling 1.152
-      Perl::Critic::Policy::Documentation::RequirePackageMatchesPodName 1.152
-      Perl::Critic::Policy::Documentation::RequirePodAtEnd 1.152
-      Perl::Critic::Policy::Documentation::RequirePodSections 1.152
-      Perl::Critic::Policy::ErrorHandling::RequireCarping 1.152
-      Perl::Critic::Policy::ErrorHandling::RequireCheckingReturnValueOfEval 1.152
-      Perl::Critic::Policy::InputOutput::ProhibitBacktickOperators 1.152
-      Perl::Critic::Policy::InputOutput::ProhibitBarewordDirHandles 1.152
-      Perl::Critic::Policy::InputOutput::ProhibitBarewordFileHandles 1.152
-      Perl::Critic::Policy::InputOutput::ProhibitExplicitStdin 1.152
-      Perl::Critic::Policy::InputOutput::ProhibitInteractiveTest 1.152
-      Perl::Critic::Policy::InputOutput::ProhibitJoinedReadline 1.152
-      Perl::Critic::Policy::InputOutput::ProhibitOneArgSelect 1.152
-      Perl::Critic::Policy::InputOutput::ProhibitReadlineInForLoop 1.152
-      Perl::Critic::Policy::InputOutput::ProhibitTwoArgOpen 1.152
-      Perl::Critic::Policy::InputOutput::RequireBracedFileHandleWithPrint 1.152
-      Perl::Critic::Policy::InputOutput::RequireBriefOpen 1.152
-      Perl::Critic::Policy::InputOutput::RequireCheckedClose 1.152
-      Perl::Critic::Policy::InputOutput::RequireCheckedOpen 1.152
-      Perl::Critic::Policy::InputOutput::RequireCheckedSyscalls 1.152
-      Perl::Critic::Policy::InputOutput::RequireEncodingWithUTF8Layer 1.152
-      Perl::Critic::Policy::Miscellanea::ProhibitFormats 1.152
-      Perl::Critic::Policy::Miscellanea::ProhibitTies 1.152
-      Perl::Critic::Policy::Miscellanea::ProhibitUnrestrictedNoCritic 1.152
-      Perl::Critic::Policy::Miscellanea::ProhibitUselessNoCritic 1.152
-      Perl::Critic::Policy::Modules::ProhibitAutomaticExportation 1.152
-      Perl::Critic::Policy::Modules::ProhibitConditionalUseStatements 1.152
-      Perl::Critic::Policy::Modules::ProhibitEvilModules 1.152
-      Perl::Critic::Policy::Modules::ProhibitExcessMainComplexity 1.152
-      Perl::Critic::Policy::Modules::ProhibitMultiplePackages 1.152
-      Perl::Critic::Policy::Modules::RequireBarewordIncludes 1.152
-      Perl::Critic::Policy::Modules::RequireEndWithOne 1.152
-      Perl::Critic::Policy::Modules::RequireExplicitPackage 1.152
-      Perl::Critic::Policy::Modules::RequireFilenameMatchesPackage 1.152
-      Perl::Critic::Policy::Modules::RequireNoMatchVarsWithUseEnglish 1.152
-      Perl::Critic::Policy::Modules::RequireVersionVar 1.152
-      Perl::Critic::Policy::NamingConventions::Capitalization 1.152
-      Perl::Critic::Policy::NamingConventions::ProhibitAmbiguousNames 1.152
-      Perl::Critic::Policy::Objects::ProhibitIndirectSyntax 1.152
-      Perl::Critic::Policy::References::ProhibitDoubleSigils 1.152
-      Perl::Critic::Policy::RegularExpressions::ProhibitCaptureWithoutTest 1.152
-      Perl::Critic::Policy::RegularExpressions::ProhibitComplexRegexes 1.152
-      Perl::Critic::Policy::RegularExpressions::ProhibitEnumeratedClasses 1.152
-      Perl::Critic::Policy::RegularExpressions::ProhibitEscapedMetacharacters 1.152
-      Perl::Critic::Policy::RegularExpressions::ProhibitFixedStringMatches 1.152
-      Perl::Critic::Policy::RegularExpressions::ProhibitSingleCharAlternation 1.152
-      Perl::Critic::Policy::RegularExpressions::ProhibitUnusedCapture 1.152
-      Perl::Critic::Policy::RegularExpressions::ProhibitUnusualDelimiters 1.152
-      Perl::Critic::Policy::RegularExpressions::ProhibitUselessTopic 1.152
-      Perl::Critic::Policy::RegularExpressions::RequireBracesForMultiline 1.152
-      Perl::Critic::Policy::RegularExpressions::RequireDotMatchAnything 1.152
-      Perl::Critic::Policy::RegularExpressions::RequireExtendedFormatting 1.152
-      Perl::Critic::Policy::RegularExpressions::RequireLineBoundaryMatching 1.152
-      Perl::Critic::Policy::Subroutines::ProhibitAmpersandSigils 1.152
-      Perl::Critic::Policy::Subroutines::ProhibitBuiltinHomonyms 1.152
-      Perl::Critic::Policy::Subroutines::ProhibitExcessComplexity 1.152
-      Perl::Critic::Policy::Subroutines::ProhibitExplicitReturnUndef 1.152
-      Perl::Critic::Policy::Subroutines::ProhibitManyArgs 1.152
-      Perl::Critic::Policy::Subroutines::ProhibitNestedSubs 1.152
-      Perl::Critic::Policy::Subroutines::ProhibitReturnSort 1.152
-      Perl::Critic::Policy::Subroutines::ProhibitSubroutinePrototypes 1.152
-      Perl::Critic::Policy::Subroutines::ProhibitUnusedPrivateSubroutines 1.152
-      Perl::Critic::Policy::Subroutines::ProtectPrivateSubs 1.152
-      Perl::Critic::Policy::Subroutines::RequireArgUnpacking 1.152
-      Perl::Critic::Policy::Subroutines::RequireFinalReturn 1.152
-      Perl::Critic::Policy::TestingAndDebugging::ProhibitNoStrict 1.152
-      Perl::Critic::Policy::TestingAndDebugging::ProhibitNoWarnings 1.152
-      Perl::Critic::Policy::TestingAndDebugging::ProhibitProlongedStrictureOverride 1.152
-      Perl::Critic::Policy::TestingAndDebugging::RequireTestLabels 1.152
-      Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict 1.152
-      Perl::Critic::Policy::TestingAndDebugging::RequireUseWarnings 1.152
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitCommaSeparatedStatements 1.152
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitComplexVersion 1.152
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitConstantPragma 1.152
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitEmptyQuotes 1.152
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitEscapedCharacters 1.152
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitImplicitNewlines 1.152
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitInterpolationOfLiterals 1.152
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitLeadingZeros 1.152
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitLongChainsOfMethodCalls 1.152
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitMagicNumbers 1.152
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitMismatchedOperators 1.152
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitMixedBooleanOperators 1.152
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitNoisyQuotes 1.152
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitQuotesAsQuotelikeOperatorDelimiters 1.152
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitSpecialLiteralHeredocTerminator 1.152
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitVersionStrings 1.152
-      Perl::Critic::Policy::ValuesAndExpressions::RequireConstantVersion 1.152
-      Perl::Critic::Policy::ValuesAndExpressions::RequireInterpolationOfMetachars 1.152
-      Perl::Critic::Policy::ValuesAndExpressions::RequireNumberSeparators 1.152
-      Perl::Critic::Policy::ValuesAndExpressions::RequireQuotedHeredocTerminator 1.152
-      Perl::Critic::Policy::ValuesAndExpressions::RequireUpperCaseHeredocTerminator 1.152
-      Perl::Critic::Policy::Variables::ProhibitAugmentedAssignmentInDeclaration 1.152
-      Perl::Critic::Policy::Variables::ProhibitConditionalDeclarations 1.152
-      Perl::Critic::Policy::Variables::ProhibitEvilVariables 1.152
-      Perl::Critic::Policy::Variables::ProhibitLocalVars 1.152
-      Perl::Critic::Policy::Variables::ProhibitMatchVars 1.152
-      Perl::Critic::Policy::Variables::ProhibitPackageVars 1.152
-      Perl::Critic::Policy::Variables::ProhibitPerl4PackageNames 1.152
-      Perl::Critic::Policy::Variables::ProhibitPunctuationVars 1.152
-      Perl::Critic::Policy::Variables::ProhibitReusedNames 1.152
-      Perl::Critic::Policy::Variables::ProhibitUnusedVariables 1.152
-      Perl::Critic::Policy::Variables::ProtectPrivateVars 1.152
-      Perl::Critic::Policy::Variables::RequireInitializationForLocalVars 1.152
-      Perl::Critic::Policy::Variables::RequireLexicalLoopIterators 1.152
-      Perl::Critic::Policy::Variables::RequireLocalizedPunctuationVars 1.152
-      Perl::Critic::Policy::Variables::RequireNegativeIndices 1.152
-      Perl::Critic::PolicyConfig 1.152
-      Perl::Critic::PolicyFactory 1.152
-      Perl::Critic::PolicyListing 1.152
-      Perl::Critic::PolicyParameter 1.152
-      Perl::Critic::PolicyParameter::Behavior 1.152
-      Perl::Critic::PolicyParameter::Behavior::Boolean 1.152
-      Perl::Critic::PolicyParameter::Behavior::Enumeration 1.152
-      Perl::Critic::PolicyParameter::Behavior::Integer 1.152
-      Perl::Critic::PolicyParameter::Behavior::String 1.152
-      Perl::Critic::PolicyParameter::Behavior::StringList 1.152
-      Perl::Critic::ProfilePrototype 1.152
-      Perl::Critic::Statistics 1.152
-      Perl::Critic::TestUtils 1.152
-      Perl::Critic::Theme 1.152
-      Perl::Critic::ThemeListing 1.152
-      Perl::Critic::UserProfile 1.152
-      Perl::Critic::Utils 1.152
-      Perl::Critic::Utils::Constants 1.152
-      Perl::Critic::Utils::McCabe 1.152
-      Perl::Critic::Utils::POD 1.152
-      Perl::Critic::Utils::PPI 1.152
-      Perl::Critic::Utils::Perl 1.152
-      Perl::Critic::Violation 1.152
-      Test::Perl::Critic::Policy 1.152
+      Perl::Critic 1.156
+      Perl::Critic::Annotation 1.156
+      Perl::Critic::Command 1.156
+      Perl::Critic::Config 1.156
+      Perl::Critic::Document 1.156
+      Perl::Critic::Exception 1.156
+      Perl::Critic::Exception::AggregateConfiguration 1.156
+      Perl::Critic::Exception::Configuration 1.156
+      Perl::Critic::Exception::Configuration::Generic 1.156
+      Perl::Critic::Exception::Configuration::NonExistentPolicy 1.156
+      Perl::Critic::Exception::Configuration::Option 1.156
+      Perl::Critic::Exception::Configuration::Option::Global 1.156
+      Perl::Critic::Exception::Configuration::Option::Global::ExtraParameter 1.156
+      Perl::Critic::Exception::Configuration::Option::Global::ParameterValue 1.156
+      Perl::Critic::Exception::Configuration::Option::Policy 1.156
+      Perl::Critic::Exception::Configuration::Option::Policy::ExtraParameter 1.156
+      Perl::Critic::Exception::Configuration::Option::Policy::ParameterValue 1.156
+      Perl::Critic::Exception::Fatal 1.156
+      Perl::Critic::Exception::Fatal::Generic 1.156
+      Perl::Critic::Exception::Fatal::Internal 1.156
+      Perl::Critic::Exception::Fatal::PolicyDefinition 1.156
+      Perl::Critic::Exception::IO 1.156
+      Perl::Critic::Exception::Parse 1.156
+      Perl::Critic::OptionsProcessor 1.156
+      Perl::Critic::Policy 1.156
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitBooleanGrep 1.156
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitComplexMappings 1.156
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitLvalueSubstr 1.156
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitReverseSortBlock 1.156
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitShiftRef 1.156
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitSleepViaSelect 1.156
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitStringyEval 1.156
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitStringySplit 1.156
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitUniversalCan 1.156
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitUniversalIsa 1.156
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitUselessTopic 1.156
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitVoidGrep 1.156
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitVoidMap 1.156
+      Perl::Critic::Policy::BuiltinFunctions::RequireBlockGrep 1.156
+      Perl::Critic::Policy::BuiltinFunctions::RequireBlockMap 1.156
+      Perl::Critic::Policy::BuiltinFunctions::RequireGlobFunction 1.156
+      Perl::Critic::Policy::BuiltinFunctions::RequireSimpleSortBlock 1.156
+      Perl::Critic::Policy::ClassHierarchies::ProhibitAutoloading 1.156
+      Perl::Critic::Policy::ClassHierarchies::ProhibitExplicitISA 1.156
+      Perl::Critic::Policy::ClassHierarchies::ProhibitOneArgBless 1.156
+      Perl::Critic::Policy::CodeLayout::ProhibitHardTabs 1.156
+      Perl::Critic::Policy::CodeLayout::ProhibitParensWithBuiltins 1.156
+      Perl::Critic::Policy::CodeLayout::ProhibitQuotedWordLists 1.156
+      Perl::Critic::Policy::CodeLayout::ProhibitTrailingWhitespace 1.156
+      Perl::Critic::Policy::CodeLayout::RequireConsistentNewlines 1.156
+      Perl::Critic::Policy::CodeLayout::RequireTidyCode 1.156
+      Perl::Critic::Policy::CodeLayout::RequireTrailingCommas 1.156
+      Perl::Critic::Policy::ControlStructures::ProhibitCStyleForLoops 1.156
+      Perl::Critic::Policy::ControlStructures::ProhibitCascadingIfElse 1.156
+      Perl::Critic::Policy::ControlStructures::ProhibitDeepNests 1.156
+      Perl::Critic::Policy::ControlStructures::ProhibitLabelsWithSpecialBlockNames 1.156
+      Perl::Critic::Policy::ControlStructures::ProhibitMutatingListFunctions 1.156
+      Perl::Critic::Policy::ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions 1.156
+      Perl::Critic::Policy::ControlStructures::ProhibitPostfixControls 1.156
+      Perl::Critic::Policy::ControlStructures::ProhibitUnlessBlocks 1.156
+      Perl::Critic::Policy::ControlStructures::ProhibitUnreachableCode 1.156
+      Perl::Critic::Policy::ControlStructures::ProhibitUntilBlocks 1.156
+      Perl::Critic::Policy::ControlStructures::ProhibitYadaOperator 1.156
+      Perl::Critic::Policy::Documentation::PodSpelling 1.156
+      Perl::Critic::Policy::Documentation::RequirePackageMatchesPodName 1.156
+      Perl::Critic::Policy::Documentation::RequirePodAtEnd 1.156
+      Perl::Critic::Policy::Documentation::RequirePodSections 1.156
+      Perl::Critic::Policy::ErrorHandling::RequireCarping 1.156
+      Perl::Critic::Policy::ErrorHandling::RequireCheckingReturnValueOfEval 1.156
+      Perl::Critic::Policy::InputOutput::ProhibitBacktickOperators 1.156
+      Perl::Critic::Policy::InputOutput::ProhibitBarewordDirHandles 1.156
+      Perl::Critic::Policy::InputOutput::ProhibitBarewordFileHandles 1.156
+      Perl::Critic::Policy::InputOutput::ProhibitExplicitStdin 1.156
+      Perl::Critic::Policy::InputOutput::ProhibitInteractiveTest 1.156
+      Perl::Critic::Policy::InputOutput::ProhibitJoinedReadline 1.156
+      Perl::Critic::Policy::InputOutput::ProhibitOneArgSelect 1.156
+      Perl::Critic::Policy::InputOutput::ProhibitReadlineInForLoop 1.156
+      Perl::Critic::Policy::InputOutput::ProhibitTwoArgOpen 1.156
+      Perl::Critic::Policy::InputOutput::RequireBracedFileHandleWithPrint 1.156
+      Perl::Critic::Policy::InputOutput::RequireBriefOpen 1.156
+      Perl::Critic::Policy::InputOutput::RequireCheckedClose 1.156
+      Perl::Critic::Policy::InputOutput::RequireCheckedOpen 1.156
+      Perl::Critic::Policy::InputOutput::RequireCheckedSyscalls 1.156
+      Perl::Critic::Policy::InputOutput::RequireEncodingWithUTF8Layer 1.156
+      Perl::Critic::Policy::Miscellanea::ProhibitFormats 1.156
+      Perl::Critic::Policy::Miscellanea::ProhibitTies 1.156
+      Perl::Critic::Policy::Miscellanea::ProhibitUnrestrictedNoCritic 1.156
+      Perl::Critic::Policy::Miscellanea::ProhibitUselessNoCritic 1.156
+      Perl::Critic::Policy::Modules::ProhibitAutomaticExportation 1.156
+      Perl::Critic::Policy::Modules::ProhibitConditionalUseStatements 1.156
+      Perl::Critic::Policy::Modules::ProhibitEvilModules 1.156
+      Perl::Critic::Policy::Modules::ProhibitExcessMainComplexity 1.156
+      Perl::Critic::Policy::Modules::ProhibitMultiplePackages 1.156
+      Perl::Critic::Policy::Modules::RequireBarewordIncludes 1.156
+      Perl::Critic::Policy::Modules::RequireEndWithOne 1.156
+      Perl::Critic::Policy::Modules::RequireExplicitPackage 1.156
+      Perl::Critic::Policy::Modules::RequireFilenameMatchesPackage 1.156
+      Perl::Critic::Policy::Modules::RequireNoMatchVarsWithUseEnglish 1.156
+      Perl::Critic::Policy::Modules::RequireVersionVar 1.156
+      Perl::Critic::Policy::NamingConventions::Capitalization 1.156
+      Perl::Critic::Policy::NamingConventions::ProhibitAmbiguousNames 1.156
+      Perl::Critic::Policy::Objects::ProhibitIndirectSyntax 1.156
+      Perl::Critic::Policy::References::ProhibitDoubleSigils 1.156
+      Perl::Critic::Policy::RegularExpressions::ProhibitCaptureWithoutTest 1.156
+      Perl::Critic::Policy::RegularExpressions::ProhibitComplexRegexes 1.156
+      Perl::Critic::Policy::RegularExpressions::ProhibitEnumeratedClasses 1.156
+      Perl::Critic::Policy::RegularExpressions::ProhibitEscapedMetacharacters 1.156
+      Perl::Critic::Policy::RegularExpressions::ProhibitFixedStringMatches 1.156
+      Perl::Critic::Policy::RegularExpressions::ProhibitSingleCharAlternation 1.156
+      Perl::Critic::Policy::RegularExpressions::ProhibitUnusedCapture 1.156
+      Perl::Critic::Policy::RegularExpressions::ProhibitUnusualDelimiters 1.156
+      Perl::Critic::Policy::RegularExpressions::ProhibitUselessTopic 1.156
+      Perl::Critic::Policy::RegularExpressions::RequireBracesForMultiline 1.156
+      Perl::Critic::Policy::RegularExpressions::RequireDotMatchAnything 1.156
+      Perl::Critic::Policy::RegularExpressions::RequireExtendedFormatting 1.156
+      Perl::Critic::Policy::RegularExpressions::RequireLineBoundaryMatching 1.156
+      Perl::Critic::Policy::Subroutines::ProhibitAmpersandSigils 1.156
+      Perl::Critic::Policy::Subroutines::ProhibitBuiltinHomonyms 1.156
+      Perl::Critic::Policy::Subroutines::ProhibitExcessComplexity 1.156
+      Perl::Critic::Policy::Subroutines::ProhibitExplicitReturnUndef 1.156
+      Perl::Critic::Policy::Subroutines::ProhibitManyArgs 1.156
+      Perl::Critic::Policy::Subroutines::ProhibitNestedSubs 1.156
+      Perl::Critic::Policy::Subroutines::ProhibitReturnSort 1.156
+      Perl::Critic::Policy::Subroutines::ProhibitSubroutinePrototypes 1.156
+      Perl::Critic::Policy::Subroutines::ProhibitUnusedPrivateSubroutines 1.156
+      Perl::Critic::Policy::Subroutines::ProtectPrivateSubs 1.156
+      Perl::Critic::Policy::Subroutines::RequireArgUnpacking 1.156
+      Perl::Critic::Policy::Subroutines::RequireFinalReturn 1.156
+      Perl::Critic::Policy::TestingAndDebugging::ProhibitNoStrict 1.156
+      Perl::Critic::Policy::TestingAndDebugging::ProhibitNoWarnings 1.156
+      Perl::Critic::Policy::TestingAndDebugging::ProhibitProlongedStrictureOverride 1.156
+      Perl::Critic::Policy::TestingAndDebugging::RequireTestLabels 1.156
+      Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict 1.156
+      Perl::Critic::Policy::TestingAndDebugging::RequireUseWarnings 1.156
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitCommaSeparatedStatements 1.156
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitComplexVersion 1.156
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitConstantPragma 1.156
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitEmptyQuotes 1.156
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitEscapedCharacters 1.156
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitImplicitNewlines 1.156
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitInterpolationOfLiterals 1.156
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitLeadingZeros 1.156
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitLongChainsOfMethodCalls 1.156
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitMagicNumbers 1.156
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitMismatchedOperators 1.156
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitMixedBooleanOperators 1.156
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitNoisyQuotes 1.156
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitQuotesAsQuotelikeOperatorDelimiters 1.156
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitSpecialLiteralHeredocTerminator 1.156
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitVersionStrings 1.156
+      Perl::Critic::Policy::ValuesAndExpressions::RequireConstantVersion 1.156
+      Perl::Critic::Policy::ValuesAndExpressions::RequireInterpolationOfMetachars 1.156
+      Perl::Critic::Policy::ValuesAndExpressions::RequireNumberSeparators 1.156
+      Perl::Critic::Policy::ValuesAndExpressions::RequireQuotedHeredocTerminator 1.156
+      Perl::Critic::Policy::ValuesAndExpressions::RequireUpperCaseHeredocTerminator 1.156
+      Perl::Critic::Policy::Variables::ProhibitAugmentedAssignmentInDeclaration 1.156
+      Perl::Critic::Policy::Variables::ProhibitConditionalDeclarations 1.156
+      Perl::Critic::Policy::Variables::ProhibitEvilVariables 1.156
+      Perl::Critic::Policy::Variables::ProhibitLocalVars 1.156
+      Perl::Critic::Policy::Variables::ProhibitMatchVars 1.156
+      Perl::Critic::Policy::Variables::ProhibitPackageVars 1.156
+      Perl::Critic::Policy::Variables::ProhibitPerl4PackageNames 1.156
+      Perl::Critic::Policy::Variables::ProhibitPunctuationVars 1.156
+      Perl::Critic::Policy::Variables::ProhibitReusedNames 1.156
+      Perl::Critic::Policy::Variables::ProhibitUnusedVariables 1.156
+      Perl::Critic::Policy::Variables::ProtectPrivateVars 1.156
+      Perl::Critic::Policy::Variables::RequireInitializationForLocalVars 1.156
+      Perl::Critic::Policy::Variables::RequireLexicalLoopIterators 1.156
+      Perl::Critic::Policy::Variables::RequireLocalizedPunctuationVars 1.156
+      Perl::Critic::Policy::Variables::RequireNegativeIndices 1.156
+      Perl::Critic::PolicyConfig 1.156
+      Perl::Critic::PolicyFactory 1.156
+      Perl::Critic::PolicyListing 1.156
+      Perl::Critic::PolicyParameter 1.156
+      Perl::Critic::PolicyParameter::Behavior 1.156
+      Perl::Critic::PolicyParameter::Behavior::Boolean 1.156
+      Perl::Critic::PolicyParameter::Behavior::Enumeration 1.156
+      Perl::Critic::PolicyParameter::Behavior::Integer 1.156
+      Perl::Critic::PolicyParameter::Behavior::String 1.156
+      Perl::Critic::PolicyParameter::Behavior::StringList 1.156
+      Perl::Critic::ProfilePrototype 1.156
+      Perl::Critic::Statistics 1.156
+      Perl::Critic::TestUtils 1.156
+      Perl::Critic::Theme 1.156
+      Perl::Critic::ThemeListing 1.156
+      Perl::Critic::UserProfile 1.156
+      Perl::Critic::Utils 1.156
+      Perl::Critic::Utils::Constants 1.156
+      Perl::Critic::Utils::McCabe 1.156
+      Perl::Critic::Utils::POD 1.156
+      Perl::Critic::Utils::PPI 1.156
+      Perl::Critic::Utils::Perl 1.156
+      Perl::Critic::Violation 1.156
+      Test::Perl::Critic::Policy 1.156
     requirements:
       B::Keywords 1.23
       Carp 0
@@ -6312,65 +6378,38 @@ DISTRIBUTIONS
       strict 0
       version 0.77
       warnings 0
-  Perl-Critic-Community-v1.0.3
-    pathname: D/DB/DBOOK/Perl-Critic-Community-v1.0.3.tar.gz
+  Perl-Critic-Community-v1.0.4
+    pathname: D/DB/DBOOK/Perl-Critic-Community-v1.0.4.tar.gz
     provides:
-      Perl::Critic::Community v1.0.3
-      Perl::Critic::Community::Utils v1.0.3
-      Perl::Critic::Freenode v1.0.3
-      Perl::Critic::Freenode::Utils v1.0.3
-      Perl::Critic::Policy::Community::AmpersandSubCalls v1.0.3
-      Perl::Critic::Policy::Community::ArrayAssignAref v1.0.3
-      Perl::Critic::Policy::Community::BarewordFilehandles v1.0.3
-      Perl::Critic::Policy::Community::ConditionalDeclarations v1.0.3
-      Perl::Critic::Policy::Community::ConditionalImplicitReturn v1.0.3
-      Perl::Critic::Policy::Community::DeprecatedFeatures v1.0.3
-      Perl::Critic::Policy::Community::DiscouragedModules v1.0.3
-      Perl::Critic::Policy::Community::DollarAB v1.0.3
-      Perl::Critic::Policy::Community::Each v1.0.3
-      Perl::Critic::Policy::Community::EmptyReturn v1.0.3
-      Perl::Critic::Policy::Community::IndirectObjectNotation v1.0.3
-      Perl::Critic::Policy::Community::LexicalForeachIterator v1.0.3
-      Perl::Critic::Policy::Community::LoopOnHash v1.0.3
-      Perl::Critic::Policy::Community::ModPerl v1.0.3
-      Perl::Critic::Policy::Community::MultidimensionalArrayEmulation v1.0.3
-      Perl::Critic::Policy::Community::OpenArgs v1.0.3
-      Perl::Critic::Policy::Community::OverloadOptions v1.0.3
-      Perl::Critic::Policy::Community::POSIXImports v1.0.3
-      Perl::Critic::Policy::Community::PackageMatchesFilename v1.0.3
-      Perl::Critic::Policy::Community::PreferredAlternatives v1.0.3
-      Perl::Critic::Policy::Community::Prototypes v1.0.3
-      Perl::Critic::Policy::Community::StrictWarnings v1.0.3
-      Perl::Critic::Policy::Community::Threads v1.0.3
-      Perl::Critic::Policy::Community::Wantarray v1.0.3
-      Perl::Critic::Policy::Community::WarningsSwitch v1.0.3
-      Perl::Critic::Policy::Community::WhileDiamondDefaultAssignment v1.0.3
-      Perl::Critic::Policy::Freenode::AmpersandSubCalls v1.0.3
-      Perl::Critic::Policy::Freenode::ArrayAssignAref v1.0.3
-      Perl::Critic::Policy::Freenode::BarewordFilehandles v1.0.3
-      Perl::Critic::Policy::Freenode::ConditionalDeclarations v1.0.3
-      Perl::Critic::Policy::Freenode::ConditionalImplicitReturn v1.0.3
-      Perl::Critic::Policy::Freenode::DeprecatedFeatures v1.0.3
-      Perl::Critic::Policy::Freenode::DiscouragedModules v1.0.3
-      Perl::Critic::Policy::Freenode::DollarAB v1.0.3
-      Perl::Critic::Policy::Freenode::Each v1.0.3
-      Perl::Critic::Policy::Freenode::EmptyReturn v1.0.3
-      Perl::Critic::Policy::Freenode::IndirectObjectNotation v1.0.3
-      Perl::Critic::Policy::Freenode::LexicalForeachIterator v1.0.3
-      Perl::Critic::Policy::Freenode::LoopOnHash v1.0.3
-      Perl::Critic::Policy::Freenode::ModPerl v1.0.3
-      Perl::Critic::Policy::Freenode::MultidimensionalArrayEmulation v1.0.3
-      Perl::Critic::Policy::Freenode::OpenArgs v1.0.3
-      Perl::Critic::Policy::Freenode::OverloadOptions v1.0.3
-      Perl::Critic::Policy::Freenode::POSIXImports v1.0.3
-      Perl::Critic::Policy::Freenode::PackageMatchesFilename v1.0.3
-      Perl::Critic::Policy::Freenode::PreferredAlternatives v1.0.3
-      Perl::Critic::Policy::Freenode::Prototypes v1.0.3
-      Perl::Critic::Policy::Freenode::StrictWarnings v1.0.3
-      Perl::Critic::Policy::Freenode::Threads v1.0.3
-      Perl::Critic::Policy::Freenode::Wantarray v1.0.3
-      Perl::Critic::Policy::Freenode::WarningsSwitch v1.0.3
-      Perl::Critic::Policy::Freenode::WhileDiamondDefaultAssignment v1.0.3
+      Perl::Critic::Community v1.0.4
+      Perl::Critic::Community::Utils v1.0.4
+      Perl::Critic::Policy::Community::AmpersandSubCalls v1.0.4
+      Perl::Critic::Policy::Community::ArrayAssignAref v1.0.4
+      Perl::Critic::Policy::Community::BarewordFilehandles v1.0.4
+      Perl::Critic::Policy::Community::ConditionalDeclarations v1.0.4
+      Perl::Critic::Policy::Community::ConditionalImplicitReturn v1.0.4
+      Perl::Critic::Policy::Community::DeprecatedFeatures v1.0.4
+      Perl::Critic::Policy::Community::DiscouragedModules v1.0.4
+      Perl::Critic::Policy::Community::DollarAB v1.0.4
+      Perl::Critic::Policy::Community::Each v1.0.4
+      Perl::Critic::Policy::Community::EmptyReturn v1.0.4
+      Perl::Critic::Policy::Community::IndirectObjectNotation v1.0.4
+      Perl::Critic::Policy::Community::LexicalForeachIterator v1.0.4
+      Perl::Critic::Policy::Community::LoopOnHash v1.0.4
+      Perl::Critic::Policy::Community::ModPerl v1.0.4
+      Perl::Critic::Policy::Community::MultidimensionalArrayEmulation v1.0.4
+      Perl::Critic::Policy::Community::OpenArgs v1.0.4
+      Perl::Critic::Policy::Community::OverloadOptions v1.0.4
+      Perl::Critic::Policy::Community::POSIXImports v1.0.4
+      Perl::Critic::Policy::Community::PackageMatchesFilename v1.0.4
+      Perl::Critic::Policy::Community::PreferredAlternatives v1.0.4
+      Perl::Critic::Policy::Community::Prototypes v1.0.4
+      Perl::Critic::Policy::Community::SplitQuotedPattern v1.0.4
+      Perl::Critic::Policy::Community::StrictWarnings v1.0.4
+      Perl::Critic::Policy::Community::Threads v1.0.4
+      Perl::Critic::Policy::Community::Wantarray v1.0.4
+      Perl::Critic::Policy::Community::WarningsSwitch v1.0.4
+      Perl::Critic::Policy::Community::WhileDiamondDefaultAssignment v1.0.4
     requirements:
       Carp 0
       Exporter 0
@@ -6380,8 +6419,8 @@ DISTRIBUTIONS
       Path::Tiny 0.101
       Perl::Critic 1.126
       Perl::Critic::Policy::Objects::ProhibitIndirectSyntax 1.126
+      Perl::Critic::Policy::Plicease::ProhibitArrayAssignAref 100.00
       Perl::Critic::Policy::Subroutines::ProhibitAmpersandSigils 1.126
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitArrayAssignAref 90
       Perl::Critic::Policy::Variables::ProhibitConditionalDeclarations 1.126
       Perl::Critic::Policy::Variables::ProhibitLoopOnHash 0.005
       Perl::Critic::Policy::Variables::RequireLexicalLoopIterators 1.126
@@ -6389,6 +6428,53 @@ DISTRIBUTIONS
       parent 0
       perl 5.010001
       version 0
+  Perl-Critic-Freenode-v1.0.4
+    pathname: D/DB/DBOOK/Perl-Critic-Freenode-v1.0.4.tar.gz
+    provides:
+      Perl::Critic::Freenode v1.0.4
+      Perl::Critic::Freenode::Utils v1.0.4
+      Perl::Critic::Policy::Freenode::AmpersandSubCalls v1.0.4
+      Perl::Critic::Policy::Freenode::ArrayAssignAref v1.0.4
+      Perl::Critic::Policy::Freenode::BarewordFilehandles v1.0.4
+      Perl::Critic::Policy::Freenode::ConditionalDeclarations v1.0.4
+      Perl::Critic::Policy::Freenode::ConditionalImplicitReturn v1.0.4
+      Perl::Critic::Policy::Freenode::DeprecatedFeatures v1.0.4
+      Perl::Critic::Policy::Freenode::DiscouragedModules v1.0.4
+      Perl::Critic::Policy::Freenode::DollarAB v1.0.4
+      Perl::Critic::Policy::Freenode::Each v1.0.4
+      Perl::Critic::Policy::Freenode::EmptyReturn v1.0.4
+      Perl::Critic::Policy::Freenode::IndirectObjectNotation v1.0.4
+      Perl::Critic::Policy::Freenode::LexicalForeachIterator v1.0.4
+      Perl::Critic::Policy::Freenode::LoopOnHash v1.0.4
+      Perl::Critic::Policy::Freenode::ModPerl v1.0.4
+      Perl::Critic::Policy::Freenode::MultidimensionalArrayEmulation v1.0.4
+      Perl::Critic::Policy::Freenode::OpenArgs v1.0.4
+      Perl::Critic::Policy::Freenode::OverloadOptions v1.0.4
+      Perl::Critic::Policy::Freenode::POSIXImports v1.0.4
+      Perl::Critic::Policy::Freenode::PackageMatchesFilename v1.0.4
+      Perl::Critic::Policy::Freenode::PreferredAlternatives v1.0.4
+      Perl::Critic::Policy::Freenode::Prototypes v1.0.4
+      Perl::Critic::Policy::Freenode::StrictWarnings v1.0.4
+      Perl::Critic::Policy::Freenode::Threads v1.0.4
+      Perl::Critic::Policy::Freenode::Wantarray v1.0.4
+      Perl::Critic::Policy::Freenode::WarningsSwitch v1.0.4
+      Perl::Critic::Policy::Freenode::WhileDiamondDefaultAssignment v1.0.4
+    requirements:
+      Exporter 0
+      Module::Build::Tiny 0.034
+      Perl::Critic::Community v1.0.0
+      Perl::Critic::Community::Utils v1.0.0
+      parent 0
+      perl 5.010001
+  Perl-Critic-Policy-Plicease-ProhibitArrayAssignAref-100.00
+    pathname: P/PL/PLICEASE/Perl-Critic-Policy-Plicease-ProhibitArrayAssignAref-100.00.tar.gz
+    provides:
+      Perl::Critic::Policy::Plicease::ProhibitArrayAssignAref 100.00
+    requirements:
+      ExtUtils::MakeMaker 0
+      Perl::Critic::Policy 0
+      Perl::Critic::Utils 0
+      perl 5.006
   Perl-Critic-Policy-Variables-ProhibitLoopOnHash-0.008
     pathname: X/XS/XSAWYERX/Perl-Critic-Policy-Variables-ProhibitLoopOnHash-0.008.tar.gz
     provides:
@@ -6399,103 +6485,23 @@ DISTRIBUTIONS
       List::Util 1.33
       Perl::Critic 1.126
       parent 0
-  Perl-Critic-Pulp-99
-    pathname: K/KR/KRYDE/Perl-Critic-Pulp-99.tar.gz
+  Perl-Tidy-20250311
+    pathname: S/SH/SHANCOCK/Perl-Tidy-20250311.tar.gz
     provides:
-      Perl::Critic::PodParser::ProhibitVerbatimMarkup 99
-      Perl::Critic::Policy::CodeLayout::ProhibitFatCommaNewline 99
-      Perl::Critic::Policy::CodeLayout::ProhibitIfIfSameLine 99
-      Perl::Critic::Policy::CodeLayout::RequireFinalSemicolon 99
-      Perl::Critic::Policy::CodeLayout::RequireTrailingCommaAtNewline 99
-      Perl::Critic::Policy::Compatibility::ConstantLeadingUnderscore 99
-      Perl::Critic::Policy::Compatibility::ConstantPragmaHash 99
-      Perl::Critic::Policy::Compatibility::Gtk2Constants 99
-      Perl::Critic::Policy::Compatibility::PerlMinimumVersionAndWhy 99
-      Perl::Critic::Policy::Compatibility::PodMinimumVersion 99
-      Perl::Critic::Policy::Compatibility::ProhibitUnixDevNull 99
-      Perl::Critic::Policy::Documentation::ProhibitAdjacentLinks 99
-      Perl::Critic::Policy::Documentation::ProhibitAdjacentLinks::Parser 99
-      Perl::Critic::Policy::Documentation::ProhibitBadAproposMarkup 99
-      Perl::Critic::Policy::Documentation::ProhibitDuplicateHeadings 99
-      Perl::Critic::Policy::Documentation::ProhibitDuplicateSeeAlso 99
-      Perl::Critic::Policy::Documentation::ProhibitLinkToSelf 99
-      Perl::Critic::Policy::Documentation::ProhibitParagraphEndComma 99
-      Perl::Critic::Policy::Documentation::ProhibitParagraphTwoDots 99
-      Perl::Critic::Policy::Documentation::ProhibitUnbalancedParens 99
-      Perl::Critic::Policy::Documentation::ProhibitVerbatimMarkup 99
-      Perl::Critic::Policy::Documentation::RequireEndBeforeLastPod 99
-      Perl::Critic::Policy::Documentation::RequireFilenameMarkup 99
-      Perl::Critic::Policy::Documentation::RequireFinalCut 99
-      Perl::Critic::Policy::Documentation::RequireLinkedURLs 99
-      Perl::Critic::Policy::Miscellanea::TextDomainPlaceholders 99
-      Perl::Critic::Policy::Miscellanea::TextDomainUnused 99
-      Perl::Critic::Policy::Modules::ProhibitModuleShebang 99
-      Perl::Critic::Policy::Modules::ProhibitPOSIXimport 99
-      Perl::Critic::Policy::Modules::ProhibitUseQuotedVersion 99
-      Perl::Critic::Policy::ValuesAndExpressions::ConstantBeforeLt 99
-      Perl::Critic::Policy::ValuesAndExpressions::NotWithCompare 99
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitArrayAssignAref 99
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitBarewordDoubleColon 99
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitDuplicateHashKeys 99
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitEmptyCommas 99
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitFiletest_f 99
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitNullStatements 99
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitUnknownBackslash 99
-      Perl::Critic::Policy::ValuesAndExpressions::RequireNumericVersion 99
-      Perl::Critic::Policy::ValuesAndExpressions::UnexpandedSpecialLiteral 99
-      Perl::Critic::Pulp 99
-      Perl::Critic::Pulp::PodMinimumVersionViolation 99
-      Perl::Critic::Pulp::PodParser 99
-      Perl::Critic::Pulp::PodParser::ProhibitBadAproposMarkup 99
-      Perl::Critic::Pulp::PodParser::ProhibitDuplicateHeadings 99
-      Perl::Critic::Pulp::PodParser::ProhibitDuplicateSeeAlso 99
-      Perl::Critic::Pulp::PodParser::ProhibitLinkToSelf 99
-      Perl::Critic::Pulp::PodParser::ProhibitParagraphEndComma 99
-      Perl::Critic::Pulp::PodParser::ProhibitParagraphTwoDots 99
-      Perl::Critic::Pulp::PodParser::ProhibitUnbalancedParens 99
-      Perl::Critic::Pulp::PodParser::RequireFilenameMarkup 99
-      Perl::Critic::Pulp::PodParser::RequireFinalCut 99
-      Perl::Critic::Pulp::PodParser::RequireLinkedURLs 99
-      Perl::Critic::Pulp::ProhibitDuplicateHashKeys::Qword 99
-      Perl::Critic::Pulp::Utils 99
-    requirements:
-      ExtUtils::MakeMaker 0
-      IO::String 1.02
-      List::MoreUtils 0.24
-      List::Util 0
-      PPI 1.220
-      PPI::Document 0
-      PPI::Dumper 0
-      Perl::Critic 1.084
-      Perl::Critic::Policy 1.084
-      Perl::Critic::Utils 1.100
-      Perl::Critic::Utils::PPI 0
-      Perl::Critic::Violation 0
-      Pod::Escapes 0
-      Pod::MinimumVersion 50
-      Pod::ParseLink 0
-      Pod::Parser 0
-      Scalar::Util 0
-      Test::More 0
-      perl 5.006
-      version 0
-  Perl-Tidy-20240511
-    pathname: S/SH/SHANCOCK/Perl-Tidy-20240511.tar.gz
-    provides:
-      Perl::Tidy 20240511
-      Perl::Tidy::Debugger 20240511
-      Perl::Tidy::Diagnostics 20240511
-      Perl::Tidy::FileWriter 20240511
-      Perl::Tidy::Formatter 20240511
-      Perl::Tidy::HtmlWriter 20240511
-      Perl::Tidy::IOScalar 20240511
-      Perl::Tidy::IOScalarArray 20240511
-      Perl::Tidy::IndentationItem 20240511
-      Perl::Tidy::Logger 20240511
-      Perl::Tidy::Tokenizer 20240511
-      Perl::Tidy::VerticalAligner 20240511
-      Perl::Tidy::VerticalAligner::Alignment 20240511
-      Perl::Tidy::VerticalAligner::Line 20240511
+      Perl::Tidy 20250311
+      Perl::Tidy::Debugger 20250311
+      Perl::Tidy::Diagnostics 20250311
+      Perl::Tidy::FileWriter 20250311
+      Perl::Tidy::Formatter 20250311
+      Perl::Tidy::HtmlWriter 20250311
+      Perl::Tidy::IOScalar 20250311
+      Perl::Tidy::IOScalarArray 20250311
+      Perl::Tidy::IndentationItem 20250311
+      Perl::Tidy::Logger 20250311
+      Perl::Tidy::Tokenizer 20250311
+      Perl::Tidy::VerticalAligner 20250311
+      Perl::Tidy::VerticalAligner::Alignment 20250311
+      Perl::Tidy::VerticalAligner::Line 20250311
     requirements:
       ExtUtils::MakeMaker 0
       perl 5.008
@@ -6656,20 +6662,6 @@ DISTRIBUTIONS
       perl 5.012
       strict 0
       warnings 0
-  Pod-MinimumVersion-50
-    pathname: K/KR/KRYDE/Pod-MinimumVersion-50.tar.gz
-    provides:
-      Pod::MinimumVersion 50
-      Pod::MinimumVersion::Parser 50
-      Pod::MinimumVersion::Report 50
-    requirements:
-      ExtUtils::MakeMaker 0
-      IO::String 1.02
-      List::Util 0
-      Pod::Parser 0
-      Test 0
-      perl 5.004
-      version 0
   Pod-Parser-1.67
     pathname: M/MA/MAREKR/Pod-Parser-1.67.tar.gz
     provides:
@@ -6692,11 +6684,11 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       File::Basename 0
       Test::More 0.6
-  Pod-Spell-1.26
-    pathname: H/HA/HAARG/Pod-Spell-1.26.tar.gz
+  Pod-Spell-1.27
+    pathname: H/HA/HAARG/Pod-Spell-1.27.tar.gz
     provides:
-      Pod::Spell 1.26
-      Pod::Wordlist 1.26
+      Pod::Spell 1.27
+      Pod::Wordlist 1.27
     requirements:
       Carp 0
       Class::Tiny 0
@@ -6711,7 +6703,7 @@ DISTRIBUTIONS
       constant 0
       locale 0
       parent 0
-      perl 5.008
+      perl 5.008001
   Readonly-2.05
     pathname: S/SA/SANKO/Readonly-2.05.tar.gz
     provides:
@@ -7132,52 +7124,53 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
-  Specio-0.48
-    pathname: D/DR/DROLSKY/Specio-0.48.tar.gz
+  Specio-0.50
+    pathname: D/DR/DROLSKY/Specio-0.50.tar.gz
     provides:
-      Specio 0.48
-      Specio::Coercion 0.48
-      Specio::Constraint::AnyCan 0.48
-      Specio::Constraint::AnyDoes 0.48
-      Specio::Constraint::AnyIsa 0.48
-      Specio::Constraint::Enum 0.48
-      Specio::Constraint::Intersection 0.48
-      Specio::Constraint::ObjectCan 0.48
-      Specio::Constraint::ObjectDoes 0.48
-      Specio::Constraint::ObjectIsa 0.48
-      Specio::Constraint::Parameterizable 0.48
-      Specio::Constraint::Parameterized 0.48
-      Specio::Constraint::Role::CanType 0.48
-      Specio::Constraint::Role::DoesType 0.48
-      Specio::Constraint::Role::Interface 0.48
-      Specio::Constraint::Role::IsaType 0.48
-      Specio::Constraint::Simple 0.48
-      Specio::Constraint::Structurable 0.48
-      Specio::Constraint::Structured 0.48
-      Specio::Constraint::Union 0.48
-      Specio::Declare 0.48
-      Specio::DeclaredAt 0.48
-      Specio::Exception 0.48
-      Specio::Exporter 0.48
-      Specio::Helpers 0.48
-      Specio::Library::Builtins 0.48
-      Specio::Library::Numeric 0.48
-      Specio::Library::Perl 0.48
-      Specio::Library::String 0.48
-      Specio::Library::Structured 0.48
-      Specio::Library::Structured::Dict 0.48
-      Specio::Library::Structured::Map 0.48
-      Specio::Library::Structured::Tuple 0.48
-      Specio::OO 0.48
-      Specio::PartialDump 0.48
-      Specio::Registry 0.48
-      Specio::Role::Inlinable 0.48
-      Specio::Subs 0.48
-      Specio::TypeChecks 0.48
-      Test::Specio 0.48
+      Specio 0.50
+      Specio::Coercion 0.50
+      Specio::Constraint::AnyCan 0.50
+      Specio::Constraint::AnyDoes 0.50
+      Specio::Constraint::AnyIsa 0.50
+      Specio::Constraint::Enum 0.50
+      Specio::Constraint::Intersection 0.50
+      Specio::Constraint::ObjectCan 0.50
+      Specio::Constraint::ObjectDoes 0.50
+      Specio::Constraint::ObjectIsa 0.50
+      Specio::Constraint::Parameterizable 0.50
+      Specio::Constraint::Parameterized 0.50
+      Specio::Constraint::Role::CanType 0.50
+      Specio::Constraint::Role::DoesType 0.50
+      Specio::Constraint::Role::Interface 0.50
+      Specio::Constraint::Role::IsaType 0.50
+      Specio::Constraint::Simple 0.50
+      Specio::Constraint::Structurable 0.50
+      Specio::Constraint::Structured 0.50
+      Specio::Constraint::Union 0.50
+      Specio::Declare 0.50
+      Specio::DeclaredAt 0.50
+      Specio::Exception 0.50
+      Specio::Exporter 0.50
+      Specio::Helpers 0.50
+      Specio::Library::Builtins 0.50
+      Specio::Library::Numeric 0.50
+      Specio::Library::Perl 0.50
+      Specio::Library::String 0.50
+      Specio::Library::Structured 0.50
+      Specio::Library::Structured::Dict 0.50
+      Specio::Library::Structured::Map 0.50
+      Specio::Library::Structured::Tuple 0.50
+      Specio::OO 0.50
+      Specio::PartialDump 0.50
+      Specio::Registry 0.50
+      Specio::Role::Inlinable 0.50
+      Specio::Subs 0.50
+      Specio::TypeChecks 0.50
+      Test::Specio 0.50
     requirements:
       B 0
       Carp 0
+      Clone 0
       Devel::StackTrace 0
       Eval::Closure 0
       Exporter 0
@@ -7189,7 +7182,6 @@ DISTRIBUTIONS
       Role::Tiny 1.003003
       Role::Tiny::With 0
       Scalar::Util 0
-      Storable 0
       Sub::Quote 0
       Test::Fatal 0
       Test::More 0.96
@@ -7287,10 +7279,10 @@ DISTRIBUTIONS
       perl 5.008000
       strict 0
       warnings 0
-  Sub-Name-0.27
-    pathname: E/ET/ETHER/Sub-Name-0.27.tar.gz
+  Sub-Name-0.28
+    pathname: E/ET/ETHER/Sub-Name-0.28.tar.gz
     provides:
-      Sub::Name 0.27
+      Sub::Name 0.28
     requirements:
       Exporter 0
       ExtUtils::MakeMaker 0
@@ -7701,10 +7693,10 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       Test::More 0
-  Text-CSV_XS-1.56
-    pathname: H/HM/HMBRAND/Text-CSV_XS-1.56.tgz
+  Text-CSV_XS-1.60
+    pathname: H/HM/HMBRAND/Text-CSV_XS-1.60.tgz
     provides:
-      Text::CSV_XS 1.56
+      Text::CSV_XS 1.60
     requirements:
       Config 0
       ExtUtils::MakeMaker 0
@@ -7748,10 +7740,10 @@ DISTRIBUTIONS
       Test::Exception 0
       Test::More 0.42
       Text::Balanced 0
-  Text-MultiMarkdown-1.002
-    pathname: B/BD/BDFOY/Text-MultiMarkdown-1.002.tar.gz
+  Text-MultiMarkdown-1.004
+    pathname: B/BR/BRIANDFOY/Text-MultiMarkdown-1.004.tar.gz
     provides:
-      Text::MultiMarkdown 1.002
+      Text::MultiMarkdown 1.004
     requirements:
       Digest::MD5 0
       Encode 0
@@ -7759,6 +7751,7 @@ DISTRIBUTIONS
       File::Spec::Functions 0
       HTML::Entities 0
       Text::Markdown v1.0.26
+      Text::Unidecode 0
       perl 5.008
   Text-Template-1.61
     pathname: M/MS/MSCHOUT/Text-Template-1.61.tar.gz
@@ -7781,10 +7774,10 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       perl 5.008
-  TheSchwartz-1.17
-    pathname: A/AK/AKIYM/TheSchwartz-1.17.tar.gz
+  TheSchwartz-1.18
+    pathname: A/AK/AKIYM/TheSchwartz-1.18.tar.gz
     provides:
-      TheSchwartz 1.17
+      TheSchwartz 1.18
       TheSchwartz::Error undef
       TheSchwartz::ExitStatus undef
       TheSchwartz::FuncMap undef
@@ -7897,60 +7890,60 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
-  Type-Tiny-2.004000
-    pathname: T/TO/TOBYINK/Type-Tiny-2.004000.tar.gz
+  Type-Tiny-2.006000
+    pathname: T/TO/TOBYINK/Type-Tiny-2.006000.tar.gz
     provides:
-      Devel::TypeTiny::Perl58Compat 2.004000
-      Error::TypeTiny 2.004000
-      Error::TypeTiny::Assertion 2.004000
-      Error::TypeTiny::Compilation 2.004000
-      Error::TypeTiny::WrongNumberOfParameters 2.004000
-      Eval::TypeTiny 2.004000
-      Eval::TypeTiny::CodeAccumulator 2.004000
-      Reply::Plugin::TypeTiny 2.004000
-      Test::TypeTiny 2.004000
-      Type::Coercion 2.004000
-      Type::Coercion::FromMoose 2.004000
-      Type::Coercion::Union 2.004000
-      Type::Library 2.004000
-      Type::Params 2.004000
-      Type::Params::Alternatives 2.004000
-      Type::Params::Parameter 2.004000
-      Type::Params::Signature 2.004000
-      Type::Parser 2.004000
-      Type::Parser::AstBuilder 2.004000
-      Type::Parser::Token 2.004000
-      Type::Parser::TokenStream 2.004000
-      Type::Registry 2.004000
-      Type::Tie 2.004000
-      Type::Tie::ARRAY 2.004000
-      Type::Tie::BASE 2.004000
-      Type::Tie::HASH 2.004000
-      Type::Tie::SCALAR 2.004000
-      Type::Tiny 2.004000
-      Type::Tiny::Bitfield 2.004000
-      Type::Tiny::Class 2.004000
-      Type::Tiny::ConstrainedObject 2.004000
-      Type::Tiny::Duck 2.004000
-      Type::Tiny::Enum 2.004000
-      Type::Tiny::Intersection 2.004000
-      Type::Tiny::Role 2.004000
-      Type::Tiny::Union 2.004000
-      Type::Utils 2.004000
-      Types::Common 2.004000
-      Types::Common::Numeric 2.004000
-      Types::Common::String 2.004000
-      Types::Standard 2.004000
-      Types::Standard::ArrayRef 2.004000
-      Types::Standard::CycleTuple 2.004000
-      Types::Standard::Dict 2.004000
-      Types::Standard::HashRef 2.004000
-      Types::Standard::Map 2.004000
-      Types::Standard::ScalarRef 2.004000
-      Types::Standard::StrMatch 2.004000
-      Types::Standard::Tied 2.004000
-      Types::Standard::Tuple 2.004000
-      Types::TypeTiny 2.004000
+      Devel::TypeTiny::Perl58Compat 2.006000
+      Error::TypeTiny 2.006000
+      Error::TypeTiny::Assertion 2.006000
+      Error::TypeTiny::Compilation 2.006000
+      Error::TypeTiny::WrongNumberOfParameters 2.006000
+      Eval::TypeTiny 2.006000
+      Eval::TypeTiny::CodeAccumulator 2.006000
+      Reply::Plugin::TypeTiny 2.006000
+      Test::TypeTiny 2.006000
+      Type::Coercion 2.006000
+      Type::Coercion::FromMoose 2.006000
+      Type::Coercion::Union 2.006000
+      Type::Library 2.006000
+      Type::Params 2.006000
+      Type::Params::Alternatives 2.006000
+      Type::Params::Parameter 2.006000
+      Type::Params::Signature 2.006000
+      Type::Parser 2.006000
+      Type::Parser::AstBuilder 2.006000
+      Type::Parser::Token 2.006000
+      Type::Parser::TokenStream 2.006000
+      Type::Registry 2.006000
+      Type::Tie 2.006000
+      Type::Tie::ARRAY 2.006000
+      Type::Tie::BASE 2.006000
+      Type::Tie::HASH 2.006000
+      Type::Tie::SCALAR 2.006000
+      Type::Tiny 2.006000
+      Type::Tiny::Bitfield 2.006000
+      Type::Tiny::Class 2.006000
+      Type::Tiny::ConstrainedObject 2.006000
+      Type::Tiny::Duck 2.006000
+      Type::Tiny::Enum 2.006000
+      Type::Tiny::Intersection 2.006000
+      Type::Tiny::Role 2.006000
+      Type::Tiny::Union 2.006000
+      Type::Utils 2.006000
+      Types::Common 2.006000
+      Types::Common::Numeric 2.006000
+      Types::Common::String 2.006000
+      Types::Standard 2.006000
+      Types::Standard::ArrayRef 2.006000
+      Types::Standard::CycleTuple 2.006000
+      Types::Standard::Dict 2.006000
+      Types::Standard::HashRef 2.006000
+      Types::Standard::Map 2.006000
+      Types::Standard::ScalarRef 2.006000
+      Types::Standard::StrMatch 2.006000
+      Types::Standard::Tied 2.006000
+      Types::Standard::Tuple 2.006000
+      Types::TypeTiny 2.006000
     requirements:
       Exporter::Tiny 1.006000
       ExtUtils::MakeMaker 6.17
@@ -7965,56 +7958,62 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       common::sense 0
-  URI-5.28
-    pathname: O/OA/OALDERS/URI-5.28.tar.gz
+  URI-5.31
+    pathname: O/OA/OALDERS/URI-5.31.tar.gz
     provides:
-      URI 5.28
-      URI::Escape 5.28
-      URI::Heuristic 5.28
-      URI::IRI 5.28
-      URI::QueryParam 5.28
-      URI::Split 5.28
-      URI::URL 5.28
-      URI::WithBase 5.28
-      URI::data 5.28
-      URI::file 5.28
-      URI::file::Base 5.28
-      URI::file::FAT 5.28
-      URI::file::Mac 5.28
-      URI::file::OS2 5.28
-      URI::file::QNX 5.28
-      URI::file::Unix 5.28
-      URI::file::Win32 5.28
-      URI::ftp 5.28
-      URI::geo 5.28
-      URI::gopher 5.28
-      URI::http 5.28
-      URI::https 5.28
-      URI::icap 5.28
-      URI::icaps 5.28
-      URI::ldap 5.28
-      URI::ldapi 5.28
-      URI::ldaps 5.28
-      URI::mailto 5.28
-      URI::mms 5.28
-      URI::news 5.28
-      URI::nntp 5.28
-      URI::nntps 5.28
-      URI::pop 5.28
-      URI::rlogin 5.28
-      URI::rsync 5.28
-      URI::rtsp 5.28
-      URI::rtspu 5.28
-      URI::sftp 5.28
-      URI::sip 5.28
-      URI::sips 5.28
-      URI::snews 5.28
-      URI::ssh 5.28
-      URI::telnet 5.28
-      URI::tn3270 5.28
-      URI::urn 5.28
-      URI::urn::isbn 5.28
-      URI::urn::oid 5.28
+      URI 5.31
+      URI::Escape 5.31
+      URI::Heuristic 5.31
+      URI::IRI 5.31
+      URI::QueryParam 5.31
+      URI::Split 5.31
+      URI::URL 5.31
+      URI::WithBase 5.31
+      URI::data 5.31
+      URI::file 5.31
+      URI::file::Base 5.31
+      URI::file::FAT 5.31
+      URI::file::Mac 5.31
+      URI::file::OS2 5.31
+      URI::file::QNX 5.31
+      URI::file::Unix 5.31
+      URI::file::Win32 5.31
+      URI::ftp 5.31
+      URI::ftpes 5.31
+      URI::ftps 5.31
+      URI::geo 5.31
+      URI::gopher 5.31
+      URI::http 5.31
+      URI::https 5.31
+      URI::icap 5.31
+      URI::icaps 5.31
+      URI::irc 5.31
+      URI::ircs 5.31
+      URI::ldap 5.31
+      URI::ldapi 5.31
+      URI::ldaps 5.31
+      URI::mailto 5.31
+      URI::mms 5.31
+      URI::news 5.31
+      URI::nntp 5.31
+      URI::nntps 5.31
+      URI::otpauth 5.31
+      URI::pop 5.31
+      URI::rlogin 5.31
+      URI::rsync 5.31
+      URI::rtsp 5.31
+      URI::rtspu 5.31
+      URI::scp 5.31
+      URI::sftp 5.31
+      URI::sip 5.31
+      URI::sips 5.31
+      URI::snews 5.31
+      URI::ssh 5.31
+      URI::telnet 5.31
+      URI::tn3270 5.31
+      URI::urn 5.31
+      URI::urn::isbn 5.31
+      URI::urn::oid 5.31
     requirements:
       Carp 0
       Cwd 0
@@ -8022,6 +8021,7 @@ DISTRIBUTIONS
       Encode 0
       Exporter 5.57
       ExtUtils::MakeMaker 0
+      MIME::Base32 0
       MIME::Base64 2
       Net::Domain 0
       Scalar::Util 0
@@ -8187,15 +8187,15 @@ DISTRIBUTIONS
       XML::SAX 0.15
       XML::SAX::Expat 0
       perl 5.008
-  XML-Twig-3.52
-    pathname: M/MI/MIROD/XML-Twig-3.52.tar.gz
+  XML-Twig-3.53
+    pathname: M/MI/MIROD/XML-Twig-3.53.tar.gz
     provides:
-      XML::Twig 3.52
-      XML::Twig::Elt 3.52
-      XML::Twig::Entity 3.52
-      XML::Twig::Entity_list 3.52
-      XML::Twig::Notation 3.52
-      XML::Twig::Notation_list 3.52
+      XML::Twig 3.53
+      XML::Twig::Elt 3.53
+      XML::Twig::Entity 3.53
+      XML::Twig::Entity_list 3.53
+      XML::Twig::Notation 3.53
+      XML::Twig::Notation_list 3.53
       XML::Twig::XPath 0.02
       XML::Twig::XPath::Attribute 0.02
       XML::Twig::XPath::Elt 0.02
@@ -8266,15 +8266,78 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       perl 5.008001
-  YAML-LibYAML-0.89
-    pathname: T/TI/TINITA/YAML-LibYAML-0.89.tar.gz
+  YAML-LibYAML-v0.903.0
+    pathname: T/TI/TINITA/YAML-LibYAML-v0.903.0.tar.gz
     provides:
-      YAML::LibYAML 0.89
-      YAML::XS 0.89
-      YAML::XS::LibYAML undef
+      YAML::LibYAML v0.903.0
+      YAML::XS v0.903.0
     requirements:
+      B::Deparse 0
+      Exporter 0
       ExtUtils::MakeMaker 0
+      Scalar::Util 0
+      base 0
+      constant 0
       perl 5.008001
+      strict 0
+      warnings 0
+  YAML-PP-v0.39.0
+    pathname: T/TI/TINITA/YAML-PP-v0.39.0.tar.gz
+    provides:
+      YAML::PP v0.39.0
+      YAML::PP::Common v0.39.0
+      YAML::PP::Constructor v0.39.0
+      YAML::PP::Dumper v0.39.0
+      YAML::PP::Emitter v0.39.0
+      YAML::PP::Exception v0.39.0
+      YAML::PP::Grammar v0.39.0
+      YAML::PP::Highlight v0.39.0
+      YAML::PP::Lexer v0.39.0
+      YAML::PP::Loader v0.39.0
+      YAML::PP::Parser v0.39.0
+      YAML::PP::Perl v0.39.0
+      YAML::PP::Preserve::Array v0.39.0
+      YAML::PP::Preserve::Hash v0.39.0
+      YAML::PP::Preserve::Scalar v0.39.0
+      YAML::PP::Reader v0.39.0
+      YAML::PP::Reader::File v0.39.0
+      YAML::PP::Render v0.39.0
+      YAML::PP::Representer v0.39.0
+      YAML::PP::Schema v0.39.0
+      YAML::PP::Schema::Binary v0.39.0
+      YAML::PP::Schema::Catchall v0.39.0
+      YAML::PP::Schema::Core v0.39.0
+      YAML::PP::Schema::Failsafe v0.39.0
+      YAML::PP::Schema::Include v0.39.0
+      YAML::PP::Schema::JSON v0.39.0
+      YAML::PP::Schema::Merge v0.39.0
+      YAML::PP::Schema::Perl v0.39.0
+      YAML::PP::Schema::Tie::IxHash v0.39.0
+      YAML::PP::Schema::YAML1_1 v0.39.0
+      YAML::PP::Type::MergeKey v0.39.0
+      YAML::PP::Writer v0.39.0
+      YAML::PP::Writer::File v0.39.0
+    requirements:
+      B 0
+      B::Deparse 0
+      Carp 0
+      Data::Dumper 0
+      Encode 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      File::Basename 0
+      Getopt::Long 0
+      MIME::Base64 0
+      Module::Load 0
+      Scalar::Util 1.07
+      Tie::Array 0
+      Tie::Hash 0
+      base 0
+      constant 0
+      overload 0
+      perl 5.008000
+      strict 0
+      warnings 0
   bareword-filehandles-0.007
     pathname: I/IL/ILMARI/bareword-filehandles-0.007.tar.gz
     provides:
@@ -8313,32 +8376,32 @@ DISTRIBUTIONS
       XSLoader 0
       lib 0
       perl 5.008001
-  libwww-perl-6.77
-    pathname: O/OA/OALDERS/libwww-perl-6.77.tar.gz
+  libwww-perl-6.78
+    pathname: O/OA/OALDERS/libwww-perl-6.78.tar.gz
     provides:
-      LWP 6.77
-      LWP::Authen::Basic 6.77
-      LWP::Authen::Digest 6.77
-      LWP::Authen::Ntlm 6.77
-      LWP::ConnCache 6.77
-      LWP::Debug 6.77
-      LWP::Debug::TraceHTTP 6.77
-      LWP::DebugFile 6.77
-      LWP::MemberMixin 6.77
-      LWP::Protocol 6.77
-      LWP::Protocol::cpan 6.77
-      LWP::Protocol::data 6.77
-      LWP::Protocol::file 6.77
-      LWP::Protocol::ftp 6.77
-      LWP::Protocol::gopher 6.77
-      LWP::Protocol::http 6.77
-      LWP::Protocol::loopback 6.77
-      LWP::Protocol::mailto 6.77
-      LWP::Protocol::nntp 6.77
-      LWP::Protocol::nogo 6.77
-      LWP::RobotUA 6.77
-      LWP::Simple 6.77
-      LWP::UserAgent 6.77
+      LWP 6.78
+      LWP::Authen::Basic 6.78
+      LWP::Authen::Digest 6.78
+      LWP::Authen::Ntlm 6.78
+      LWP::ConnCache 6.78
+      LWP::Debug 6.78
+      LWP::Debug::TraceHTTP 6.78
+      LWP::DebugFile 6.78
+      LWP::MemberMixin 6.78
+      LWP::Protocol 6.78
+      LWP::Protocol::cpan 6.78
+      LWP::Protocol::data 6.78
+      LWP::Protocol::file 6.78
+      LWP::Protocol::ftp 6.78
+      LWP::Protocol::gopher 6.78
+      LWP::Protocol::http 6.78
+      LWP::Protocol::loopback 6.78
+      LWP::Protocol::mailto 6.78
+      LWP::Protocol::nntp 6.78
+      LWP::Protocol::nogo 6.78
+      LWP::RobotUA 6.78
+      LWP::Simple 6.78
+      LWP::UserAgent 6.78
     requirements:
       Digest::MD5 0
       Encode 2.12
@@ -8388,15 +8451,15 @@ DISTRIBUTIONS
       perl 5.008001
       strict 0
       warnings 0
-  namespace-autoclean-0.29
-    pathname: E/ET/ETHER/namespace-autoclean-0.29.tar.gz
+  namespace-autoclean-0.31
+    pathname: E/ET/ETHER/namespace-autoclean-0.31.tar.gz
     provides:
-      namespace::autoclean 0.29
+      namespace::autoclean 0.31
     requirements:
+      B 0
       B::Hooks::EndOfScope 0.12
       ExtUtils::MakeMaker 0
       List::Util 0
-      Sub::Identify 0
       namespace::clean 0.20
       perl 5.006
       strict 0


### PR DESCRIPTION
Sub::Identify needs to be explicitly required now that a previous dependency stopped needing it and we no longer get it automatically.