### PR TITLE
Bug 1987854 - Make name for advisory credits more clear

### DIFF
--- a/extensions/BMO/template/en/default/account/create.html.tmpl
+++ b/extensions/BMO/template/en/default/account/create.html.tmpl
@@ -124,6 +124,10 @@ function onSubmit() {
         you'll be asked to set a password and then you can start filing [% terms.bugs %]
         and helping fix them.
       </li>
+      <li>
+        Also note that the value used for the your real name, when creating the account,
+        will be used on any advisory credits.
+      </li>
     </ol>
   </div>
 

--- a/template/en/default/account/prefs/account.html.tmpl
+++ b/template/en/default/account/prefs/account.html.tmpl
@@ -43,7 +43,8 @@
         <td>&nbsp;</td>
         <td>
           Note: You can set nickname by putting <code>[:nickname]</code> in the
-          field.
+          field. Also note that the value used for the your real name will be used
+          on any advisory credits.
         </td>
       </tr>
 


### PR DESCRIPTION
add a note to the sign-up/profile editing page to let people know that whatever they put in the "Your real name:" field will be used on any advisory credits. Also on the user preferences page where they can change their current real name.