### PR TITLE
Bug 1947837 - Uncaught SyntaxError: redeclaration of const formatDate

### DIFF
--- a/extensions/BugModal/template/en/default/bug/create/create-modal.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug/create/create-modal.html.tmpl
@@ -14,8 +14,7 @@
       "js/data-table.js",
       "js/bug.js", # Possible Duplicates table
       "js/attachment.js",
-      "extensions/BugModal/web/create.js",
-      "js/util.js"
+      "extensions/BugModal/web/create.js"
     ]
     style_urls = [
       "skins/standard/attachment.css",

--- a/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
@@ -64,8 +64,7 @@
     "extensions/ComponentWatching/web/js/overlay.js",
     "js/bugzilla-readable-status-min.js",
     "js/field.js",
-    "js/comments.js",
-    "js/util.js"
+    "js/comments.js"
   );
   jquery.push(
     "contextMenu",


### PR DESCRIPTION
The util.js is loaded for every page already, and the BugModal code (enter bug, show bug) was also loading util.js which caused the redeclaration error so I fixed to only load util.js once.