### PR TITLE
Bug 1980977 - When looking for a reviewer from rotation group and run out of choices, add a comment to the revision stating a reviewer was not found

### DIFF
--- a/extensions/PhabBugz/lib/Comment.pm
+++ b/extensions/PhabBugz/lib/Comment.pm
@@ -1,0 +1,67 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::Extension::PhabBugz::Comment;
+
+use 5.10.1;
+use Moo;
+use Types::Standard -all;
+
+use Bugzilla::Extension::PhabBugz::User;
+use Bugzilla::Extension::PhabBugz::Types qw(:types);
+
+#########################
+#    Initialization     #
+#########################
+
+has id              => (is => 'ro',   isa => Int);
+has phid            => (is => 'ro',   isa => Str);
+has author_phid     => (is => 'ro',   isa => Str);
+has creation_ts     => (is => 'ro',   isa => Str);
+has modification_ts => (is => 'ro',   isa => Str);
+has text            => (is => 'ro',   isa => Str);
+has author          => (is => 'lazy', isa => PhabUser);
+
+sub BUILDARGS {
+  my ($class, $params) = @_;
+
+  $params->{author_phid}     = $params->{authorPHID};
+  $params->{creation_ts}     = $params->{dateCreated};
+  $params->{modification_ts} = $params->{dateModified};
+  $params->{text}            = $params->{content}{raw};
+
+  return $params;
+}
+
+# {
+#   "id": 1424261,
+#   "phid": "PHID-XCMT-thonchbcyvvwkcjq2bwa",
+#   "version": 1,
+#   "authorPHID": "PHID-APPS-PhabricatorHeraldApplication",
+#   "dateCreated": 1754346670,
+#   "dateModified": 1754346670,
+#   "removed": false,
+#   "content": {
+#     "raw": "This revision requires a [[https://firefox-source-docs.mozilla.org/testing/testing-policy/ | Testing Policy]] Project Tag to be set before landing. Please apply one of `testing-approved`, `testing-exception-unchanged`, `testing-exception-ui`, `testing-exception-elsewhere`, `testing-exception-other`. Tip: [[https://addons.mozilla.org/en-US/firefox/addon/phab-test-policy/ | this Firefox add-on]] makes it easy!"
+#   }
+# }
+
+############
+# Builders #
+############
+
+sub _build_author {
+  my ($self) = @_;
+  return $self->{author} if $self->{author};
+  my $phab_user
+    = Bugzilla::Extension::PhabBugz::User->new_from_query({
+    phids => [$self->author_phid]
+    });
+  return $self->{author} = $phab_user;
+}
+
+1;

--- a/extensions/PhabBugz/lib/Util.pm
+++ b/extensions/PhabBugz/lib/Util.pm
@@ -21,8 +21,7 @@ use Bugzilla::Util qw(mojo_user_agent trim);
 use Bugzilla::Extension::PhabBugz::Constants;
 use Bugzilla::Extension::PhabBugz::Types qw(:types);
 
-use List::MoreUtils qw(any);
-use List::Util      qw(any first);
+use List::Util      qw(first none);
 use Try::Tiny;
 use Type::Params qw( compile );
 use Type::Utils;
@@ -406,7 +405,7 @@ PROJECT: foreach my $project (@review_projects) {
     # then use the same reviewer for this revision
     if (@stack_reviewers) {
       foreach my $member (@project_members) {
-        next if !any { $_->id == $member->id } @stack_reviewers;
+        next if none { $_->id == $member->id } @stack_reviewers;
         INFO('Found a previous stack reviewer: ' . $member->name);
         set_new_reviewer($revision, $project, $member, $is_blocking, \@review_users);
         next PROJECT;
@@ -419,7 +418,7 @@ PROJECT: foreach my $project (@review_projects) {
     # do not want this reviewer set to last reviewer in the DB.
     if (@review_users) {
       foreach my $member (@project_members) {
-        next if !any { $_->id == $member->id } @review_users;
+        next if none { $_->id == $member->id } @review_users;
         INFO('Member manually set as a reviewer so done: ' . $member->name);
         $revision->remove_reviewer($project->phid);
         next PROJECT;
@@ -454,8 +453,25 @@ PROJECT: foreach my $project (@review_projects) {
       {
         INFO('Promoting member to reviewer: ' . $member->name);
         set_new_reviewer($revision, $project, $member, $is_blocking, \@review_users);
-        last;
+        next PROJECT;
       }
+    }
+
+    # If we got to this point, we did not find a suitable reviewer so
+    # we will leave a comment in the revision with explanation. First
+    # we need to check to make sure we have not already added this comment.
+    my $comments     = $revision->comments;
+    my $project_name = $project->name;
+    INFO("A reviewer was not found for $project_name.");
+    if (none {$_->text =~ /REVIEWER ROTATION:.* $project_name/} @{$comments}) {
+      INFO('Adding comment to revision because reviewer not found');
+      $revision->add_comment(
+        'REVIEWER ROTATION: An available rotation reviewer was not found from the group '
+          . $project->name
+          . ' for this revision.');
+    }
+    else {
+      INFO('Comment already added previously. Skipping.');
     }
   }
 


### PR DESCRIPTION
Add a comment to the revision stating that an individual reviewer could not be found from a rotation pool. Also allow a way to get current comments for a revision that can be queried up on the next time the revision is changed so that we only add the comment once. We do not want to keep looping and re-adding the comment.