### PR TITLE
Bug 1971281 - Webhooks fail with anything other than 200 response code

### DIFF
--- a/extensions/Push/lib/Connector/Webhook.pm
+++ b/extensions/Push/lib/Connector/Webhook.pm
@@ -177,8 +177,8 @@ sub send {
     }
 
     my $tx = mojo_user_agent()->post($webhook->url, $headers => json => $payload);
-    if ($tx->res->code != 200) {
-      die 'Expected HTTP 200, got '
+    if (!$tx->res->is_success) {
+      die 'Expected HTTP 2xx, got '
         . $tx->res->code . ' ('
         . $tx->error->{message} . ') '
         . $tx->res->body;


### PR DESCRIPTION
This uses $response->is_success which under the hood considers any code 2xx to be a success. This is better than just looking for 200.