### PR TITLE
Bug 1988707 - Clarify the User Statistics is updated daily.

### DIFF
--- a/extensions/UserProfile/template/en/default/pages/user_profile.html.tmpl
+++ b/extensions/UserProfile/template/en/default/pages/user_profile.html.tmpl
@@ -204,7 +204,7 @@
   <td colspan="4" class="separator"><hr></td>
 </tr>
 <tr>
-  <td>User Statistics</td>
+  <td>User Statistics (Updated daily)</td>
 </tr>
 
 <tr>


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=1988707

This does:
  * Add "(Updated daily)" after the "User Statistics" section name, to clarify the delay