### PR TITLE
Bug 1985464 - Switch guided bug entry cards to flex layout to avoid a fixed height

### DIFF
--- a/extensions/GuidedBugEntry/web/style/guided.css
+++ b/extensions/GuidedBugEntry/web/style/guided.css
@@ -41,6 +41,8 @@
 }
 
 ul.product-list {
+  display: flex;
+  flex-wrap: wrap;
   margin: 0 -10px 20px;
   padding: 0;
   list-style: outside none none;
@@ -55,8 +57,6 @@ ul.product-list > li {
   border-radius: var(--primary-region-border-radius);
   padding: 1px;
   width: 300px;
-  min-height: 166px;
-  height: 168px;
   background-color: var(--primary-region-background-color);
   background-clip: padding-box;
   box-shadow: var(--primary-region-box-shadow);


### PR DESCRIPTION
This fixes: [Bug 1985464](https://bugzilla.mozilla.org/show_bug.cgi?id=1985464) by switching the card layout to flex. This way we can avoid having a fixed height on the cards, but retain the equal height/grid look of the cards. I also removed the min-height as it seems unnecessary with the new setup.

Previous:
<img width="968" height="390" alt="image" src="https://github.com/user-attachments/assets/01649de7-73c5-472f-aabe-3c68ac241056" />

Fixed:
<img width="965" height="433" alt="image" src="https://github.com/user-attachments/assets/72db0059-8101-4075-a1d1-5c60caaf5751" />