### PR TITLE
Bug 1971059 - Dependency tree items are misaligned

### DIFF
--- a/skins/standard/dependency-tree.css
+++ b/skins/standard/dependency-tree.css
@@ -64,7 +64,7 @@
 }
 
 .expander {
-  width: 18px;
+  width: 18px !important;
   height: 18px;
 }
 


### PR DESCRIPTION
[Bug 1971059 - Dependency tree items are misaligned](https://bugzilla.mozilla.org/show_bug.cgi?id=1971059)

Fix an unexpected style override.