### PR TITLE
Bug 1987016 - Apply better styling for disabled checkboxes.

### DIFF
--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -779,6 +779,19 @@ input[type="checkbox"]:checked {
   background-size: 18px 18px;
 }
 
+input[type="checkbox"]:disabled {
+  border-color: var(--disabled-button-foreground-color);
+  background-color: var(--disabled-button-background-color);
+  border-width: 1px;
+  cursor: default;
+}
+
+input[type="checkbox"]:disabled:checked {
+  border-color: var(--disabled-control-foreground-color);
+  background-color: var(--disabled-control-foreground-color);
+  cursor: default;
+}
+
 input[type="radio"] {
   border-radius: 50%;
 }


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1987016

This does:
  * apply dedicate styling for disabled checkboxes

<img width="250" height="249" alt="checkboxes" src="https://github.com/user-attachments/assets/6206e6a5-9dd1-476e-8d3b-8c30902ef889" />

(we may need to do the same for other controls, but I'd leave it for other bugs, as I haven't bumped into other disabled controls)