### PR TITLE
Bug 1933892 - missing/misplaced horizontal scrollbar on bug lists

### DIFF
--- a/skins/standard/buglist.css
+++ b/skins/standard/buglist.css
@@ -213,15 +213,18 @@ td.bz_total {
   }
 
   .bz_buglist.responsive tbody td {
-    display: flex;
+    display: flow-root;
     gap: 4px;
-    padding: 2px 0 !important;
+    margin-block: 8px;
+    padding: 0 0 0 90px !important;
     width: auto;
     text-align: left;
   }
 
   .bz_buglist.responsive tbody td::before {
     display: block;
+    float: left;
+    margin-inline: -90px 10px;
     min-width: 80px;
     color: var(--secondary-label-color);
     font-size: var(--font-size-small);

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -935,19 +935,18 @@ input[type="radio"]:checked {
 #bugzilla-body {
   display: flow-root;
   position: relative;
-  overflow: auto;
   outline: none;
 }
 
 @media screen {
   :root {
     scroll-padding-top: calc(var(--global-header-height) + var(--private-bug-banner-height, 0px) + 8px);
+    scrollbar-color: var(--scrollbar-color);
   }
 
   body {
     color: var(--application-foreground-color);
     background-color: var(--application-background-color);
-    scrollbar-color: var(--scrollbar-color);
   }
 
   #wrapper {
@@ -971,6 +970,7 @@ input[type="radio"]:checked {
  */
 
 #header {
+  width: 100dvw;
   height: var(--global-header-height);
   color: var(--application-header-foreground-color);
   background-color: var(--application-header-background-color);


### PR DESCRIPTION
[Bug 1933892 - missing/misplaced horizontal scrollbar on bug lists](https://bugzilla.mozilla.org/show_bug.cgi?id=1933892)

This change ensures that the horizontal scrollbar is always displayed when the page overflows due to a large bug table while keeping the header fixed at the top and centre of the page. It also adjusts the bug table’s style for mobile so that a large number of bugs (blockers, etc.) do not overflow the table.

<img width="1287" height="810" alt="Screenshot 2025-08-19 at 10 00 02 PM" src="https://github.com/user-attachments/assets/43c36e16-487c-4b59-b5f7-31e59bb7f384" />