### PR TITLE
Bug 1959361 - Adding attachments doesn't add you to the bug's CC list

### DIFF
--- a/attachment.cgi
+++ b/attachment.cgi
@@ -648,6 +648,12 @@ sub insert {
     $owner = $bug->assigned_to->login;
     $bug->set_assigned_to($user);
   }
+
+  # Add user to CC if requested
+  if ($cgi->param('addselfcc')) {
+    $bug->add_cc(Bugzilla->user);
+  }
+
   $bug->update($timestamp);
 
   # We have to update the attachment after updating the bug, to ensure new
@@ -822,6 +828,11 @@ sub update {
 
   # Figure out when the changes were made.
   my $timestamp = $dbh->selectrow_array('SELECT LOCALTIMESTAMP(0)');
+
+  # Add user to CC if requested
+  if ($cgi->param('addselfcc')) {
+    $bug->add_cc(Bugzilla->user);
+  }
 
   # Commit the comment, if any.
   # This has to happen before updating the attachment, to ensure new comments

--- a/extensions/BugModal/template/en/default/bug_modal/attachments_overlay.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/attachments_overlay.html.tmpl
@@ -169,7 +169,7 @@
           <div class="comment-pane">
             <section class="comment-wrapper">
               <h3>Comment (on the [% terms.bug %])</h3>
-              [% INCLUDE bug_modal/new_comment.html.tmpl id_prefix = "att-overlay" add_extras = 0 add_self_cc = 1 %]
+              [% INCLUDE bug_modal/new_comment.html.tmpl id_prefix = "att-overlay" add_extras = 0 %]
             </section>
           </div>
         [% END %]

--- a/extensions/BugModal/template/en/default/bug_modal/attachments_overlay.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/attachments_overlay.html.tmpl
@@ -169,7 +169,7 @@
           <div class="comment-pane">
             <section class="comment-wrapper">
               <h3>Comment (on the [% terms.bug %])</h3>
-              [% INCLUDE bug_modal/new_comment.html.tmpl id_prefix = "att-overlay" add_extras = 0 %]
+              [% INCLUDE bug_modal/new_comment.html.tmpl id_prefix = "att-overlay" add_extras = 0 add_self_cc = 1 %]
             </section>
           </div>
         [% END %]

--- a/extensions/BugModal/template/en/default/bug_modal/new_comment.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/new_comment.html.tmpl
@@ -11,6 +11,7 @@
   # bug: bug object
   # id_prefix: (string) prefix for some element IDs (default: empty)
   # add_extras: (boolean) whether to show extra controls (default: true)
+  # add_self_cc: (boolean) whether to show the add self to cc (default: false)
   #%]
 
 [%
@@ -20,6 +21,9 @@
   IF !add_extras.defined;
     add_extras = 1;
   END;
+  IF !add_self_cc.defined;
+    add_self_cc = 0;
+  END
 %]
 
 <div id="add-comment">
@@ -73,32 +77,36 @@
         check_add_self = 0;
       END;
     %]
-    [% IF bug.id && add_extras %]
-      <table id="add-self-cc-container" [%= 'style="display:none"' IF hide_add_self %]>
-        <tr>
-          <td>
-            <input type="checkbox" name="addselfcc" id="add-self-cc"
-                   [%= "disabled" IF hide_add_self %] [%= "checked" IF check_add_self %]>
-          </td>
-          <td>
-            <label for="add-self-cc">Add me to CC list (follow this [% terms.bug %])</label>
-          </td>
-        </tr>
-      </table>
-      <table class="edit-show">
-        <tr>
-          <td>
-            <input type="checkbox" name="bug_ignored" id="bug-ignored"
-                   [%= "checked" IF user.is_bug_ignored(bug.id) %]>
-            <input type="hidden" name="defined_bug_ignored" value="1">
-          </td>
-          <td>
-            <label for="bug-ignored" title="You will still receive emails for flag requests directed at you">
-              Never email me about this [% terms.bug %]
-            </label>
-          </td>
-        </tr>
-      </table>
+    [% IF bug.id %]
+      [% IF add_self_cc %]
+        <table id="add-self-cc-container" [%= 'style="display:none"' IF hide_add_self %]>
+          <tr>
+            <td>
+              <input type="checkbox" name="addselfcc" id="add-self-cc"
+                    [%= "disabled" IF hide_add_self %] [%= "checked" IF check_add_self %]>
+            </td>
+            <td>
+              <label for="add-self-cc">Add me to CC list (follow this [% terms.bug %])</label>
+            </td>
+          </tr>
+        </table>
+      [% END %]
+      [% IF add_extras %]
+        <table class="edit-show">
+          <tr>
+            <td>
+              <input type="checkbox" name="bug_ignored" id="bug-ignored"
+                    [%= "checked" IF user.is_bug_ignored(bug.id) %]>
+              <input type="hidden" name="defined_bug_ignored" value="1">
+            </td>
+            <td>
+              <label for="bug-ignored" title="You will still receive emails for flag requests directed at you">
+                Never email me about this [% terms.bug %]
+              </label>
+            </td>
+          </tr>
+        </table>
+      [% END %]
     [% END %]
   </div>
 </div>

--- a/extensions/BugModal/template/en/default/bug_modal/new_comment.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/new_comment.html.tmpl
@@ -11,7 +11,7 @@
   # bug: bug object
   # id_prefix: (string) prefix for some element IDs (default: empty)
   # add_extras: (boolean) whether to show extra controls (default: true)
-  # add_self_cc: (boolean) whether to show the add self to cc (default: false)
+  # add_self_cc: (boolean) whether to show the add self to cc (default: true)
   #%]
 
 [%
@@ -22,7 +22,7 @@
     add_extras = 1;
   END;
   IF !add_self_cc.defined;
-    add_self_cc = 0;
+    add_self_cc = 1;
   END
 %]
 

--- a/template/en/default/attachment/create.html.tmpl
+++ b/template/en/default/attachment/create.html.tmpl
@@ -128,6 +128,30 @@
       </tr>
     [% END %]
 
+    [% IF NOT bug.cc || NOT bug.cc.contains(user.login) %]
+      [%
+        IF user.settings.state_addselfcc.value == 'always';
+          check_add_self = 1;
+        ELSIF user.settings.state_addselfcc.value == 'cc_unless_role';
+          check_add_self = !(
+              bug.user.isreporter
+              || bug.assigned_to.id == user.id
+              || (bug.qa_contact && bug.qa_contact.id == user.id)
+            );
+        ELSE;
+          check_add_self = 0;
+        END;
+      %]
+      <tr>
+        <td></td>
+        <td>
+          <input type="checkbox" name="addselfcc" id="add-self-cc"
+                 [%= "checked" IF check_add_self %]>
+          <label for="add-self-cc">Add me to CC list (follow this [% terms.bug %])</label>
+        </td>
+      </tr>
+    [% END %]
+
     [% Hook.process('form_before_submit') %]
 
     <tr>


### PR DESCRIPTION
This change adds the Add me to CC option for attachments similar to the bug page. It also will use the preferences of the user to determine if it is automatically checked or not.