### PR TITLE
Bug 1967336 - The error message generated by timeout of long running searches needs to also work with REST API in addition to the web UI

### DIFF
--- a/Bugzilla/DB/Mysql.pm
+++ b/Bugzilla/DB/Mysql.pm
@@ -77,7 +77,7 @@ sub on_dbi_connected {
     # causing bug 321645. TRADITIONAL sets these modes (among others) as
     # well, so it has to be stipped as well
     my $new_sql_mode = join(",",
-      grep { $_ !~ /^STRICT_(?:TRANS|ALL)_TABLES|TRADITIONAL$/ }
+      grep { $_ !~ /^STRICT_(?:TRANS|ALL)_TABLES|TRADITIONAL|ONLY_FULL_GROUP_BY$/ }
         split(/,/, $sql_mode));
 
     if ($sql_mode ne $new_sql_mode) {

--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -875,7 +875,7 @@ sub data {
 
   $start_time = [gettimeofday()];
   $sql        = $search->_sql;
-  my $unsorted_data = $search->_sql_execute($sql);
+  my $unsorted_data = $search->_sql_execute($sql, 'selectall_arrayref');
   push(@extra_data, {sql => $sql, time => tv_interval($start_time)});
 
   # Let's sort the data. We didn't do it in the query itself because
@@ -994,7 +994,6 @@ END
 
 sub _sql_execute {
   my ($self, $sql, $func) = @_;
-  $func ||= 'selectall_arrayref';
   my $dbh = Bugzilla->dbh;
 
   my $results;

--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -22,6 +22,7 @@ use Bugzilla::Error;
 use Bugzilla::Field;
 use Bugzilla::Group;
 use Bugzilla::Keyword;
+use Bugzilla::Logging;
 use Bugzilla::Search::Clause;
 use Bugzilla::Search::ClauseGroup;
 use Bugzilla::Search::Condition qw(condition);
@@ -837,7 +838,7 @@ sub data {
 
   # Do we just want bug IDs to pass to the 2nd query or all the data immediately?
   my $func = $all_in_bugs_table ? 'selectall_arrayref' : 'selectcol_arrayref';
-  my $bug_ids = $dbh->$func($sql);
+  my $bug_ids = $self->_sql_execute($sql, $func);
   my @extra_data = ({sql => $sql, time => tv_interval($start_time)});
 
   # Restore the original 'fields' argument, just in case.
@@ -874,7 +875,7 @@ sub data {
 
   $start_time = [gettimeofday()];
   $sql        = $search->_sql;
-  my $unsorted_data = $dbh->selectall_arrayref($sql);
+  my $unsorted_data = $search->_sql_execute($sql);
   push(@extra_data, {sql => $sql, time => tv_interval($start_time)});
 
   # Let's sort the data. We didn't do it in the query itself because
@@ -989,6 +990,34 @@ query-string: $query_string
 END
   $self->{sql} = $query;
   return $self->{sql};
+}
+
+sub _sql_execute {
+  my ($self, $sql, $func) = @_;
+  $func ||= 'selectall_arrayref';
+  my $dbh = Bugzilla->dbh;
+
+  my $results;
+  do {
+    local $SIG{__DIE__}  = undef;
+    local $SIG{__WARN__} = undef;
+
+    $results = eval { $dbh->$func($sql) };
+
+    # If the search query failed, handle Throw*Error correctly, or for all other
+    # failures log it and return an empty list of bugs.
+    if (my $search_err = $@) {
+      return if ref $search_err eq 'ARRAY' && $search_err->[0] eq "EXIT\n";
+      if (!ref $search_err
+        && $search_err =~ /maximum statement execution time exceeded/)
+      {
+        ThrowUserError('db_search_timeout');
+      }
+      ERROR(Dumper($self->_params) . ' ' . Dumper($search_err));
+    }
+  };
+
+  return $results;
 }
 
 sub search_description {

--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -693,21 +693,7 @@ sub search {
   my $search = new Bugzilla::Search(%options);
 
   # Execute the query.
-  my $data = [];
-  do {
-    local $SIG{__DIE__}  = undef;
-    local $SIG{__WARN__} = undef;
-    ($data) = eval { $search->data };
-    # If the search query failed, handle Throw*Error correctly, or for all other
-    # failures log it and return an empty list of bugs.
-    if (my $search_err = $@) {
-      return if ref $search_err eq 'ARRAY' && $search_err->[0] eq "EXIT\n";
-      if (!ref $search_err && $search_err =~ /maximum statement execution time exceeded/) {
-        ThrowUserError('db_search_timeout');
-      }
-      ERROR('REST error: ' . dumper \%options . " " . dumper $search_err);
-    }
-  };
+  my ($data) = $search->data;
 
   # BMO if the caller only wants the count, that's all we need to return
   if ($params->{count_only}) {

--- a/Bugzilla/WebService/Constants.pm
+++ b/Bugzilla/WebService/Constants.pm
@@ -229,6 +229,7 @@ use constant WS_ERROR_CODE => {
 
   # Search errors are 1000-1100
   buglist_parameters_required => 1000,
+  db_search_timeout           => 1001,
 
   # Job queue errors 1400-1500
   jobqueue_status_error => 1400,

--- a/buglist.cgi
+++ b/buglist.cgi
@@ -721,24 +721,10 @@ $::SIG{TERM} = 'DEFAULT';
 $::SIG{PIPE} = 'DEFAULT';
 
 # Execute the query.
-my ($data, $extra_data);
-do {
-  local $SIG{__DIE__}  = undef;
-  local $SIG{__WARN__} = undef;
-  ($data, $extra_data) = eval { $search->data };
-  # If the search query failed, handle Throw*Error correctly, or for all other
-  # failures log it and return an empty list of bugs.
-  if (my $search_err = $@) {
-    return if ref $search_err eq 'ARRAY' && $search_err->[0] eq "EXIT\n";
-    if (!ref $search_err && $search_err =~ /maximum statement execution time exceeded/) {
-      ThrowUserError('db_search_timeout');
-    }
-    use Data::Dumper;
-    ERROR 'buglist.cgi?' . $cgi->query_string . " " . Dumper($search_err);
-  }
-};
+my ($data, $extra_data) = $search->data;
 
 $vars->{'search_description'} = $search->search_description;
+
 if ( $cgi->param('debug')
   && Bugzilla->params->{debug_group}
   && $user->in_group(Bugzilla->params->{debug_group}))

--- a/template/en/default/global/user-error.html.tmpl
+++ b/template/en/default/global/user-error.html.tmpl
@@ -491,9 +491,9 @@
 
   [% ELSIF error == "db_search_timeout" %]
     [% title = "Request Timed Out" %]
-     Sorry, it’s taking too long to get the information you asked for. Please
-     try again in a moment. If it still doesn’t work, try using a simpler
-     search or narrowing down your request.
+    Sorry, it's taking too long to get the information you asked for. Please
+    try again in a moment. If it still doesn't work, try using a simpler
+    search or narrowing down your request.
 
   [% ELSIF error == "dependency_loop_multi" %]
     [% title = "Dependency Loop Detected" %]


### PR DESCRIPTION
- Removed the MySQL setting ONLY_FULL_GROUP_BY due to some BMO code still not listing full group by column list. MySQL changed to checking by default in recent versions and this change now crashes certain queries that worked before.
- Created a single _sql_execute() function in Search.pm that can be used in multiple places to check for time out error instead of doing in both buglist.cgi and REST API.