### PR TITLE
Bug 1986495 - Optimize bug updates in Phabbugz by converting to a single update

### DIFF
--- a/extensions/PhabBugz/lib/Feed.pm
+++ b/extensions/PhabBugz/lib/Feed.pm
@@ -465,7 +465,6 @@ sub process_uplift_request_form_change {
   # Process an uplift request form change for the passed revision object.
   my ($revision, $bug) = @_;
 
-  my ($timestamp) = Bugzilla->dbh->selectrow_array('SELECT NOW()');
   my $phab_bot_user = Bugzilla::User->new({name => PHAB_AUTOMATION_USER});
 
   INFO('Commenting the uplift form on the bug.');
@@ -478,7 +477,6 @@ sub process_uplift_request_form_change {
     'isprivate'   => 0,
   };
   $bug->add_comment($comment_content, $comment_params);
-  $bug->update($timestamp);
 
   my $revision_phid = $revision->phid;
   INFO(
@@ -526,14 +524,11 @@ sub process_uplift_request_form_change {
   if ($revision->uplift_request->{'Needs manual QE test'}) {
     INFO('Needs manual QE test is set.');
 
-    # Reload the current bug object so we can call update again
-    my $reloaded_bug = Bugzilla::Bug->new($bug->id);
-
     my @old_flags;
     my @new_flags;
 
     # Find the current `qe-verify` flag state if it exists.
-    foreach my $flag (@{$reloaded_bug->flags}) {
+    foreach my $flag (@{$bug->flags}) {
       # Ignore for all flags except `qe-verify`.
       next if $flag->name ne 'qe-verify';
       # Set the flag to `+`. If already '+', it will be non-change.
@@ -556,8 +551,7 @@ sub process_uplift_request_form_change {
     }
 
     # Set the flags.
-    $reloaded_bug->set_flags(\@old_flags, \@new_flags);
-    $reloaded_bug->update($timestamp);
+    $bug->set_flags(\@old_flags, \@new_flags);
   }
 
   INFO("Finished processing uplift request form change for $revision_phid.");
@@ -600,6 +594,8 @@ sub process_revision_change {
   # change to the phabricator user, which returns a guard that restores the previous user.
   my $restore_prev_user = set_phab_user();
   my $bug               = $revision->bug;
+
+  my ($timestamp) = Bugzilla->dbh->selectrow_array("SELECT NOW()");
 
   # Process uplift request form changes if the hash has changed since phab-bot last
   # saw it.
@@ -677,8 +673,6 @@ sub process_revision_change {
     my $subscribers = get_bug_role_phids($bug);
     $revision->set_subscribers($subscribers);
   }
-
-  my ($timestamp) = Bugzilla->dbh->selectrow_array("SELECT NOW()");
 
   # Create new or retrieve current attachment
   INFO('Checking for revision attachment');


### PR DESCRIPTION
After reviewing [bug 1985621](https://bugzilla.mozilla.org/show_bug.cgi?id=1985621), I discovered a few places which can cause a object corruption issue due to updating a bug multiple times instead a single time. This patch fixes this issue.