### PR TITLE
Bug 1985621: trigger uplift changes when hash of last form changes

### DIFF
--- a/extensions/PhabBugz/Extension.pm
+++ b/extensions/PhabBugz/Extension.pm
@@ -125,6 +125,13 @@ sub db_schema_abstract_schema {
       user_phid     => {TYPE => 'VARCHAR(255)', NOTNULL => 1,},
     ]
   };
+  $args->{'schema'}->{'phab_uplift_form_state'} = {
+    FIELDS => [
+      id               => {TYPE => 'INTSERIAL',    NOTNULL => 1, PRIMARYKEY => 1,},
+      revision_phid    => {TYPE => 'VARCHAR(255)', NOTNULL => 1,},
+      uplift_form_hash => {TYPE => 'VARCHAR(255)', NOTNULL => 1,},
+    ]
+  };
 }
 
 sub install_filesystem {

--- a/extensions/PhabBugz/lib/Revision.pm
+++ b/extensions/PhabBugz/lib/Revision.pm
@@ -321,6 +321,15 @@ sub secured_title {
   return $self->is_private ? '(secure)' : $self->title;
 }
 
+sub uplift_hash {
+  my ($self) = @_;
+
+  my $uplift_json_encoded = encode_json(
+    $self->uplift_request, {canonical => 1}
+  );
+  return sha1_hex($uplift_json_encoded);
+}
+
 #########################
 #      Builders         #
 #########################


### PR DESCRIPTION
After bug 1982619 is deployed to Lando, the uplift request form
will be updated via the Conduit API. When the form is updated via
the API, no feed story is produced, and the transactions view does
not provide enough detail to determine if the uplift form has changed.

Add a new table to track a hash of the contents of the uplift request
form for each revision. When processing a revision change, if the
uplift request form is non-empty, compare against the previously
stored hash and perform the uplift processing steps if the hash has
changed, then store the new hash for the revision.

After processing the form, if the story text indicates the event was
triggered from an update of the uplift request form via the Phabricator
form, we can exit early as there are no more actions to be taken.
