### PR TITLE
Bug 1974359 - Cannot remove see-also from bug when user can edit the other bug and the other bug doe not have a see-also back

### DIFF
--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -3493,7 +3493,7 @@ sub remove_see_also {
 
       # Check to see that the referenced bug has this bug as a see_also
       # and if so remove it.
-      if (any { $_ eq $self_url } @{ref_bug->see_also}) {
+      if (any { $_ eq $self_url } @{$ref_bug->see_also}) {
         $ref_bug->remove_see_also($self_url, 'skip_recursion');
         push @{$self->{_update_ref_bugs}}, $ref_bug;
         push @{$self->{see_also_changes}}, $ref_bug->id;

--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -3490,14 +3490,9 @@ sub remove_see_also {
       && $ref_can_change->{allowed})
     {
       my $self_url = $removed_bug_url->local_uri($self->id);
-
-      # Check to see that the referenced bug has this bug as a see_also
-      # and if so remove it.
-      if (any { $_ eq $self_url } @{$ref_bug->see_also}) {
-        $ref_bug->remove_see_also($self_url, 'skip_recursion');
-        push @{$self->{_update_ref_bugs}}, $ref_bug;
-        push @{$self->{see_also_changes}}, $ref_bug->id;
-      }
+      $ref_bug->remove_see_also($self_url, 'skip_recursion');
+      push @{$self->{_update_ref_bugs}}, $ref_bug;
+      push @{$self->{see_also_changes}}, $ref_bug->id;
     }
   }
 


### PR DESCRIPTION
~~This change simply checks first to see if the destination bug as a reverse see_also back to the source bug. This is instead of before of just assuming that a reverse relationship exists which can cause error if it doesn't.~~

Turns out a shorter fix was all that was necessary after some more testing. My reordering of the conditions in the if block was all that was needed. Before the code was accessing `$removed_bug_url->ref_bug_url->bug_id` before checking if `$removed_bug_url->ref_bug_url` even existed which was causing a fatal error loop. By reordering, it not just short circuits before the line causing the error.