### PR TITLE
Bug 1982101 - Add a note that markdown is supported with a link to help on the Guided bug entry page

### DIFF
--- a/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
+++ b/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
@@ -428,7 +428,13 @@ explain how to write effective [% terms.bug %] reports.</li>
 </tr>
 
 <tr>
-  <td class="label" colspan="3">What did you do? (steps to reproduce)</td>
+  <td class="label" colspan="3">
+    What did you do? (steps to reproduce)
+    <span id="guided-markdown-help">
+      <a href="https://guides.github.com/features/mastering-markdown/" target="_blank">
+        Markdown supported</a>
+    </span>
+  </td>
   <td valign="top">
   [% PROCESS help id="steps_help" %]
   <div id="steps_help" class="help" role="tooltip" hidden>

--- a/extensions/GuidedBugEntry/web/style/guided.css
+++ b/extensions/GuidedBugEntry/web/style/guided.css
@@ -227,3 +227,8 @@ ul.product-list > li > .product-item {
 .help-good {
   color: var(--positive-message-foreground-color);
 }
+
+#guided-markdown-help {
+  float: right;
+  font-size: var(--font-size-small);
+}


### PR DESCRIPTION
<img width="1414" height="566" alt="Screenshot 2025-08-08 at 16-12-54 Enter A Bug" src="https://github.com/user-attachments/assets/4cefff92-4039-407a-95ec-2ec323626d9b" />
