### PR TITLE
Bug 1989605 - Don't allow brand-new accounts to use the Triage Request Form to self-grant `canconfirm`

### DIFF
--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -417,7 +417,7 @@ sub parse_bounty_attachment_description {
 sub triage_request {
   my ($vars) = @_;
   my $user = Bugzilla->login(LOGIN_REQUIRED);
-  if (Bugzilla->input_params->{update}) {
+  if (!$user->is_new && Bugzilla->input_params->{update}) {
     Bugzilla->set_user(Bugzilla::User->super_user);
     $user->set_groups({add => ['canconfirm']});
     Bugzilla->set_user($user);

--- a/extensions/BMO/template/en/default/pages/get_permissions.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/get_permissions.html.tmpl
@@ -12,10 +12,12 @@
 
 <h3>How to apply for upgraded permissions</h3>
 
-<p>
-  If you want <kbd>canconfirm</kbd>, you can add it yourself using
-  the <a href="[% basepath FILTER none %]page.cgi?id=triage_request.html">triage request form</a>.
-</p>
+[% IF !user.is_new %]
+  <p>
+    If you want <kbd>canconfirm</kbd>, you can add it yourself using
+    the <a href="[% basepath FILTER none %]page.cgi?id=triage_request.html">triage request form</a>.
+  </p>
+[% END %]
 
 [% editbugs = basepath _ "enter_bug.cgi?assigned_to=nobody%40mozilla.org&bug_file_loc=http%3A%2F%2F&bug_ignored=0&bug_type=task&bug_severity=--&bug_status=NEW&cf_fx_iteration=---&cf_fx_points=---&component=Editbugs%20Requests&contenttypemethod=autodetect&contenttypeselection=text%2Fplain&defined_groups=1&flag_type-4=X&flag_type-607=X&flag_type-791=X&flag_type-800=X&flag_type-803=X&flag_type-916=X&form_name=enter_bug&maketemplate=Remember%20values%20as%20bookmarkable%20template&op_sys=Unspecified&priority=--&product=bugzilla.mozilla.org&rep_platform=Unspecified&target_milestone=---&version=Production" %]
 

--- a/extensions/BMO/template/en/default/pages/triage_request.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/triage_request.html.tmpl
@@ -47,6 +47,13 @@
       faster.
     </p>
 
+  [% ELSIF user.is_new %]
+
+    <p>
+      Your account is still too new to request the ability to triage [% terms.bugs %].
+      Please check back at a later time to see when you will become eligible.
+    </p>
+
   [% ELSE %]
 
     <p>


### PR DESCRIPTION
If the user is new (is_new() provided by the TagNewUser extension) then do not allow them to give themselves canconfirm permissions.