### PR TITLE
Bug 1977358 - New bug template does not display on initial page load unless selecting a component even when one is selected

### DIFF
--- a/extensions/BugModal/web/create.js
+++ b/extensions/BugModal/web/create.js
@@ -257,6 +257,10 @@ window.addEventListener('DOMContentLoaded', () => {
     if ($form.component.options.length === 1) {
       $form.component.selectedIndex = 0;
     } else {
+      // Select first compponent if more than one and none are selected
+      if ($form.component.selectedIndex === -1) {
+        $form.component.selectedIndex = 0;
+      }
       $form.component.addEventListener('change', () => {
         onComponentChange();
       });


### PR DESCRIPTION
The default initial page load of the new bug page will automatically select the first component in the list. But if a new bug template is setup for a product or component, it does not display on the initial page load. This is do the the initial page load javascript executing before the DOM reflects that a component has been preselected by default. If you change the window.addEventListener('DOMContentReady') to window.addEventListener('load') it works properly and shows the new bug template on page load. But instead of changing that and maybe cause other issues, update the javascript to set component.selectedIndex to 0 (first component) when its value is -1 (nothing selected yet).