### PR TITLE
Bug 1983944 - My dashboard should render updated comments in markdown

### DIFF
--- a/extensions/MyDashboard/lib/WebService.pm
+++ b/extensions/MyDashboard/lib/WebService.pm
@@ -77,8 +77,8 @@ sub run_last_changes {
     my $bug = Bugzilla::Bug->check($params->{bug_id});
     my $html
       = Bugzilla->params->{use_markdown}
-      ? Bugzilla->markdown->render_html($text, $bug, $comment, $user)
-      : Bugzilla::Template::quoteUrls($text, $bug, $comment, $user);
+      ? Bugzilla->markdown->render_html($text, $bug)
+      : Bugzilla::Template::quoteUrls($text, $bug);
     $last_changes->{comment_html} = $html;
     $last_changes->{email} = $comment->{creator} if !$last_changes->{email};
     my $datetime = datetime_from($comment->{creation_time});

--- a/extensions/MyDashboard/lib/WebService.pm
+++ b/extensions/MyDashboard/lib/WebService.pm
@@ -14,6 +14,7 @@ use base qw(Bugzilla::WebService Bugzilla::WebService::Bug);
 
 use Bugzilla::Constants;
 use Bugzilla::Error;
+use Bugzilla::Template;
 use Bugzilla::Util qw(detaint_natural template_var datetime_from);
 use Bugzilla::WebService::Util qw(validate);
 
@@ -72,7 +73,13 @@ sub run_last_changes {
   if ($last_comment_id) {
     my $comments = $self->comments({comment_ids => [$last_comment_id]});
     my $comment = $comments->{comments}{$last_comment_id};
-    $last_changes->{comment} = $comment->{text};
+    my $text = $comment->{text};
+    my $bug = Bugzilla::Bug->check($params->{bug_id});
+    my $html
+      = Bugzilla->params->{use_markdown}
+      ? Bugzilla->markdown->render_html($text, $bug, $comment, $user)
+      : Bugzilla::Template::quoteUrls($text, $bug, $comment, $user);
+    $last_changes->{comment_html} = $html;
     $last_changes->{email} = $comment->{creator} if !$last_changes->{email};
     my $datetime = datetime_from($comment->{creation_time});
     $datetime->set_time_zone($user->timezone);

--- a/extensions/MyDashboard/web/js/query.js
+++ b/extensions/MyDashboard/web/js/query.js
@@ -121,7 +121,7 @@ window.addEventListener('DOMContentLoaded', () => {
     }
 
     if (lastChangesCache[bug_id]) {
-      const { email, when, activity, comment_html } = lastChangesCache[bug_id];
+      const { email, when, activity, comment_html = '' } = lastChangesCache[bug_id];
 
       $target.innerHTML = `
         <div id="last_changes_${bug_id}">
@@ -157,7 +157,7 @@ window.addEventListener('DOMContentLoaded', () => {
                     `
                     : ``
                 }
-                ${comment_html ?? ''}
+                ${comment_html}
               `
               : `This is a new ${BUGZILLA.string.bug} and no changes have been made yet.`
           }

--- a/extensions/MyDashboard/web/js/query.js
+++ b/extensions/MyDashboard/web/js/query.js
@@ -121,7 +121,7 @@ window.addEventListener('DOMContentLoaded', () => {
     }
 
     if (lastChangesCache[bug_id]) {
-      const { email, when, activity, comment } = lastChangesCache[bug_id];
+      const { email, when, activity, comment_html } = lastChangesCache[bug_id];
 
       $target.innerHTML = `
         <div id="last_changes_${bug_id}">
@@ -157,7 +157,7 @@ window.addEventListener('DOMContentLoaded', () => {
                     `
                     : ``
                 }
-                ${comment ? `<pre class='bz_comment_text'>${comment.htmlEncode()}</pre>` : ``}
+                ${comment_html ?? ''}
               `
               : `This is a new ${BUGZILLA.string.bug} and no changes have been made yet.`
           }


### PR DESCRIPTION
[Bug 1983944 - My dashboard should render updated comments in markdown](https://bugzilla.mozilla.org/show_bug.cgi?id=1983944)

Return rendered HTML with the API, and use it as-is.